### PR TITLE
Add result management buttons to admin panel

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -434,6 +434,45 @@ document.addEventListener('DOMContentLoaded', function () {
       });
   });
 
+  const resultsResetBtn = document.getElementById('resultsResetBtn');
+  const resultsDownloadBtn = document.getElementById('resultsDownloadBtn');
+
+  resultsResetBtn?.addEventListener('click', function (e) {
+    e.preventDefault();
+    if (!confirm('Alle Ergebnisse löschen?')) return;
+    fetch('/results', { method: 'DELETE' })
+      .then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        notify('Ergebnisse gelöscht', 'success');
+        window.location.reload();
+      })
+      .catch(err => {
+        console.error(err);
+        notify('Fehler beim Löschen', 'danger');
+      });
+  });
+
+  resultsDownloadBtn?.addEventListener('click', function (e) {
+    e.preventDefault();
+    fetch('/results/download')
+      .then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        return r.blob();
+      })
+      .then(blob => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'results.json';
+        a.click();
+        URL.revokeObjectURL(url);
+      })
+      .catch(err => {
+        console.error(err);
+        notify('Fehler beim Herunterladen', 'danger');
+      });
+  });
+
   // Zähler für eindeutige Namen von Eingabefeldern
   let cardIndex = 0;
 });

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -25,6 +25,15 @@ class ResultController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
+    public function download(Request $request, Response $response): Response
+    {
+        $content = json_encode($this->service->getAll(), JSON_PRETTY_PRINT);
+        $response->getBody()->write($content);
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Content-Disposition', 'attachment; filename="results.json"');
+    }
+
     public function post(Request $request, Response $response): Response
     {
         $data = json_decode((string) $request->getBody(), true);
@@ -39,5 +48,11 @@ class ResultController
         $view = Twig::fromRequest($request);
         $results = $this->service->getAll();
         return $view->render($response, 'results.twig', ['results' => $results]);
+    }
+
+    public function delete(Request $request, Response $response): Response
+    {
+        $this->service->clear();
+        return $response->withStatus(204);
     }
 }

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -48,4 +48,9 @@ class ResultService
         file_put_contents($this->path, json_encode($results, JSON_PRETTY_PRINT) . "\n");
         return $entry;
     }
+
+    public function clear(): void
+    {
+        file_put_contents($this->path, "[]\n");
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -57,7 +57,9 @@ return function (\Slim\App $app) {
     $app->get('/admin', AdminController::class)->add(new AdminAuthMiddleware());
     $app->get('/results', [$resultController, 'page']);
     $app->get('/results.json', [$resultController, 'get']);
+    $app->get('/results/download', [$resultController, 'download']);
     $app->post('/results', [$resultController, 'post']);
+    $app->delete('/results', [$resultController, 'delete']);
     $app->get('/config.json', [$configController, 'get']);
     $app->post('/config.json', [$configController, 'post']);
     $app->get('/kataloge/{file}', [$catalogController, 'get']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -116,6 +116,10 @@
             {% endfor %}
           </tbody>
         </table>
+        <div class="uk-margin uk-flex uk-flex-between">
+          <button id="resultsResetBtn" class="uk-button uk-button-default">Zurücksetzen</button>
+          <button id="resultsDownloadBtn" class="uk-button uk-button-primary">Herunterladen</button>
+        </div>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
## Summary
- add `ResultService::clear` to wipe `results.json`
- support deleting and downloading results in `ResultController`
- wire up new routes for results management
- expose buttons in `admin.twig` and implement their behaviour in `admin.js`

## Testing
- `python3 -m pytest -q tests/test_html_validity.py tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684af0f40ac0832b8f8da5c20a4591df