### PR TITLE
Add admin option for CheckAnswerButton

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -36,6 +36,15 @@
             <label class="uk-form-label" for="cfgButtonColor">Buttonfarbe</label>
             <div class="uk-form-controls"><input class="uk-input" type="text" id="cfgButtonColor"></div>
           </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="cfgCheckAnswerButton">Antwort-Pr&uuml;fen-Button anzeigen</label>
+            <div class="uk-form-controls">
+              <select class="uk-select" id="cfgCheckAnswerButton">
+                <option value="yes">Ja</option>
+                <option value="no">Nein</option>
+              </select>
+            </div>
+          </div>
         </form>
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="cfgResetBtn" class="uk-button uk-button-default">Zurücksetzen</button>
@@ -88,7 +97,8 @@
       header: document.getElementById('cfgHeader'),
       subheader: document.getElementById('cfgSubheader'),
       backgroundColor: document.getElementById('cfgBackgroundColor'),
-      buttonColor: document.getElementById('cfgButtonColor')
+      buttonColor: document.getElementById('cfgButtonColor'),
+      checkAnswerButton: document.getElementById('cfgCheckAnswerButton')
     };
     function renderCfg(data){
       cfgFields.logoPath.value = data.logoPath || '';
@@ -96,6 +106,7 @@
       cfgFields.subheader.value = data.subheader || '';
       cfgFields.backgroundColor.value = data.backgroundColor || '';
       cfgFields.buttonColor.value = data.buttonColor || '';
+      cfgFields.checkAnswerButton.value = data.CheckAnswerButton || 'yes';
     }
     renderCfg(cfgInitial);
     document.getElementById('cfgResetBtn').addEventListener('click', function(e){
@@ -109,7 +120,8 @@
         header: cfgFields.header.value.trim(),
         subheader: cfgFields.subheader.value.trim(),
         backgroundColor: cfgFields.backgroundColor.value.trim(),
-        buttonColor: cfgFields.buttonColor.value.trim()
+        buttonColor: cfgFields.buttonColor.value.trim(),
+        CheckAnswerButton: cfgFields.checkAnswerButton.value
       };
       const content = 'window.quizConfig = ' + JSON.stringify(data, null, 2) + ';\n';
       const blob = new Blob([content], {type: 'text/javascript'});


### PR DESCRIPTION
## Summary
- allow configuring the "Antwort prüfen" button visibility in admin

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68422428e388832b87c9d63f35dac830