### PR TITLE
Add missing favicon.ico

### DIFF
--- a/public/favicon.ico
+++ b/public/favicon.ico
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="18" fill="#FFD93B"></circle>
+  <!-- Sonnenstrahlen -->
+  <g stroke="#FFC300" stroke-width="3">
+    <line x1="32" y1="6" x2="32" y2="18"></line>
+    <line x1="32" y1="46" x2="32" y2="58"></line>
+    <line x1="6" y1="32" x2="18" y2="32"></line>
+    <line x1="46" y1="32" x2="58" y2="32"></line>
+    <line x1="14" y1="14" x2="22" y2="22"></line>
+    <line x1="42" y1="42" x2="50" y2="50"></line>
+    <line x1="14" y1="50" x2="22" y2="42"></line>
+    <line x1="42" y1="22" x2="50" y2="14"></line>
+  </g>
+  <!-- Party-Konfetti -->
+  <circle cx="16" cy="18" r="2" fill="#E9446A"></circle>
+  <circle cx="48" cy="20" r="2" fill="#3EC300"></circle>
+  <circle cx="20" cy="46" r="2" fill="#39C2F1"></circle>
+  <circle cx="44" cy="50" r="2" fill="#F8AC3C"></circle>
+</svg>


### PR DESCRIPTION
## Summary
- add `favicon.ico` to avoid 404 errors when browsers request it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2daa96a0832bb5fe21a1e4d9f8a3