### PR TITLE
Update mobile spacing for legal pages

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -164,4 +164,8 @@ a.uk-accordion-title {
     padding-left: 0;
     padding-right: 0;
   }
+  .legal-container {
+    padding-left: 2px;
+    padding-right: 2px;
+  }
 }

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -20,7 +20,7 @@
       </div>
     {% endblock %}
   {% endembed %}
-  <div class="uk-container uk-container-small">
+  <div class="uk-container uk-container-small legal-container">
     <h1 class="uk-heading-divider uk-hidden">Datenschutzerklärung</h1>
 
     <h2 class="uk-heading-bullet">1. Verantwortlicher</h2>

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -20,7 +20,7 @@
       </div>
     {% endblock %}
   {% endembed %}
-  <div class="uk-container uk-container-small">
+  <div class="uk-container uk-container-small legal-container">
     <h1 class="uk-heading-divider uk-hidden">Impressum</h1>
 
     <p>Angaben gem\u00e4\u00df \u00a7 5 TMG</p>

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -20,7 +20,7 @@
       </div>
     {% endblock %}
   {% endembed %}
-  <div class="uk-container uk-container-small">
+  <div class="uk-container uk-container-small legal-container">
     <h1 class="uk-heading-divider uk-hidden">Lizenz</h1>
 
     <p>Diese Anwendung steht unter der <a href="https://opensource.org/licenses/MIT">MIT-Lizenz</a>. Den vollst\u00e4ndigen Text finden Sie in der Datei <code>LICENSE</code>.</p>


### PR DESCRIPTION
## Summary
- add a CSS class for Impressum, Datenschutz and Lizenz pages
- style that class so these pages get 2px side padding on small screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6f6e4580832ba1c40d8d0b79499f