### PR TITLE
Fix back button links

### DIFF
--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -12,7 +12,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="../" class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+      <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -12,7 +12,7 @@
   {% block body %}
     {% embed 'topbar.twig' %}
       {% block left %}
-        <a href="../" class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+        <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
       {% endblock %}
       {% block right %}
         <div class="theme-switch">

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -12,7 +12,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="/" class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zur\u00fcck" aria-label="Zur\u00fcck"></a>
+      <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zur\u00fcck" aria-label="Zur\u00fcck"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -12,7 +12,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="/" class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zur\u00fcck" aria-label="Zur\u00fcck"></a>
+      <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zur\u00fcck" aria-label="Zur\u00fcck"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">


### PR DESCRIPTION
## Summary
- fix back button links so they work when hosting in a subdirectory

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6d8988ec832b93de6838d08aa5b8