### PR TITLE
Fix header duplication after catalog selection

### DIFF
--- a/js/quiz.js
+++ b/js/quiz.js
@@ -12,6 +12,8 @@ function runQuiz(questions){
 
   const container = document.getElementById('quiz');
   const progress = document.getElementById('progress');
+  // Vorhandene Inhalte entfernen (z.B. Katalogauswahl)
+  if (container) container.innerHTML = '';
 
   // Liste wohlklingender Namen für die Teilnehmer
   const melodicNames = [
@@ -104,6 +106,7 @@ function runQuiz(questions){
   // build header from config
   const headerEl = document.getElementById('quiz-header');
   if(headerEl){
+    headerEl.innerHTML = '';
     if(cfg.logoPath){
       const img = document.createElement('img');
       img.src = cfg.logoPath;


### PR DESCRIPTION
## Summary
- clear quiz container when starting questions to remove catalog grid
- reset header before building to avoid duplicate titles

## Testing
- `node server.js & sleep 2; pkill node`

------
https://chatgpt.com/codex/tasks/task_e_68495279f03c832b959be7cac521e12c