### PR TITLE
Improve navbar alignment and hide headers

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -105,29 +105,11 @@ function runQuiz(questions){
   styleEl.textContent = `\n    body { background-color: ${cfg.backgroundColor || '#f8f8f8'}; }\n    .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n  `;
   document.head.appendChild(styleEl);
 
-  // build header from config
+  // hide header once the quiz starts
   const headerEl = document.getElementById('quiz-header');
-  if(headerEl){
+  if (headerEl) {
     headerEl.innerHTML = '';
-    if(cfg.logoPath){
-      const img = document.createElement('img');
-      img.src = cfg.logoPath;
-      img.alt = cfg.header || 'Logo';
-      img.className = 'uk-margin-small-bottom';
-      headerEl.appendChild(img);
-    }
-    if(cfg.header){
-      const h = document.createElement('h1');
-      h.textContent = cfg.header;
-      h.className = 'uk-margin-remove-bottom';
-      headerEl.appendChild(h);
-    }
-    if(cfg.subheader){
-      const p = document.createElement('p');
-      p.textContent = cfg.subheader;
-      p.className = 'uk-text-lead';
-      headerEl.appendChild(p);
-    }
+    headerEl.classList.add('uk-hidden');
   }
 
   elements.forEach((el, i) => {

--- a/templates/faq.php
+++ b/templates/faq.php
@@ -59,17 +59,21 @@
 <body class="uk-background-muted uk-padding">
   <div class="uk-navbar-container topbar" uk-navbar>
     <div class="uk-navbar-left">
-      <a href="/" class="uk-icon-button" uk-icon="arrow-left" title="Zurück" aria-label="Zurück"></a>
+      <div class="uk-navbar-item">
+        <a href="/" class="uk-icon-button" uk-icon="arrow-left" title="Zurück" aria-label="Zurück"></a>
+      </div>
     </div>
     <div class="uk-navbar-right">
-      <div class="theme-switch">
-        <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-        <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+      <div class="uk-navbar-item">
+        <div class="theme-switch">
+          <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
+          <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+        </div>
       </div>
     </div>
   </div>
   <div class="uk-container uk-container-small">
-    <h1 class="uk-heading-divider">FAQ</h1>
+    <h1 class="uk-heading-divider uk-hidden">FAQ</h1>
     <p class="uk-text-lead">Auf dieser Seite findest du Antworten auf häufig gestellte Fragen rund um die Anwendung und Administration des Quiz.</p>
 
     <h2 id="anwendung" class="uk-heading-bullet">Anwendung</h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -151,13 +151,17 @@
 <body class="uk-padding uk-flex uk-flex-center">
   <div class="uk-navbar-container topbar" uk-navbar>
     <div class="uk-navbar-left">
-      <div class="theme-switch">
-        <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-        <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+      <div class="uk-navbar-item">
+        <div class="theme-switch">
+          <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
+          <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+        </div>
       </div>
     </div>
     <div class="uk-navbar-right">
-      <a href="/faq" class="uk-icon-button" uk-icon="question" title="Hilfe" aria-label="Hilfe"></a>
+      <div class="uk-navbar-item">
+        <a href="/faq" class="uk-icon-button" uk-icon="question" title="Hilfe" aria-label="Hilfe"></a>
+      </div>
     </div>
   </div>
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">

--- a/templates/index.php
+++ b/templates/index.php
@@ -151,13 +151,17 @@
 <body class="uk-padding uk-flex uk-flex-center">
   <div class="uk-navbar-container topbar" uk-navbar>
     <div class="uk-navbar-left">
-      <div class="theme-switch">
-        <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-        <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+      <div class="uk-navbar-item">
+        <div class="theme-switch">
+          <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
+          <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+        </div>
       </div>
     </div>
     <div class="uk-navbar-right">
-      <a href="/faq" class="uk-icon-button" uk-icon="question" title="Hilfe" aria-label="Hilfe"></a>
+      <div class="uk-navbar-item">
+        <a href="/faq" class="uk-icon-button" uk-icon="question" title="Hilfe" aria-label="Hilfe"></a>
+      </div>
     </div>
   </div>
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">


### PR DESCRIPTION
## Summary
- align theme switch and FAQ/back buttons using `uk-navbar-item`
- hide FAQ heading
- hide header and subheader while questions are displayed

## Testing
- `python3 tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6849a33c46e0832bb2f22821a8fba2a7