### PR TITLE
Fix admin loading of catalogs

### DIFF
--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -21,8 +21,12 @@ class CatalogController
     {
         $file = basename($args['file']);
         $accept = strtolower($request->getHeaderLine('Accept'));
+        $ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
 
-        if ($accept === '' || strpos($accept, 'application/json') === false) {
+        $isJson = $ext === 'json' || strpos($accept, 'application/json') !== false;
+        // redirect only when neither the file extension nor the Accept header
+        // indicate a JSON response
+        if (!$isJson) {
             $id = pathinfo($file, PATHINFO_FILENAME);
             return $response
                 ->withHeader('Location', '/?katalog=' . urlencode($id))


### PR DESCRIPTION
## Summary
- allow direct JSON access for catalog endpoints
- improve JSON detection for catalog API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b2a7c9878832b8cc09cd388fdd47a