### PR TITLE
Fix catalog list when opened locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,22 @@ SOFTWARE.</code></pre>
   <script src="./js/uikit.min.js"></script>
   <script src="./js/uikit-icons.min.js"></script>
   <script src="./js/config.js"></script>
+  <script id="catalogs-data" type="application/json">
+    [
+      {
+        "id": "fragen_basis",
+        "file": "fragen_basis.json",
+        "name": "Basisfragen",
+        "description": "Beispielkatalog mit allgemeinen Fragen"
+      },
+      {
+        "id": "fragen_it",
+        "file": "fragen_it.json",
+        "name": "IT-Katalog",
+        "description": "Fragen rund um Computer und Technik"
+      }
+    ]
+  </script>
   <script src="./js/catalog.js"></script>
   <script src="./js/confetti.js"></script>
   <script src="./js/quiz.js"></script>

--- a/js/catalog.js
+++ b/js/catalog.js
@@ -32,11 +32,21 @@
   async function loadCatalogList(){
     try{
       const res = await fetch('kataloge/catalogs.json');
-      return await res.json();
+      if(res.ok){
+        return await res.json();
+      }
     }catch(e){
-      console.error('Katalogliste konnte nicht geladen werden.', e);
-      return [];
+      console.warn('Katalogliste konnte nicht geladen werden.', e);
     }
+    const inline = document.getElementById('catalogs-data');
+    if(inline){
+      try{
+        return JSON.parse(inline.textContent);
+      }catch(err){
+        console.error('Inline-Katalogliste ung\u00fcltig.', err);
+      }
+    }
+    return [];
   }
 
   async function loadQuestions(file){


### PR DESCRIPTION
## Summary
- inline default catalog list in `index.html`
- fall back to the inline list if `catalogs.json` can't be fetched

## Testing
- `node --check js/catalog.js`


------
https://chatgpt.com/codex/tasks/task_e_68494c657fcc832b88aa6f10cef99e56