### PR TITLE
Fix offline catalog load and improve dark mode text

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -13,6 +13,10 @@ body.dark-mode .uk-card-default {
 body.dark-mode .uk-card-default a {
   color: #9dc6ff;
 }
+body.dark-mode .uk-card h3,
+body.dark-mode .uk-card p {
+  color: #f5f5f5;
+}
 body.dark-mode .uk-progress {
   background-color: #333;
   color: #1e87f0;

--- a/index.html
+++ b/index.html
@@ -191,6 +191,85 @@ SOFTWARE.</code></pre>
       }
     ]
   </script>
+  <script id="fragen_basis-data" type="application/json">
+    [
+      {
+        "type": "sort",
+        "prompt": "Bringe die Schritte zum Serienbrief in die richtige Reihenfolge:",
+        "items": [
+          "Datenquelle (Tabelle) erstellen",
+          "Neues Dokument von Vorlage anlegen",
+          "Serienbrieffunktion in Word starten",
+          "Abgangsvermerk am Dokument anbringen"
+        ]
+      },
+      {
+        "type": "assign",
+        "prompt": "Ordne die Begriffe den Definitionen zu:",
+        "terms": [
+          {"term": "Akte", "definition": "Sammlung von Vorg\u00e4ngen und Dokumenten"},
+          {"term": "OE", "definition": "Organisationseinheit mit Rechten an der Akte"},
+          {"term": "Snapshot", "definition": "PDF mit Status zum Zeichnungsprozess"}
+        ]
+      },
+      {
+        "type": "mc",
+        "prompt": "Wer hat automatisch Schreibrechte an einer Akte?",
+        "options": [
+          "Nur die Fachadministration",
+          "Die besitzende OE",
+          "Alle Nutzer"
+        ],
+        "answers": [1]
+      },
+      {
+        "type": "mc",
+        "prompt": "In welchem Monat beginnt der Sommer?",
+        "options": ["Januar", "M\u00e4rz", "Juni", "September"],
+        "answers": [2]
+      },
+      {
+        "type": "sort",
+        "prompt": "Sortiere die Jahreszeiten chronologisch:",
+        "items": ["Fr\u00fchling", "Sommer", "Herbst", "Winter"]
+      }
+    ]
+  </script>
+  <script id="fragen_it-data" type="application/json">
+    [
+      {
+        "type": "mc",
+        "prompt": "Welches Protokoll wird f\u00fcr verschl\u00fcsselte Webseiten verwendet?",
+        "options": ["FTP", "HTTP", "HTTPS"],
+        "answers": [2]
+      },
+      {
+        "type": "sort",
+        "prompt": "Sortiere die Speichermedien nach Geschwindigkeit (langsam zu schnell):",
+        "items": ["DVD", "HDD", "SSD"]
+      },
+      {
+        "type": "assign",
+        "prompt": "Ordne die Begriffe den passenden Erkl\u00e4rungen zu:",
+        "terms": [
+          {"term": "RAM", "definition": "Fl\u00fcchtiger Arbeitsspeicher"},
+          {"term": "CPU", "definition": "Zentrale Recheneinheit"},
+          {"term": "GPU", "definition": "Grafikprozessor"}
+        ]
+      },
+      {
+        "type": "mc",
+        "prompt": "Welches Betriebssystem ist quelloffen?",
+        "options": ["Windows", "macOS", "Linux"],
+        "answers": [2]
+      },
+      {
+        "type": "sort",
+        "prompt": "Bringe die Netzwerkger\u00e4te nach Reichweite in die richtige Reihenfolge:",
+        "items": ["Bluetooth", "WLAN", "Mobilfunk"]
+      }
+    ]
+  </script>
   <script src="./js/catalog.js"></script>
   <script src="./js/confetti.js"></script>
   <script src="./js/quiz.js"></script>

--- a/js/catalog.js
+++ b/js/catalog.js
@@ -49,7 +49,7 @@
     return [];
   }
 
-  async function loadQuestions(file){
+  async function loadQuestions(id, file){
     try{
       const res = await fetch('kataloge/' + file);
       const data = await res.json();
@@ -57,8 +57,21 @@
       if(window.startQuiz){
         window.startQuiz(data);
       }
+      return;
     }catch(e){
-      console.error('Fragen konnten nicht geladen werden.', e);
+      console.warn('Fragen konnten nicht geladen werden, versuche inline Daten', e);
+    }
+    const inline = document.getElementById(id + '-data');
+    if(inline){
+      try{
+        const data = JSON.parse(inline.textContent);
+        window.quizQuestions = data;
+        if(window.startQuiz){
+          window.startQuiz(data);
+        }
+      }catch(err){
+        console.error('Inline-Daten ung\u00fcltig.', err);
+      }
     }
   }
 
@@ -76,7 +89,7 @@
       card.style.cursor = 'pointer';
       card.addEventListener('click', () => {
         history.replaceState(null, '', '?katalog=' + cat.id);
-        loadQuestions(cat.file);
+        loadQuestions(cat.id, cat.file);
       });
       const title = document.createElement('h3');
       title.textContent = cat.name || cat.id;
@@ -97,7 +110,7 @@
     const id = params.get('katalog');
     const selected = catalogs.find(c => c.id === id);
     if(selected){
-      loadQuestions(selected.file);
+      loadQuestions(selected.id, selected.file);
     }else{
       showSelection(catalogs);
     }


### PR DESCRIPTION
## Summary
- fallback to inline question data when fetch fails
- ensure dark mode text is readable
- include inline copies of catalog question data

## Testing
- `node -c server.js`
- `node -c js/catalog.js && node -c js/quiz.js`
- `node -c js/config.js`

------
https://chatgpt.com/codex/tasks/task_e_68494f001678832b8612ae06f3b91d95