### PR TITLE
Admin supports multiple question catalogs

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -79,6 +79,12 @@
     <li>
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Fragen bearbeiten</h2>
+        <div class="uk-margin">
+          <label class="uk-form-label" for="catalogSelect">Fragenkatalog</label>
+          <div class="uk-form-controls">
+            <select id="catalogSelect" class="uk-select"></select>
+          </div>
+        </div>
         <div id="questions"></div>
         <div class="uk-margin">
           <button id="addBtn" class="uk-button uk-button-default">Neue Frage</button>
@@ -90,7 +96,7 @@
         <div class="uk-alert-primary" uk-alert>
           <p>
             Nach dem Klick auf <strong>Speichern</strong> wird eine JSON-Datei
-            f&uuml;r den aktuell bearbeiteten Fragenkatalog heruntergeladen.
+            f&uuml;r den gewählten Fragenkatalog heruntergeladen.
             Kopiere sie danach in den Ordner <code>kataloge/</code>, um den
             vorhandenen Katalog zu ersetzen. Die Admin-Seite kann das
             Verzeichnis nicht automatisch beschreiben.
@@ -157,12 +163,40 @@
     const addBtn = document.getElementById('addBtn');
     const saveBtn = document.getElementById('saveBtn');
     const resetBtn = document.getElementById('resetBtn');
-    const catalogFile = 'fragen_basis.json';
+    const catSelect = document.getElementById('catalogSelect');
+    let catalogs = [];
+    let catalogFile = '';
     let initial = [];
-    fetch('kataloge/' + catalogFile)
+
+    function loadCatalog(id){
+      const cat = catalogs.find(c => c.id === id);
+      if(!cat) return;
+      catalogFile = cat.file;
+      fetch('kataloge/' + catalogFile)
+        .then(r => r.json())
+        .then(data => { initial = data; renderAll(initial); })
+        .catch(() => { initial = []; renderAll(initial); });
+    }
+
+    fetch('kataloge/catalogs.json')
       .then(r => r.json())
-      .then(data => { initial = data; renderAll(initial); })
-      .catch(() => renderAll(initial));
+      .then(list => {
+        catalogs = list;
+        catalogs.forEach(c => {
+          const opt = document.createElement('option');
+          opt.value = c.id;
+          opt.textContent = c.name || c.id;
+          catSelect.appendChild(opt);
+        });
+        const params = new URLSearchParams(window.location.search);
+        const id = params.get('katalog') || (catalogs[0] && catalogs[0].id);
+        if(id){
+          catSelect.value = id;
+          loadCatalog(id);
+        }
+      });
+
+    catSelect.addEventListener('change', () => loadCatalog(catSelect.value));
 
     // Rendert alle Fragen im Editor neu
     function renderAll(data){


### PR DESCRIPTION
## Summary
- enable catalog selection in `admin.html`
- load catalog list to edit questions from chosen catalog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495dd3222c832b80a36bcbf2daa9e2