### PR TITLE
Fix missing embed tag

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -10,12 +10,10 @@
 {% block body_class %}index-page uk-padding uk-flex uk-flex-center{% endblock %}
 
 {% block body %}
-  <nav class="uk-navbar-container topbar" uk-navbar>
-    <div class="uk-navbar-left">
-      <div class="uk-navbar-item">
-        <div class="theme-switch">
-          <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
-        </div>
+  {% embed 'topbar.twig' %}
+    {% block left %}
+      <div class="theme-switch">
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
       </div>
     {% endblock %}
     {% block center %}


### PR DESCRIPTION
## Summary
- use `{% embed 'topbar.twig' %}` in `index.twig`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ef88bdc4832b9b1055bb8b6772a4