### PR TITLE
Add admin credentials to config management

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Das **Sommerfest-Quiz** ist eine sofort einsetzbare Web-App, mit der Sie Besuche
 
 ## Anpassung
 
-Alle wichtigen Einstellungen finden Sie in `config/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `kataloge/*.json` und können mit jedem Texteditor angepasst werden.
+Alle wichtigen Einstellungen finden Sie in `config/config.json`. Ändern Sie hier Logo, Farben, die Zugangsdaten für den Adminbereich oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `kataloge/*.json` und können mit jedem Texteditor angepasst werden.
 
 ## Tests
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -20,7 +20,9 @@ document.addEventListener('DOMContentLoaded', function () {
     backgroundColor: document.getElementById('cfgBackgroundColor'),
     buttonColor: document.getElementById('cfgButtonColor'),
     checkAnswerButton: document.getElementById('cfgCheckAnswerButton'),
-    qrUser: document.getElementById('cfgQRUser')
+    qrUser: document.getElementById('cfgQRUser'),
+    adminUser: document.getElementById('cfgAdminUser'),
+    adminPass: document.getElementById('cfgAdminPass')
   };
   // Füllt das Formular mit den Werten aus einem Konfigurationsobjekt
   function renderCfg(data) {
@@ -32,6 +34,8 @@ document.addEventListener('DOMContentLoaded', function () {
     cfgFields.buttonColor.value = data.buttonColor || '';
     cfgFields.checkAnswerButton.value = data.CheckAnswerButton || 'yes';
     cfgFields.qrUser.value = String(data.QRUser) || 'false';
+    cfgFields.adminUser.value = data.adminUser || '';
+    cfgFields.adminPass.value = data.adminPass || '';
   }
   renderCfg(cfgInitial);
   document.getElementById('cfgResetBtn').addEventListener('click', function (e) {
@@ -48,7 +52,9 @@ document.addEventListener('DOMContentLoaded', function () {
       backgroundColor: cfgFields.backgroundColor.value.trim(),
       buttonColor: cfgFields.buttonColor.value.trim(),
       CheckAnswerButton: cfgFields.checkAnswerButton.value,
-      QRUser: cfgFields.qrUser.value === 'true'
+      QRUser: cfgFields.qrUser.value === 'true',
+      adminUser: cfgFields.adminUser.value.trim(),
+      adminPass: cfgFields.adminPass.value
     };
     fetch(url('config.json'), {
       method: 'POST',

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -22,6 +22,10 @@ window.quizConfig = {
   // QR-Code-Login aktivieren (true/false)
   QRUser: true,
 
+  // Zugangsdaten für den Admin-Bereich
+  adminUser: 'admin',
+  adminPass: 'password',
+
   // Teilnahme auf bekannte Namen beschränken
   QRRestrict: false
 };

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -71,6 +71,14 @@
               </select>
             </div>
           </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="cfgAdminUser">Admin-Benutzer</label>
+            <div class="uk-form-controls"><input class="uk-input" type="text" id="cfgAdminUser"></div>
+          </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="cfgAdminPass">Admin-Passwort</label>
+            <div class="uk-form-controls"><input class="uk-input" type="password" id="cfgAdminPass"></div>
+          </div>
         </form>
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="cfgResetBtn" class="uk-button uk-button-default">Zurücksetzen</button>


### PR DESCRIPTION
## Summary
- extend admin UI to configure admin username and password
- update admin.js logic to handle new fields
- document admin credentials in README and example config

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b220eac28832b813aca9542e08fb2