### PR TITLE
Add QR download and reorder tabs

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -494,23 +494,44 @@ document.addEventListener('DOMContentLoaded', function () {
     input.type = 'text';
     input.className = 'uk-input uk-width-expand';
     input.value = name;
-    const img = document.createElement('img');
-    img.className = 'uk-margin-left';
-    img.width = 64;
-    img.height = 64;
-    function update(){
-      const val = input.value.trim();
-      img.src = val ? qrSrc(val) : '';
+  const img = document.createElement('img');
+  img.className = 'uk-margin-left';
+  img.width = 64;
+  img.height = 64;
+  const dl = document.createElement('button');
+  dl.className = 'uk-button uk-button-default uk-margin-left';
+  dl.innerHTML = '<span uk-icon="download"></span>';
+  dl.setAttribute('aria-label', 'QR-Code herunterladen');
+  function triggerDownload(text) {
+    const a = document.createElement('a');
+    a.href = qrSrc(text);
+    a.download = text + '.png';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+  function update() {
+    const val = input.value.trim();
+    if (val) {
+      img.src = qrSrc(val);
+      dl.disabled = false;
+      dl.onclick = e => { e.preventDefault(); triggerDownload(val); };
+    } else {
+      img.src = '';
+      dl.disabled = true;
+      dl.onclick = null;
     }
-    input.addEventListener('input', update);
-    update();
-    const del = document.createElement('button');
-    del.className = 'uk-button uk-button-danger uk-margin-left';
-    del.textContent = '×';
-    del.onclick = () => div.remove();
-    div.appendChild(input);
-    div.appendChild(img);
-    div.appendChild(del);
+  }
+  input.addEventListener('input', update);
+  update();
+  const del = document.createElement('button');
+  del.className = 'uk-button uk-button-danger uk-margin-left';
+  del.textContent = '×';
+  del.onclick = () => div.remove();
+  div.appendChild(input);
+  div.appendChild(img);
+  div.appendChild(dl);
+  div.appendChild(del);
     return div;
   }
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -18,9 +18,9 @@
   </div>
   <ul uk-tab>
     <li class="uk-active"><a href="#">Veranstaltung konfigurieren</a></li>
+    <li><a href="#">Teams/Personen</a></li>
     <li><a href="#">Fragen anpassen</a></li>
     <li><a href="#">Ergebnisse</a></li>
-    <li><a href="#">Teams/Personen</a></li>
   </ul>
   <ul class="uk-switcher uk-margin">
     <li>
@@ -78,6 +78,21 @@
       </div>
     </li>
     <li>
+      <div class="uk-container uk-container-small">
+        <h2 class="uk-heading-bullet">Teams/Personen</h2>
+        <div id="teamsList" class="uk-margin"></div>
+        <div class="uk-margin">
+          <button id="teamAddBtn" class="uk-button uk-button-default">Hinzufügen</button>
+        </div>
+        <div class="uk-margin">
+          <label><input class="uk-checkbox" type="checkbox" id="teamRestrict"> Nur Teams/Personen aus der Liste dürfen teilnehmen.</label>
+        </div>
+        <div class="uk-margin">
+          <button id="teamsSaveBtn" class="uk-button uk-button-primary">Speichern</button>
+        </div>
+      </div>
+    </li>
+    <li>
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Fragen bearbeiten</h2>
         <div class="uk-margin">
@@ -120,21 +135,6 @@
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="resultsResetBtn" class="uk-button uk-button-default">Zurücksetzen</button>
           <button id="resultsDownloadBtn" class="uk-button uk-button-primary">Herunterladen</button>
-        </div>
-      </div>
-    </li>
-    <li>
-      <div class="uk-container uk-container-small">
-        <h2 class="uk-heading-bullet">Teams/Personen</h2>
-        <div id="teamsList" class="uk-margin"></div>
-        <div class="uk-margin">
-          <button id="teamAddBtn" class="uk-button uk-button-default">Hinzufügen</button>
-        </div>
-        <div class="uk-margin">
-          <label><input class="uk-checkbox" type="checkbox" id="teamRestrict"> Nur Teams/Personen aus der Liste dürfen teilnehmen.</label>
-        </div>
-        <div class="uk-margin">
-          <button id="teamsSaveBtn" class="uk-button uk-button-primary">Speichern</button>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- move Teams tab to second position in admin page
- allow downloading team QR codes

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b0084cb40832b88d5185b5edac8aa