### PR TITLE
Add footer with legal links

### DIFF
--- a/public/Datenschutz.html
+++ b/public/Datenschutz.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Datenschutz</title>
+  <link rel="stylesheet" href="/css/uikit.min.css">
+  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/dark.css">
+</head>
+<body class="uk-padding uk-background-muted">
+  <h1>Datenschutz</h1>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.</p>
+</body>
+</html>

--- a/public/Impressum.html
+++ b/public/Impressum.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Impressum</title>
+  <link rel="stylesheet" href="/css/uikit.min.css">
+  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/dark.css">
+</head>
+<body class="uk-padding uk-background-muted">
+  <h1>Impressum</h1>
+  <p>Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+</body>
+</html>

--- a/public/Lizenz.html
+++ b/public/Lizenz.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Lizenz</title>
+  <link rel="stylesheet" href="/css/uikit.min.css">
+  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/dark.css">
+</head>
+<body class="uk-padding uk-background-muted">
+  <h1>Lizenz</h1>
+  <p>Donec ullamcorper nulla non metus auctor fringilla.</p>
+</body>
+</html>

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -74,6 +74,11 @@ body.dark-mode .topbar {
   border-color: #444;
 }
 
+body.dark-mode .bottombar {
+  background-color: #1e1e1e;
+  border-color: #444;
+}
+
 /* Hoverfarbe für Katalogkarten im Dunkelmodus */
 body.dark-mode .uk-card-hover:hover {
   background-color: #333;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -133,6 +133,25 @@ body {
   height: 56px;
 }
 
+.bottombar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1000;
+}
+
+.bottombar .uk-navbar-item {
+  margin-left: 0.5mm;
+  margin-right: 0.5mm;
+  display: flex;
+  align-items: center;
+}
+
+.footer-placeholder {
+  height: 56px;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -9,7 +9,17 @@
 </head>
 <body class="{% block body_class %}{% endblock %}">
 {% block body %}{% endblock %}
-<script src="/js/uikit.min.js"></script>
-{% block scripts %}{% endblock %}
+  <div class="footer-placeholder"></div>
+  <nav class="uk-navbar-container bottombar" uk-navbar>
+    <div class="uk-navbar-center">
+      <ul class="uk-navbar-nav">
+        <li><a href="/Datenschutz.html">Datenschutz</a></li>
+        <li><a href="/Impressum.html">Impressum</a></li>
+        <li><a href="/Lizenz.html">Lizenz</a></li>
+      </ul>
+    </div>
+  </nav>
+  <script src="/js/uikit.min.js"></script>
+  {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add fixed footer to the base layout
- style new footer and placeholder
- support dark mode for the footer
- add static pages for Datenschutz, Impressum and Lizenz

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e968fa50832b9290ea466ef96380