### PR TITLE
Implement question deletion API

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -120,13 +120,16 @@ document.addEventListener('DOMContentLoaded', function () {
   // Rendert alle Fragen im Editor neu
   function renderAll(data) {
     container.innerHTML = '';
-    data.forEach(q => container.appendChild(createCard(q)));
+    data.forEach((q, i) => container.appendChild(createCard(q, i)));
   }
 
   // Erstellt ein Bearbeitungsformular für eine Frage
-  function createCard(q) {
+  function createCard(q, index = -1) {
     const card = document.createElement('div');
     card.className = 'uk-card uk-card-default uk-card-body uk-margin question-card';
+    if (index >= 0) {
+      card.dataset.index = String(index);
+    }
     const typeSelect = document.createElement('select');
     typeSelect.className = 'uk-select uk-margin-small-bottom type-select';
     ['sort', 'assign', 'mc'].forEach(t => {
@@ -161,7 +164,23 @@ document.addEventListener('DOMContentLoaded', function () {
     const removeBtn = document.createElement('button');
     removeBtn.className = 'uk-button uk-button-danger uk-margin-small-top uk-align-right';
     removeBtn.textContent = 'Entfernen';
-    removeBtn.onclick = () => card.remove();
+    removeBtn.onclick = () => {
+      const idx = card.dataset.index;
+      if (idx !== undefined) {
+        fetch('/kataloge/' + catalogFile + '/' + idx, { method: 'DELETE' })
+          .then(r => {
+            if (!r.ok) throw new Error(r.statusText);
+            initial.splice(Number(idx), 1);
+            renderAll(initial);
+          })
+          .catch(err => {
+            console.error(err);
+            notify('Fehler beim Löschen', 'danger');
+          });
+      } else {
+        card.remove();
+      }
+    };
 
     // Hilfsfunktionen zum Anlegen der Eingabefelder
     function addItem(value = '') {
@@ -351,7 +370,7 @@ document.addEventListener('DOMContentLoaded', function () {
   addBtn.addEventListener('click', function (e) {
     e.preventDefault();
     container.appendChild(
-      createCard({ type: 'mc', prompt: '', options: ['', ''], answers: [0] })
+      createCard({ type: 'mc', prompt: '', options: ['', ''], answers: [0] }, -1)
     );
   });
 

--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -71,4 +71,13 @@ class CatalogController
 
         return $response->withStatus(204);
     }
+
+    public function deleteQuestion(Request $request, Response $response, array $args): Response
+    {
+        $file = basename($args['file']);
+        $index = (int) $args['index'];
+        $this->service->deleteQuestion($file, $index);
+
+        return $response->withStatus(204);
+    }
 }

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -48,4 +48,22 @@ class CatalogService
             unlink($path);
         }
     }
+
+    public function deleteQuestion(string $file, int $index): void
+    {
+        $path = $this->path($file);
+        if (!file_exists($path)) {
+            return;
+        }
+        $json = file_get_contents($path);
+        $data = json_decode($json, true);
+        if (!is_array($data)) {
+            return;
+        }
+        if ($index < 0 || $index >= count($data)) {
+            return;
+        }
+        array_splice($data, $index, 1);
+        file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -62,6 +62,7 @@ return function (\Slim\App $app) {
     $app->post('/config.json', [$configController, 'post']);
     $app->get('/kataloge/{file}', [$catalogController, 'get']);
     $app->post('/kataloge/{file}', [$catalogController, 'post']);
+    $app->delete('/kataloge/{file}/{index}', [$catalogController, 'deleteQuestion']);
     $app->put('/kataloge/{file}', [$catalogController, 'create']);
     $app->delete('/kataloge/{file}', [$catalogController, 'delete']);
 };

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -68,4 +68,25 @@ class CatalogControllerTest extends TestCase
 
         rmdir($dir);
     }
+
+    public function testDeleteQuestion(): void
+    {
+        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
+        mkdir($dir);
+        $service = new CatalogService($dir);
+        $controller = new CatalogController($service);
+
+        $service->write('cat.json', [['a' => 1], ['b' => 2]]);
+
+        $req = $this->createRequest('DELETE', '/kataloge/cat.json/0');
+        $res = $controller->deleteQuestion($req, new Response(), ['file' => 'cat.json', 'index' => '0']);
+        $this->assertEquals(204, $res->getStatusCode());
+
+        $data = json_decode($service->read('cat.json'), true);
+        $this->assertCount(1, $data);
+        $this->assertSame(['b' => 2], $data[0]);
+
+        unlink($dir . '/cat.json');
+        rmdir($dir);
+    }
 }

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -47,4 +47,22 @@ class CatalogServiceTest extends TestCase
         $this->assertFileDoesNotExist($dir . '/' . $file);
         rmdir($dir);
     }
+
+    public function testDeleteQuestion(): void
+    {
+        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
+        mkdir($dir);
+        $service = new CatalogService($dir);
+        $file = 'q.json';
+        $data = [['a' => 1], ['b' => 2]];
+        $service->write($file, $data);
+
+        $service->deleteQuestion($file, 0);
+        $remaining = json_decode($service->read($file), true);
+        $this->assertCount(1, $remaining);
+        $this->assertSame(['b' => 2], $remaining[0]);
+
+        unlink($dir . '/' . $file);
+        rmdir($dir);
+    }
 }


### PR DESCRIPTION
## Summary
- add ability to delete questions by index in `CatalogService`
- expose new `/kataloge/{file}/{index}` route in `CatalogController`
- modify `admin.js` to store question indices and call the delete API
- test deleting questions via service and controller

## Testing
- `pytest -q`
- `composer install` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aea157da8832b825d2495b275d7f1