### PR TITLE
Fix route 404 issue due to base path

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,9 @@ $basePath = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
 if (basename($basePath) === 'public') {
     $basePath = dirname($basePath);
 }
+if ($basePath === '/') {
+    $basePath = '';
+}
 if ($basePath !== '') {
     $app->setBasePath($basePath);
 }


### PR DESCRIPTION
## Summary
- adjust base path detection in `public/index.php`

## Testing
- `python3 -m pytest -q`
- `./vendor/bin/phpunit --no-coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b328608b8832ba8f9b1d064056094