### PR TITLE
Fix topbar button order

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -12,15 +12,15 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
+      <a href="faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
     {% block center %}
       <span class="uk-navbar-title">Sommerfest 2025</span>
     {% endblock %}
     {% block right %}
-      <a href="faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+      <div class="theme-switch">
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">


### PR DESCRIPTION
## Summary
- swap FAQ and theme toggle buttons so theme toggle is consistently placed on the right

## Testing
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a621b9bdc832bbf352f47ed66f6c3