### PR TITLE
Update Docker image to PHP 8.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
     slim:
-        image: php:7-alpine
+        image: php:8.2-alpine
         working_dir: /var/www
         command: php -S 0.0.0.0:8080 -t public
         environment:


### PR DESCRIPTION
## Summary
- use PHP 8.2 for the Docker environment

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68497a9b709c832b966acedaf9546fa0