### PR TITLE
Add catalog selection on start page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Dieses Projekt enthält ein vollständig clientseitiges Quiz, das ohne Serverver
 - **css/dark.css** – Zusätzliche Styles für den Dunkelmodus.
 - **js/** – JavaScript-Dateien von UIkit und die Skripte für das Quiz.
 - **js/config.js** – Einstellungen für Logo, Farben und Texte.
-- **js/questions.js** – Enthält alle Quizfragen.
+- **kataloge/** – Enthält einzelne Fragenkataloge als JSON-Dateien.
+- **kataloge/catalogs.json** – Indexdatei mit allen verfügbaren Katalogen.
 - **server.js** – Ein kleiner Node.js-Server zum lokalen Hosten der Dateien.
 
 ## Quiz starten
@@ -27,6 +28,12 @@ Anschließend ist die Anwendung unter `http://localhost:3000` erreichbar.
 ## Fragen bearbeiten und Design anpassen
 
 Die Datei `admin.html` stellt eine einfache Administrationsoberfläche bereit. Dort können Fragen hinzugefügt oder angepasst und Farben, Logo sowie Überschriften geändert werden. Beim Klick auf **Speichern** wird jeweils eine neue `config.js` bzw. `questions.js` heruntergeladen. Diese heruntergeladene Datei muss danach manuell in den Ordner `js/` kopiert und dort die vorhandene Datei ersetzen.
+
+## Eigene Fragenkataloge
+
+Alle Fragen liegen als einzelne JSON-Dateien im Unterordner `kataloge/`. Die Datei `catalogs.json` listet die verfügbaren Kataloge samt Anzeigenamen und Beschreibung. Um einen neuen Katalog anzulegen, wird eine weitere JSON-Datei in diesem Ordner gespeichert und `catalogs.json` um einen entsprechenden Eintrag ergänzt.
+
+Beim Aufruf von `index.html` erscheint zunächst eine Übersicht der vorhandenen Kataloge. Nach Auswahl wird der passende Fragenkatalog geladen und das Quiz gestartet. Alternativ kann ein Katalog direkt über den URL‑Parameter `?katalog=<id>` geöffnet werden, z.&nbsp;B. `index.html?katalog=fragen_it`.
 
 ## Ablauf des Quiz
 

--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@ SOFTWARE.</code></pre>
   <script src="./js/uikit.min.js"></script>
   <script src="./js/uikit-icons.min.js"></script>
   <script src="./js/config.js"></script>
-  <script src="./js/questions.js"></script>
+  <script src="./js/catalog.js"></script>
   <script src="./js/confetti.js"></script>
   <script src="./js/quiz.js"></script>
   <script>

--- a/js/catalog.js
+++ b/js/catalog.js
@@ -1,0 +1,67 @@
+// Lädt die verfügbaren Fragenkataloge und startet nach Auswahl das Quiz
+(function(){
+  async function loadCatalogList(){
+    try{
+      const res = await fetch('kataloge/catalogs.json');
+      return await res.json();
+    }catch(e){
+      console.error('Katalogliste konnte nicht geladen werden.', e);
+      return [];
+    }
+  }
+
+  async function loadQuestions(file){
+    try{
+      const res = await fetch('kataloge/' + file);
+      const data = await res.json();
+      window.quizQuestions = data;
+      if(window.startQuiz){
+        window.startQuiz(data);
+      }
+    }catch(e){
+      console.error('Fragen konnten nicht geladen werden.', e);
+    }
+  }
+
+  function showSelection(catalogs){
+    const container = document.getElementById('quiz');
+    if(!container) return;
+    container.innerHTML = '';
+    const grid = document.createElement('div');
+    grid.className = 'uk-child-width-1-2@s uk-grid-small uk-grid-match';
+    catalogs.forEach(cat => {
+      const cardWrap = document.createElement('div');
+      const card = document.createElement('div');
+      card.className = 'uk-card uk-card-default uk-card-body';
+      const title = document.createElement('h3');
+      title.textContent = cat.name || cat.id;
+      const desc = document.createElement('p');
+      desc.textContent = cat.description || '';
+      const btn = document.createElement('button');
+      btn.className = 'uk-button uk-button-primary';
+      btn.textContent = 'Starten';
+      btn.addEventListener('click', () => {
+        history.replaceState(null, '', '?katalog=' + cat.id);
+        loadQuestions(cat.file);
+      });
+      card.appendChild(title);
+      card.appendChild(desc);
+      card.appendChild(btn);
+      cardWrap.appendChild(card);
+      grid.appendChild(cardWrap);
+    });
+    container.appendChild(grid);
+  }
+
+  document.addEventListener('DOMContentLoaded', async () => {
+    const catalogs = await loadCatalogList();
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('katalog');
+    const selected = catalogs.find(c => c.id === id);
+    if(selected){
+      loadQuestions(selected.file);
+    }else{
+      showSelection(catalogs);
+    }
+  });
+})();

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,7 +1,7 @@
 // Hauptskript des Quizzes. Dieses File erzeugt dynamisch alle Fragen,
 // wertet Antworten aus und speichert das Ergebnis im Browser.
 // Der Code wird ausgeführt, sobald das DOM geladen ist.
-document.addEventListener('DOMContentLoaded', function(){
+function runQuiz(questions){
   // Konfiguration laden und einstellen, ob der "Antwort prüfen"-Button
   // eingeblendet werden soll
   const cfg = window.quizConfig || {};
@@ -12,7 +12,6 @@ document.addEventListener('DOMContentLoaded', function(){
 
   const container = document.getElementById('quiz');
   const progress = document.getElementById('progress');
-  const questions = window.quizQuestions || [];
 
   // Liste wohlklingender Namen für die Teilnehmer
   const melodicNames = [
@@ -593,4 +592,17 @@ document.addEventListener('DOMContentLoaded', function(){
     div.appendChild(restart);
     return div;
   }
-});
+}
+
+function startQuiz(qs){
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', () => runQuiz(qs));
+  } else {
+    runQuiz(qs);
+  }
+}
+
+window.startQuiz = startQuiz;
+if(window.quizQuestions){
+  startQuiz(window.quizQuestions);
+}

--- a/kataloge/catalogs.json
+++ b/kataloge/catalogs.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "fragen_basis",
+    "file": "fragen_basis.json",
+    "name": "Basisfragen",
+    "description": "Beispielkatalog mit allgemeinen Fragen"
+  },
+  {
+    "id": "fragen_it",
+    "file": "fragen_it.json",
+    "name": "IT-Katalog",
+    "description": "Fragen rund um Computer und Technik"
+  }
+]

--- a/kataloge/fragen_basis.json
+++ b/kataloge/fragen_basis.json
@@ -1,0 +1,31 @@
+[
+  {
+    "type": "sort",
+    "prompt": "Bringe die Schritte zum Serienbrief in die richtige Reihenfolge:",
+    "items": [
+      "Datenquelle (Tabelle) erstellen",
+      "Neues Dokument von Vorlage anlegen",
+      "Serienbrieffunktion in Word starten",
+      "Abgangsvermerk am Dokument anbringen"
+    ]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne die Begriffe den Definitionen zu:",
+    "terms": [
+      {"term": "Akte", "definition": "Sammlung von Vorgängen und Dokumenten"},
+      {"term": "OE", "definition": "Organisationseinheit mit Rechten an der Akte"},
+      {"term": "Snapshot", "definition": "PDF mit Status zum Zeichnungsprozess"}
+    ]
+  },
+  {
+    "type": "mc",
+    "prompt": "Wer hat automatisch Schreibrechte an einer Akte?",
+    "options": [
+      "Nur die Fachadministration",
+      "Die besitzende OE",
+      "Alle Nutzer"
+    ],
+    "answers": [1]
+  }
+]

--- a/kataloge/fragen_it.json
+++ b/kataloge/fragen_it.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "mc",
+    "prompt": "Welches Protokoll wird für verschlüsselte Webseiten verwendet?",
+    "options": ["FTP", "HTTP", "HTTPS"],
+    "answers": [2]
+  },
+  {
+    "type": "sort",
+    "prompt": "Sortiere die Speichermedien nach Geschwindigkeit (langsam zu schnell):",
+    "items": ["DVD", "HDD", "SSD"]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne die Begriffe den passenden Erklärungen zu:",
+    "terms": [
+      {"term": "RAM", "definition": "Flüchtiger Arbeitsspeicher"},
+      {"term": "CPU", "definition": "Zentrale Recheneinheit"},
+      {"term": "GPU", "definition": "Grafikprozessor"}
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- group question sets under `kataloge/` folder
- show available catalogs on the start page and load selected catalog
- support `?katalog=` URL parameter
- refactor quiz to start after questions are loaded
- document how to create and use catalogs

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6849467251a4832b876b334ea74648c3