### PR TITLE
Update quiz start flow and dark mode hover

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -68,3 +68,9 @@ body.dark-mode .mc-option input {
   transform: scale(1.3);
   margin-right: 8px;
 }
+
+/* Hoverfarbe für Katalogkarten im Dunkelmodus */
+body.dark-mode .uk-card-hover:hover {
+  background-color: #333;
+  color: #f5f5f5;
+}


### PR DESCRIPTION
## Summary
- remove intro screen and start quiz immediately
- ensure a name is generated at quiz start
- show progress bar from the first question
- fix white-on-white hover in dark mode catalog cards

## Testing
- `node --version`
- `timeout 5 node server.js`

------
https://chatgpt.com/codex/tasks/task_e_684950e2dfc8832b9089071d61dd04fd