### PR TITLE
Add login protection for admin area

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -6,5 +6,7 @@
   "subheader": "Willkommen beim Veranstaltungsquiz",
   "backgroundColor": "#f8f8f8",
   "buttonColor": "#1e87f0",
-  "CheckAnswerButton": "no"
+  "CheckAnswerButton": "no",
+  "adminUser": "admin",
+  "adminPass": "password"
 }

--- a/public/index.php
+++ b/public/index.php
@@ -3,12 +3,14 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Slim\Views\Twig;
 use Slim\Views\TwigMiddleware;
+use App\Application\Middleware\SessionMiddleware;
 
 $settings = require __DIR__ . '/../config/settings.php';
 $app = \Slim\Factory\AppFactory::create();
 
 $twig = Twig::create(__DIR__ . '/../templates', ['cache' => false]);
 $app->add(TwigMiddleware::create($app, $twig));
+$app->add(new SessionMiddleware());
 
 $app->addErrorMiddleware($settings['displayErrorDetails'], true, true);
 (require __DIR__ . '/../src/routes.php')($app);

--- a/src/Application/Middleware/AdminAuthMiddleware.php
+++ b/src/Application/Middleware/AdminAuthMiddleware.php
@@ -6,18 +6,20 @@ namespace App\Application\Middleware;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Psr\Http\Server\MiddlewareInterface as Middleware;
+use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
+use Slim\Psr7\Response as SlimResponse;
 
-class SessionMiddleware implements Middleware
+class AdminAuthMiddleware implements MiddlewareInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function process(Request $request, RequestHandler $handler): Response
     {
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
+        }
+        if (empty($_SESSION['admin'])) {
+            $response = new SlimResponse();
+            return $response->withHeader('Location', '/login')->withStatus(302);
         }
 
         return $handler->handle($request);

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\ConfigService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
+
+class LoginController
+{
+    public function show(Request $request, Response $response): Response
+    {
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'login.twig');
+    }
+
+    public function login(Request $request, Response $response): Response
+    {
+        $data = $request->getParsedBody();
+        if ($request->getHeaderLine('Content-Type') === 'application/json') {
+            $data = json_decode((string) $request->getBody(), true);
+        }
+
+        $config = (new ConfigService(__DIR__ . '/../../config/config.json'))->getConfig();
+        $user = $config['adminUser'] ?? 'admin';
+        $pass = $config['adminPass'] ?? 'password';
+
+        if (($data['username'] ?? '') === $user && ($data['password'] ?? '') === $pass) {
+            if (session_status() === PHP_SESSION_NONE) {
+                session_start();
+            }
+            $_SESSION['admin'] = true;
+            return $response->withHeader('Location', '/admin')->withStatus(302);
+        }
+
+        $view = Twig::fromRequest($request);
+        return $view->render($response->withStatus(401), 'login.twig', ['error' => true]);
+    }
+}

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class LogoutController
+{
+    public function __invoke(Request $request, Response $response): Response
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        session_destroy();
+        return $response->withHeader('Location', '/login')->withStatus(302);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -7,8 +7,11 @@ use App\Controller\DatenschutzController;
 use App\Controller\ImpressumController;
 use App\Controller\LizenzController;
 use App\Controller\AdminController;
+use App\Controller\LoginController;
+use App\Controller\LogoutController;
 use App\Controller\ConfigController;
 use App\Controller\CatalogController;
+use App\Application\Middleware\AdminAuthMiddleware;
 use App\Service\ConfigService;
 use App\Service\CatalogService;
 
@@ -18,6 +21,8 @@ require_once __DIR__ . '/Controller/DatenschutzController.php';
 require_once __DIR__ . '/Controller/ImpressumController.php';
 require_once __DIR__ . '/Controller/LizenzController.php';
 require_once __DIR__ . '/Controller/AdminController.php';
+require_once __DIR__ . '/Controller/LoginController.php';
+require_once __DIR__ . '/Controller/LogoutController.php';
 require_once __DIR__ . '/Controller/ConfigController.php';
 require_once __DIR__ . '/Controller/CatalogController.php';
 
@@ -41,7 +46,11 @@ return function (\Slim\App $app) {
     $app->get('/datenschutz', DatenschutzController::class);
     $app->get('/impressum', ImpressumController::class);
     $app->get('/lizenz', LizenzController::class);
-    $app->get('/admin', AdminController::class);
+    $app->get('/login', [LoginController::class, 'show']);
+    $app->post('/login', [LoginController::class, 'login']);
+    $app->get('/logout', LogoutController::class);
+
+    $app->get('/admin', AdminController::class)->add(new AdminAuthMiddleware());
     $app->get('/config.json', [$configController, 'get']);
     $app->post('/config.json', [$configController, 'post']);
     $app->get('/kataloge/{file}', [$catalogController, 'get']);

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -1,0 +1,27 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Admin Login{% endblock %}
+
+{% block body_class %}uk-padding{% endblock %}
+
+{% block body %}
+<div class="uk-container uk-width-1-1 uk-width-1-3@m">
+  <h2 class="uk-heading-bullet">Login</h2>
+  {% if error %}
+  <div class="uk-alert-danger" uk-alert>
+    <p>Benutzername oder Passwort falsch.</p>
+  </div>
+  {% endif %}
+  <form method="post" action="/login" class="uk-form-stacked">
+    <div class="uk-margin">
+      <label class="uk-form-label" for="username">Benutzername</label>
+      <input class="uk-input" type="text" name="username" id="username" required>
+    </div>
+    <div class="uk-margin">
+      <label class="uk-form-label" for="password">Passwort</label>
+      <input class="uk-input" type="password" name="password" id="password" required>
+    </div>
+    <button class="uk-button uk-button-primary">Einloggen</button>
+  </form>
+</div>
+{% endblock %}

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -8,11 +8,23 @@ use Tests\TestCase;
 
 class AdminControllerTest extends TestCase
 {
-    public function testAdminPage(): void
+    public function testRedirectWhenNotLoggedIn(): void
     {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/admin');
         $response = $app->handle($request);
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('/login', $response->getHeaderLine('Location'));
+    }
+
+    public function testAdminPageAfterLogin(): void
+    {
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['admin'] = true;
+        $request = $this->createRequest('GET', '/admin');
+        $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
+        session_destroy();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,7 @@ use Slim\Psr7\Request as SlimRequest;
 use Slim\Psr7\Uri;
 use Slim\Views\Twig;
 use Slim\Views\TwigMiddleware;
+use App\Application\Middleware\SessionMiddleware;
 
 class TestCase extends PHPUnit_TestCase
 {
@@ -35,6 +36,7 @@ class TestCase extends PHPUnit_TestCase
 
         $twig = Twig::create(__DIR__ . '/../templates', ['cache' => false]);
         $app->add(TwigMiddleware::create($app, $twig));
+        $app->add(new SessionMiddleware());
 
         // Register error middleware
         $app->addErrorMiddleware($settings['displayErrorDetails'], true, true);


### PR DESCRIPTION
## Summary
- implement session middleware always-on
- add AdminAuth middleware for /admin
- create login and logout controllers
- register login/logout routes and protect admin route
- add login template
- extend config with admin credentials
- include session middleware in `public/index.php` and tests
- update admin controller tests to cover login

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684ac6ddeadc832b8f1017e033afa1c7