### PR TITLE
Add HTML test workflow

### DIFF
--- a/.github/workflows/html-validity.yml
+++ b/.github/workflows/html-validity.yml
@@ -1,0 +1,18 @@
+name: HTML Validity Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run tests
+        run: python -m unittest discover -s tests
+

--- a/tests/test_html_validity.py
+++ b/tests/test_html_validity.py
@@ -1,0 +1,48 @@
+import unittest
+from html.parser import HTMLParser
+
+class HTMLValidator(HTMLParser):
+    VOID_TAGS = {
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+        'link', 'meta', 'param', 'source', 'track', 'wbr',
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.stack = []
+        self.errors = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag not in self.VOID_TAGS:
+            self.stack.append(tag)
+
+    def handle_endtag(self, tag):
+        if not self.stack:
+            self.errors.append(f"Unexpected closing tag: {tag}")
+            return
+        open_tag = self.stack.pop()
+        if open_tag != tag:
+            self.errors.append(f"Mismatched tag: expected {open_tag} but got {tag}")
+
+    def close(self):
+        super().close()
+        if self.stack:
+            self.errors.append('Unclosed tags: ' + ', '.join(self.stack))
+
+
+def validate_html_file(path):
+    parser = HTMLValidator()
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            parser.feed(line)
+    parser.close()
+    return parser.errors
+
+
+class TestHTMLValidity(unittest.TestCase):
+    def test_index_html_is_valid(self):
+        errors = validate_html_file('index.html')
+        self.assertEqual(errors, [], msg='\n'.join(errors))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- run the HTML validity unittest in GitHub Actions

## Testing
- `python3 -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_684955810edc832b98ebdcbf85f69e08