### PR TITLE
Add eight new station question catalogs

### DIFF
--- a/kataloge/catalogs.json
+++ b/kataloge/catalogs.json
@@ -10,5 +10,53 @@
     "file": "fragen_it.json",
     "name": "IT-Katalog",
     "description": "Fragen rund um Computer und Technik"
+  },
+  {
+    "id": "station_1",
+    "file": "station_1.json",
+    "name": "Station-1",
+    "description": "Einfache IT-Fragen"
+  },
+  {
+    "id": "station_2",
+    "file": "station_2.json",
+    "name": "Station-2",
+    "description": "Einfache IT-Fragen"
+  },
+  {
+    "id": "station_3",
+    "file": "station_3.json",
+    "name": "Station-3",
+    "description": "Einfache IT-Fragen"
+  },
+  {
+    "id": "station_4",
+    "file": "station_4.json",
+    "name": "Station-4",
+    "description": "Einfache IT-Fragen"
+  },
+  {
+    "id": "station_5",
+    "file": "station_5.json",
+    "name": "Station-5",
+    "description": "Einfache IT-Fragen"
+  },
+  {
+    "id": "station_6",
+    "file": "station_6.json",
+    "name": "Station-6",
+    "description": "Einfache IT-Fragen"
+  },
+  {
+    "id": "station_7",
+    "file": "station_7.json",
+    "name": "Station-7",
+    "description": "Einfache IT-Fragen"
+  },
+  {
+    "id": "station_8",
+    "file": "station_8.json",
+    "name": "Station-8",
+    "description": "Einfache IT-Fragen"
   }
 ]

--- a/kataloge/station_1.json
+++ b/kataloge/station_1.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "mc",
+    "prompt": "Womit kann man Daten auf einem USB-Stick speichern?",
+    "options": ["Bilder", "Tintenpatronen", "Wasser"],
+    "answers": [0]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne die Ger\u00e4te der richtigen Funktion zu:",
+    "terms": [
+      {"term": "Maus", "definition": "Zeigeger\u00e4t"},
+      {"term": "Monitor", "definition": "Bildausgabe"},
+      {"term": "Tastatur", "definition": "Eingabeger\u00e4t"}
+    ]
+  },
+  {
+    "type": "sort",
+    "prompt": "Sortiere die Dateigr\u00f6\u00dfen (klein zu gro\u00df):",
+    "items": ["KB", "MB", "GB"]
+  }
+]

--- a/kataloge/station_2.json
+++ b/kataloge/station_2.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "mc",
+    "prompt": "Welche Taste schlie\u00dft ein Fenster?",
+    "options": ["Esc", "Enter", "F1"],
+    "answers": [0]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne die Symbole dem richtigen Zweck zu:",
+    "terms": [
+      {"term": "Ordner", "definition": "Ablage f\u00fcr Dateien"},
+      {"term": "Papierkorb", "definition": "Hier landen gel\u00f6schte Dateien"},
+      {"term": "Lupe", "definition": "Suchfunktion"}
+    ]
+  },
+  {
+    "type": "sort",
+    "prompt": "Bringe die Schritte beim Starten eines Computers in die richtige Reihenfolge:",
+    "items": ["Einschalten", "Betriebssystem l\u00e4dt", "Anmelden"]
+  }
+]

--- a/kataloge/station_3.json
+++ b/kataloge/station_3.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "mc",
+    "prompt": "Wof\u00fcr steht die Abk\u00fcrzung 'WWW'?",
+    "options": ["World Wide Web", "Warm Water World", "Wild West War"],
+    "answers": [0]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne die Speicherarten zu:",
+    "terms": [
+      {"term": "RAM", "definition": "Kurzzeit-Speicher"},
+      {"term": "Festplatte", "definition": "Langzeit-Speicher"},
+      {"term": "Cache", "definition": "Zwischenspeicher"}
+    ]
+  },
+  {
+    "type": "sort",
+    "prompt": "Sortiere die Kabeltypen nach Datenrate (langsam zu schnell):",
+    "items": ["USB 2.0", "USB 3.0", "Thunderbolt"]
+  }
+]

--- a/kataloge/station_4.json
+++ b/kataloge/station_4.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "mc",
+    "prompt": "Was zeigt der Mauszeiger beim Laden?",
+    "options": ["Sanduhr", "Smiley", "Kreuz"],
+    "answers": [0]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne die Begriffe der passenden Erkl\u00e4rung zu:",
+    "terms": [
+      {"term": "Browser", "definition": "Programm zum Surfen"},
+      {"term": "E-Mail", "definition": "Elektronischer Brief"},
+      {"term": "Firewall", "definition": "Sch\u00fctzt vor unerw\u00fcnschten Zugriffen"}
+    ]
+  },
+  {
+    "type": "sort",
+    "prompt": "Ordne die Ger\u00e4te nach Gr\u00f6\u00dfe (klein zu gro\u00df):",
+    "items": ["Smartphone", "Laptop", "Desktop-PC"]
+  }
+]

--- a/kataloge/station_5.json
+++ b/kataloge/station_5.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "mc",
+    "prompt": "Welches Zahlensystem nutzt ein Computer intern?",
+    "options": ["Dezimalsystem", "Bin\u00e4rsystem", "R\u00f6mische Zahlen"],
+    "answers": [1]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne das Programm dem Zweck zu:",
+    "terms": [
+      {"term": "Textverarbeitung", "definition": "Briefe schreiben"},
+      {"term": "Tabellenkalkulation", "definition": "Berechnungen erstellen"},
+      {"term": "Bildbearbeitung", "definition": "Fotos retuschieren"}
+    ]
+  },
+  {
+    "type": "sort",
+    "prompt": "Sortiere die Drahtlos-Techniken nach Reichweite (kurz zu lang):",
+    "items": ["NFC", "WLAN", "Mobilfunk"]
+  }
+]

--- a/kataloge/station_6.json
+++ b/kataloge/station_6.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "mc",
+    "prompt": "Was ist eine URL?",
+    "options": ["Webadresse", "Programmiersprache", "Grafikformat"],
+    "answers": [0]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne die Dateitypen dem Programm zu:",
+    "terms": [
+      {"term": ".docx", "definition": "Textverarbeitung"},
+      {"term": ".jpg", "definition": "Bilddatei"},
+      {"term": ".mp3", "definition": "Audio"}
+    ]
+  },
+  {
+    "type": "sort",
+    "prompt": "Bringe die Schritte zum Speichern einer Datei in die richtige Reihenfolge:",
+    "items": ["Datei-Men\u00fc \u00f6ffnen", "Speichern anklicken", "Name w\u00e4hlen und best\u00e4tigen"]
+  }
+]

--- a/kataloge/station_7.json
+++ b/kataloge/station_7.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "mc",
+    "prompt": "Welche Tastenkombination kopiert markierten Text?",
+    "options": ["Strg+C", "Strg+V", "Strg+X"],
+    "answers": [0]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne die Netzwerkbegriffe zu:",
+    "terms": [
+      {"term": "Router", "definition": "verbindet Netzwerke"},
+      {"term": "LAN", "definition": "lokales Netzwerk"},
+      {"term": "WLAN", "definition": "kabelloses Netzwerk"}
+    ]
+  },
+  {
+    "type": "sort",
+    "prompt": "Sortiere die Internet-Geschwindigkeiten (langsam zu schnell):",
+    "items": ["ISDN", "DSL", "Glasfaser"]
+  }
+]

--- a/kataloge/station_8.json
+++ b/kataloge/station_8.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "mc",
+    "prompt": "Was bedeutet 'Cloud' in der IT?",
+    "options": ["Speicherung im Internet", "Regenwolke", "Neues Betriebssystem"],
+    "answers": [0]
+  },
+  {
+    "type": "assign",
+    "prompt": "Ordne die Schaltfl\u00e4chen der Bedeutung zu:",
+    "terms": [
+      {"term": "Play", "definition": "Startet die Wiedergabe"},
+      {"term": "Pause", "definition": "Unterbricht"},
+      {"term": "Stop", "definition": "Beendet"}
+    ]
+  },
+  {
+    "type": "sort",
+    "prompt": "Sortiere die Schritte beim Herunterfahren eines PCs:",
+    "items": ["Startmen\u00fc \u00f6ffnen", "Herunterfahren w\u00e4hlen", "Best\u00e4tigen"]
+  }
+]


### PR DESCRIPTION
## Summary
- add Station-1 through Station-8 quiz catalogs
- register new stations in `catalogs.json`

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python3 tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6849dfedb3ec832ba1d48248e66eb762