### PR TITLE
Add Slim skeleton build workflow

### DIFF
--- a/.github/workflows/build-slim.yml
+++ b/.github/workflows/build-slim.yml
@@ -1,0 +1,25 @@
+name: Build Slim Skeleton
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer
+      - name: Create Slim skeleton
+        run: composer create-project slim/slim-skeleton temp-slim
+      - name: Copy skeleton files
+        run: |
+          rsync -a temp-slim/ ./
+      - name: Clean up
+        run: rm -rf temp-slim

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Dieses Quiz läuft vollständig im Browser und benötigt keine permanente Server
 
 Dieses Tool ist ein reiner Prototyp, der zu 100% mit Codex von OpenAI umgesetzt wurde. Die Arbeit diente ausschließlich der Erprobung des Coding-Assistenten und seiner Möglichkeiten. Sämtliche Dateien in diesem Repository – angefangen bei HTML und CSS über die Skripte bis hin zu dieser Dokumentation – wurden mithilfe des Assistenten generiert. Manuelle Eingriffe beschränkten sich auf minimale Korrekturen sowie die Begleitung des Generierungsprozesses. Die vorliegende Anwendung soll daher insbesondere demonstrieren, wie sich mithilfe von Codex ein funktionsfähiger Prototyp realisieren lässt.
 
+## Build-Slim Workflow
+
+Um das Slim-Skeleton bei Bedarf automatisiert in dieses Repository zu kopieren, existiert der Workflow [`build-slim.yml`](.github/workflows/build-slim.yml). Er installiert PHP samt Composer, führt `composer create-project slim/slim-skeleton temp-slim` aus und übernimmt die erzeugten Dateien per `rsync`. Anschließend wird das temporäre Verzeichnis wieder entfernt. So bleibt das Grundgerüst jederzeit reproduzierbar.
+
 ## Lizenz
 
 <details>


### PR DESCRIPTION
## Summary
- add build-slim.yml workflow to generate the Slim skeleton
- document the workflow usage in README

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68496c5e5e68832b9cf2645fe4e19112