### PR TITLE
Introduce controller classes

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SommerfestQuiz\Controller;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class AdminController
+{
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $path = dirname(__DIR__, 2) . '/templates/admin.html';
+        $response->getBody()->write(file_get_contents($path));
+        return $response;
+    }
+}

--- a/src/Controller/FaqController.php
+++ b/src/Controller/FaqController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SommerfestQuiz\Controller;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class FaqController
+{
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $path = dirname(__DIR__, 2) . '/templates/faq.php';
+        ob_start();
+        include $path;
+        $content = ob_get_clean();
+        $response->getBody()->write($content);
+        return $response;
+    }
+}

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SommerfestQuiz\Controller;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class HomeController
+{
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $indexPath = dirname(__DIR__, 2) . '/templates/index.html';
+        $response->getBody()->write(file_get_contents($indexPath));
+        return $response->withHeader('Content-Type', 'text/html');
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -2,27 +2,18 @@
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
+require_once __DIR__ . '/Controller/HomeController.php';
+require_once __DIR__ . '/Controller/FaqController.php';
+require_once __DIR__ . '/Controller/AdminController.php';
+
+use SommerfestQuiz\Controller\HomeController;
+use SommerfestQuiz\Controller\FaqController;
+use SommerfestQuiz\Controller\AdminController;
+
 return function (\Slim\App $app) {
-    $app->get('/', function (Request $request, Response $response) {
-        $indexPath = __DIR__ . '/../templates/index.html';
-        $response->getBody()->write(file_get_contents($indexPath));
-        return $response->withHeader('Content-Type', 'text/html');
-    });
-
-    $app->get('/faq', function (Request $request, Response $response) {
-        $path = __DIR__ . '/../templates/faq.php';
-        ob_start();
-        include $path;
-        $content = ob_get_clean();
-        $response->getBody()->write($content);
-        return $response;
-    });
-
-    $app->get('/admin', function (Request $request, Response $response) {
-        $path = __DIR__ . '/../templates/admin.html';
-        $response->getBody()->write(file_get_contents($path));
-        return $response;
-    });
+    $app->get('/', HomeController::class);
+    $app->get('/faq', FaqController::class);
+    $app->get('/admin', AdminController::class);
     $app->get('/config.js', function (Request $request, Response $response) {
         $path = __DIR__ . '/../public/js/config.js';
         if (!file_exists($path)) {


### PR DESCRIPTION
## Summary
- add controller classes for main pages
- move closure logic into controllers and wire them in routes
- require controller files in `routes.php` and register them by class name

## Testing
- `python3 -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_6849cada31e8832ba9580556c630b49d