### PR TITLE
Add catalog management tab with QR codes

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -18,6 +18,7 @@
   </div>
   <ul uk-tab>
     <li class="uk-active"><a href="#">Veranstaltung konfigurieren</a></li>
+    <li><a href="#">Kataloge</a></li>
     <li><a href="#">Fragen anpassen</a></li>
     <li><a href="#">Ergebnisse</a></li>
     <li><a href="#">Teams/Personen</a></li>
@@ -75,6 +76,15 @@
           <button id="cfgSaveBtn" class="uk-button uk-button-primary">Speichern</button>
         </div>
 
+      </div>
+    </li>
+    <li>
+      <div class="uk-container uk-container-small">
+        <h2 class="uk-heading-bullet">Kataloge</h2>
+        <div class="uk-margin">
+          <button id="newCatBtn" class="uk-button uk-button-default">Neuer Katalog</button>
+        </div>
+        <div id="catalogList" class="uk-margin"></div>
       </div>
     </li>
     <li>


### PR DESCRIPTION
## Summary
- add a new "Kataloge" tab to the admin page
- list available catalogs and allow creating new ones
- include QR codes for each catalog path
- update admin JavaScript to render catalogs and handle create/delete actions

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b01e65f70832b8eec676c1963be59