### PR TITLE
Fix theme toggle icons and load scripts correctly

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4,9 +4,11 @@ document.addEventListener('DOMContentLoaded', function () {
   const isDark = localStorage.getItem('darkMode') === 'true';
   if (isDark) {
     document.body.classList.add('dark-mode', 'uk-light');
-    toggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
-  } else {
+    // show sun icon when dark mode is active
     toggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
+  } else {
+    // show moon icon when light mode is active
+    toggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
   }
   UIkit.icon(toggle);
   toggle.addEventListener('click', function () {
@@ -14,10 +16,12 @@ document.addEventListener('DOMContentLoaded', function () {
     document.body.classList.toggle('uk-light', dark);
     if (dark) {
       localStorage.setItem('darkMode', 'true');
-      toggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
+      // after enabling dark mode show sun icon
+      toggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
     } else {
       localStorage.setItem('darkMode', 'false');
-      toggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
+      // after disabling dark mode show moon icon
+      toggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
     }
     UIkit.icon(toggle);
   });

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -16,7 +16,7 @@
     {% endblock %}
     {% block right %}
       <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
       </div>
     {% endblock %}
   {% endembed %}
@@ -60,9 +60,9 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="js/uikit-icons.min.js"></script>
-  <script src="js/app.js"></script>
-  <script src="js/custom-icons.js"></script>
+  <script src="/js/uikit-icons.min.js"></script>
+  <script src="/js/app.js"></script>
+  <script src="/js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -42,7 +42,7 @@
       {% endblock %}
       {% block right %}
         <div class="theme-switch">
-          <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
+          <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
         </div>
       {% endblock %}
     {% endembed %}
@@ -187,9 +187,9 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="js/uikit-icons.min.js"></script>
-  <script src="js/app.js"></script>
-  <script src="js/custom-icons.js"></script>
+  <script src="/js/uikit-icons.min.js"></script>
+  <script src="/js/app.js"></script>
+  <script src="/js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -16,7 +16,7 @@
     {% endblock %}
     {% block right %}
       <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
       </div>
     {% endblock %}
   {% endembed %}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -13,7 +13,7 @@
   {% embed 'topbar.twig' %}
     {% block left %}
       <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
       </div>
     {% endblock %}
     {% block center %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -16,7 +16,7 @@
     {% endblock %}
     {% block right %}
       <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: sun; ratio: 2" aria-label="Design wechseln"></button>
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
       </div>
     {% endblock %}
   {% endembed %}


### PR DESCRIPTION
## Summary
- ensure dark mode toggle shows the opposite icon
- fix script paths for FAQ and Datenschutz pages
- load moon icon by default on all pages

## Testing
- `pytest -q`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fa0859c4832b9425b040d0722a07