### PR TITLE
Add repo link and rename info section

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,8 +134,9 @@
       <div id="quiz"></div>
     </div>
     <div class="uk-card uk-card-default uk-card-body uk-margin">
-      <h3 class="uk-heading-bullet">Bedingungen &amp; Lizenz</h3>
+      <h3 class="uk-heading-bullet">Informationen zur Quiz-Anwendung</h3>
       <p>Dieses Tool ist ein reiner Prototyp, der zu 100% mit Codex von OpenAI umgesetzt wurde. Die Arbeit diente ausschließlich der Erprobung des Coding-Assistenten und seiner Möglichkeiten.</p>
+      <p>Der Quellcode befindet sich auf GitHub: <a href="https://github.com/bastelix/sommerfest-quiz">https://github.com/bastelix/sommerfest-quiz</a>.</p>
       <ul uk-accordion>
         <li>
           <a class="uk-accordion-title" href="#">Der Code steht unter der MIT-Lizenz. Siehe die Datei <code>LICENSE</code> f&uuml;r Details.</a>


### PR DESCRIPTION
## Summary
- rename "Bedingungen & Lizenz" heading to "Informationen zur Quiz-Anwendung"
- reference GitHub repository in the info block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842de09dfbc832ba2b6644ab6c0a876