### PR TITLE
Fix artifact action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Fetch libraries
         run: bash quiz-app/fetch_libs.sh
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: quiz-app
           path: quiz-app/


### PR DESCRIPTION
## Summary
- update workflow to use `actions/upload-artifact@v4`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841c7114680832b8a1ae6898073582d