### PR TITLE
Fix duplicate controller import

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -9,14 +9,6 @@ require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
 require_once __DIR__ . '/Controller/AdminController.php';
 
-use SommerfestQuiz\Controller\HomeController;
-use SommerfestQuiz\Controller\FaqController;
-use SommerfestQuiz\Controller\AdminController;
-
-use SommerfestQuiz\Controller\HomeController;
-use SommerfestQuiz\Controller\FaqController;
-use SommerfestQuiz\Controller\AdminController;
-
 return function (\Slim\App $app) {
     $app->get('/', HomeController::class);
     $app->get('/faq', FaqController::class);


### PR DESCRIPTION
## Summary
- remove repeated `use` statements in `src/routes.php`

## Testing
- `php --version` *(fails: command not found)*
- `composer --version` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d1596264832b862e6597a6e3fd45