### PR TITLE
Fix undefined config issue

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -1,6 +1,10 @@
 <?php
 $path = __DIR__ . '/config.json';
+$settings = [];
 if (file_exists($path)) {
-    return json_decode(file_get_contents($path), true) ?? [];
+    $settings = json_decode(file_get_contents($path), true) ?? [];
 }
-return [];
+$settings += [
+    'displayErrorDetails' => false,
+];
+return $settings;


### PR DESCRIPTION
## Summary
- make sure displayErrorDetails has a default value

## Testing
- `pytest tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684aefec6a48832b9409fe68669aae9e