### PR TITLE
Add unified JSON config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Das **Sommerfest-Quiz** ist eine sofort einsetzbare Web-App, mit der Sie Besuche
 
 - **Einfache Installation**: Nur Composer-Abhängigkeiten installieren und einen PHP-Server starten.
 - **Intuitives UI**: Komplett auf UIkit3 basierendes Frontend mit flüssigen Animationen und responsive Design.
-- **Stark anpassbar**: Farben, Logo und Texte können jederzeit über `public/js/config.js` oder die Admin-Oberfläche geändert werden.
+- **Stark anpassbar**: Farben, Logo und Texte lassen sich über `config/config.json` oder die Admin-Oberfläche anpassen.
 - **Vollständig im Browser**: Das Quiz benötigt keine Serverpersistenz und funktioniert auch offline, sobald die Seite geladen ist.
 
 ## Projektstruktur
@@ -38,7 +38,7 @@ Das **Sommerfest-Quiz** ist eine sofort einsetzbare Web-App, mit der Sie Besuche
 
 ## Anpassung
 
-Alle wichtigen Einstellungen finden Sie in `public/js/config.js`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `kataloge/*.json` und können mit jedem Texteditor angepasst werden. Über die Admin-Seite lassen sich neue Versionen dieser Dateien herunterladen.
+Alle wichtigen Einstellungen finden Sie in `config/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `kataloge/*.json` und können mit jedem Texteditor angepasst werden. Über die Admin-Seite lassen sich neue Versionen dieser Dateien herunterladen.
 
 ## Tests
 

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,10 @@
+{
+  "displayErrorDetails": true,
+  "QRUser": true,
+  "logoPath": "",
+  "header": "Sommerfest 2025",
+  "subheader": "Willkommen beim Veranstaltungsquiz",
+  "backgroundColor": "#f8f8f8",
+  "buttonColor": "#1e87f0",
+  "CheckAnswerButton": "no"
+}

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,6 +1,6 @@
 <?php
-return [
-    'displayErrorDetails' => true,
-    'qrUser' => true,
-    'catalogPath' => __DIR__ . '/../kataloge',
-];
+$path = __DIR__ . '/config.json';
+if (file_exists($path)) {
+    return json_decode(file_get_contents($path), true) ?? [];
+}
+return [];

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function () {
   // --------- Konfiguration bearbeiten ---------
-  // Ausgangswerte aus der bestehenden config.js
+  // Ausgangswerte aus der bestehenden Konfiguration
   const cfgInitial = window.quizConfig || {};
   // Verweise auf die Formularfelder
   const cfgFields = {
@@ -38,12 +38,12 @@ document.addEventListener('DOMContentLoaded', function () {
       CheckAnswerButton: cfgFields.checkAnswerButton.value,
       QRUser: cfgFields.qrUser.value === 'true'
     };
-    const content = 'window.quizConfig = ' + JSON.stringify(data, null, 2) + ';\n';
-    const blob = new Blob([content], { type: 'text/javascript' });
+    const content = JSON.stringify(data, null, 2) + '\n';
+    const blob = new Blob([content], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'js/config.js';
+    a.download = 'config/config.json';
     a.click();
     URL.revokeObjectURL(url);
   });

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -7,12 +7,14 @@ namespace App\Controller;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use App\Service\ConfigService;
 
 class AdminController
 {
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'admin.twig');
+        $cfg = (new ConfigService(__DIR__ . '/../../config/config.json'))->getConfig();
+        return $view->render($response, 'admin.twig', ['config' => $cfg]);
     }
 }

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -19,13 +19,13 @@ class ConfigController
 
     public function get(Request $request, Response $response): Response
     {
-        $content = $this->service->getJs();
+        $content = $this->service->getJson();
         if ($content === null) {
             return $response->withStatus(404);
         }
 
         $response->getBody()->write($content);
-        return $response->withHeader('Content-Type', 'text/javascript');
+        return $response->withHeader('Content-Type', 'application/json');
     }
 
     public function post(Request $request, Response $response): Response

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use App\Service\ConfigService;
 use Slim\Views\Twig;
 
 class HomeController
@@ -13,6 +14,7 @@ class HomeController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'index.twig');
+        $cfg = (new ConfigService(__DIR__ . '/../../config/config.json'))->getConfig();
+        return $view->render($response, 'index.twig', ['config' => $cfg]);
     }
 }

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -13,7 +13,7 @@ class ConfigService
         $this->path = $path;
     }
 
-    public function getJs(): ?string
+    public function getJson(): ?string
     {
         if (!file_exists($this->path)) {
             return null;
@@ -24,26 +24,17 @@ class ConfigService
 
     public function getConfig(): array
     {
-        $content = $this->getJs();
+        $content = $this->getJson();
         if ($content === null) {
             return [];
         }
 
-        $prefix = 'window.quizConfig = ';
-        if (str_starts_with($content, $prefix)) {
-            $json = trim(substr($content, strlen($prefix)));
-        } else {
-            $json = trim($content);
-        }
-
-        $json = rtrim($json, ";\n");
-
-        return json_decode($json, true) ?? [];
+        return json_decode($content, true) ?? [];
     }
 
     public function saveConfig(array $data): void
     {
-        $content = 'window.quizConfig = ' . json_encode($data, JSON_PRETTY_PRINT) . "\n";
-        file_put_contents($this->path, $content);
+        $json = json_encode($data, JSON_PRETTY_PRINT) . "\n";
+        file_put_contents($this->path, $json);
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/Controller/ConfigController.php';
 require_once __DIR__ . '/Controller/CatalogController.php';
 
 return function (\Slim\App $app) {
-    $configService = new ConfigService(__DIR__ . '/../public/js/config.js');
+    $configService = new ConfigService(__DIR__ . '/../config/config.json');
     $catalogService = new CatalogService(__DIR__ . '/../kataloge');
 
     $configController = new ConfigController($configService);
@@ -34,8 +34,8 @@ return function (\Slim\App $app) {
     $app->get('/impressum', ImpressumController::class);
     $app->get('/lizenz', LizenzController::class);
     $app->get('/admin', AdminController::class);
-    $app->get('/config.js', [$configController, 'get']);
-    $app->post('/config.js', [$configController, 'post']);
+    $app->get('/config.json', [$configController, 'get']);
+    $app->post('/config.json', [$configController, 'post']);
     $app->get('/kataloge/{file}', [$catalogController, 'get']);
     $app->post('/kataloge/{file}', [$catalogController, 'post']);
 };

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -64,8 +64,8 @@
         <div class="uk-alert-primary" uk-alert>
           <p>
             Nach dem Klick auf <strong>Speichern</strong> wird eine neue
-            <code>config.js</code> heruntergeladen. Kopiere diese Datei danach
-            manuell in das Verzeichnis <code>js/</code> deines Projekts und
+            <code>config.json</code> heruntergeladen. Kopiere diese Datei danach
+            manuell in das Verzeichnis <code>config/</code> deines Projekts und
             ersetze die vorhandene Datei. Das ist n&ouml;tig, weil das Quiz
             komplett im Browser l&auml;uft und keinen direkten Schreibzugriff
             auf dieses Verzeichnis hat.
@@ -105,6 +105,8 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="js/config.js"></script>
+  <script>
+    window.quizConfig = {{ config|json_encode|raw }};
+  </script>
   <script src="js/admin.js"></script>
 {% endblock %}

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -143,7 +143,7 @@
       <li>
         <a class="uk-accordion-title" href="#">Wie speichere ich meine Änderungen?</a>
         <div class="uk-accordion-content">
-          <p>Nach dem Klick auf <strong>Speichern</strong> wird eine neue <code>config.js</code> sowie eine JSON-Datei f&uuml;r den ausgew&auml;hlten Fragenkatalog erstellt. Kopiere die Dateien anschlie&szlig;end in die Ordner <code>js/</code> bzw. <code>kataloge/</code>.</p>
+          <p>Nach dem Klick auf <strong>Speichern</strong> wird eine neue <code>config.json</code> sowie eine JSON-Datei f&uuml;r den ausgew&auml;hlten Fragenkatalog erstellt. Kopiere die Dateien anschlie&szlig;end in die Ordner <code>config/</code> bzw. <code>kataloge/</code>.</p>
         </div>
       </li>
       <li>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -44,7 +44,9 @@
   <script src="js/uikit-icons.min.js"></script>
   <script src="js/custom-icons.js"></script>
   <script src="https://unpkg.com/html5-qrcode@2.3.7/html5-qrcode.min.js"></script>
-  <script src="js/config.js"></script>
+  <script>
+    window.quizConfig = {{ config|json_encode|raw }};
+  </script>
   <script id="catalogs-data" type="application/json">
     [
       {

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -16,7 +16,7 @@ class ConfigControllerTest extends TestCase
         $tmp = tempnam(sys_get_temp_dir(), 'config');
         unlink($tmp);
         $controller = new ConfigController(new ConfigService($tmp));
-        $request = $this->createRequest('GET', '/config.js');
+        $request = $this->createRequest('GET', '/config.json');
         $response = $controller->get($request, new Response());
 
         $this->assertEquals(404, $response->getStatusCode());
@@ -28,12 +28,12 @@ class ConfigControllerTest extends TestCase
         $service = new ConfigService($tmp);
         $controller = new ConfigController($service);
 
-        $request = $this->createRequest('POST', '/config.js');
+        $request = $this->createRequest('POST', '/config.json');
         $request = $request->withParsedBody(['foo' => 'bar']);
         $postResponse = $controller->post($request, new Response());
         $this->assertEquals(204, $postResponse->getStatusCode());
 
-        $getResponse = $controller->get($this->createRequest('GET', '/config.js'), new Response());
+        $getResponse = $controller->get($this->createRequest('GET', '/config.json'), new Response());
         $this->assertEquals(200, $getResponse->getStatusCode());
         $this->assertStringContainsString('foo', (string) $getResponse->getBody());
 

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -17,20 +17,20 @@ class ConfigServiceTest extends TestCase
 
         $service->saveConfig($data);
         $this->assertFileExists($tmp);
-        $expected = 'window.quizConfig = ' . json_encode($data, JSON_PRETTY_PRINT) . "\n";
-        $this->assertSame($expected, $service->getJs());
+        $expected = json_encode($data, JSON_PRETTY_PRINT) . "\n";
+        $this->assertSame($expected, $service->getJson());
         $this->assertEquals($data, $service->getConfig());
 
         unlink($tmp);
     }
 
-    public function testGetJsReturnsNullIfFileMissing(): void
+    public function testGetJsonReturnsNullIfFileMissing(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'config');
         unlink($tmp);
         $service = new ConfigService($tmp);
 
-        $this->assertNull($service->getJs());
+        $this->assertNull($service->getJson());
         $this->assertEquals([], $service->getConfig());
     }
 }


### PR DESCRIPTION
## Summary
- centralize app settings in `config/config.json`
- load JSON config in PHP and Twig
- drop legacy `config.js` usage
- update admin tool and docs for new config
- adjust tests for JSON configuration

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0a083508832bbb6fb2cef15a189e