### PR TITLE
Fix catalog initialization

### DIFF
--- a/js/catalog.js
+++ b/js/catalog.js
@@ -148,7 +148,7 @@
     container.appendChild(div);
   }
 
-  document.addEventListener('DOMContentLoaded', async () => {
+  async function init(){
     applyConfig();
     const catalogs = await loadCatalogList();
     const params = new URLSearchParams(window.location.search);
@@ -169,5 +169,11 @@
       }
       proceed();
     }
-  });
+  }
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', init);
+  }else{
+    init();
+  }
 })();


### PR DESCRIPTION
## Summary
- ensure `catalog.js` runs even if DOM is already loaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495d317c08832b8148be085e2b85e3