### PR TITLE
Handle QR scanner init failures

### DIFF
--- a/js/catalog.js
+++ b/js/catalog.js
@@ -120,11 +120,18 @@
       div.appendChild(info);
       div.appendChild(qrDiv);
       if(typeof Html5QrcodeScanner !== 'undefined'){
-        const scanner = new Html5QrcodeScanner('login-qr', {fps:10, qrbox:250});
-        scanner.render(text=>{
-          sessionStorage.setItem('quizUser', text.trim());
-          scanner.clear().then(()=> onDone());
-        });
+        try{
+          const scanner = new Html5QrcodeScanner('login-qr', {fps:10, qrbox:250});
+          scanner.render(text=>{
+            sessionStorage.setItem('quizUser', text.trim());
+            scanner.clear().then(()=> onDone());
+          });
+        }catch(err){
+          console.error('QR scanner initialization failed.', err);
+          const warn = document.createElement('p');
+          warn.textContent = 'QR-Scanner konnte nicht gestartet werden. Bitte Kamera freigeben oder QR-Login deaktivieren.';
+          div.appendChild(warn);
+        }
       }else{
         const warn = document.createElement('p');
         warn.textContent = 'QR-Scanner nicht verf\u00fcgbar.';


### PR DESCRIPTION
## Summary
- guard QR scanner initialization with try/catch
- show error message if camera access fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68495f8fb0e4832bb9184e72b065bc98