### PR TITLE
Increase size of drag-and-drop elements

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -35,10 +35,13 @@ body.dark-mode select {
   border-color: #555;
 }
 body.dark-mode .sortable-list li,
+body.dark-mode .terms li,
 body.dark-mode .dropzone {
   background-color: #1e1e1e;
   border-color: #444;
   color: #f5f5f5;
+  font-size: 1.5em;
+  padding: 16px;
 }
 body.dark-mode .dropzone.over {
   background-color: #2a2a2a;

--- a/index.html
+++ b/index.html
@@ -15,22 +15,34 @@
       background: #f3f7fa;
       border: 1px solid #ddd;
       border-radius: 8px;
-      padding: 8px;
-      margin-bottom: 8px;
+      padding: 16px;
+      margin-bottom: 12px;
+      font-size: 1.5em;
+    }
+
+    .terms li {
+      cursor: grab;
+      background: #f3f7fa;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 12px;
+      font-size: 1.5em;
     }
 
     .sortable-list li:focus {
       outline: 2px solid #39f;
     }
     .dropzone {
-      min-height: 2.5em;
+      min-height: 3.5em;
       background: #f3f7fa;
       border: 1.5px dashed #aaa;
       border-radius: 8px;
-      margin-bottom: 8px;
+      margin-bottom: 12px;
       display: flex;
       align-items: center;
-      padding: 4px 8px;
+      padding: 8px 12px;
+      font-size: 1.5em;
     }
     .dropzone.over {
       border-color: #39f;


### PR DESCRIPTION
## Summary
- enlarge list items, terms, and dropzones
- keep dark mode style in sync

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6842356bc5fc832baa63a494befd9ec0