### PR TITLE
Add Vue3 Tailwind quiz demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,17 @@
 # sommerfest-quiz
 
-Dieses Repository enthält ein kleines clientseitiges Quizsystem. Im Verzeichnis `quiz-app` befindet sich die Anwendung, die ohne Build-Prozess direkt im Browser läuft.
+Dieses Repository enth\u00e4lt ein kleines clientseitiges Quizsystem. Neben dem urspr\u00fcnglichen Ordner `quiz-app` befindet sich jetzt das Beispiel `quiz-admin`, das ein moderneres Layout mit Vue&nbsp;3 und Tailwind per CDN demonstriert.
 
-Die JavaScript- und CSS-Dateien liegen bereits im Ordner `quiz-app/libs`. Das
-Skript `fetch_libs.sh` muss nur ausgeführt werden, wenn du diese Bibliotheken
-aktualisieren möchtest. Anschließend kannst du `quiz-app/index.html` direkt im
-Browser öffnen.
+Die JavaScript- und CSS-Dateien f\u00fcr `quiz-app` liegen bereits im Ordner `quiz-app/libs`. Das Skript `fetch_libs.sh` muss nur ausgef\u00fchrt werden, wenn du diese Bibliotheken aktualisieren m\u00f6chtest. Anschlie\u00dfend kannst du `quiz-app/index.html` direkt im Browser \u00f6ffnen.
 
-Siehe `quiz-app/README.md` für weitere Informationen zur Nutzung und zum Hinzufügen neuer Fragen.
+Im Verzeichnis `quiz-admin` befindet sich eine weitere Variante, die die Fragen aus `questions.json` l\u00e4dt und ein Card-basiertes Layout nutzt. Auch diese Seite kann ohne Build-Prozess direkt ge\u00f6ffnet werden.
+
+Siehe die jeweiligen README-Dateien f\u00fcr weitere Informationen.
 
 ## Offline-Paket erstellen
 
-Mit `quiz-app/package.sh` lässt sich ein ZIP-Archiv erzeugen, das alle Dateien
-inklusive der JavaScript-Bibliotheken enthält. So kann das Quiz bequem ohne
-Internetverbindung verteilt werden.
+Mit `quiz-app/package.sh` l\u00e4sst sich ein ZIP-Archiv erzeugen, das alle Dateien inklusive der JavaScript-Bibliotheken enth\u00e4lt. So kann das Quiz bequem ohne Internetverbindung verteilt werden.
 
 ## Deploy per GitHub Actions
 
-Im Repository befindet sich ein Workflow `.github/workflows/deploy.yml`. Er lädt den Code, führt `quiz-app/fetch_libs.sh` aus und stellt das komplette `quiz-app/` Verzeichnis als Artefakt bereit. Dadurch kann ein fertiges Offline-Paket direkt aus dem Actions-Bereich heruntergeladen werden.
-
+Im Repository befindet sich ein Workflow `.github/workflows/deploy.yml`. Er l\u00e4dt den Code, f\u00fchrt `quiz-app/fetch_libs.sh` aus und stellt das komplette `quiz-app/` Verzeichnis als Artefakt bereit. Dadurch kann ein fertiges Offline-Paket direkt aus dem Actions-Bereich heruntergeladen werden.

--- a/quiz-admin/README.md
+++ b/quiz-admin/README.md
@@ -1,0 +1,12 @@
+# Quiz Admin
+
+Diese statische Quiz-App basiert auf Vue 3 und Tailwind CSS. Sie nutzt keine
+Serverkomponenten und l\u00e4dt die Fragen aus der lokalen Datei `questions.json`.
+
+## Nutzung
+
+1. `index.html` im Browser \u00f6ffnen.
+2. Die App l\u00e4dt automatisch die Fragen und startet das Quiz.
+3. Der Dark/Light-Mode kann \u00fcber den Schalter in der Topbar gewechselt werden.
+
+Die Dateien unter `assets/` dienen als Platz f\u00fcr optionale Bilder oder Icons.

--- a/quiz-admin/index.html
+++ b/quiz-admin/index.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="de" class="h-full" :class="{dark: darkMode}">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quiz Admin</title>
+  <!-- Tailwind & Vue via CDN -->
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vuedraggable@4.1.0/dist/vuedraggable.umd.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" rel="stylesheet">
+  <!-- Heroicons -->
+  <script src="https://unpkg.com/heroicons@2.0.18/dist/24/outline.js"></script>
+</head>
+<body class="h-full bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100" id="app">
+  <div class="flex h-full">
+    <!-- Sidebar -->
+    <aside class="hidden sm:flex flex-col w-16 bg-teal-700 text-white items-center py-4 space-y-4">
+      <svg class="w-8 h-8" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2L2 7v6c0 5 3 9 10 13 7-4 10-8 10-13V7l-10-5z"/></svg>
+      <svg class="w-6 h-6" viewBox="0 0 24 24"><path fill="currentColor" d="M12 4.25a.75.75 0 0 1 .75.75v6h6a.75.75 0 0 1 0 1.5h-6v6a.75.75 0 0 1-1.5 0v-6h-6a.75.75 0 0 1 0-1.5h6v-6A.75.75 0 0 1 12 4.25z"/></svg>
+      <svg class="w-6 h-6" viewBox="0 0 24 24"><path fill="currentColor" d="M4.5 4a1 1 0 0 0-1 1v9a.5.5 0 0 0 .757.429L12 9.41l7.743 5.02A.5.5 0 0 0 20.5 14V5a1 1 0 0 0-1-1h-15z"/></svg>
+      <svg class="w-6 h-6" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm-7 18a7 7 0 0 1 14 0H5z"/></svg>
+    </aside>
+    <!-- Main -->
+    <div class="flex-1 flex flex-col">
+      <!-- Topbar -->
+      <header class="flex justify-between items-center p-4 shadow bg-white dark:bg-gray-800">
+        <h1 class="text-2xl font-semibold">Quiz Admin</h1>
+        <button @click="toggleDark" class="p-2 rounded-full bg-gray-200 dark:bg-gray-700">
+          <svg v-if="!darkMode" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8.66-10H21m-16.66 0H3M17.657 6.343l-.707-.707m-9.9 9.9l-.707-.707m0-8.486l.707-.707m9.9 9.9l.707-.707M12 5a7 7 0 0 1 0 14 7 7 0 0 1 0-14z"/></svg>
+          <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3c4.866 0 8.996 3.664 9 8.5A9 9 0 0 1 12.5 21 9 9 0 0 1 12 3z"/></svg>
+        </button>
+      </header>
+      <!-- Content -->
+      <main class="flex-1 overflow-y-auto p-4">
+        <div class="max-w-2xl mx-auto">
+          <!-- Progress -->
+          <div class="h-2 bg-teal-200 rounded-full overflow-hidden mb-4">
+            <div class="bg-teal-500 h-full transition-all" :style="{width: progress + '%'}"></div>
+          </div>
+          <!-- Score -->
+          <div class="text-right mb-2 text-sm">Punkte: {{ score }}</div>
+          <!-- Question Card -->
+          <div v-if="currentIndex < questions.length" class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-6">
+            <component :is="currentComponent" :question="currentQuestion" @answered="onAnswered"></component>
+            <p v-if="feedback" class="mt-4 font-semibold" :class="feedback.correct ? 'text-green-600' : 'text-red-600'">{{ feedback.correct ? 'Richtig!' : 'Leider falsch.' }}</p>
+            <button v-if="feedback" @click="next" class="mt-4 px-4 py-2 bg-teal-500 hover:bg-teal-700 text-white rounded-xl shadow">Nächste Frage</button>
+          </div>
+          <!-- Result -->
+          <div v-else class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-6">
+            <h2 class="text-xl font-bold mb-4">Auswertung</h2>
+            <p class="mb-4">Du hast {{ score }} von {{ questions.length }} Punkten erreicht.</p>
+            <div v-for="(q, idx) in questions" :key="idx" class="mb-4">
+              <p class="font-semibold">{{ q.question }}</p>
+              <p>Deine Antwort: {{ formatAnswer(userAnswers[idx]) }}</p>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+
+<script type="module">
+const { createApp, ref, computed, onMounted } = Vue;
+createApp({
+  setup() {
+    const questions = ref([]);
+    const currentIndex = ref(0);
+    const score = ref(0);
+    const feedback = ref(null);
+    const userAnswers = ref({});
+    const darkMode = ref(false);
+
+    onMounted(async () => {
+      const res = await fetch('questions.json');
+      questions.value = await res.json();
+    });
+
+    const currentQuestion = computed(() => questions.value[currentIndex.value]);
+    const currentComponent = computed(() => {
+      switch(currentQuestion.value?.type) {
+        case 'match': return 'match-question';
+        case 'choice': return 'choice-question';
+        case 'sort': return 'sort-question';
+      }
+      return 'div';
+    });
+    const progress = computed(() => ((currentIndex.value)/questions.value.length)*100);
+
+    function onAnswered(result) {
+      feedback.value = result;
+      if (result.correct) score.value++;
+      userAnswers.value[currentIndex.value] = result.answer;
+    }
+
+    function next() {
+      feedback.value = null;
+      currentIndex.value++;
+    }
+
+    function formatAnswer(a) {
+      return Array.isArray(a) ? a.join(', ') : a;
+    }
+
+    function toggleDark() {
+      darkMode.value = !darkMode.value;
+    }
+
+    return {questions, currentIndex, score, feedback, currentQuestion, currentComponent, next, onAnswered, formatAnswer, progress, darkMode, toggleDark, userAnswers};
+  }
+})
+.component('choice-question', {
+  props: ['question'],
+  setup(props, {emit}) {
+    const selected = ref(null);
+    function select(idx) {
+      if (selected.value !== null) return;
+      selected.value = idx;
+      const correct = idx === props.question.correct;
+      emit('answered', {correct, answer: props.question.options[idx]});
+    }
+    function btnClass(idx) {
+      if (selected.value === null) return 'border';
+      if (idx === props.question.correct) return 'bg-green-200 border';
+      if (idx === selected.value) return 'bg-red-200 border';
+      return 'border';
+    }
+    return {selected, select, btnClass};
+  },
+  template: `
+    <div>
+      <h2 class="text-xl font-bold mb-4">{{ question.question }}</h2>
+      <button v-for="(opt, idx) in question.options" :key="idx" @click="select(idx)" :class="btnClass(idx) + ' w-full text-left p-2 mb-2 rounded-xl'">
+        {{ opt }}
+      </button>
+    </div>
+  `
+})
+.component('sort-question', {
+  components: { draggable: vuedraggable },
+  props: ['question'],
+  setup(props, {emit}) {
+    const items = ref([...props.question.items]);
+    const checked = ref(false);
+    const correct = ref(false);
+    function check() {
+      checked.value = true;
+      const currentOrder = items.value.map(i => props.question.items.indexOf(i));
+      correct.value = JSON.stringify(currentOrder) === JSON.stringify(props.question.correctOrder);
+      emit('answered', {correct: correct.value, answer: items.value});
+    }
+    return {items, check, checked, correct};
+  },
+  template: `
+    <div>
+      <h2 class="text-xl font-bold mb-4">{{ question.question }}</h2>
+      <draggable v-model="items" item-key="text" ghost-class="opacity-50" class="bg-gray-100 dark:bg-gray-700 p-2 rounded-xl">
+        <template #item="{element}">
+          <div class="p-2 mb-2 bg-white dark:bg-gray-600 border rounded cursor-move">{{ element }}</div>
+        </template>
+      </draggable>
+      <button @click="check" class="mt-4 px-4 py-2 bg-teal-500 text-white rounded-xl shadow">Antwort prüfen</button>
+      <p v-if="checked" class="mt-2 font-semibold" :class="correct ? 'text-green-600' : 'text-red-600'">{{ correct ? 'Richtig!' : 'Leider falsch.' }}</p>
+    </div>
+  `
+})
+.component('match-question', {
+  components: { draggable: vuedraggable },
+  props: ['question'],
+  setup(props, {emit}) {
+    const pool = ref(props.question.pairs.map(p => p.term));
+    const answers = ref(props.question.pairs.map(() => []));
+    const checked = ref(false);
+    const correct = ref(false);
+    function check() {
+      checked.value = true;
+      correct.value = answers.value.every((arr, idx) => arr[0] === props.question.pairs[idx].term);
+      const ans = answers.value.map(a => a[0] || '');
+      emit('answered', {correct: correct.value, answer: ans});
+    }
+    return {pool, answers, check, checked, correct};
+  },
+  template: `
+    <div>
+      <h2 class="text-xl font-bold mb-4">{{ question.question }}</h2>
+      <div class="flex flex-col md:flex-row gap-4">
+        <div class="md:w-1/3">
+          <p class="font-semibold mb-2">Begriffe</p>
+          <draggable v-model="pool" group="items" class="min-h-[40px] p-2 bg-gray-100 dark:bg-gray-700 rounded-xl">
+            <template #item="{element}">
+              <div class="p-2 m-1 bg-teal-200 dark:bg-teal-600 rounded cursor-move">{{ element }}</div>
+            </template>
+          </draggable>
+        </div>
+        <div class="flex-1">
+          <p class="font-semibold mb-2">Definitionen</p>
+          <div v-for="(pair, idx) in question.pairs" :key="idx" class="mb-4">
+            <div class="p-2 bg-gray-200 dark:bg-gray-600 rounded mb-2">{{ pair.definition }}</div>
+            <draggable v-model="answers[idx]" group="items" :animation="150" class="min-h-[40px] p-2 border rounded-xl">
+              <template #item="{element}">
+                <div class="p-2 bg-teal-200 dark:bg-teal-600 rounded cursor-move">{{ element }}</div>
+              </template>
+            </draggable>
+          </div>
+        </div>
+      </div>
+      <button @click="check" class="mt-4 px-4 py-2 bg-teal-500 text-white rounded-xl shadow">Antwort prüfen</button>
+      <p v-if="checked" class="mt-2 font-semibold" :class="correct ? 'text-green-600' : 'text-red-600'">{{ correct ? 'Richtig!' : 'Leider falsch.' }}</p>
+    </div>
+  `
+})
+.mount('#app');
+</script>
+</body>
+</html>

--- a/quiz-admin/questions.json
+++ b/quiz-admin/questions.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "match",
+    "question": "Ordne die Begriffe den Definitionen zu:",
+    "pairs": [
+      { "term": "Akte", "definition": "Sammlung von Vorgängen und Dokumenten" },
+      { "term": "OE", "definition": "Organisationseinheit mit Rechten an der Akte" },
+      { "term": "Snapshot", "definition": "PDF mit Status zum Zeichnungsprozess" }
+    ]
+  },
+  {
+    "type": "choice",
+    "question": "Wer hat automatisch Schreibrechte an einer Akte?",
+    "options": [
+      "Nur die Fachadministration",
+      "Die besitzende OE",
+      "Alle Nutzer"
+    ],
+    "correct": 1
+  },
+  {
+    "type": "sort",
+    "question": "Bringe die folgenden Schritte beim Erstellen eines Serienbriefs in die richtige Reihenfolge:",
+    "items": [
+      "Datenquelle (Tabelle) erstellen",
+      "Neues Dokument von Vorlage anlegen",
+      "Serienbrieffunktion in Word starten",
+      "Abgangsvermerk am Dokument anbringen"
+    ],
+    "correctOrder": [0,1,2,3]
+  }
+]


### PR DESCRIPTION
## Summary
- add a new `quiz-admin` example with Vue3 and Tailwind via CDN
- show a sidebar, topbar with dark mode toggle and card layout for questions
- update the main README to mention the new folder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841cbd35e98832bad78de1e8be79562