### PR TITLE
Add theme toggle to admin page without topbar

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -3,12 +3,19 @@
 {% block title %}Quiz Verwaltung{% endblock %}
 
 {% block head %}
+  <link rel="stylesheet" href="/css/dark.css">
   <link rel="stylesheet" href="/css/main.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
 
 {% block body %}
+  <div class="uk-flex uk-flex-between uk-margin-small-bottom">
+    <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+    <div class="theme-switch">
+      <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+    </div>
+  </div>
   <ul uk-tab>
     <li class="uk-active"><a href="#">Veranstaltung konfigurieren</a></li>
     <li><a href="#">Fragen anpassen</a></li>
@@ -115,8 +122,11 @@
 {% endblock %}
 
 {% block scripts %}
+  <script src="/js/uikit-icons.min.js"></script>
+  <script src="/js/custom-icons.js"></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
   </script>
   <script src="/js/admin.js"></script>
+  <script src="/js/app.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- restore admin layout by removing topbar
- add dark.css and theme switch button to admin
- load UIkit icons, custom icons and app.js for toggle functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aec2748e8832b809a2f6854e61025