### PR TITLE
Kombiniere Grundlayout mit Vue-Quiz

### DIFF
--- a/grundlayout.html
+++ b/grundlayout.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>EL.DOK Sommerfest-Quiz</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vuedraggable@4.1.0/dist/vuedraggable.umd.min.js"></script>
   <style>
     .bingo-highlight {
       animation: bingoFlash 1s linear 1;
@@ -24,186 +27,29 @@
 <body class="bg-gradient-to-br from-blue-100 to-teal-200 min-h-screen flex items-center justify-center">
   <div class="bg-white shadow-2xl rounded-2xl p-8 max-w-xl w-full" id="quiz-container">
     <h1 class="text-2xl font-extrabold text-gray-700 mb-4 text-center">EL.DOK Sommerfest-Quiz</h1>
-    <div id="quiz-content">
-      <!-- Quiz wird per JS gerendert -->
+    <div id="app">
+      <div v-if="currentIndex < questions.length">
+        <div class="mb-4 flex justify-between">
+          <span>Frage {{ currentIndex + 1 }} von {{ questions.length }}</span>
+          <span>Punkte: {{ score }}</span>
+        </div>
+        <component :is="currentComponent" :question="currentQuestion" @answered="onAnswered"></component>
+        <p v-if="feedback" class="mt-4 font-semibold" :class="feedback.correct ? 'text-green-600' : 'text-red-600'">{{ feedback.correct ? 'Richtig!' : 'Leider falsch.' }}</p>
+        <button v-if="feedback" @click="next" class="mt-4 px-4 py-2 bg-teal-500 text-white rounded">Nächste Frage</button>
+      </div>
+      <div v-else>
+        <h2 class="text-xl font-bold mb-4">Auswertung</h2>
+        <p class="mb-4">Du hast {{ score }} von {{ questions.length }} Punkten erreicht.</p>
+        <div v-for="(q, idx) in questions" :key="idx" class="mb-4">
+          <p class="font-semibold">{{ q.question }}</p>
+          <p>Deine Antwort: {{ formatAnswer(userAnswers[idx]) }}</p>
+        </div>
+      </div>
     </div>
     <div class="mt-8 text-center text-gray-500 text-sm">
       © 2025 Sommerfest | EL.DOK Lernmodul
     </div>
   </div>
-  <script>
-    // Die Fragen als JS-Array
-    const quizQuestions = [
-      {
-        title: "Was passiert, wenn du beim Zeichnungsprozess den Haken bei „Snapshot bei Aufgabenerledigung“ setzt?",
-        options: [
-          "Ein PDF-Snapshot wird in deinem persönlichen Verzeichnis gespeichert.",
-          "Du erhältst eine E-Mail mit allen Zeichnungen.",
-          "Das Dokument wird automatisch finalisiert und gelöscht.",
-          "Der Geschäftsgang wird umbenannt."
-        ],
-        correct: 0,
-        feedback: [
-          "✅ Richtig! Der Snapshot enthält alle relevanten Metadaten und Zeichnungen und liegt in deinem Ordner 'Snapshots'.",
-          "❌ Leider falsch – es wird <strong>kein</strong> E-Mail-Versand ausgelöst.",
-          "❌ Falsch – das Dokument wird <strong>nicht</strong> gelöscht.",
-          "❌ Nein – die Benennung bleibt unverändert."
-        ]
-      },
-      {
-        title: "Berechtigungs-Bingo: Wer hat automatisch Schreibrechte an einer Akte?",
-        options: [
-          "A) Nur die Fachadministration",
-          "B) Die besitzende OE",
-          "C) Alle Nutzer"
-        ],
-        correct: 1,
-        bingo: true,
-        feedback: [
-          "❌ Leider falsch! Schreibrechte liegen nicht exklusiv bei der Fachadministration.",
-          "🎉 <span class='bingo-highlight p-2'>BINGO! Die besitzende OE hat automatisch Schreibrechte an der Akte.</span> <br><span class='text-sm text-gray-600'>Andere OEs können Leserechte erhalten, aber standardmäßig darf nur die besitzende Organisationseinheit (OE) schreiben.</span>",
-          "❌ Falsch – nicht alle Nutzer haben automatisch Schreibrechte."
-        ]
-      },
-      {
-        title: "Wie lange verbleiben gelöschte Dokumente im Papierkorb von EL.DOK, bevor sie endgültig entfernt werden?",
-        options: [
-          "Sofort nach dem Löschen",
-          "7 Tage",
-          "30 Tage",
-          "Bis zum nächsten Monatswechsel"
-        ],
-        correct: 2,
-        feedback: [
-          "❌ Nein, sie bleiben noch eine Zeit lang zur Wiederherstellung erhalten.",
-          "❌ Falsch, die Frist ist länger.",
-          "✅ Richtig! Nach 30 Tagen werden Dokumente im Papierkorb endgültig gelöscht.",
-          "❌ Falsch, das Löschen ist nicht an den Monatswechsel gebunden."
-        ]
-      }
-    ];
-
-    let currentQuestion = 0;
-    let score = 0;
-    let userAnswers = [];
-
-    function renderQuestion() {
-      const q = quizQuestions[currentQuestion];
-      let html = `
-        <div class="mb-8 text-center">
-          <span class="inline-block bg-teal-100 text-teal-700 px-3 py-1 rounded-full text-sm mb-2">Frage ${currentQuestion + 1} von ${quizQuestions.length}${q.bingo ? " • Berechtigungs-Bingo" : ""}</span>
-          <h2 class="text-lg font-semibold text-gray-800">${q.title}</h2>
-        </div>
-        <form id="quiz-form" class="space-y-4">
-      `;
-      q.options.forEach((opt, idx) => {
-        html += `
-          <div>
-            <label class="flex items-center space-x-2 cursor-pointer">
-              <input type="radio" name="answer" value="${idx}" class="accent-teal-500">
-              <span>${opt}</span>
-            </label>
-          </div>
-        `;
-      });
-      html += `
-        <button type="submit" class="mt-6 w-full bg-teal-500 hover:bg-teal-600 text-white font-bold py-2 px-4 rounded-xl transition-all shadow">
-          Antwort prüfen
-        </button>
-      </form>
-      <div id="feedback" class="mt-6 text-center text-lg font-semibold"></div>
-      `;
-      if (q.bingo) {
-        html += `
-        <div class="mt-4 flex justify-center">
-          <div id="bingo-card" class="grid grid-cols-3 gap-2">
-            <div class="bingo-cell bg-gray-100 rounded-lg px-4 py-2 text-center">A</div>
-            <div class="bingo-cell bg-gray-100 rounded-lg px-4 py-2 text-center">B</div>
-            <div class="bingo-cell bg-gray-100 rounded-lg px-4 py-2 text-center">C</div>
-          </div>
-        </div>
-        <div class="text-center text-xs text-teal-700 mt-1">Bingo-Feld erscheint bei richtiger Antwort!</div>
-        `;
-      }
-      document.getElementById('quiz-content').innerHTML = html;
-      document.getElementById('quiz-form').addEventListener('submit', handleAnswer);
-    }
-
-    function handleAnswer(e) {
-      e.preventDefault();
-      const selected = document.querySelector('input[name="answer"]:checked');
-      const feedback = document.getElementById('feedback');
-      if (!selected) {
-        feedback.innerHTML = "<span class='text-red-500'>Bitte wähle eine Antwort aus.</span>";
-        return;
-      }
-      const idx = parseInt(selected.value, 10);
-      const q = quizQuestions[currentQuestion];
-      feedback.innerHTML = `<span class="${idx === q.correct ? 'text-green-600' : 'text-red-600'}">${q.feedback[idx]}</span>`;
-      document.querySelectorAll('input[name="answer"]').forEach(i => i.disabled = true);
-      if (q.bingo && idx === q.correct) {
-        setTimeout(() => {
-          const bingoCells = document.querySelectorAll('#bingo-card .bingo-cell');
-          if (bingoCells[q.correct]) {
-            bingoCells[q.correct].classList.add('bingo-highlight');
-            bingoCells[q.correct].innerText = 'BINGO!';
-          }
-        }, 100);
-      }
-      const btn = e.target.querySelector('button');
-      btn.disabled = false;
-      btn.innerText = (currentQuestion + 1 === quizQuestions.length) ? "Auswertung anzeigen" : "Nächste Frage";
-      btn.type = "button";
-      btn.onclick = nextQuestion;
-      userAnswers[currentQuestion] = idx;
-      if (idx === q.correct) score++;
-    }
-
-    function nextQuestion() {
-      currentQuestion++;
-      if (currentQuestion < quizQuestions.length) {
-        renderQuestion();
-      } else {
-        showResults();
-      }
-    }
-
-    function showResults() {
-      let resultText = `
-        <div class="text-center mb-6">
-          <span class="inline-block bg-teal-100 text-teal-700 px-3 py-1 rounded-full text-sm mb-2">Auswertung</span>
-          <h2 class="text-2xl font-bold mb-4">Du hast ${score} von ${quizQuestions.length} Punkten erreicht!</h2>
-          <div class="mb-4">
-            ${score === quizQuestions.length
-              ? "<span class='text-green-600 font-semibold'>Super gemacht – volle Punktzahl! 🎉</span>"
-              : score > 0
-                ? "<span class='text-yellow-600 font-semibold'>Schon gut – noch ein Versuch?</span>"
-                : "<span class='text-red-600 font-semibold'>Probiere es nochmal und lerne EL.DOK kennen!</span>"
-            }
-          </div>
-        </div>
-        <div class="mb-4">
-          <button onclick="location.reload()" class="bg-teal-500 hover:bg-teal-600 text-white font-bold py-2 px-4 rounded-xl shadow transition-all w-full">
-            Quiz erneut starten
-          </button>
-        </div>
-        <div class="text-left text-sm">
-          <strong>Lösungen:</strong><br>
-      `;
-      quizQuestions.forEach((q, i) => {
-        resultText += `
-          <div class="mb-2">
-            <span class="font-semibold">Frage ${i + 1}:</span> ${q.title}<br>
-            <span>Deine Antwort: <span class="${userAnswers[i] === q.correct ? 'text-green-600' : 'text-red-600'}">${q.options[userAnswers[i]] ?? "-"}</span></span><br>
-            <span class="text-gray-600">Richtig: ${q.options[q.correct]}</span>
-          </div>
-        `;
-      });
-      resultText += "</div>";
-      document.getElementById('quiz-content').innerHTML = resultText;
-    }
-
-    renderQuestion();
-  </script>
+  <script type="module" src="logic.js"></script>
 </body>
 </html>

--- a/logic.js
+++ b/logic.js
@@ -1,0 +1,139 @@
+import { questions } from './questions.js';
+const { createApp, ref, computed, reactive } = Vue;
+
+createApp({
+  setup() {
+    const currentIndex = ref(0);
+    const score = ref(0);
+    const feedback = ref(null);
+    const userAnswers = reactive({});
+
+    const currentQuestion = computed(() => questions[currentIndex.value]);
+    const currentComponent = computed(() => {
+      switch(currentQuestion.value?.type) {
+        case 'match': return 'match-question';
+        case 'choice': return 'choice-question';
+        case 'sort': return 'sort-question';
+      }
+      return 'div';
+    });
+
+    function onAnswered(result) {
+      feedback.value = result;
+      if (result.correct) score.value++;
+      userAnswers[currentIndex.value] = result.answer;
+    }
+
+    function next() {
+      feedback.value = null;
+      currentIndex.value++;
+    }
+
+    function formatAnswer(a) {
+      return Array.isArray(a) ? a.join(', ') : a;
+    }
+
+    return { questions, currentIndex, score, feedback, currentQuestion, currentComponent, next, onAnswered, formatAnswer, userAnswers };
+  }
+})
+.component('choice-question', {
+  props: ['question'],
+  setup(props, { emit }) {
+    const selected = ref(null);
+    function select(idx) {
+      if (selected.value !== null) return;
+      selected.value = idx;
+      const correct = idx === props.question.correct;
+      emit('answered', { correct, answer: props.question.options[idx] });
+    }
+    function btnClass(idx) {
+      if (selected.value === null) return 'border';
+      if (idx === props.question.correct) return 'bg-green-200 border';
+      if (idx === selected.value) return 'bg-red-200 border';
+      return 'border';
+    }
+    return { selected, select, btnClass };
+  },
+  template: `
+    <div>
+      <h2 class="text-lg font-semibold mb-4">{{ question.question }}</h2>
+      <button v-for="(opt, idx) in question.options" :key="idx" @click="select(idx)" :class="btnClass(idx) + ' w-full text-left p-2 mb-2 rounded'">
+        {{ opt }}
+      </button>
+    </div>
+  `
+})
+.component('sort-question', {
+  components: { draggable: vuedraggable },
+  props: ['question'],
+  setup(props, { emit }) {
+    const items = ref([...props.question.items]);
+    const checked = ref(false);
+    const correct = ref(false);
+    function check() {
+      checked.value = true;
+      const currentOrder = items.value.map(i => props.question.items.indexOf(i));
+      correct.value = JSON.stringify(currentOrder) === JSON.stringify(props.question.correctOrder);
+      emit('answered', { correct: correct.value, answer: items.value });
+    }
+    return { items, check, checked, correct };
+  },
+  template: `
+    <div>
+      <h2 class="text-lg font-semibold mb-4">{{ question.question }}</h2>
+      <draggable v-model="items" item-key="text" ghost-class="opacity-50" class="bg-gray-100 p-2 rounded">
+        <template #item="{element}">
+          <div class="p-2 mb-2 bg-white border rounded cursor-move">{{ element }}</div>
+        </template>
+      </draggable>
+      <button @click="check" class="mt-4 px-4 py-2 bg-teal-500 text-white rounded">Antwort prüfen</button>
+      <p v-if="checked" class="mt-2 font-semibold" :class="correct ? 'text-green-600' : 'text-red-600'">{{ correct ? 'Richtig!' : 'Leider falsch.' }}</p>
+    </div>
+  `
+})
+.component('match-question', {
+  components: { draggable: vuedraggable },
+  props: ['question'],
+  setup(props, { emit }) {
+    const pool = ref(props.question.pairs.map(p => p.term));
+    const answers = ref(props.question.pairs.map(() => []));
+    const checked = ref(false);
+    const correct = ref(false);
+    function check() {
+      checked.value = true;
+      correct.value = answers.value.every((arr, idx) => arr[0] === props.question.pairs[idx].term);
+      const ans = answers.value.map(a => a[0] || '');
+      emit('answered', { correct: correct.value, answer: ans });
+    }
+    return { pool, answers, check, checked, correct };
+  },
+  template: `
+    <div>
+      <h2 class="text-lg font-semibold mb-4">{{ question.question }}</h2>
+      <div class="flex flex-col md:flex-row gap-4">
+        <div class="md:w-1/3">
+          <p class="font-semibold mb-2">Begriffe</p>
+          <draggable v-model="pool" group="items" class="min-h-[50px] p-2 bg-gray-100 rounded">
+            <template #item="{element}">
+              <div class="p-2 m-1 bg-teal-200 rounded cursor-move">{{ element }}</div>
+            </template>
+          </draggable>
+        </div>
+        <div class="flex-1">
+          <p class="font-semibold mb-2">Definitionen</p>
+          <div v-for="(pair, idx) in question.pairs" :key="idx" class="mb-4">
+            <div class="p-2 bg-gray-200 rounded mb-2">{{ pair.definition }}</div>
+            <draggable v-model="answers[idx]" group="items" :animation="150" class="min-h-[40px] p-2 border rounded">
+              <template #item="{element}">
+                <div class="p-2 bg-teal-200 rounded cursor-move">{{ element }}</div>
+              </template>
+            </draggable>
+          </div>
+        </div>
+      </div>
+      <button @click="check" class="mt-4 px-4 py-2 bg-teal-500 text-white rounded">Antwort prüfen</button>
+      <p v-if="checked" class="mt-2 font-semibold" :class="correct ? 'text-green-600' : 'text-red-600'">{{ correct ? 'Richtig!' : 'Leider falsch.' }}</p>
+    </div>
+  `
+})
+.mount('#app');

--- a/questions.js
+++ b/questions.js
@@ -1,0 +1,32 @@
+export const questions = [
+  {
+    type: "match",
+    question: "Ordne die Begriffe den Definitionen zu:",
+    pairs: [
+      { term: "Akte", definition: "Sammlung von Vorg\u00e4ngen und Dokumenten" },
+      { term: "OE", definition: "Organisationseinheit mit Rechten an der Akte" },
+      { term: "Snapshot", definition: "PDF mit Status zum Zeichnungsprozess" }
+    ]
+  },
+  {
+    type: "choice",
+    question: "Wer hat automatisch Schreibrechte an einer Akte?",
+    options: [
+      "Nur die Fachadministration",
+      "Die besitzende OE",
+      "Alle Nutzer"
+    ],
+    correct: 1
+  },
+  {
+    type: "sort",
+    question: "Bringe die folgenden Schritte beim Erstellen eines Serienbriefs in die richtige Reihenfolge:",
+    items: [
+      "Datenquelle (Tabelle) erstellen",
+      "Neues Dokument von Vorlage anlegen",
+      "Serienbrieffunktion in Word starten",
+      "Abgangsvermerk am Dokument anbringen"
+    ],
+    correctOrder: [0, 1, 2, 3]
+  }
+];


### PR DESCRIPTION
## Summary
- integriere Vue und Drag&amp;Drop-Bibliotheken in das Grundlayout
- ersetze die bisherige Vanilla-JS-Logik durch eine Vue-App
- Fragen sind jetzt in `questions.js` ausgelagert
- neues Script `logic.js` steuert die Quiz-Komponenten

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841ee18a810832b983a96918bf8da54