### PR TITLE
Improve dark mode styling

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -1,19 +1,57 @@
 /* Zusätzliche Styles für Dark Mode */
 body.dark-mode {
   background-color: #121212;
-  color: #eee;
+  color: #f5f5f5;
+}
+body.dark-mode a {
+  color: #9dc6ff;
 }
 body.dark-mode .uk-card-default {
   background-color: #1e1e1e;
-  color: #eee;
+  color: #f5f5f5;
 }
 body.dark-mode .uk-card-default a {
   color: #9dc6ff;
 }
 body.dark-mode .uk-progress {
   background-color: #333;
+  color: #1e87f0;
 }
 body.dark-mode .uk-button-primary {
   background-color: #1e87f0;
   border-color: #1e87f0;
+}
+body.dark-mode .uk-button,
+body.dark-mode .uk-button-default {
+  color: #fff;
+  background-color: #333;
+  border-color: #555;
+}
+body.dark-mode input,
+body.dark-mode textarea,
+body.dark-mode select {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+  border-color: #555;
+}
+body.dark-mode .sortable-list li,
+body.dark-mode .dropzone {
+  background-color: #1e1e1e;
+  border-color: #444;
+  color: #f5f5f5;
+}
+body.dark-mode .dropzone.over {
+  background-color: #2a2a2a;
+}
+body.dark-mode .uk-alert-success {
+  background-color: #145214;
+  color: #fff;
+}
+body.dark-mode .uk-alert-danger {
+  background-color: #5a1a1a;
+  color: #fff;
+}
+body.dark-mode .uk-alert-primary {
+  background-color: #003366;
+  color: #fff;
 }

--- a/index.html
+++ b/index.html
@@ -120,15 +120,15 @@
       const toggle = document.getElementById('theme-toggle');
       const isDark = localStorage.getItem('darkMode') === 'true';
       if(isDark){
-        document.body.classList.add('dark-mode');
+        document.body.classList.add('dark-mode','uk-light');
         toggle.checked = true;
       }
       toggle.addEventListener('change', function(){
         if(this.checked){
-          document.body.classList.add('dark-mode');
+          document.body.classList.add('dark-mode','uk-light');
           localStorage.setItem('darkMode', 'true');
         } else {
-          document.body.classList.remove('dark-mode');
+          document.body.classList.remove('dark-mode','uk-light');
           localStorage.setItem('darkMode', 'false');
         }
       });


### PR DESCRIPTION
## Summary
- adjust body dark mode toggle to apply `uk-light`
- expand `dark.css` to style more UIkit elements

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6842300cc8b4832b89d65244e2baf79e