### PR TITLE
Add optional QR-code user login

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Die Datei `js/config.js` enthält alle zentralen Einstellungen:
 - `backgroundColor` – Hintergrundfarbe der Seite.
 - `buttonColor` – Farbe für Schaltflächen.
 - `CheckAnswerButton` – Wenn auf `"no"` gesetzt, wird der Button **Antwort prüfen** ausgeblendet und nur **Weiter** angezeigt.
+- `QRUser` – Bei `true` startet das Quiz mit einem QR-Code-Login. Der Inhalt des Codes wird als Nutzername verwendet.
+
+## QR-Code-Login
+
+Ist die Option `QRUser` aktiviert, erscheint vor dem Quiz ein einfacher QR-Scanner. 
+Der eingelesene Text dient als eindeutiger Benutzername für diese Sitzung. 
+Zur Erzeugung des Codes kann jedes gängige Tool verwendet werden (z.B. Online-Generatoren oder Apps).
 
 ## Datenschutz und DSGVO
 

--- a/admin.html
+++ b/admin.html
@@ -50,6 +50,15 @@
               </select>
             </div>
           </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="cfgQRUser">QR-Code-Login verwenden</label>
+            <div class="uk-form-controls">
+              <select class="uk-select" id="cfgQRUser">
+                <option value="false">Nein</option>
+                <option value="true">Ja</option>
+              </select>
+            </div>
+          </div>
         </form>
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="cfgResetBtn" class="uk-button uk-button-default">Zurücksetzen</button>
@@ -104,7 +113,8 @@
       subheader: document.getElementById('cfgSubheader'),
       backgroundColor: document.getElementById('cfgBackgroundColor'),
       buttonColor: document.getElementById('cfgButtonColor'),
-      checkAnswerButton: document.getElementById('cfgCheckAnswerButton')
+      checkAnswerButton: document.getElementById('cfgCheckAnswerButton'),
+      qrUser: document.getElementById('cfgQRUser')
     };
     // Füllt das Formular mit den Werten aus einem Konfigurationsobjekt
     function renderCfg(data){
@@ -114,6 +124,7 @@
       cfgFields.backgroundColor.value = data.backgroundColor || '';
       cfgFields.buttonColor.value = data.buttonColor || '';
       cfgFields.checkAnswerButton.value = data.CheckAnswerButton || 'yes';
+      cfgFields.qrUser.value = String(data.QRUser) || 'false';
     }
     renderCfg(cfgInitial);
     document.getElementById('cfgResetBtn').addEventListener('click', function(e){
@@ -128,7 +139,8 @@
         subheader: cfgFields.subheader.value.trim(),
         backgroundColor: cfgFields.backgroundColor.value.trim(),
         buttonColor: cfgFields.buttonColor.value.trim(),
-        CheckAnswerButton: cfgFields.checkAnswerButton.value
+        CheckAnswerButton: cfgFields.checkAnswerButton.value,
+        QRUser: cfgFields.qrUser.value === 'true'
       };
       const content = 'window.quizConfig = ' + JSON.stringify(data, null, 2) + ';\n';
       const blob = new Blob([content], {type: 'text/javascript'});

--- a/index.html
+++ b/index.html
@@ -174,6 +174,7 @@ SOFTWARE.</code></pre>
   </div>
   <script src="./js/uikit.min.js"></script>
   <script src="./js/uikit-icons.min.js"></script>
+  <script src="https://unpkg.com/html5-qrcode@2.3.7/html5-qrcode.min.js"></script>
   <script src="./js/config.js"></script>
   <script id="catalogs-data" type="application/json">
     [

--- a/js/config.js
+++ b/js/config.js
@@ -14,5 +14,8 @@ window.quizConfig = {
   buttonColor: '#1e87f0',
 
   // Falls "no", wird der Button "Antwort prüfen" ausgeblendet
-  CheckAnswerButton: 'yes'
+  CheckAnswerButton: 'yes',
+
+  // QR-Code-Login aktivieren (true/false)
+  QRUser: false
 };

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -504,6 +504,32 @@ function runQuiz(questions){
     div.setAttribute('uk-scrollspy', 'cls: uk-animation-slide-bottom-small; target: > *; delay: 100');
     const stats = document.createElement('div');
     stats.className = 'uk-margin';
+
+    if(cfg.QRUser){
+      const info = document.createElement('p');
+      info.textContent = 'Bitte QR-Code scannen, um fortzufahren:';
+      const qrDiv = document.createElement('div');
+      qrDiv.id = 'qr-reader';
+      qrDiv.style.width = '250px';
+      qrDiv.className = 'uk-align-center';
+      div.appendChild(info);
+      div.appendChild(qrDiv);
+      // QR-Code-Scanner initialisieren, falls Bibliothek geladen
+      if(typeof Html5QrcodeScanner !== 'undefined'){
+        const scanner = new Html5QrcodeScanner('qr-reader', { fps: 10, qrbox: 250 });
+        scanner.render((text)=>{
+          sessionStorage.setItem('quizUser', text.trim());
+          div.innerHTML = '<div class="uk-alert-success" uk-alert>Angemeldet als '+text+'.</div>';
+          scanner.clear().then(()=>{ next(); });
+        });
+      } else {
+        const warn = document.createElement('p');
+        warn.textContent = 'QR-Scanner nicht verfügbar.';
+        div.appendChild(warn);
+      }
+      return div;
+    }
+
     const startBtn = document.createElement('button');
     startBtn.className = 'uk-button uk-button-primary uk-button-large';
     startBtn.textContent = 'UND LOS';


### PR DESCRIPTION
## Summary
- allow enabling QR-based user identification in `config.js`
- load html5-qrcode in `index.html`
- show QR login screen if `QRUser` is active
- extend admin interface with field to configure QR login
- document QRUser option in README

## Testing
- `node --version`
- `node server.js` *(started and stopped to ensure no errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849516ceaa4832bb00e5e90515eb423