### PR TITLE
Enable catalog deep link

### DIFF
--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -20,6 +20,15 @@ class CatalogController
     public function get(Request $request, Response $response, array $args): Response
     {
         $file = basename($args['file']);
+        $accept = $request->getHeaderLine('Accept');
+
+        if (strpos($accept, 'text/html') !== false) {
+            $id = pathinfo($file, PATHINFO_FILENAME);
+            return $response
+                ->withHeader('Location', '/?katalog=' . urlencode($id))
+                ->withStatus(302);
+        }
+
         $content = $this->service->read($file);
         if ($content === null) {
             return $response->withStatus(404);

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -16,7 +16,7 @@ class CatalogControllerTest extends TestCase
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
         $controller = new CatalogController(new CatalogService($dir));
-        $request = $this->createRequest('GET', '/kataloge/missing.json');
+        $request = $this->createRequest('GET', '/kataloge/missing.json', ['HTTP_ACCEPT' => 'application/json']);
         $response = $controller->get($request, new Response(), ['file' => 'missing.json']);
         $this->assertEquals(404, $response->getStatusCode());
         rmdir($dir);
@@ -34,7 +34,11 @@ class CatalogControllerTest extends TestCase
         $postResponse = $controller->post($request, new Response(), ['file' => 'test.json']);
         $this->assertEquals(204, $postResponse->getStatusCode());
 
-        $getResponse = $controller->get($this->createRequest('GET', '/kataloge/test.json'), new Response(), ['file' => 'test.json']);
+        $getResponse = $controller->get(
+            $this->createRequest('GET', '/kataloge/test.json', ['HTTP_ACCEPT' => 'application/json']),
+            new Response(),
+            ['file' => 'test.json']
+        );
         $this->assertEquals(200, $getResponse->getStatusCode());
         $this->assertJsonStringEqualsJsonString('{"a":1}', (string) $getResponse->getBody());
 


### PR DESCRIPTION
## Summary
- redirect requests to `/kataloge/<file>.json` with `Accept: text/html` back to the main page so a catalog link starts the quiz
- adjust tests to request JSON when verifying the CatalogController

## Testing
- `pytest -q`
- ❌ `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849f7968d40832b94a625154ae0628e