### PR TITLE
Fix theme switch alignment

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -88,7 +88,7 @@ body.uk-padding {
 .theme-switch {
   display: inline-block;
   margin-left: 8px;
-  margin-top: -2mm;
+  margin-top: 0;
 }
 
 .theme-switch button {


### PR DESCRIPTION
## Summary
- remove negative margin from the topbar theme switch to match icon alignment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a7ca63e9c832b9ca2734c312c5452