### PR TITLE
Add manual composer install workflow

### DIFF
--- a/.github/workflows/composer-install.yml
+++ b/.github/workflows/composer-install.yml
@@ -1,0 +1,34 @@
+name: Manual Composer Install
+
+on:
+  workflow_dispatch:
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+
+      - name: Commit updated composer.lock
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          if [ -n "$(git status --porcelain composer.lock)" ]; then
+            git add composer.lock
+            git commit -m "Update composer.lock via workflow"
+            git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Die HTML-Validierung laesst sich mit Python testen:
 python3 tests/test_html_validity.py
 ```
 
+## Composer-Abhaengigkeiten aktualisieren
+
+Mit dem manuellen Workflow **Manual Composer Install** laesst sich `composer install` direkt auf GitHub ausfuehren. Hinterlege dazu ein Repository Secret **GH_PAT** mit einem Personal Access Token, das mindestens die Rechte `repo` und `workflow` besitzt. Der Workflow verwendet dieses Token beim Push und schreibt bei Bedarf eine aktualisierte `composer.lock` zurueck ins Repository. Gestartet wird er im Actions-Menue.
+
 ## Datenschutz
 
 Alle Eingaben bleiben im Browser. Es findet keine serverseitige Speicherung statt.


### PR DESCRIPTION
## Summary
- add a workflow to run `composer install` manually and push changes with the `GH_PAT` PAT
- document the manual workflow in the README

## Testing
- `python3 -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_6849d7151f9c832bbb05992ad16744b7