### PR TITLE
Fix composer allow plugins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,9 @@ jobs:
                   php-version: ${{ matrix.php }}
                   coverage: xdebug
 
+            - name: Configure Composer allow-plugins
+              run: composer config --no-plugins allow-plugins.phpstan/extension-installer true
+
             - name: Install dependencies with Composer
               uses: ramsey/composer-install@v2
 


### PR DESCRIPTION
## Summary
- enable phpstan's extension installer before composer install in tests

## Testing
- `composer install --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849befcba0c832ba1edd9fcc4866431