### PR TITLE
Add license text on license page

### DIFF
--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -12,7 +12,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zur\u00fcck" aria-label="Zur\u00fcck"></a>
+      <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">
@@ -23,7 +23,59 @@
   <div class="uk-container uk-container-small">
     <h1 class="uk-heading-divider uk-hidden">Lizenz</h1>
 
-    <p>Diese Anwendung steht unter der <a href="https://opensource.org/licenses/MIT">MIT-Lizenz</a>. Den vollst\u00e4ndigen Text finden Sie in der Datei <code>LICENSE</code>.</p>
+    <p>Diese Anwendung steht unter der <a href="https://opensource.org/licenses/MIT">MIT-Lizenz</a>. Den vollständigen Text finden Sie auch untenstehend sowie in der Datei <code>LICENSE</code>.</p>
+
+    <h2 class="uk-heading-bullet">MIT-Lizenz (Deutsch)</h2>
+<pre class="uk-text-small">
+MIT-Lizenz
+
+Copyright (c) 2025 calhelp
+
+Hiermit wird unentgeltlich jeder Person, die eine Kopie der Software
+und der zugehörigen Dokumentationsdateien (die "Software") erhält,
+die Erlaubnis erteilt, uneingeschränkt mit der Software zu verfahren,
+einschließlich aber nicht beschränkt auf die Rechte, die Software zu
+nutzen, zu kopieren, zu modifizieren, zusammenzuführen, zu veröffentlichen,
+zu verbreiten, zu unterlizenzieren und/oder zu verkaufen, sowie Personen,
+denen die Software bereitgestellt wird, diese Rechte zu gewähren, vorbehaltlich
+der folgenden Bedingungen:
+
+Der obige Urheberrechtsvermerk und dieser Erlaubnisvermerk sind in allen
+Kopien oder wesentlichen Teilen der Software beizulegen.
+
+DIE SOFTWARE WIRD OHNE JEDE AUSDRÜCKLICHE ODER STILLSCHWEIGENDE GEWÄHRLEISTUNG
+BEREITGESTELLT, EINSCHLIESSLICH UND NICHT BESCHRÄNKT AUF DIE GEWÄHRLEISTUNGEN
+DER MARKTGÄNGIGKEIT, DER EIGNUNG FÜR EINEN BESTIMMTEN ZWECK UND DER NICHTVERLETZUNG.
+IN KEINEM FALL SIND DIE AUTOREN ODER URHEBERRECHTSINHABER FÜR JEGLICHE ANSPRÜCHE,
+SCHÄDEN ODER SONSTIGE HAFTUNGEN VERANTWORTLICH, OB IN EINEM VERTRAGSVERHÄLTNIS,
+EINER UNERLAUBTEN HANDLUNG ODER ANDERWEITIG, DIE SICH AUS DER SOFTWARE ODER DER
+NUTZUNG ODER ANDEREN GESCHÄFTEN MIT DER SOFTWARE ERGEBEN.
+</pre>
+
+    <h2 class="uk-heading-bullet">MIT License (English)</h2>
+<pre class="uk-text-small">
+MIT License
+
+Copyright (c) 2025 calhelp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
   </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- show full MIT license text in German and English on the licence page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684a6f24e71c832b9db2f2f4d5515b6e