### PR TITLE
Add configurable page title

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -2,6 +2,7 @@
   "displayErrorDetails": true,
   "QRUser": true,
   "logoPath": "",
+  "pageTitle": "Modernes Quiz mit UIkit",
   "header": "Sommerfest 2025",
   "subheader": "Willkommen beim Veranstaltungsquiz",
   "backgroundColor": "#f8f8f8",

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Verweise auf die Formularfelder
   const cfgFields = {
     logoPath: document.getElementById('cfgLogoPath'),
+    pageTitle: document.getElementById('cfgPageTitle'),
     header: document.getElementById('cfgHeader'),
     subheader: document.getElementById('cfgSubheader'),
     backgroundColor: document.getElementById('cfgBackgroundColor'),
@@ -22,6 +23,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Füllt das Formular mit den Werten aus einem Konfigurationsobjekt
   function renderCfg(data) {
     cfgFields.logoPath.value = data.logoPath || '';
+    cfgFields.pageTitle.value = data.pageTitle || '';
     cfgFields.header.value = data.header || '';
     cfgFields.subheader.value = data.subheader || '';
     cfgFields.backgroundColor.value = data.backgroundColor || '';
@@ -38,6 +40,7 @@ document.addEventListener('DOMContentLoaded', function () {
     e.preventDefault();
     const data = {
       logoPath: cfgFields.logoPath.value.trim(),
+      pageTitle: cfgFields.pageTitle.value.trim(),
       header: cfgFields.header.value.trim(),
       subheader: cfgFields.subheader.value.trim(),
       backgroundColor: cfgFields.backgroundColor.value.trim(),

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -5,6 +5,9 @@ window.quizConfig = {
   // optionaler Pfad zu einem eigenen Logo
   logoPath: '',
 
+  // Titel im Browser-Tab
+  pageTitle: 'Modernes Quiz mit UIkit',
+
   // Überschrift und Untertitel auf der Startseite
   header: 'Sommerfest 2025',
   subheader: 'Willkommen beim Veranstaltungsquiz',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -31,6 +31,10 @@
             <div class="uk-form-controls"><input class="uk-input" type="text" id="cfgLogoPath"></div>
           </div>
           <div class="uk-margin">
+            <label class="uk-form-label" for="cfgPageTitle">Titel im Browser-Tab</label>
+            <div class="uk-form-controls"><input class="uk-input" type="text" id="cfgPageTitle"></div>
+          </div>
+          <div class="uk-margin">
             <label class="uk-form-label" for="cfgHeader">Überschrift</label>
             <div class="uk-form-controls"><input class="uk-input" type="text" id="cfgHeader"></div>
           </div>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -1,6 +1,6 @@
 {% extends 'layout.twig' %}
 
-{% block title %}Modernes Quiz mit UIkit{% endblock %}
+{% block title %}{{ config.pageTitle|default('Modernes Quiz mit UIkit') }}{% endblock %}
 
 {% block head %}
   <link rel="stylesheet" href="/css/dark.css">


### PR DESCRIPTION
## Summary
- allow setting a custom page title for the quiz via configuration
- expose the field in the admin UI
- persist the new value through admin.js
- use the configured title on the start page

## Testing
- `python3 -m pytest -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684af4c995c4832b82eb1caad720baf6