### PR TITLE
Move license card below quiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,8 +133,6 @@
       <progress id="progress" class="uk-progress" value="0" max="1" aria-label="Fortschritt"></progress>
       <div id="quiz"></div>
     </div>
-  </div>
-  <div class="uk-container uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-margin">
       <h3 class="uk-heading-bullet">Bedingungen &amp; Lizenz</h3>
       <p>Dieses Tool ist ein reiner Prototyp, der zu 100% mit Codex von OpenAI umgesetzt wurde. Die Arbeit diente ausschließlich der Erprobung des Coding-Assistenten und seiner Möglichkeiten.</p>


### PR DESCRIPTION
## Summary
- nest the license info card within the same container as the quiz

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6842d8dc73f4832b813b47344c56e505