### PR TITLE
Add QR code PDF export

### DIFF
--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\CatalogService;
+use App\Service\TeamService;
+use App\Service\PdfExportService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class PdfExportController
+{
+    private CatalogService $catalogs;
+    private TeamService $teams;
+    private PdfExportService $pdf;
+
+    public function __construct(CatalogService $catalogs, TeamService $teams, PdfExportService $pdf)
+    {
+        $this->catalogs = $catalogs;
+        $this->teams = $teams;
+        $this->pdf = $pdf;
+    }
+
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $catalogsJson = $this->catalogs->read('catalogs.json');
+        $list = $catalogsJson ? json_decode($catalogsJson, true) : [];
+        $teams = $this->teams->getAll();
+        $uri = $request->getUri();
+        $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
+        if ($uri->getPort()) {
+            $baseUrl .= ':' . $uri->getPort();
+        }
+        $data = $this->pdf->build($list, $teams, $baseUrl);
+        $response->getBody()->write($data);
+        return $response
+            ->withHeader('Content-Type', 'application/pdf')
+            ->withHeader('Content-Disposition', 'inline; filename="qrcodes.pdf"');
+    }
+}
+

--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class PdfExportService
+{
+    private function createPageImage(string $label, string $qrData): string
+    {
+        $qrUrl = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' . urlencode($qrData);
+        $qrContent = @file_get_contents($qrUrl);
+        if ($qrContent === false) {
+            $qrContent = '';
+        }
+        $qrImg = $qrContent ? imagecreatefromstring($qrContent) : false;
+        $width = 595;
+        $height = 842;
+        $img = imagecreatetruecolor($width, $height);
+        $white = imagecolorallocate($img, 255, 255, 255);
+        $black = imagecolorallocate($img, 0, 0, 0);
+        imagefill($img, 0, 0, $white);
+        imagestring($img, 5, 30, 30, $label, $black);
+        if ($qrImg !== false) {
+            $w = imagesx($qrImg);
+            $h = imagesy($qrImg);
+            imagecopyresampled($img, $qrImg, ($width - 200) / 2, 100, 0, 0, 200, 200, $w, $h);
+            imagedestroy($qrImg);
+        }
+        ob_start();
+        imagejpeg($img, null, 90);
+        $data = ob_get_clean();
+        imagedestroy($img);
+        return $data === false ? '' : $data;
+    }
+
+    /**
+     * @param list<array{id:string,name?:string}> $catalogs
+     * @param list<string> $teams
+     */
+    public function build(array $catalogs, array $teams, string $baseUrl): string
+    {
+        $pdf = new SimplePdf();
+        foreach ($catalogs as $cat) {
+            $label = 'Katalog: ' . ($cat['name'] ?? $cat['id']);
+            $data = $this->createPageImage($label, $baseUrl . '/?katalog=' . urlencode($cat['id']));
+            $pdf->addPage([[
+                'data' => $data,
+                'width' => 595,
+                'height' => 842,
+                'x' => 0,
+                'y' => 0,
+            ]]);
+        }
+        foreach ($teams as $team) {
+            $label = 'Team: ' . $team;
+            $data = $this->createPageImage($label, $team);
+            $pdf->addPage([[
+                'data' => $data,
+                'width' => 595,
+                'height' => 842,
+                'x' => 0,
+                'y' => 0,
+            ]]);
+        }
+        return $pdf->output();
+    }
+}
+

--- a/src/Service/SimplePdf.php
+++ b/src/Service/SimplePdf.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Minimal PDF builder supporting image pages.
+ */
+class SimplePdf
+{
+    /** @var list<string|null> */
+    private array $objects = [];
+    /** @var list<int> */
+    private array $pages = [];
+
+    public function __construct()
+    {
+        $this->objects[1] = null; // Catalog
+        $this->objects[2] = null; // Pages
+    }
+
+    private function addObject(string $content): int
+    {
+        $id = count($this->objects) + 1;
+        $this->objects[$id] = $content;
+        return $id;
+    }
+
+    /**
+     * @param array<int, array{data:string,width:int,height:int,x:int,y:int}> $images
+     */
+    public function addPage(array $images, int $width = 595, int $height = 842): void
+    {
+        $resourcesParts = [];
+        foreach ($images as $i => $img) {
+            $imgObj = $this->addObject(
+                "<< /Type /XObject /Subtype /Image /Width {$img['width']} /Height {$img['height']} " .
+                "/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length " . strlen($img['data']) . " >>\n" .
+                "stream\n{$img['data']}\nendstream"
+            );
+            $name = '/Im' . ($i + 1);
+            $resourcesParts[] = $name . ' ' . $imgObj . ' 0 R';
+            $images[$i]['name'] = $name;
+        }
+
+        $content = "q\n";
+        foreach ($images as $img) {
+            $x = $img['x'];
+            $y = $height - $img['y'] - $img['height'];
+            $name = $img['name'];
+            $content .= "{$img['width']} 0 0 {$img['height']} $x $y cm\n{$name} Do\n";
+        }
+        $content .= "Q";
+        $contentObj = $this->addObject("<< /Length " . strlen($content) . " >>\nstream\n" . $content . "\nendstream");
+        $resources = "<< /XObject << " . implode(' ', $resourcesParts) . " >> >>";
+        $pageObj = $this->addObject(
+            "<< /Type /Page /Parent 2 0 R /Resources $resources /MediaBox [0 0 $width $height] /Contents $contentObj 0 R >>"
+        );
+        $this->pages[] = $pageObj;
+    }
+
+    public function output(): string
+    {
+        $pagesKids = implode(' ', array_map(fn($id) => "$id 0 R", $this->pages));
+        $this->objects[2] = "<< /Type /Pages /Kids [$pagesKids] /Count " . count($this->pages) . " >>";
+        $this->objects[1] = "<< /Type /Catalog /Pages 2 0 R >>";
+
+        $pdf = "%PDF-1.4\n";
+        $offsets = [0];
+        for ($i = 1; $i <= count($this->objects); $i++) {
+            $offsets[$i] = strlen($pdf);
+            $content = $this->objects[$i];
+            $pdf .= "$i 0 obj\n$content\nendobj\n";
+        }
+        $xref = strlen($pdf);
+        $pdf .= "xref\n0 " . (count($this->objects) + 1) . "\n0000000000 65535 f \n";
+        for ($i = 1; $i <= count($this->objects); $i++) {
+            $pdf .= sprintf("%010d 00000 n \n", $offsets[$i]);
+        }
+        $pdf .= "trailer << /Size " . (count($this->objects) + 1) . " /Root 1 0 R >>\n";
+        $pdf .= "startxref\n$xref\n%%EOF";
+        return $pdf;
+    }
+}
+

--- a/src/routes.php
+++ b/src/routes.php
@@ -17,8 +17,10 @@ use App\Service\CatalogService;
 use App\Service\ResultService;
 use App\Service\XlsxExportService;
 use App\Service\TeamService;
+use App\Service\PdfExportService;
 use App\Controller\ResultController;
 use App\Controller\TeamController;
+use App\Controller\PdfExportController;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
@@ -32,6 +34,7 @@ require_once __DIR__ . '/Controller/ConfigController.php';
 require_once __DIR__ . '/Controller/CatalogController.php';
 require_once __DIR__ . '/Controller/ResultController.php';
 require_once __DIR__ . '/Controller/TeamController.php';
+require_once __DIR__ . '/Controller/PdfExportController.php';
 
 return function (\Slim\App $app) {
     $configService = new ConfigService(__DIR__ . '/../config/config.json');
@@ -39,11 +42,13 @@ return function (\Slim\App $app) {
     $resultService = new ResultService(__DIR__ . '/../data/results.json');
     $xlsxService = new XlsxExportService();
     $teamService = new TeamService(__DIR__ . '/../data/teams.json');
+    $pdfService = new PdfExportService();
 
     $configController = new ConfigController($configService);
     $catalogController = new CatalogController($catalogService);
     $resultController = new ResultController($resultService, $xlsxService);
     $teamController = new TeamController($teamService);
+    $pdfController = new PdfExportController($catalogService, $teamService, $pdfService);
 
     $app->get('/', HomeController::class);
     $app->get('/favicon.ico', function (Request $request, Response $response) {
@@ -77,4 +82,6 @@ return function (\Slim\App $app) {
 
     $app->get('/teams.json', [$teamController, 'get']);
     $app->post('/teams.json', [$teamController, 'post']);
+
+    $app->get('/export.pdf', $pdfController)->add(new AdminAuthMiddleware());
 };

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -12,6 +12,7 @@
 {% block body %}
   <div class="uk-flex uk-flex-between uk-margin-small-bottom">
     <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+    <a href="/export.pdf" target="_blank" class="uk-button uk-button-default">QR-PDF</a>
     <div class="theme-switch">
       <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
     </div>


### PR DESCRIPTION
## Summary
- add `PdfExportService` with simple PDF generation
- create `PdfExportController` to serve `/export.pdf`
- wire controller into routes and add export button in admin UI
- implement lightweight `SimplePdf` helper for embedding images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0d734e64832b95b2007e09003900