### PR TITLE
Load catalog list in admin page

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
 use App\Service\ConfigService;
 use App\Service\ResultService;
+use App\Service\CatalogService;
 
 class AdminController
 {
@@ -17,9 +18,17 @@ class AdminController
         $view = Twig::fromRequest($request);
         $cfg = (new ConfigService(__DIR__ . '/../../config/config.json'))->getConfig();
         $results = (new ResultService(__DIR__ . '/../../data/results.json'))->getAll();
+        $catalogSvc = new CatalogService(__DIR__ . '/../../kataloge');
+        $catalogsJson = $catalogSvc->read('catalogs.json');
+        $catalogs = [];
+        if ($catalogsJson !== null) {
+            $catalogs = json_decode($catalogsJson, true) ?? [];
+        }
+
         return $view->render($response, 'admin.twig', [
             'config' => $cfg,
             'results' => $results,
+            'catalogs' => $catalogs,
         ]);
     }
 }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -80,7 +80,11 @@
         <div class="uk-margin">
           <label class="uk-form-label" for="catalogSelect">Fragenkatalog</label>
           <div class="uk-form-controls">
-            <select id="catalogSelect" class="uk-select"></select>
+            <select id="catalogSelect" class="uk-select">
+              {% for c in catalogs %}
+              <option value="{{ c.id }}">{{ c.name ?? c.id }}</option>
+              {% endfor %}
+            </select>
           </div>
         </div>
         <div id="questions"></div>


### PR DESCRIPTION
## Summary
- import CatalogService in AdminController
- read `catalogs.json` and pass the decoded array to Twig
- render catalog options in `admin.twig`

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684adadb0cc0832ba4327bf9b7616a1c