### PR TITLE
Add question deletion endpoint and auto sync

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -150,7 +150,20 @@ document.addEventListener('DOMContentLoaded', function () {
     const removeBtn = document.createElement('button');
     removeBtn.className = 'uk-button uk-button-danger uk-margin-small-top uk-align-right';
     removeBtn.textContent = 'Entfernen';
-    removeBtn.onclick = () => card.remove();
+    removeBtn.onclick = () => {
+      const idx = Array.from(container.children).indexOf(card);
+      card.remove();
+      initial.splice(idx, 1);
+      fetch('/kataloge/' + catalogFile + '/' + idx, { method: 'DELETE' })
+        .then(r => {
+          if (!r.ok) throw new Error(r.statusText);
+          notify('Frage gelöscht', 'success');
+        })
+        .catch(err => {
+          console.error(err);
+          notify('Fehler beim Löschen', 'danger');
+        });
+    };
 
     // Hilfsfunktionen zum Anlegen der Eingabefelder
     function addItem(value = '') {

--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -50,4 +50,16 @@ class CatalogController
 
         return $response->withStatus(204);
     }
+
+    public function delete(Request $request, Response $response, array $args): Response
+    {
+        $file = basename($args['file']);
+        $index = (int)($args['index'] ?? -1);
+
+        if ($this->service->deleteQuestion($file, $index)) {
+            return $response->withStatus(204);
+        }
+
+        return $response->withStatus(404);
+    }
 }

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -40,4 +40,23 @@ class CatalogService
 
         file_put_contents($path, (string) $data);
     }
+
+    public function deleteQuestion(string $file, int $index): bool
+    {
+        $path = $this->path($file);
+        if (!file_exists($path)) {
+            return false;
+        }
+
+        $json = file_get_contents($path);
+        $data = json_decode($json, true);
+        if (!is_array($data) || $index < 0 || $index >= count($data)) {
+            return false;
+        }
+
+        array_splice($data, $index, 1);
+        file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
+
+        return true;
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -62,4 +62,5 @@ return function (\Slim\App $app) {
     $app->post('/config.json', [$configController, 'post']);
     $app->get('/kataloge/{file}', [$catalogController, 'get']);
     $app->post('/kataloge/{file}', [$catalogController, 'post']);
+    $app->delete('/kataloge/{file}/{index}', [$catalogController, 'delete']);
 };

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -45,4 +45,23 @@ class CatalogControllerTest extends TestCase
         unlink($dir . '/test.json');
         rmdir($dir);
     }
+
+    public function testDelete(): void
+    {
+        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
+        mkdir($dir);
+        $service = new CatalogService($dir);
+        $controller = new CatalogController($service);
+
+        $service->write('test.json', [['a' => 1], ['b' => 2]]);
+
+        $request = $this->createRequest('DELETE', '/kataloge/test.json/0');
+        $delResponse = $controller->delete($request, new Response(), ['file' => 'test.json', 'index' => 0]);
+        $this->assertEquals(204, $delResponse->getStatusCode());
+        $content = $service->read('test.json');
+        $this->assertJsonStringEqualsJsonString(json_encode([['b' => 2]], JSON_PRETTY_PRINT), $content);
+
+        unlink($dir . '/test.json');
+        rmdir($dir);
+    }
 }

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -34,4 +34,23 @@ class CatalogServiceTest extends TestCase
 
         rmdir($dir);
     }
+
+    public function testDeleteQuestion(): void
+    {
+        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
+        mkdir($dir);
+        $service = new CatalogService($dir);
+        $file = 'test.json';
+        $data = [['a' => 1], ['b' => 2]];
+        $service->write($file, $data);
+
+        $this->assertTrue($service->deleteQuestion($file, 0));
+        $expected = json_encode([['b' => 2]], JSON_PRETTY_PRINT);
+        $this->assertJsonStringEqualsJsonString($expected, $service->read($file));
+
+        $this->assertFalse($service->deleteQuestion($file, 5));
+
+        unlink($dir . '/' . $file);
+        rmdir($dir);
+    }
 }


### PR DESCRIPTION
## Summary
- support deleting single questions via CatalogService and CatalogController
- expose DELETE /kataloge/{file}/{index} route
- auto-delete questions from admin UI
- test Catalog deletion logic

## Testing
- `pytest -q`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684ae51790ec832b80a67363e08e5e27