### PR TITLE
Integrate nginx and Let's Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ Copyright (c) 2025 calhelp
 Or you can use `docker-compose` to run the app with `docker`, so you can run these commands:
 ```bash
 cd [my-app-name]
+export CERTBOT_DOMAIN=example.com
+export CERTBOT_EMAIL=admin@example.com
 docker-compose up -d
 ```
-After that, open `http://localhost:8080` in your browser.
+After that, open `http://localhost` or `https://localhost` in your browser.
 
 Run this command in the application directory to run the test suite
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.7'
 volumes:
     logs:
         driver: local
+    certbot-etc:
+    certbot-var:
 
 services:
     slim:
@@ -11,8 +13,33 @@ services:
         command: php -S 0.0.0.0:8080 -t public
         environment:
             docker: "true"
-        ports:
-            - "8080:8080"
+        expose:
+            - "8080"
         volumes:
             - .:/var/www
             - logs:/var/www/logs
+
+    nginx:
+        image: nginx:alpine
+        depends_on:
+            - slim
+        environment:
+            DOMAIN: ${CERTBOT_DOMAIN:-example.com}
+        ports:
+            - "80:80"
+            - "443:443"
+        volumes:
+            - .:/var/www
+            - ./nginx/default.conf.template:/etc/nginx/conf.d/default.conf.template
+            - ./certbot/www:/var/www/certbot
+            - certbot-etc:/etc/letsencrypt
+            - certbot-var:/var/lib/letsencrypt
+        command: /bin/sh -c "envsubst '$$DOMAIN' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+
+    certbot:
+        image: certbot/certbot
+        volumes:
+            - ./certbot/www:/var/www/certbot
+            - certbot-etc:/etc/letsencrypt
+            - certbot-var:/var/lib/letsencrypt
+        entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot --quiet; sleep 12h & wait $${!}; done'"

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,0 +1,34 @@
+server {
+    listen 80;
+    server_name ${DOMAIN};
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        proxy_pass http://slim:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name ${DOMAIN};
+
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass http://slim:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- add nginx reverse proxy setup
- include certbot container for automatic Let's Encrypt renewals
- provide default nginx config template
- document how to run docker-compose with SSL variables

## Testing
- `python -m unittest discover -s tests`
- `composer test` *(fails: composer not available)*

------
https://chatgpt.com/codex/tasks/task_e_6849893927f4832bae75f0d0b63c976c