### PR TITLE
Disable mandatory QR login

### DIFF
--- a/public/js/config.js
+++ b/public/js/config.js
@@ -17,5 +17,5 @@ window.quizConfig = {
   CheckAnswerButton: 'no',
 
   // QR-Code-Login aktivieren (true/false)
-  QRUser: true
+  QRUser: false
 };


### PR DESCRIPTION
## Summary
- turn off QR code login in the default configuration so catalogs start immediately

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a02f43a2c832bb6ba76db1a58e538