### PR TITLE
Introduce services for config and catalog management

### DIFF
--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\CatalogService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class CatalogController
+{
+    private CatalogService $service;
+
+    public function __construct(CatalogService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function get(Request $request, Response $response, array $args): Response
+    {
+        $file = basename($args['file']);
+        $content = $this->service->read($file);
+        if ($content === null) {
+            return $response->withStatus(404);
+        }
+
+        $response->getBody()->write($content);
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    public function post(Request $request, Response $response, array $args): Response
+    {
+        $file = basename($args['file']);
+        $data = $request->getParsedBody();
+        if ($request->getHeaderLine('Content-Type') === 'application/json') {
+            $data = json_decode((string) $request->getBody(), true);
+        }
+
+        $this->service->write($file, $data ?? []);
+
+        return $response->withStatus(204);
+    }
+}

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\ConfigService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class ConfigController
+{
+    private ConfigService $service;
+
+    public function __construct(ConfigService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function get(Request $request, Response $response): Response
+    {
+        $content = $this->service->getJs();
+        if ($content === null) {
+            return $response->withStatus(404);
+        }
+
+        $response->getBody()->write($content);
+        return $response->withHeader('Content-Type', 'text/javascript');
+    }
+
+    public function post(Request $request, Response $response): Response
+    {
+        $data = $request->getParsedBody();
+        if ($request->getHeaderLine('Content-Type') === 'application/json') {
+            $data = json_decode((string) $request->getBody(), true);
+        }
+
+        $this->service->saveConfig($data ?? []);
+
+        return $response->withStatus(204);
+    }
+}

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class CatalogService
+{
+    private string $basePath;
+
+    public function __construct(string $basePath)
+    {
+        $this->basePath = rtrim($basePath, '/');
+    }
+
+    private function path(string $file): string
+    {
+        return $this->basePath . '/' . basename($file);
+    }
+
+    public function read(string $file): ?string
+    {
+        $path = $this->path($file);
+        if (!file_exists($path)) {
+            return null;
+        }
+
+        return file_get_contents($path);
+    }
+
+    /**
+     * @param array|string $data
+     */
+    public function write(string $file, $data): void
+    {
+        $path = $this->path($file);
+        if (is_array($data)) {
+            $data = json_encode($data, JSON_PRETTY_PRINT);
+        }
+
+        file_put_contents($path, (string) $data);
+    }
+}

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class ConfigService
+{
+    private string $path;
+
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    public function getJs(): ?string
+    {
+        if (!file_exists($this->path)) {
+            return null;
+        }
+
+        return file_get_contents($this->path);
+    }
+
+    public function getConfig(): array
+    {
+        $content = $this->getJs();
+        if ($content === null) {
+            return [];
+        }
+
+        $prefix = 'window.quizConfig = ';
+        if (str_starts_with($content, $prefix)) {
+            $json = trim(substr($content, strlen($prefix)));
+        } else {
+            $json = trim($content);
+        }
+
+        $json = rtrim($json, ";\n");
+
+        return json_decode($json, true) ?? [];
+    }
+
+    public function saveConfig(array $data): void
+    {
+        $content = 'window.quizConfig = ' . json_encode($data, JSON_PRETTY_PRINT) . "\n";
+        file_put_contents($this->path, $content);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ConfigService` for reading and writing `config.js`
- add `CatalogService` to manage JSON catalog files
- provide `ConfigController` and `CatalogController` that use the services
- wire up controllers in `routes.php`

## Testing
- `python3 tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6849d9508cc4832b97535264159f665e