### PR TITLE
Fix dark mode styling for scan modal

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -89,6 +89,12 @@ body.dark-mode .uk-icon-button {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
+/* Styles fuer QR-Scan-Popup im Dunkelmodus */
+body.dark-mode .uk-modal-dialog {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+
 /* Hoverfarbe für Katalogkarten im Dunkelmodus */
 body.dark-mode .uk-card-hover:hover {
   background-color: #333;


### PR DESCRIPTION
## Summary
- apply dark colors to the UIkit modal used for scanning

## Testing
- `pytest -k test_json_validity.py`
- `pytest -k test_html_validity.py`
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fc465e7c832ba3a0818f6a048b02