### PR TITLE
Unify namespace usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SommerfestQuiz\\": "src/"
+            "App\\": "src/"
         }
     }
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace SommerfestQuiz\Controller;
+namespace App\Controller;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;

--- a/src/Controller/FaqController.php
+++ b/src/Controller/FaqController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace SommerfestQuiz\Controller;
+namespace App\Controller;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace SommerfestQuiz\Controller;
+namespace App\Controller;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,9 +1,9 @@
 <?php
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use SommerfestQuiz\Controller\HomeController;
-use SommerfestQuiz\Controller\FaqController;
-use SommerfestQuiz\Controller\AdminController;
+use App\Controller\HomeController;
+use App\Controller\FaqController;
+use App\Controller\AdminController;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';


### PR DESCRIPTION
## Summary
- switch autoload namespace to `App` in composer.json
- update controllers and routes to use `App` namespace

## Testing
- `composer dump-autoload` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6849d2b07bb4832b804efa4f34b55750