### PR TITLE
Add larger multiple choice options

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -36,7 +36,8 @@ body.dark-mode select {
 }
 body.dark-mode .sortable-list li,
 body.dark-mode .terms li,
-body.dark-mode .dropzone {
+body.dark-mode .dropzone,
+body.dark-mode .mc-option {
   background-color: #1e1e1e;
   border-color: #444;
   color: #f5f5f5;
@@ -57,4 +58,9 @@ body.dark-mode .uk-alert-danger {
 body.dark-mode .uk-alert-primary {
   background-color: #003366;
   color: #fff;
+}
+
+body.dark-mode .mc-option input {
+  transform: scale(1.3);
+  margin-right: 8px;
 }

--- a/index.html
+++ b/index.html
@@ -30,6 +30,16 @@
       font-size: 1.5em;
     }
 
+    .mc-option {
+      display: block;
+      font-size: 1.5em;
+      margin-bottom: 12px;
+    }
+    .mc-option input {
+      transform: scale(1.3);
+      margin-right: 8px;
+    }
+
     .sortable-list li:focus {
       outline: 2px solid #39f;
     }

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -453,6 +453,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
     order.forEach((orig,i) => {
       const label = document.createElement('label');
+      label.className = 'mc-option';
       const input = document.createElement('input');
       input.className = 'uk-checkbox';
       input.type = 'checkbox';
@@ -461,7 +462,6 @@ document.addEventListener('DOMContentLoaded', function(){
       label.appendChild(input);
       label.append(' ' + q.options[orig]);
       options.appendChild(label);
-      options.appendChild(document.createElement('br'));
     });
 
     const feedback = document.createElement('div');


### PR DESCRIPTION
## Summary
- enlarge multiple choice option text and checkbox size
- apply same enlargement in dark mode

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6842376f0e5c832b98f0bd4196437d9d