### PR TITLE
Fix asset paths for subdirectory deployment

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -3,7 +3,7 @@
 {% block title %}Quiz Verwaltung{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="css/main.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -105,6 +105,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/config.js"></script>
-  <script src="/js/admin.js"></script>
+  <script src="js/config.js"></script>
+  <script src="js/admin.js"></script>
 {% endblock %}

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -3,8 +3,8 @@
 {% block title %}Datenschutz{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/dark.css">
-  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="css/dark.css">
+  <link rel="stylesheet" href="css/main.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -60,9 +60,9 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/custom-icons.js"></script>
+  <script src="js/uikit-icons.min.js"></script>
+  <script src="js/app.js"></script>
+  <script src="js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -3,7 +3,7 @@
 {% block title %}FAQ{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/dark.css">
+  <link rel="stylesheet" href="css/dark.css">
   <style>
     body {
       padding-top: 96px;
@@ -187,9 +187,9 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/custom-icons.js"></script>
+  <script src="js/uikit-icons.min.js"></script>
+  <script src="js/app.js"></script>
+  <script src="js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -3,8 +3,8 @@
 {% block title %}Impressum{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/dark.css">
-  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="css/dark.css">
+  <link rel="stylesheet" href="css/main.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -50,9 +50,9 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/custom-icons.js"></script>
+  <script src="js/uikit-icons.min.js"></script>
+  <script src="js/app.js"></script>
+  <script src="js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -3,8 +3,8 @@
 {% block title %}Modernes Quiz mit UIkit{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/dark.css">
-  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="css/dark.css">
+  <link rel="stylesheet" href="css/main.css">
 {% endblock %}
 
 {% block body_class %}index-page uk-padding uk-flex uk-flex-center{% endblock %}
@@ -44,7 +44,7 @@
   <script src="js/uikit-icons.min.js"></script>
   <script src="js/custom-icons.js"></script>
   <script src="https://unpkg.com/html5-qrcode@2.3.7/html5-qrcode.min.js"></script>
-  <script src="/js/config.js"></script>
+  <script src="js/config.js"></script>
   <script id="catalogs-data" type="application/json">
     [
       {
@@ -97,8 +97,8 @@
       }
     ]
   </script>
-  <script src="/js/catalog.js"></script>
-  <script src="/js/confetti.js"></script>
-  <script src="/js/quiz.js"></script>
-  <script src="/js/app.js"></script>
+  <script src="js/catalog.js"></script>
+  <script src="js/confetti.js"></script>
+  <script src="js/quiz.js"></script>
+  <script src="js/app.js"></script>
 {% endblock %}

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>{% block title %}Quiz{% endblock %}</title>
-  <link rel="stylesheet" href="/css/uikit.min.css">
+  <link rel="stylesheet" href="css/uikit.min.css">
   {% block head %}{% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}">
@@ -19,7 +19,7 @@
       </ul>
     </div>
   </nav>
-  <script src="/js/uikit.min.js"></script>
+  <script src="js/uikit.min.js"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -3,8 +3,8 @@
 {% block title %}Lizenz{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="/css/dark.css">
-  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="css/dark.css">
+  <link rel="stylesheet" href="css/main.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -28,9 +28,9 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
-  <script src="/js/app.js"></script>
-  <script src="/js/custom-icons.js"></script>
+  <script src="js/uikit-icons.min.js"></script>
+  <script src="js/app.js"></script>
+  <script src="js/custom-icons.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function(){
       const toggle = document.getElementById('theme-toggle');


### PR DESCRIPTION
## Summary
- use relative paths for CSS and JS assets
- ensures quiz scripts load when served from subdirectories

## Testing
- `pytest -q tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a002ace3c832b9118203b9e82f908