### PR TITLE
Show username on quiz summary

### DIFF
--- a/js/quiz.js
+++ b/js/quiz.js
@@ -183,6 +183,8 @@ document.addEventListener('DOMContentLoaded', function(){
     const user = sessionStorage.getItem('quizUser') || generateUserName();
     const p = summaryEl.querySelector('p');
     if(p) p.textContent = `Du hast ${score} von ${questionCount} richtig.`;
+    const heading = summaryEl.querySelector('h3');
+    if(heading) heading.textContent = `🎉 Danke fürs Mitmachen ${user}!`;
     if(score === questionCount && typeof window.startConfetti === 'function'){
       window.startConfetti();
     }


### PR DESCRIPTION
## Summary
- display the current user name in the quiz summary heading

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68422f87f15c832b9ecd36d87e71a6a9