### PR TITLE
Add offline package script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 Dieses Repository enthält ein kleines clientseitiges Quizsystem. Im Verzeichnis `quiz-app` befindet sich die Anwendung, die ohne Build-Prozess direkt im Browser läuft.
 
-Vor dem Start können die Bibliotheken lokal in `quiz-app/libs` abgelegt werden. Führe dazu im Unterordner den Befehl `./fetch_libs.sh` aus und öffne anschließend `quiz-app/index.html` direkt im Browser.
+Die JavaScript- und CSS-Dateien liegen bereits im Ordner `quiz-app/libs`. Das
+Skript `fetch_libs.sh` muss nur ausgeführt werden, wenn du diese Bibliotheken
+aktualisieren möchtest. Anschließend kannst du `quiz-app/index.html` direkt im
+Browser öffnen.
 
 Siehe `quiz-app/README.md` für weitere Informationen zur Nutzung und zum Hinzufügen neuer Fragen.
+
+## Offline-Paket erstellen
+
+Mit `quiz-app/package.sh` lässt sich ein ZIP-Archiv erzeugen, das alle Dateien
+inklusive der JavaScript-Bibliotheken enthält. So kann das Quiz bequem ohne
+Internetverbindung verteilt werden.
 
 ## Deploy per GitHub Actions
 

--- a/quiz-app/README.md
+++ b/quiz-app/README.md
@@ -1,7 +1,6 @@
 # Quiz App
 
-Dieses kleine Quizsystem basiert auf Vue.js und Tailwind CSS und läuft komplett im Browser. Die benötigten Bibliotheken können lokal hinterlegt werden, sodass keine Verbindung zu externen CDNs notwendig ist.
-Führe im Ordner **quiz-app** das Skript `fetch_libs.sh` aus, um die JavaScript- und CSS-Dateien in das Verzeichnis `libs/` herunterzuladen. Danach kann `index.html` direkt im Browser geöffnet werden und funktioniert auch ohne Webserver.
+Dieses kleine Quizsystem basiert auf Vue.js und Tailwind CSS und läuft komplett im Browser. Die notwendigen Bibliotheken befinden sich bereits im Verzeichnis `libs/`, sodass keine Verbindung zu externen CDNs erforderlich ist. Das Skript `fetch_libs.sh` dient lediglich dazu, diese Dateien bei Bedarf zu aktualisieren.
 
 
 ## Fragen bearbeiten
@@ -23,9 +22,11 @@ quiz-app/
 
 ## Nutzung
 
-1. Abhängigkeiten mit `./fetch_libs.sh` herunterladen (einmalig).
-2. `index.html` im Browser öffnen (z. B. per Doppelklick).
-3. Das Quiz lädt automatisch die Fragen aus `questions.json` über ein eingebettetes Skript.
+1. `index.html` im Browser öffnen (z. B. per Doppelklick).
+2. Das Quiz lädt automatisch die Fragen aus `questions.json` über ein eingebettetes Skript.
+3. Falls du die Bibliotheken aktualisieren möchtest, führe zuvor `./fetch_libs.sh` aus.
+4. Möchtest du ein eigenständiges Paket verteilen, kannst du mit `./package.sh`
+   eine ZIP-Datei erstellen, die alle Dateien der Anwendung enthält.
 
 ## Automatischer Build
 

--- a/quiz-app/package.sh
+++ b/quiz-app/package.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Create a ZIP package of the quiz app with all dependencies for offline use.
+set -e
+cd "$(dirname "$0")"
+
+if [ ! -f libs/vue.global.prod.js ]; then
+  echo "Dependencies missing. Fetching..." >&2
+  bash fetch_libs.sh
+fi
+
+zipfile="quiz-app-offline.zip"
+rm -f "$zipfile"
+zip -r "$zipfile" . > /dev/null
+
+printf "Created %s\n" "$zipfile"
+


### PR DESCRIPTION
## Summary
- clarify README that libraries are already included
- document optional use of `fetch_libs.sh`
- provide `package.sh` to create a ZIP archive for offline use
- mention the packaging script in docs

## Testing
- `bash quiz-app/package.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841ca553c9c832bbcce5d3447ec4540