### PR TITLE
Fix back button icon display

### DIFF
--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -12,7 +12,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+      <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -12,7 +12,7 @@
   {% block body %}
     {% embed 'topbar.twig' %}
       {% block left %}
-        <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+        <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
       {% endblock %}
       {% block right %}
         <div class="theme-switch">

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -12,7 +12,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+      <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -12,7 +12,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="." class="uk-icon-button" uk-icon="arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+      <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">


### PR DESCRIPTION
## Summary
- fix `uk-icon` syntax for arrow-left icons in legal and FAQ pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a7bfd3f0c832bbf0e98d1cce71c8e