### PR TITLE
Improve catalog link handling

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const cat = catalogs.find(c => c.id === id);
     if (!cat) return;
     catalogFile = cat.file;
-    fetch('/kataloge/' + catalogFile)
+    fetch('/kataloge/' + catalogFile, { headers: { 'Accept': 'application/json' } })
       .then(r => r.json())
       .then(data => {
         initial = data;
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', function () {
       });
   }
 
-  fetch('/kataloge/catalogs.json')
+  fetch('/kataloge/catalogs.json', { headers: { 'Accept': 'application/json' } })
     .then(r => r.json())
     .then(list => {
       catalogs = list;

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -61,7 +61,7 @@
   }
   async function loadCatalogList(){
     try{
-      const res = await fetch('/kataloge/catalogs.json');
+      const res = await fetch('/kataloge/catalogs.json', { headers: { 'Accept': 'application/json' } });
       if(res.ok){
         return await res.json();
       }
@@ -81,7 +81,7 @@
 
   async function loadQuestions(id, file){
     try{
-      const res = await fetch('/kataloge/' + file);
+      const res = await fetch('/kataloge/' + file, { headers: { 'Accept': 'application/json' } });
       const data = await res.json();
       window.quizQuestions = data;
       if(window.startQuiz){

--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -20,9 +20,9 @@ class CatalogController
     public function get(Request $request, Response $response, array $args): Response
     {
         $file = basename($args['file']);
-        $accept = $request->getHeaderLine('Accept');
+        $accept = strtolower($request->getHeaderLine('Accept'));
 
-        if (strpos($accept, 'text/html') !== false) {
+        if ($accept === '' || strpos($accept, 'application/json') === false) {
             $id = pathinfo($file, PATHINFO_FILENAME);
             return $response
                 ->withHeader('Location', '/?katalog=' . urlencode($id))


### PR DESCRIPTION
## Summary
- redirect catalog requests to HTML unless JSON is explicitly requested
- ensure JS fetches request JSON from catalog APIs

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_684a09621ae4832b86ee009911ad1603