### PR TITLE
Fix Docker router

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,8 @@ services:
       - VIRTUAL_HOST=${DOMAIN}
       - LETSENCRYPT_HOST=${DOMAIN}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
-    command: php -S 0.0.0.0:8080 -t public
+    # Use router.php so that Slim handles routes for non-existent static files
+    command: php -S 0.0.0.0:8080 -t public router.php
     expose:
       - "8080"
     networks:


### PR DESCRIPTION
## Summary
- ensure PHP built-in server uses router.php so Slim handles quiz catalog routes

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a022c2da0832b83ea261c80e05fec