### PR TITLE
Implement server-side result logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ Dieses Repository enthält ein kleines clientseitiges Quiz, das komplett offline
 - `css/` \u2013 enth\u00e4lt die Stylesheets von UIkit.
 - `js/` \u2013 enth\u00e4lt die JavaScript-Dateien von UIkit inklusive Icons.
 - `js/config.js` \u2013 Konfiguration f\u00fcr Logo, Texte und Farben.
-- `statistical.log` – wird im Browser mit Ergebnissen bef\u00fcllt.
+- `statistical.log` – enthält die bisher erzielten Ergebnisse.
+
+## Server
+
+Mit `node server.js` lässt sich ein kleiner Server starten, der die
+Ergebnisse bei jedem abgeschlossenen Quiz in `statistical.log` speichert.
 
 
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,58 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const root = __dirname;
+const logFile = path.join(root, 'statistical.log');
+
+function serveStatic(filePath, res){
+  fs.readFile(filePath, (err, data) => {
+    if(err){
+      res.statusCode = 404;
+      res.end('Not found');
+    }else{
+      res.end(data);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if(req.method === 'POST' && req.url === '/log'){
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try{
+        const data = JSON.parse(body);
+        if(data.user && typeof data.score === 'number' && typeof data.total === 'number'){
+          const line = `${data.user} ${data.score}/${data.total}\n`;
+          fs.appendFile(logFile, line, err => {
+            if(err) console.error('Failed to write log:', err);
+          });
+        }
+      }catch(e){ /* ignore invalid json */ }
+      res.statusCode = 204;
+      res.end();
+    });
+    return;
+  }
+  if(req.method === 'GET' && req.url === '/log'){
+    fs.readFile(logFile, 'utf8', (err, text) => {
+      if(err){
+        res.statusCode = 204;
+        return res.end();
+      }
+      res.setHeader('Content-Type','text/plain');
+      res.end(text);
+    });
+    return;
+  }
+
+  const pathname = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(root, pathname);
+  serveStatic(filePath, res);
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- create a small Node server to save quiz results in `statistical.log`
- persist results on the server from the quiz script
- load logged results from the server when starting the quiz
- document how to run the server

## Testing
- `node -c js/quiz.js`
- `node -c server.js`
- `node server.js & sleep 1; kill $!; tail -n 1 /tmp/server.log`

------
https://chatgpt.com/codex/tasks/task_e_68421a57d2b8832b831d15af3966646c