### PR TITLE
Fix duplicate catalogs in admin

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -106,6 +106,7 @@ document.addEventListener('DOMContentLoaded', function () {
     .then(r => r.json())
     .then(list => {
       catalogs = list;
+      catSelect.innerHTML = '';
       catalogs.forEach(c => {
         const opt = document.createElement('option');
         opt.value = c.id;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -78,11 +78,7 @@
         <div class="uk-margin">
           <label class="uk-form-label" for="catalogSelect">Fragenkatalog</label>
           <div class="uk-form-controls">
-            <select id="catalogSelect" class="uk-select">
-              {% for c in catalogs %}
-              <option value="{{ c.id }}">{{ c.name ?? c.id }}</option>
-              {% endfor %}
-            </select>
+            <select id="catalogSelect" class="uk-select"></select>
           </div>
         </div>
         <div id="questions"></div>


### PR DESCRIPTION
## Summary
- clear the `#catalogSelect` dropdown before populating catalog options
- remove server-side options from `admin.twig`

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af00514c0832b987e6dd8b6ec8e1b