### PR TITLE
Fix dark mode toggle on subpages

### DIFF
--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -16,8 +16,7 @@
     {% endblock %}
     {% block right %}
       <div class="theme-switch">
-        <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-        <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
       </div>
     {% endblock %}
   {% endembed %}
@@ -62,25 +61,5 @@
 
 {% block scripts %}
   <script src="js/uikit-icons.min.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function(){
-      const toggle = document.getElementById('theme-toggle');
-      const isDark = localStorage.getItem('darkMode') === 'true';
-      if(isDark){
-        document.body.classList.add('dark-mode','uk-light');
-        if(toggle) toggle.checked = true;
-      }
-      if(toggle){
-        toggle.addEventListener('change', function(){
-          if(this.checked){
-            document.body.classList.add('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'true');
-          } else {
-            document.body.classList.remove('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'false');
-          }
-        });
-      }
-    });
-  </script>
+  <script src="js/app.js"></script>
 {% endblock %}

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -42,8 +42,7 @@
       {% endblock %}
       {% block right %}
         <div class="theme-switch">
-          <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-          <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+          <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
         </div>
       {% endblock %}
     {% endembed %}
@@ -189,30 +188,5 @@
 
 {% block scripts %}
   <script src="js/uikit-icons.min.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function(){
-      const toggle = document.getElementById('theme-toggle');
-      if(!toggle) return;
-      const isDark = localStorage.getItem('darkMode') === 'true';
-      if(isDark){
-        document.body.classList.add('dark-mode','uk-light');
-        toggle.setAttribute('uk-icon','icon: moon; ratio: 2');
-      } else {
-        toggle.setAttribute('uk-icon','icon: sun; ratio: 2');
-      }
-      UIkit.icon(toggle);
-      toggle.addEventListener('click', function(){
-        const dark = document.body.classList.toggle('dark-mode');
-        document.body.classList.toggle('uk-light', dark);
-        if(dark){
-          localStorage.setItem('darkMode','true');
-          toggle.setAttribute('uk-icon','icon: moon; ratio: 2');
-        } else {
-          localStorage.setItem('darkMode','false');
-          toggle.setAttribute('uk-icon','icon: sun; ratio: 2');
-        }
-        UIkit.icon(toggle);
-      });
-    });
-  </script>
+  <script src="js/app.js"></script>
 {% endblock %}

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -16,8 +16,7 @@
     {% endblock %}
     {% block right %}
       <div class="theme-switch">
-        <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-        <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
       </div>
     {% endblock %}
   {% endembed %}
@@ -52,25 +51,5 @@
 
 {% block scripts %}
   <script src="/js/uikit-icons.min.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function(){
-      const toggle = document.getElementById('theme-toggle');
-      const isDark = localStorage.getItem('darkMode') === 'true';
-      if(isDark){
-        document.body.classList.add('dark-mode','uk-light');
-        if(toggle) toggle.checked = true;
-      }
-      if(toggle){
-        toggle.addEventListener('change', function(){
-          if(this.checked){
-            document.body.classList.add('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'true');
-          } else {
-            document.body.classList.remove('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'false');
-          }
-        });
-      }
-    });
-  </script>
+  <script src="/js/app.js"></script>
 {% endblock %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -16,8 +16,7 @@
     {% endblock %}
     {% block right %}
       <div class="theme-switch">
-        <input type="checkbox" id="theme-toggle" aria-label="Design wechseln">
-        <label for="theme-toggle" class="theme-switch-label">Design wechseln</label>
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
       </div>
     {% endblock %}
   {% endembed %}
@@ -30,25 +29,5 @@
 
 {% block scripts %}
   <script src="/js/uikit-icons.min.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function(){
-      const toggle = document.getElementById('theme-toggle');
-      const isDark = localStorage.getItem('darkMode') === 'true';
-      if(isDark){
-        document.body.classList.add('dark-mode','uk-light');
-        if(toggle) toggle.checked = true;
-      }
-      if(toggle){
-        toggle.addEventListener('change', function(){
-          if(this.checked){
-            document.body.classList.add('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'true');
-          } else {
-            document.body.classList.remove('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'false');
-          }
-        });
-      }
-    });
-  </script>
+  <script src="/js/app.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace checkbox toggle with icon button on all subpages
- load shared `app.js` for theme switching

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -k test_json_validity`


------
https://chatgpt.com/codex/tasks/task_e_6849f739ef90832b8d6346465f8c8515