### PR TITLE
Improve mobile drag for questions

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -101,6 +101,7 @@
   </script>
   <script src="/js/catalog.js"></script>
   <script src="/js/confetti.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
   <script src="/js/quiz.js"></script>
   <script src="/js/app.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load SortableJS globally
- switch sort and assign handlers to use SortableJS

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa55c57a0832ba00d8938c7d50bda