### PR TITLE
Implement XLSX result export

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python3 tests/test_json_validity.py
 
 ## Datenschutz
 
-Ergebnisse können nun serverseitig in einer `results.json` abgelegt werden. Die Ablage erfolgt anonymisiert und entspricht den Vorgaben der DSGVO. Jede Zeile enthält ein Pseudonym, den verwendeten Katalog, die Versuchnummer und die Punktzahl. Alternativ lassen sich die Daten weiterhin lokal als `statistical.log` exportieren.
+Ergebnisse können nun serverseitig in einer `results.xlsx` abgelegt werden. Die Ablage erfolgt anonymisiert und entspricht den Vorgaben der DSGVO. Jede Zeile enthält ein Pseudonym, den verwendeten Katalog, die Versuchnummer und die Punktzahl. Alternativ lassen sich die Daten weiterhin lokal als `statistical.log` exportieren.
 
 ## Barrierefreiheit
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -464,7 +464,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = 'results.json';
+        a.download = 'results.xlsx';
         a.click();
         URL.revokeObjectURL(url);
       })

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\ResultService;
+use App\Service\XlsxExportService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
@@ -12,10 +13,12 @@ use Slim\Views\Twig;
 class ResultController
 {
     private ResultService $service;
+    private XlsxExportService $xlsx;
 
-    public function __construct(ResultService $service)
+    public function __construct(ResultService $service, XlsxExportService $xlsx)
     {
         $this->service = $service;
+        $this->xlsx = $xlsx;
     }
 
     public function get(Request $request, Response $response): Response
@@ -27,11 +30,23 @@ class ResultController
 
     public function download(Request $request, Response $response): Response
     {
-        $content = json_encode($this->service->getAll(), JSON_PRETTY_PRINT);
+        $data = $this->service->getAll();
+        $rows = [];
+        $rows[] = ['Name', 'Versuch', 'Katalog', 'Richtige', 'Gesamt'];
+        foreach ($data as $r) {
+            $rows[] = [
+                (string)($r['name'] ?? ''),
+                (int)($r['attempt'] ?? 0),
+                (string)($r['catalog'] ?? ''),
+                (int)($r['correct'] ?? 0),
+                (int)($r['total'] ?? 0),
+            ];
+        }
+        $content = $this->xlsx->build($rows);
         $response->getBody()->write($content);
         return $response
-            ->withHeader('Content-Type', 'application/json')
-            ->withHeader('Content-Disposition', 'attachment; filename="results.json"');
+            ->withHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+            ->withHeader('Content-Disposition', 'attachment; filename="results.xlsx"');
     }
 
     public function post(Request $request, Response $response): Response

--- a/src/Service/XlsxExportService.php
+++ b/src/Service/XlsxExportService.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class XlsxExportService
+{
+    /**
+     * @param list<array<string|int|float|null>> $rows
+     */
+    public function build(array $rows): string
+    {
+        $sheetData = '';
+        foreach ($rows as $i => $row) {
+            $rowIndex = $i + 1;
+            $sheetData .= '<row r="' . $rowIndex . '">';
+            foreach (array_values($row) as $j => $value) {
+                $col = $this->columnLetter($j + 1) . $rowIndex;
+                $text = htmlspecialchars((string)$value, ENT_XML1);
+                $sheetData .= '<c r="' . $col . '" t="inlineStr"><is><t>' . $text . '</t></is></c>';
+            }
+            $sheetData .= '</row>';
+        }
+        $sheetXml = '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+            . '<sheetData>' . $sheetData . '</sheetData>'
+            . '</worksheet>';
+
+        $contentTypes = '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+            . '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+            . '<Default Extension="xml" ContentType="application/xml"/>'
+            . '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>'
+            . '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>'
+            . '</Types>';
+
+        $rels = '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            . '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>'
+            . '</Relationships>';
+
+        $workbookRels = '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            . '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>'
+            . '</Relationships>';
+
+        $workbook = '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
+            . 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+            . '<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>'
+            . '</workbook>';
+
+        $zip = new \ZipArchive();
+        $tmp = tempnam(sys_get_temp_dir(), 'xlsx');
+        if ($tmp === false) {
+            return '';
+        }
+        $zip->open($tmp, \ZipArchive::CREATE);
+        $zip->addFromString('[Content_Types].xml', $contentTypes);
+        $zip->addFromString('_rels/.rels', $rels);
+        $zip->addFromString('xl/_rels/workbook.xml.rels', $workbookRels);
+        $zip->addFromString('xl/workbook.xml', $workbook);
+        $zip->addFromString('xl/worksheets/sheet1.xml', $sheetXml);
+        $zip->close();
+        $data = file_get_contents($tmp);
+        unlink($tmp);
+        return $data === false ? '' : $data;
+    }
+
+    private function columnLetter(int $num): string
+    {
+        $letters = '';
+        while ($num > 0) {
+            $num--;
+            $letters = chr(65 + ($num % 26)) . $letters;
+            $num = intdiv($num, 26);
+        }
+        return $letters;
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -15,6 +15,7 @@ use App\Application\Middleware\AdminAuthMiddleware;
 use App\Service\ConfigService;
 use App\Service\CatalogService;
 use App\Service\ResultService;
+use App\Service\XlsxExportService;
 use App\Service\TeamService;
 use App\Controller\ResultController;
 use App\Controller\TeamController;
@@ -36,11 +37,12 @@ return function (\Slim\App $app) {
     $configService = new ConfigService(__DIR__ . '/../config/config.json');
     $catalogService = new CatalogService(__DIR__ . '/../kataloge');
     $resultService = new ResultService(__DIR__ . '/../data/results.json');
+    $xlsxService = new XlsxExportService();
     $teamService = new TeamService(__DIR__ . '/../data/teams.json');
 
     $configController = new ConfigController($configService);
     $catalogController = new CatalogController($catalogService);
-    $resultController = new ResultController($resultService);
+    $resultController = new ResultController($resultService, $xlsxService);
     $teamController = new TeamController($teamService);
 
     $app->get('/', HomeController::class);

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -36,7 +36,7 @@
     <h2 class="uk-heading-bullet">3. Art und Umfang der erhobenen Daten</h2>
     <p><strong>Keine Erhebung personenbezogener Daten:</strong> Es werden keinerlei personenbezogene Daten (wie Name, E-Mail, Adresse etc.) abgefragt, gespeichert oder verarbeitet.</p>
     <p><strong>Quiz-Daten:</strong> Bei der Nutzung der App werden lediglich pseudonymisierte Daten wie frei gewählte Benutzernamen, erzielte Punktzahlen und ggf. technische Informationen zum Ablauf des Quiz verarbeitet.</p>
-    <p><strong>Serverdatei (results.json):</strong> Bei aktivierter Speicherung werden Pseudonyme, Katalogname, Versuch und Punktzahl serverseitig gesichert. Die Ablage erfolgt anonymisiert und konform zur DSGVO.</p>
+    <p><strong>Serverdatei (results.xlsx):</strong> Bei aktivierter Speicherung werden Pseudonyme, Katalogname, Versuch und Punktzahl serverseitig gesichert. Die Ablage erfolgt anonymisiert und konform zur DSGVO.</p>
     <p><strong>Protokolldatei (statistical.log):</strong> Beim optionalen Export werden ausschließlich Pseudonyme und Punktzahlen gespeichert.</p>
 
     <h2 class="uk-heading-bullet">4. Speicherung und Löschung</h2>


### PR DESCRIPTION
## Summary
- add `XlsxExportService` to generate spreadsheets on the fly
- export results in XLSX from `ResultController`
- update routes, admin javascript, and docs for new format

## Testing
- `python3 -m pytest -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684af5294048832b9cd283d66b020c6a