### PR TITLE
Fix topbar spacing and dark mode icon visibility

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -79,6 +79,11 @@ body.dark-mode .bottombar {
   border-color: #444;
 }
 
+body.dark-mode .uk-icon-button {
+  color: #fff;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
 /* Hoverfarbe für Katalogkarten im Dunkelmodus */
 body.dark-mode .uk-card-hover:hover {
   background-color: #333;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,9 +1,14 @@
 body {
   min-height: 100vh;
+  overflow-x: hidden;
+}
+
+body.uk-padding {
+  padding-top: 56px;
 }
 
 .index-page {
-  padding-top: 48px;
+  padding-top: 56px;
 }
 
 .sortable-list li,
@@ -76,6 +81,7 @@ body {
   left: 0;
   width: 100%;
   z-index: 1000;
+  box-sizing: border-box;
 }
 
 .theme-switch {
@@ -90,8 +96,9 @@ body {
 }
 
 .topbar .uk-navbar-item {
-  margin-left: 0.5mm;
-  margin-right: 0.5mm;
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
## Summary
- ensure page width doesn't overflow
- match index top padding with navbar height
- tweak topbar item spacing and set `box-sizing`
- improve visibility of icon buttons in dark mode

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6849f56acbdc832ba947bc8c906f46fa