### PR TITLE
Update admin saving workflow

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -62,16 +62,7 @@
           <button id="cfgResetBtn" class="uk-button uk-button-default">Zurücksetzen</button>
           <button id="cfgSaveBtn" class="uk-button uk-button-primary">Speichern</button>
         </div>
-        <div class="uk-alert-primary" uk-alert>
-          <p>
-            Nach dem Klick auf <strong>Speichern</strong> wird eine neue
-            <code>config.json</code> heruntergeladen. Kopiere diese Datei danach
-            manuell in das Verzeichnis <code>config/</code> deines Projekts und
-            ersetze die vorhandene Datei. Das ist n&ouml;tig, weil das Quiz
-            komplett im Browser l&auml;uft und keinen direkten Schreibzugriff
-            auf dieses Verzeichnis hat.
-          </p>
-        </div>
+
       </div>
     </li>
     <li>
@@ -95,15 +86,7 @@
           <button id="resetBtn" class="uk-button uk-button-default">Zurücksetzen</button>
           <button id="saveBtn" class="uk-button uk-button-primary">Speichern</button>
         </div>
-        <div class="uk-alert-primary" uk-alert>
-          <p>
-            Nach dem Klick auf <strong>Speichern</strong> wird eine JSON-Datei
-            f&uuml;r den gewählten Fragenkatalog heruntergeladen.
-            Kopiere sie danach in den Ordner <code>kataloge/</code>, um den
-            vorhandenen Katalog zu ersetzen. Die Admin-Seite kann das
-            Verzeichnis nicht automatisch beschreiben.
-          </p>
-        </div>
+
       </div>
     </li>
     <li>


### PR DESCRIPTION
## Summary
- use POST requests for saving config and question catalogs
- add success/error notifications using UIkit
- remove outdated copy instructions in admin template

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684adc4f018c832b83b91eb0c1243f7f