### PR TITLE
Fix missing sun and moon icons

### DIFF
--- a/public/js/custom-icons.js
+++ b/public/js/custom-icons.js
@@ -1,0 +1,4 @@
+UIkit.icon.add({
+  sun: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>',
+  moon: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>'
+});

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -62,6 +62,7 @@
 
 {% block scripts %}
   <script src="js/uikit-icons.min.js"></script>
+  <script src="js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -189,6 +189,7 @@
 
 {% block scripts %}
   <script src="js/uikit-icons.min.js"></script>
+  <script src="js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -52,6 +52,7 @@
 
 {% block scripts %}
   <script src="/js/uikit-icons.min.js"></script>
+  <script src="/js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -42,6 +42,7 @@
 
 {% block scripts %}
   <script src="js/uikit-icons.min.js"></script>
+  <script src="js/custom-icons.js"></script>
   <script src="https://unpkg.com/html5-qrcode@2.3.7/html5-qrcode.min.js"></script>
   <script src="js/config.js"></script>
   <script id="catalogs-data" type="application/json">

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -30,6 +30,7 @@
 
 {% block scripts %}
   <script src="/js/uikit-icons.min.js"></script>
+  <script src="/js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');


### PR DESCRIPTION
## Summary
- register custom sun and moon SVGs for UIkit
- load the new icon set in all templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849f70076d4832bb0d1385948e46465