### PR TITLE
Implement pre-catalog login step

### DIFF
--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,21 +1,8 @@
 // Hauptskript des Quizzes. Dieses File erzeugt dynamisch alle Fragen,
 // wertet Antworten aus und speichert das Ergebnis im Browser.
 // Der Code wird ausgeführt, sobald das DOM geladen ist.
-function runQuiz(questions){
-  // Konfiguration laden und einstellen, ob der "Antwort prüfen"-Button
-  // eingeblendet werden soll
-  const cfg = window.quizConfig || {};
-  const showCheck = cfg.CheckAnswerButton !== 'no';
-  if(cfg.backgroundColor){
-    document.body.style.backgroundColor = cfg.backgroundColor;
-  }
-
-  const container = document.getElementById('quiz');
-  const progress = document.getElementById('progress');
-  // Vorhandene Inhalte entfernen (z.B. Katalogauswahl)
-  if (container) container.innerHTML = '';
-
-  // Liste wohlklingender Namen für die Teilnehmer
+// Utility zum Generieren zufälliger Nutzernamen
+(function(){
   const melodicNames = [
     'Sonnenklang', 'Mondmelodie', 'Sturmserenade', 'Himmelsklang', 'Seewindlied', 'Sternenchor',
     'Fliederduft', 'Traumtänzer', 'Herbstleuchten', 'Sommernacht', 'Funkelpfad', 'Lichtklang',
@@ -56,8 +43,7 @@ function runQuiz(questions){
     'Meeresreigen', 'Lichtglanz', 'Wintersegen', 'Feuerschimmer'
   ];
 
-  // Erzeugt einen eindeutigen Namen und merkt bereits vergebene
-  function generateUserName(){
+  window.generateUserName = function(){
     const used = JSON.parse(localStorage.getItem('usedNames') || '[]');
     const available = melodicNames.filter(n => !used.includes(n));
     let name;
@@ -69,7 +55,23 @@ function runQuiz(questions){
       name = 'Gast-' + Math.random().toString(36).substr(2,5);
     }
     return name;
+  };
+})();
+
+function runQuiz(questions){
+  // Konfiguration laden und einstellen, ob der "Antwort prüfen"-Button
+  // eingeblendet werden soll
+  const cfg = window.quizConfig || {};
+  const showCheck = cfg.CheckAnswerButton !== 'no';
+  if(cfg.backgroundColor){
+    document.body.style.backgroundColor = cfg.backgroundColor;
   }
+
+  const container = document.getElementById('quiz');
+  const progress = document.getElementById('progress');
+  // Vorhandene Inhalte entfernen (z.B. Katalogauswahl)
+  if (container) container.innerHTML = '';
+
 
   // Hilfsfunktion zum Mischen von Arrays (Fisher-Yates)
   function shuffleArray(arr){
@@ -91,12 +93,12 @@ function runQuiz(questions){
   // Speichert true/false für jede beantwortete Frage
   const results = new Array(questionCount).fill(false);
   const summaryEl = createSummary(); // Abschlussseite
-  // Abschluss-Element einfügen
   elements.push(summaryEl);
   let summaryShown = false;
 
-  // neuen Teilnehmernamen speichern
-  sessionStorage.setItem('quizUser', generateUserName());
+  if(!sessionStorage.getItem('quizUser')){
+    sessionStorage.setItem('quizUser', generateUserName());
+  }
 
   // konfigurierbare Farben dynamisch in ein Style-Tag schreiben
   const styleEl = document.createElement('style');


### PR DESCRIPTION
## Summary
- show QR or button login before catalog selection
- expose username generator globally
- restore original quiz flow without internal start screen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495918814c832b8c61c9871f8a8d68