### PR TITLE
Add info block about usage terms

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,13 @@
       <div id="quiz"></div>
     </div>
   </div>
+  <div class="uk-container uk-width-1-2@s uk-width-2-3@m">
+    <div class="uk-card uk-card-default uk-card-body uk-margin">
+      <h3 class="uk-heading-bullet">Bedingungen &amp; Lizenz</h3>
+      <p>Dieses Tool ist ein reiner Prototyp, der zu 100% mit Codex von OpenAI umgesetzt wurde. Die Arbeit diente ausschließlich der Erprobung des Coding-Assistenten und seiner Möglichkeiten.</p>
+      <p>Der Code steht unter der MIT-Lizenz. Siehe die Datei <code>LICENSE</code> f&uuml;r Details.</p>
+    </div>
+  </div>
   <script src="./js/uikit.min.js"></script>
   <script src="./js/uikit-icons.min.js"></script>
   <script src="./js/config.js"></script>


### PR DESCRIPTION
## Summary
- show help block on index page summarizing README licensing info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842cb946fcc832b9490f4ebedb0489d