### PR TITLE
Add collapsible MIT license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,31 @@ Dieses Tool ist ein reiner Prototyp, der zu 100% mit Codex von OpenAI umgesetzt 
 
 ## Lizenz
 
-Der Code steht unter der MIT-Lizenz. Siehe die Datei `LICENSE` für Details.
+<details>
+<summary>Der Code steht unter der MIT-Lizenz. Siehe die Datei <code>LICENSE</code> für Details.</summary>
+
+```text
+MIT License
+
+Copyright (c) 2025 calhelp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+</details>

--- a/index.html
+++ b/index.html
@@ -136,8 +136,35 @@
     <div class="uk-card uk-card-default uk-card-body uk-margin">
       <h3 class="uk-heading-bullet">Bedingungen &amp; Lizenz</h3>
       <p>Dieses Tool ist ein reiner Prototyp, der zu 100% mit Codex von OpenAI umgesetzt wurde. Die Arbeit diente ausschließlich der Erprobung des Coding-Assistenten und seiner Möglichkeiten.</p>
-      <p>Der Code steht unter der MIT-Lizenz. Siehe die Datei <code>LICENSE</code> f&uuml;r Details.</p>
-    </div>
+      <ul uk-accordion>
+        <li>
+          <a class="uk-accordion-title" href="#">Der Code steht unter der MIT-Lizenz. Siehe die Datei <code>LICENSE</code> f&uuml;r Details.</a>
+          <div class="uk-accordion-content">
+            <pre><code>MIT License
+
+Copyright (c) 2025 calhelp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</code></pre>
+          </div>
+        </li>
+      </ul>
+      </div>
   </div>
   <script src="./js/uikit.min.js"></script>
   <script src="./js/uikit-icons.min.js"></script>


### PR DESCRIPTION
## Summary
- show MIT license accordion on main page using UIkit
- include collapsible MIT license text in README

## Testing
- `node server.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6842d9f831ac832b94e8242e8c693775