### PR TITLE
Serve favicon icon to avoid 404

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -29,6 +29,14 @@ return function (\Slim\App $app) {
     $catalogController = new CatalogController($catalogService);
 
     $app->get('/', HomeController::class);
+    $app->get('/favicon.ico', function (Request $request, Response $response) {
+        $iconPath = __DIR__ . '/../public/favicon.svg';
+        if (file_exists($iconPath)) {
+            $response->getBody()->write(file_get_contents($iconPath));
+            return $response->withHeader('Content-Type', 'image/svg+xml');
+        }
+        return $response->withStatus(404);
+    });
     $app->get('/faq', FaqController::class);
     $app->get('/datenschutz', DatenschutzController::class);
     $app->get('/impressum', ImpressumController::class);

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>{% block title %}Quiz{% endblock %}</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="css/uikit.min.css">
   {% block head %}{% endblock %}
 </head>


### PR DESCRIPTION
## Summary
- add a favicon link in `layout.twig`
- serve `/favicon.ico` through Slim so browsers get the icon

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684a627a3f14832b82c60a91957d051a