### PR TITLE
Validate JSON input

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -51,8 +51,13 @@ document.addEventListener('DOMContentLoaded', function () {
       body: JSON.stringify(data)
     })
       .then(r => {
-        if (!r.ok) throw new Error(r.statusText);
-        notify('Konfiguration gespeichert', 'success');
+        if (r.ok) {
+          notify('Konfiguration gespeichert', 'success');
+        } else if (r.status === 400) {
+          notify('Ungültige Daten', 'danger');
+        } else {
+          throw new Error(r.statusText);
+        }
       })
       .catch(err => {
         console.error(err);
@@ -351,8 +356,13 @@ document.addEventListener('DOMContentLoaded', function () {
       body: JSON.stringify(data)
     })
       .then(r => {
-        if (!r.ok) throw new Error(r.statusText);
-        notify('Fragen gespeichert', 'success');
+        if (r.ok) {
+          notify('Fragen gespeichert', 'success');
+        } else if (r.status === 400) {
+          notify('Ungültige Daten', 'danger');
+        } else {
+          throw new Error(r.statusText);
+        }
       })
       .catch(err => {
         console.error(err);

--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -42,11 +42,17 @@ class CatalogController
     {
         $file = basename($args['file']);
         $data = $request->getParsedBody();
+
         if ($request->getHeaderLine('Content-Type') === 'application/json') {
             $data = json_decode((string) $request->getBody(), true);
+            if (!is_array($data)) {
+                return $response->withStatus(400);
+            }
+        } elseif (!is_array($data)) {
+            return $response->withStatus(400);
         }
 
-        $this->service->write($file, $data ?? []);
+        $this->service->write($file, $data);
 
         return $response->withStatus(204);
     }

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -31,11 +31,17 @@ class ConfigController
     public function post(Request $request, Response $response): Response
     {
         $data = $request->getParsedBody();
+
         if ($request->getHeaderLine('Content-Type') === 'application/json') {
             $data = json_decode((string) $request->getBody(), true);
+            if (!is_array($data)) {
+                return $response->withStatus(400);
+            }
+        } elseif (!is_array($data)) {
+            return $response->withStatus(400);
         }
 
-        $this->service->saveConfig($data ?? []);
+        $this->service->saveConfig($data);
 
         return $response->withStatus(204);
     }

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -89,4 +89,23 @@ class CatalogControllerTest extends TestCase
         unlink($dir . '/cat.json');
         rmdir($dir);
     }
+
+    public function testPostInvalidJson(): void
+    {
+        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
+        mkdir($dir);
+        $controller = new CatalogController(new CatalogService($dir));
+
+        $request = $this->createRequest('POST', '/kataloge/test.json', ['HTTP_CONTENT_TYPE' => 'application/json']);
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, '{invalid');
+        rewind($stream);
+        $stream = (new \Slim\Psr7\Factory\StreamFactory())->createStreamFromResource($stream);
+        $request = $request->withBody($stream);
+
+        $response = $controller->post($request, new Response(), ['file' => 'test.json']);
+        $this->assertEquals(400, $response->getStatusCode());
+
+        rmdir($dir);
+    }
 }

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -39,4 +39,23 @@ class ConfigControllerTest extends TestCase
 
         unlink($tmp);
     }
+
+    public function testPostInvalidJson(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'config');
+        $service = new ConfigService($tmp);
+        $controller = new ConfigController($service);
+
+        $request = $this->createRequest('POST', '/config.json', ['HTTP_CONTENT_TYPE' => 'application/json']);
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, '{invalid');
+        rewind($stream);
+        $stream = (new \Slim\Psr7\Factory\StreamFactory())->createStreamFromResource($stream);
+        $request = $request->withBody($stream);
+
+        $response = $controller->post($request, new Response());
+        $this->assertEquals(400, $response->getStatusCode());
+
+        unlink($tmp);
+    }
 }


### PR DESCRIPTION
## Summary
- validate JSON data in `CatalogController::post` and `ConfigController::post`
- return `400 Bad Request` for invalid content
- show an error message if the server replies with 400 in the admin UI
- add controller tests for invalid JSON

## Testing
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aebac1424832b80bcabb5968dd535