### PR TITLE
Fix accordion link font size

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,10 @@
       from { opacity: 0; }
       to { opacity: 1; }
     }
+    /* Link-Größe an Fließtext anpassen */
+    a.uk-accordion-title {
+      font-size: 1rem;
+    }
   </style>
 </head>
 <body class="uk-padding uk-flex uk-flex-center">


### PR DESCRIPTION
## Summary
- ensure accordion title links use normal text size

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842debc5718832b8094ca262e5177e6