### PR TITLE
Improve mobile layout

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -45,7 +45,7 @@ body.dark-mode .mc-option {
   background-color: #1e1e1e;
   border-color: #444;
   color: #f5f5f5;
-  font-size: 1.5em;
+  font-size: 1rem;
   padding: 16px;
 }
 body.dark-mode .dropzone.over {
@@ -73,4 +73,25 @@ body.dark-mode .mc-option input {
 body.dark-mode .uk-card-hover:hover {
   background-color: #333;
   color: #f5f5f5;
+}
+
+@media (min-width: 640px) {
+  body.dark-mode .sortable-list li,
+  body.dark-mode .terms li,
+  body.dark-mode .dropzone,
+  body.dark-mode .mc-option {
+    font-size: 1.3rem;
+  }
+}
+
+@media (min-width: 960px) {
+  body.dark-mode .sortable-list li,
+  body.dark-mode .terms li,
+  body.dark-mode .dropzone,
+  body.dark-mode .mc-option {
+    font-size: 1.5rem;
+  }
+  body.dark-mode .mc-option input {
+    transform: scale(1.3);
+  }
 }

--- a/index.html
+++ b/index.html
@@ -10,33 +10,24 @@
     body {
       min-height: 100vh;
     }
-    .sortable-list li {
+    .sortable-list li,
+    .terms li,
+    .dropzone,
+    .mc-option {
       cursor: grab;
       background: #f3f7fa;
       border: 1px solid #ddd;
       border-radius: 8px;
       padding: 16px;
       margin-bottom: 12px;
-      font-size: 1.5em;
-    }
-
-    .terms li {
-      cursor: grab;
-      background: #f3f7fa;
-      border: 1px solid #ddd;
-      border-radius: 8px;
-      padding: 16px;
-      margin-bottom: 12px;
-      font-size: 1.5em;
+      font-size: 1rem;
     }
 
     .mc-option {
       display: block;
-      font-size: 1.5em;
-      margin-bottom: 12px;
     }
     .mc-option input {
-      transform: scale(1.3);
+      transform: scale(1.2);
       margin-right: 8px;
     }
 
@@ -52,7 +43,6 @@
       display: flex;
       align-items: center;
       padding: 8px 12px;
-      font-size: 1.5em;
     }
     .dropzone.over {
       border-color: #39f;
@@ -123,6 +113,27 @@
     a.uk-accordion-title {
       font-size: 1rem;
     }
+
+    @media (min-width: 640px) {
+      .sortable-list li,
+      .terms li,
+      .dropzone,
+      .mc-option {
+        font-size: 1.3rem;
+      }
+    }
+
+    @media (min-width: 960px) {
+      .sortable-list li,
+      .terms li,
+      .dropzone,
+      .mc-option {
+        font-size: 1.5rem;
+      }
+      .mc-option input {
+        transform: scale(1.3);
+      }
+    }
   </style>
 </head>
 <body class="uk-padding uk-flex uk-flex-center">
@@ -131,7 +142,7 @@
     <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
     <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
   </div>
-  <div class="uk-container uk-width-1-2@s uk-width-2-3@m">
+  <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin">
       <div id="quiz-header" class="uk-text-center uk-margin"></div>
       <progress id="progress" class="uk-progress" value="0" max="1" aria-label="Fortschritt"></progress>


### PR DESCRIPTION
## Summary
- make base layout mobile-first
- set responsive font sizes for questions
- tweak dark mode to match responsive fonts

## Testing
- `node server.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_684955481670832b8bab5f4d4122b8e4