### PR TITLE
Update quiz info section

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -39,38 +39,11 @@
     </div>
     <div class="uk-card uk-card-default uk-card-body uk-margin">
       <h3 class="uk-heading-bullet">Informationen zur Quiz-Anwendung</h3>
-      <p>Dieses Tool ist ein reiner Prototyp, der zu 100% mit Codex von OpenAI umgesetzt wurde. Die Arbeit diente ausschließlich der Erprobung des Coding-Assistenten und seiner Möglichkeiten.</p>
-      <p>Der Quellcode befindet sich auf GitHub: <a href="https://github.com/bastelix/sommerfest-quiz">https://github.com/bastelix/sommerfest-quiz</a>.</p>
-      <ul uk-accordion>
-        <li>
-          <a class="uk-accordion-title" href="#">Der Code steht unter der MIT-Lizenz. Siehe die Datei <code>LICENSE</code> f&uuml;r Details.</a>
-          <div class="uk-accordion-content">
-            <pre><code>MIT License
-
-Copyright (c) 2025 calhelp
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"),
-to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</code></pre>
-          </div>
-        </li>
-      </ul>
-      <p><strong>Datenschutz:</strong> Das Quiz l&auml;uft komplett im Browser und speichert Ergebnisse nur lokal im <code>localStorage</code>. Es werden keine personenbezogenen Daten an einen Server &uuml;bertragen. Beim Export der Datei <code>statistical.log</code> werden lediglich Pseudonyme und Punktzahlen gespeichert.</p>
+      <p>Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer engen Zusammenarbeit von menschlicher Erfahrung und k&uuml;nstlicher Intelligenz. Die Ideen, das Projektmanagement und die Praxiserfahrung aus vielen Softwareprojekten stammen von Menschenhand &ndash; alle Codezeilen und Optimierungen wurden jedoch bewusst vollst&auml;ndig vom OpenAI Codex Coding-Assistenten generiert.</p>
+      <p>Dieses Projekt zeigt, wie KI-Technologie bereits heute in der Softwareentwicklung eingesetzt werden kann: Menschen liefern Kreativit&auml;t und Struktur, der KI-Assistent &uuml;bernimmt die Umsetzung im Code. So entsteht eine echte Symbiose aus menschlicher Steuerung und maschineller Programmierung.</p>
+      <p>Der Quellcode ist offen auf GitHub verf&uuml;gbar: <a href="https://github.com/bastelix/sommerfest-quiz">https://github.com/bastelix/sommerfest-quiz</a></p>
+      <p>Die Software steht unter der MIT-Lizenz (Details siehe <code>LICENSE</code>-Datei).</p>
+      <p><strong>Datenschutz:</strong> Das Quiz wird zentral &uuml;ber einen Server bereitgestellt. Je nach Einstellung k&ouml;nnen Ergebnisdaten serverseitig verarbeitet oder gespeichert werden. Personenbezogene Daten werden dabei nicht erfasst &ndash; beim Export der Datei <code>statistical.log</code> werden ausschlie&szlig;lich Pseudonyme und Punktzahlen gespeichert. Details zum Datenschutz entnehmen Sie bitte der Datenschutzerkl&auml;rung.</p>
       </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- reword info section on the home page
- clarify that stats may be stored on the server

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e84b4588832bbe702c2a7d4d3af0