### PR TITLE
Fix content offset without moving navbar

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -4,11 +4,11 @@ body {
 }
 
 body.uk-padding {
-  padding-top: 56px;
+  padding-top: calc(56px + 1em);
 }
 
 .index-page {
-  padding-top: 56px;
+  padding-top: calc(56px + 1em);
 }
 
 .sortable-list li,


### PR DESCRIPTION
## Summary
- keep body offset but put the topbar back at the top

## Testing
- `pytest -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684a63ccf9d8832b8d2b9228f69fc89e