### PR TITLE
Improve sequential quiz flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,20 +36,23 @@
       border-color: #39f;
       outline: none;
     }
+    .question {
+      animation: fadeIn 0.3s ease;
+      margin-top: 1em;
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
   </style>
 </head>
 <body class="uk-background-muted uk-padding uk-flex uk-flex-center">
   <div class="uk-container uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin">
       <h2 class="uk-card-title">Quiz: Digitales Wissen</h2>
-      <ul uk-tab>
-        <li><a href="#">Sortieren</a></li>
-        <li><a href="#">Zuordnen</a></li>
-        <li><a href="#">Multiple Choice</a></li>
-      </ul>
-      <ul class="uk-switcher uk-margin">
-        <!-- Sortieren -->
-        <li>
+      <progress id="progress" class="uk-progress" value="1" max="3"></progress>
+      <!-- Sortieren -->
+      <div class="question" id="q1">
           <h4>Bringe die Schritte zum Serienbrief in die richtige Reihenfolge:</h4>
           <ul id="sortable" class="uk-list uk-list-divider sortable-list uk-margin" role="list">
             <li draggable="true" role="listitem" tabindex="0" aria-grabbed="false">Datenquelle (Tabelle) erstellen</li>
@@ -59,9 +62,10 @@
           </ul>
           <button class="uk-button uk-button-primary" onclick="checkSort()">Antwort prüfen</button>
           <div id="sortFeedback" class="uk-margin-top"></div>
-        </li>
-        <!-- Zuordnen -->
-        <li>
+          <button class="uk-button uk-button-default uk-margin-top next-btn">Weiter</button>
+      </div>
+      <!-- Zuordnen -->
+      <div class="question uk-hidden" id="q2">
           <h4>Ordne die Begriffe den Definitionen zu:</h4>
           <div class="uk-grid-small uk-child-width-1-2" uk-grid>
             <div>
@@ -79,9 +83,10 @@
           </div>
           <button class="uk-button uk-button-primary uk-margin-small-top" onclick="checkAssign()">Antwort prüfen</button>
           <div id="assignFeedback" class="uk-margin-top"></div>
-        </li>
-        <!-- Multiple Choice -->
-        <li>
+          <button class="uk-button uk-button-default uk-margin-top next-btn">Weiter</button>
+      </div>
+      <!-- Multiple Choice -->
+      <div class="question uk-hidden" id="q3">
           <h4>Wer hat automatisch Schreibrechte an einer Akte?</h4>
           <form id="mcForm">
             <label><input class="uk-radio" type="radio" name="mc" value="0"> Nur die Fachadministration</label><br>
@@ -90,8 +95,8 @@
             <button class="uk-button uk-button-primary uk-margin-top" type="submit">Antwort prüfen</button>
           </form>
           <div id="mcFeedback" class="uk-margin-top"></div>
-        </li>
-      </ul>
+          <button class="uk-button uk-button-primary uk-margin-top next-btn">Fertig</button>
+      </div>
     </div>
   </div>
   <script src="./js/uikit.min.js"></script>
@@ -197,7 +202,26 @@
         (v && v.value == "1")
         ? '<div class="uk-alert-success" uk-alert>✅ Korrekt! Die besitzende OE hat Schreibrechte.</div>'
         : '<div class="uk-alert-danger" uk-alert>❌ Das ist nicht korrekt.</div>';
+    };
+
+    // Navigation zwischen den Fragen
+    const questions = Array.from(document.querySelectorAll('.question'));
+    let current = 0;
+    function showQuestion(idx) {
+      questions.forEach((q, i) => q.classList.toggle('uk-hidden', i !== idx));
+      document.getElementById('progress').value = idx + 1;
     }
+    document.querySelectorAll('.next-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (current < questions.length - 1) {
+          current++;
+          showQuestion(current);
+        } else {
+          btn.disabled = true;
+          document.body.insertAdjacentHTML('beforeend', '<div class="uk-alert-success uk-margin-top">🎉 Danke fürs Mitmachen!</div>');
+        }
+      });
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove tab layout in favour of sequential questions
- add progress bar and fade-in animation for a modern feel
- implement navigation logic to step through the questions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff2ca7c8832ba5420835dd2417ef