### PR TITLE
Add fixed top bar and convert FAQ to PHP

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -10,8 +10,11 @@ return function (\Slim\App $app) {
     });
 
     $app->get('/faq', function (Request $request, Response $response) {
-        $path = __DIR__ . '/../templates/faq.html';
-        $response->getBody()->write(file_get_contents($path));
+        $path = __DIR__ . '/../templates/faq.php';
+        ob_start();
+        include $path;
+        $content = ob_get_clean();
+        $response->getBody()->write($content);
         return $response;
     });
 

--- a/templates/faq.php
+++ b/templates/faq.php
@@ -6,9 +6,68 @@
   <title>FAQ</title>
   <link rel="stylesheet" href="/css/uikit.min.css">
   <link rel="stylesheet" href="/css/dark.css">
+  <style>
+    body {
+      padding-top: 48px;
+    }
+    .topbar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      z-index: 1000;
+    }
+    .theme-switch {
+      display: inline-block;
+      margin-left: 8px;
+    }
+    .theme-switch input {
+      height: 0;
+      width: 0;
+      visibility: hidden;
+    }
+    .theme-switch-label {
+      cursor: pointer;
+      text-indent: -9999px;
+      width: 40px;
+      height: 20px;
+      background: #ccc;
+      display: block;
+      border-radius: 100px;
+      position: relative;
+    }
+    .theme-switch-label:after {
+      content: '';
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      width: 16px;
+      height: 16px;
+      background: #fff;
+      border-radius: 90px;
+      transition: 0.3s;
+    }
+    .theme-switch input:checked + .theme-switch-label {
+      background: #1e87f0;
+    }
+    .theme-switch input:checked + .theme-switch-label:after {
+      left: calc(100% - 2px);
+      transform: translateX(-100%);
+    }
+  </style>
 </head>
 <body class="uk-background-muted uk-padding">
-  <a href="#" class="uk-icon-button uk-position-fixed uk-position-top-left uk-margin-small-left uk-margin-small-top" uk-icon="arrow-left" title="Zurück" aria-label="Zurück" onclick="history.back();"></a>
+  <div class="uk-navbar-container topbar" uk-navbar>
+    <div class="uk-navbar-left">
+      <a href="/" class="uk-icon-button" uk-icon="arrow-left" title="Zurück" aria-label="Zurück"></a>
+    </div>
+    <div class="uk-navbar-right">
+      <div class="theme-switch">
+        <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
+        <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+      </div>
+    </div>
+  </div>
   <div class="uk-container uk-container-small">
     <h1 class="uk-heading-divider">FAQ</h1>
     <p class="uk-text-lead">Auf dieser Seite findest du Antworten auf häufig gestellte Fragen rund um die Anwendung und Administration des Quiz.</p>
@@ -152,9 +211,22 @@
   <script src="/js/uikit-icons.min.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
+      const toggle = document.getElementById('theme-toggle');
       const isDark = localStorage.getItem('darkMode') === 'true';
       if(isDark){
         document.body.classList.add('dark-mode','uk-light');
+        if(toggle) toggle.checked = true;
+      }
+      if(toggle){
+        toggle.addEventListener('change', function(){
+          if(this.checked){
+            document.body.classList.add('dark-mode','uk-light');
+            localStorage.setItem('darkMode', 'true');
+          } else {
+            document.body.classList.remove('dark-mode','uk-light');
+            localStorage.setItem('darkMode', 'false');
+          }
+        });
       }
     });
   </script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
   <style>
     body {
       min-height: 100vh;
+      padding-top: 48px;
     }
     .sortable-list li,
     .terms li,
@@ -66,11 +67,16 @@
       top: 0;
       left: 0;
     }
-    .theme-switch {
+    .topbar {
       position: fixed;
-      top: 8px;
-      left: 8px;
+      top: 0;
+      left: 0;
+      width: 100%;
       z-index: 1000;
+    }
+    .theme-switch {
+      display: inline-block;
+      margin-left: 8px;
     }
     .theme-switch input {
       height: 0;
@@ -137,10 +143,16 @@
   </style>
 </head>
 <body class="uk-padding uk-flex uk-flex-center">
-  <a href="faq.html" class="uk-icon-button uk-position-fixed uk-position-top-right uk-margin-small-right uk-margin-small-top" uk-icon="question" title="Hilfe" aria-label="Hilfe"></a>
-  <div class="theme-switch">
-    <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-    <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+  <div class="uk-navbar-container topbar" uk-navbar>
+    <div class="uk-navbar-left">
+      <div class="theme-switch">
+        <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
+        <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+      </div>
+    </div>
+    <div class="uk-navbar-right">
+      <a href="/faq" class="uk-icon-button" uk-icon="question" title="Hilfe" aria-label="Hilfe"></a>
+    </div>
   </div>
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin">

--- a/templates/index.php
+++ b/templates/index.php
@@ -9,6 +9,7 @@
   <style>
     body {
       min-height: 100vh;
+      padding-top: 48px;
     }
     .sortable-list li,
     .terms li,
@@ -66,11 +67,16 @@
       top: 0;
       left: 0;
     }
-    .theme-switch {
+    .topbar {
       position: fixed;
-      top: 8px;
-      left: 8px;
+      top: 0;
+      left: 0;
+      width: 100%;
       z-index: 1000;
+    }
+    .theme-switch {
+      display: inline-block;
+      margin-left: 8px;
     }
     .theme-switch input {
       height: 0;
@@ -137,10 +143,16 @@
   </style>
 </head>
 <body class="uk-padding uk-flex uk-flex-center">
-  <a href="faq.html" class="uk-icon-button uk-position-fixed uk-position-top-right uk-margin-small-right uk-margin-small-top" uk-icon="question" title="Hilfe" aria-label="Hilfe"></a>
-  <div class="theme-switch">
-    <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-    <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+  <div class="uk-navbar-container topbar" uk-navbar>
+    <div class="uk-navbar-left">
+      <div class="theme-switch">
+        <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
+        <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+      </div>
+    </div>
+    <div class="uk-navbar-right">
+      <a href="/faq" class="uk-icon-button" uk-icon="question" title="Hilfe" aria-label="Hilfe"></a>
+    </div>
   </div>
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin">


### PR DESCRIPTION
## Summary
- create a top bar containing the theme switcher and FAQ link
- convert `faq.html` to `faq.php` and load it through Slim
- adapt styles in all templates
- keep dark mode toggle available on the FAQ page

## Testing
- `python3 tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_684988ace41c832b9d4bcd652c77db96