### PR TITLE
Implement results overview and restart option

### DIFF
--- a/js/quiz.js
+++ b/js/quiz.js
@@ -19,7 +19,9 @@ document.addEventListener('DOMContentLoaded', function(){
   let current = 0;
   const elements = shuffled.map((q, idx) => createQuestion(q, idx));
   const results = new Array(elements.length).fill(false);
-  elements.push(createSummary());
+  const summaryEl = createSummary();
+  elements.push(summaryEl);
+  let summaryShown = false;
 
   // apply configurable styles
   const styleEl = document.createElement('style');
@@ -64,6 +66,7 @@ document.addEventListener('DOMContentLoaded', function(){
     } else {
       progress.value = questionCount;
       progress.classList.add('uk-hidden');
+      updateSummary();
     }
   }
 
@@ -74,29 +77,7 @@ document.addEventListener('DOMContentLoaded', function(){
     } else if(current === questionCount - 1){
       current++;
       showQuestion(current);
-    }else{
-      e.target.disabled = true;
-      showSummary();
     }
-  }
-
-  function showSummary(){
-    const score = results.filter(r => r).length;
-    const div = document.createElement('div');
-    div.className = 'uk-margin-top uk-text-center';
-    div.innerHTML = `<h3>Ergebnis</h3><p>Du hast ${score} von ${elements.length} richtig.</p>`;
-    const restart = document.createElement('a');
-    restart.href = 'start.html';
-    restart.textContent = 'Neu Starten';
-    restart.className = 'uk-button uk-button-primary uk-margin-top';
-    styleButton(restart);
-    div.appendChild(restart);
-    document.body.appendChild(div);
-
-    const user = sessionStorage.getItem('quizUser') || ('user-' + Math.random().toString(36).substr(2,8));
-    let log = localStorage.getItem('statistical.log') || '';
-    log += `${user} ${score}/${elements.length}\n`;
-    localStorage.setItem('statistical.log', log);
   }
 
   function styleButton(btn){
@@ -105,6 +86,19 @@ document.addEventListener('DOMContentLoaded', function(){
       btn.style.borderColor = cfg.buttonColor;
       btn.style.color = '#fff';
     }
+  }
+
+  function updateSummary(){
+    if(summaryShown) return;
+    summaryShown = true;
+    const score = results.filter(r => r).length;
+    const p = summaryEl.querySelector('p');
+    if(p) p.textContent = `Du hast ${score} von ${questionCount} richtig.`;
+
+    const user = sessionStorage.getItem('quizUser') || ('user-' + Math.random().toString(36).substr(2,8));
+    let log = localStorage.getItem('statistical.log') || '';
+    log += `${user} ${score}/${questionCount}\n`;
+    localStorage.setItem('statistical.log', log);
   }
 
   function createQuestion(q, idx){
@@ -368,10 +362,18 @@ document.addEventListener('DOMContentLoaded', function(){
 
   function createSummary(){
     const div = document.createElement('div');
-    div.className = 'question';
+    div.className = 'question uk-text-center';
     const h = document.createElement('h3');
     h.textContent = '🎉 Danke fürs Mitmachen!';
+    const p = document.createElement('p');
+    const restart = document.createElement('a');
+    restart.href = 'start.html';
+    restart.textContent = 'Neu starten';
+    restart.className = 'uk-button uk-button-primary uk-margin-top';
+    styleButton(restart);
     div.appendChild(h);
+    div.appendChild(p);
+    div.appendChild(restart);
     return div;
   }
 });

--- a/start.html
+++ b/start.html
@@ -9,14 +9,36 @@
 <body class="uk-padding uk-flex uk-flex-center">
   <div class="uk-container uk-text-center">
     <h1 class="uk-margin">Quiz Start</h1>
+    <div id="stats" class="uk-margin"></div>
     <button id="startBtn" class="uk-button uk-button-primary uk-button-large">UND LOS</button>
   </div>
   <script src="./js/uikit.min.js"></script>
+  <script src="./js/questions.js"></script>
   <script>
-  document.getElementById('startBtn').addEventListener('click', function(){
-    const user = 'user-' + Math.random().toString(36).substr(2,8);
-    sessionStorage.setItem('quizUser', user);
-    window.location.href = 'index.html';
+  document.addEventListener('DOMContentLoaded', function(){
+    const stats = document.getElementById('stats');
+    const log = localStorage.getItem('statistical.log');
+    if(log){
+      const list = document.createElement('ul');
+      list.className = 'uk-list uk-list-divider uk-width-medium uk-margin-auto';
+      log.trim().split('\n').filter(Boolean).forEach(l => {
+        const [user, score] = l.split(' ');
+        const li = document.createElement('li');
+        li.textContent = `${user}: ${score}`;
+        list.appendChild(li);
+      });
+      const h = document.createElement('h3');
+      h.textContent = 'Bisherige Ergebnisse';
+      stats.appendChild(h);
+      stats.appendChild(list);
+    } else {
+      stats.textContent = 'Noch keine Ergebnisse vorhanden.';
+    }
+    document.getElementById('startBtn').addEventListener('click', function(){
+      const user = 'user-' + Math.random().toString(36).substr(2,8);
+      sessionStorage.setItem('quizUser', user);
+      window.location.href = 'index.html';
+    });
   });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- show previous quiz results on the start page
- compute and display result on summary page
- add restart button to summary page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68421394d088832b8361a445a3b750ad