### PR TITLE
Replace dark mode slider with icon

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -84,42 +84,9 @@ body {
   margin-top: -2mm;
 }
 
-.theme-switch input {
-  height: 0;
-  width: 0;
-  visibility: hidden;
-}
-
-.theme-switch-label {
-  cursor: pointer;
-  text-indent: -9999px;
-  width: 40px;
-  height: 20px;
-  background: #ccc;
-  display: block;
-  border-radius: 100px;
-  position: relative;
-}
-
-.theme-switch-label:after {
-  content: '';
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 16px;
-  height: 16px;
-  background: #fff;
-  border-radius: 90px;
-  transition: 0.3s;
-}
-
-.theme-switch input:checked + .theme-switch-label {
-  background: #1e87f0;
-}
-
-.theme-switch input:checked + .theme-switch-label:after {
-  left: calc(100% - 2px);
-  transform: translateX(-100%);
+.theme-switch button {
+  border: none;
+  background: transparent;
 }
 
 .topbar .uk-navbar-item {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4,15 +4,21 @@ document.addEventListener('DOMContentLoaded', function () {
   const isDark = localStorage.getItem('darkMode') === 'true';
   if (isDark) {
     document.body.classList.add('dark-mode', 'uk-light');
-    toggle.checked = true;
+    toggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
+  } else {
+    toggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
   }
-  toggle.addEventListener('change', function () {
-    if (this.checked) {
-      document.body.classList.add('dark-mode', 'uk-light');
+  UIkit.icon(toggle);
+  toggle.addEventListener('click', function () {
+    const dark = document.body.classList.toggle('dark-mode');
+    document.body.classList.toggle('uk-light', dark);
+    if (dark) {
       localStorage.setItem('darkMode', 'true');
+      toggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
     } else {
-      document.body.classList.remove('dark-mode', 'uk-light');
       localStorage.setItem('darkMode', 'false');
+      toggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
     }
+    UIkit.icon(toggle);
   });
 });

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -20,38 +20,9 @@
       margin-left: 8px;
       margin-top: -2mm;
     }
-    .theme-switch input {
-      height: 0;
-      width: 0;
-      visibility: hidden;
-    }
-    .theme-switch-label {
-      cursor: pointer;
-      text-indent: -9999px;
-      width: 40px;
-      height: 20px;
-      background: #ccc;
-      display: block;
-      border-radius: 100px;
-      position: relative;
-    }
-    .theme-switch-label:after {
-      content: '';
-      position: absolute;
-      top: 2px;
-      left: 2px;
-      width: 16px;
-      height: 16px;
-      background: #fff;
-      border-radius: 90px;
-      transition: 0.3s;
-    }
-    .theme-switch input:checked + .theme-switch-label {
-      background: #1e87f0;
-    }
-    .theme-switch input:checked + .theme-switch-label:after {
-      left: calc(100% - 2px);
-      transform: translateX(-100%);
+    .theme-switch button {
+      border: none;
+      background: transparent;
     }
     .topbar .uk-navbar-item {
       margin-left: 0.5mm;
@@ -74,8 +45,7 @@
     <div class="uk-navbar-right">
       <div class="uk-navbar-item">
         <div class="theme-switch">
-          <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-          <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+          <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
         </div>
       </div>
     </div>
@@ -225,22 +195,27 @@
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');
+      if(!toggle) return;
       const isDark = localStorage.getItem('darkMode') === 'true';
       if(isDark){
         document.body.classList.add('dark-mode','uk-light');
-        if(toggle) toggle.checked = true;
+        toggle.setAttribute('uk-icon','icon: moon; ratio: 2');
+      } else {
+        toggle.setAttribute('uk-icon','icon: sun; ratio: 2');
       }
-      if(toggle){
-        toggle.addEventListener('change', function(){
-          if(this.checked){
-            document.body.classList.add('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'true');
-          } else {
-            document.body.classList.remove('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'false');
-          }
-        });
-      }
+      UIkit.icon(toggle);
+      toggle.addEventListener('click', function(){
+        const dark = document.body.classList.toggle('dark-mode');
+        document.body.classList.toggle('uk-light', dark);
+        if(dark){
+          localStorage.setItem('darkMode','true');
+          toggle.setAttribute('uk-icon','icon: moon; ratio: 2');
+        } else {
+          localStorage.setItem('darkMode','false');
+          toggle.setAttribute('uk-icon','icon: sun; ratio: 2');
+        }
+        UIkit.icon(toggle);
+      });
     });
   </script>
 {% endblock %}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -14,8 +14,7 @@
     <div class="uk-navbar-left">
       <div class="uk-navbar-item">
         <div class="theme-switch">
-          <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-          <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+          <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- switch dark mode toggle to a button with sun/moon icons
- update CSS for icon button
- adjust JS for icon button

## Testing
- `pytest -q tests/test_json_validity.py`
- `pytest -q tests/test_html_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6849edc1d238832b9ebd0574368547ea