### PR TITLE
Add controller and service tests

### DIFF
--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class AdminControllerTest extends TestCase
+{
+    public function testAdminPage(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/admin');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Controller\CatalogController;
+use App\Service\CatalogService;
+use Tests\TestCase;
+use Slim\Psr7\Response;
+
+class CatalogControllerTest extends TestCase
+{
+    public function testGetNotFound(): void
+    {
+        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
+        mkdir($dir);
+        $controller = new CatalogController(new CatalogService($dir));
+        $request = $this->createRequest('GET', '/kataloge/missing.json');
+        $response = $controller->get($request, new Response(), ['file' => 'missing.json']);
+        $this->assertEquals(404, $response->getStatusCode());
+        rmdir($dir);
+    }
+
+    public function testPostAndGet(): void
+    {
+        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
+        mkdir($dir);
+        $service = new CatalogService($dir);
+        $controller = new CatalogController($service);
+
+        $request = $this->createRequest('POST', '/kataloge/test.json');
+        $request = $request->withParsedBody(['a' => 1]);
+        $postResponse = $controller->post($request, new Response(), ['file' => 'test.json']);
+        $this->assertEquals(204, $postResponse->getStatusCode());
+
+        $getResponse = $controller->get($this->createRequest('GET', '/kataloge/test.json'), new Response(), ['file' => 'test.json']);
+        $this->assertEquals(200, $getResponse->getStatusCode());
+        $this->assertJsonStringEqualsJsonString('{"a":1}', (string) $getResponse->getBody());
+
+        unlink($dir . '/test.json');
+        rmdir($dir);
+    }
+}

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Controller\ConfigController;
+use App\Service\ConfigService;
+use Tests\TestCase;
+use Slim\Psr7\Response;
+
+class ConfigControllerTest extends TestCase
+{
+    public function testGetNotFound(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'config');
+        unlink($tmp);
+        $controller = new ConfigController(new ConfigService($tmp));
+        $request = $this->createRequest('GET', '/config.js');
+        $response = $controller->get($request, new Response());
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testPostAndGet(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'config');
+        $service = new ConfigService($tmp);
+        $controller = new ConfigController($service);
+
+        $request = $this->createRequest('POST', '/config.js');
+        $request = $request->withParsedBody(['foo' => 'bar']);
+        $postResponse = $controller->post($request, new Response());
+        $this->assertEquals(204, $postResponse->getStatusCode());
+
+        $getResponse = $controller->get($this->createRequest('GET', '/config.js'), new Response());
+        $this->assertEquals(200, $getResponse->getStatusCode());
+        $this->assertStringContainsString('foo', (string) $getResponse->getBody());
+
+        unlink($tmp);
+    }
+}

--- a/tests/Controller/FaqControllerTest.php
+++ b/tests/Controller/FaqControllerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class FaqControllerTest extends TestCase
+{
+    public function testFaqPage(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/faq');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class HomeControllerTest extends TestCase
+{
+    public function testHomePage(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\CatalogService;
+use Tests\TestCase;
+
+class CatalogServiceTest extends TestCase
+{
+    public function testReadWrite(): void
+    {
+        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
+        mkdir($dir);
+        $service = new CatalogService($dir);
+        $file = 'test.json';
+        $data = ['a' => 1];
+
+        $service->write($file, $data);
+        $this->assertJsonStringEqualsJsonString(json_encode($data, JSON_PRETTY_PRINT), $service->read($file));
+
+        unlink($dir . '/' . $file);
+        rmdir($dir);
+    }
+
+    public function testReadReturnsNullIfMissing(): void
+    {
+        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
+        mkdir($dir);
+        $service = new CatalogService($dir);
+
+        $this->assertNull($service->read('missing.json'));
+
+        rmdir($dir);
+    }
+}

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\ConfigService;
+use Tests\TestCase;
+
+class ConfigServiceTest extends TestCase
+{
+    public function testReadWriteConfig(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'config');
+        $service = new ConfigService($tmp);
+        $data = ['foo' => 'bar'];
+
+        $service->saveConfig($data);
+        $this->assertFileExists($tmp);
+        $expected = 'window.quizConfig = ' . json_encode($data, JSON_PRETTY_PRINT) . "\n";
+        $this->assertSame($expected, $service->getJs());
+        $this->assertEquals($data, $service->getConfig());
+
+        unlink($tmp);
+    }
+
+    public function testGetJsReturnsNullIfFileMissing(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'config');
+        unlink($tmp);
+        $service = new ConfigService($tmp);
+
+        $this->assertNull($service->getJs());
+        $this->assertEquals([], $service->getConfig());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,8 @@ use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\Headers;
 use Slim\Psr7\Request as SlimRequest;
 use Slim\Psr7\Uri;
+use Slim\Views\Twig;
+use Slim\Views\TwigMiddleware;
 
 class TestCase extends PHPUnit_TestCase
 {
@@ -30,6 +32,9 @@ class TestCase extends PHPUnit_TestCase
 
         // Instantiate the app
         $app = AppFactory::create();
+
+        $twig = Twig::create(__DIR__ . '/../templates', ['cache' => false]);
+        $app->add(TwigMiddleware::create($app, $twig));
 
         // Register error middleware
         $app->addErrorMiddleware($settings['displayErrorDetails'], true, true);
@@ -52,7 +57,7 @@ class TestCase extends PHPUnit_TestCase
     protected function createRequest(
         string $method,
         string $path,
-        array $headers = ['HTTP_ACCEPT' => 'application/json'],
+        array $headers = ['HTTP_ACCEPT' => 'text/html'],
         array $cookies = [],
         array $serverParams = []
     ): Request {


### PR DESCRIPTION
## Summary
- update test bootstrap to register Twig
- cover controllers with basic route tests
- add tests for ConfigService and CatalogService
- keep HTML validity test intact

## Testing
- `python3 tests/test_html_validity.py`
- `vendor/bin/phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dd6aa078832b81ea277bcb9378af