### PR TITLE
Add configurable header and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ Dieses Repository enth\u00e4lt ein kleines clientseitiges Quiz, das komplett off
 - `index.html` \u2013 Startseite des Quiz mit drei Beispielaufgaben.
 - `css/` \u2013 enth\u00e4lt die Stylesheets von UIkit.
 - `js/` \u2013 enth\u00e4lt die JavaScript-Dateien von UIkit inklusive Icons.
+- `js/config.js` \u2013 Konfiguration f\u00fcr Logo, Texte und Farben.
 
 

--- a/index.html
+++ b/index.html
@@ -49,12 +49,13 @@
 <body class="uk-background-muted uk-padding uk-flex uk-flex-center">
   <div class="uk-container uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin">
-      <h2 class="uk-card-title">Quiz: Digitales Wissen</h2>
+      <div id="quiz-header" class="uk-text-center"></div>
       <progress id="progress" class="uk-progress" value="1" max="3"></progress>
       <div id="quiz"></div>
     </div>
   </div>
   <script src="./js/uikit.min.js"></script>
+  <script src="./js/config.js"></script>
   <script src="./js/questions.js"></script>
   <script src="./js/quiz.js"></script>
 </body>

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,7 @@
+window.quizConfig = {
+  logoPath: '', // Pfad zum Logo oder leer lassen
+  header: 'Sommerfest 2024',
+  subheader: 'Willkommen beim Veranstaltungsquiz',
+  backgroundColor: '#f8f8f8',
+  buttonColor: '#1e87f0'
+};

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,9 +1,39 @@
 document.addEventListener('DOMContentLoaded', function(){
   const container = document.getElementById('quiz');
   const progress = document.getElementById('progress');
+  const cfg = window.quizConfig || {};
   const questions = window.quizQuestions || [];
   let current = 0;
   const elements = questions.map((q, idx) => createQuestion(q, idx));
+
+  // apply configurable styles
+  const styleEl = document.createElement('style');
+  styleEl.textContent = `\n    body { background-color: ${cfg.backgroundColor || '#f8f8f8'}; }\n    .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n  `;
+  document.head.appendChild(styleEl);
+
+  // build header from config
+  const headerEl = document.getElementById('quiz-header');
+  if(headerEl){
+    if(cfg.logoPath){
+      const img = document.createElement('img');
+      img.src = cfg.logoPath;
+      img.alt = cfg.header || 'Logo';
+      img.className = 'uk-margin-small-bottom';
+      headerEl.appendChild(img);
+    }
+    if(cfg.header){
+      const h = document.createElement('h2');
+      h.textContent = cfg.header;
+      h.className = 'uk-card-title uk-margin-remove-bottom';
+      headerEl.appendChild(h);
+    }
+    if(cfg.subheader){
+      const p = document.createElement('p');
+      p.textContent = cfg.subheader;
+      p.className = 'uk-text-lead';
+      headerEl.appendChild(p);
+    }
+  }
 
   elements.forEach((el, i) => {
     if (i !== 0) el.classList.add('uk-hidden');


### PR DESCRIPTION
## Summary
- add `js/config.js` for logo, header, subheader, and color options
- inject header section in `index.html`
- apply config-driven styling and header rendering in `quiz.js`
- document new config file in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684204b7e7e8832b91132250c9220922