### PR TITLE
Fix router script path in docs and compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Das **Sommerfest-Quiz** ist eine sofort einsetzbare Web-App, mit der Sie Besuche
    ```
 2. Server starten (z.B. für lokale Tests):
    ```bash
-   php -S localhost:8080 -t public router.php
+   php -S localhost:8080 -t public public/router.php
    ```
    Anschließend ist das Quiz unter <http://localhost:8080> aufrufbar.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - LETSENCRYPT_HOST=${DOMAIN}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
     # Use router.php so that Slim handles routes for non-existent static files
-    command: php -S 0.0.0.0:8080 -t public router.php
+    command: php -S 0.0.0.0:8080 -t public public/router.php
     expose:
       - "8080"
     networks:


### PR DESCRIPTION
## Summary
- fix documentation instructions to use `public/router.php`
- update docker-compose to use correct router path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a05ca2f74832ba737f430702ecee9