### PR TITLE
Fix Admin tabs mismatch

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -85,6 +85,10 @@
           <button id="newCatBtn" class="uk-button uk-button-default">Neuer Katalog</button>
         </div>
         <div id="catalogList" class="uk-margin"></div>
+      </div>
+    </li>
+    <li>
+      <div class="uk-container uk-container-small">
         <h2 class="uk-heading-bullet">Teams/Personen</h2>
         <div id="teamsList" class="uk-margin"></div>
         <div class="uk-margin">


### PR DESCRIPTION
## Summary
- split teams tab from catalog management so the admin tabs align

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b03da81c4832baa4e80036a19367d