### PR TITLE
Update CI PHP versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 8.0, 8.1]
+                php: [8.0, 8.1]
                 experimental: [false]
                 include:
                     - php: 8.1


### PR DESCRIPTION
## Summary
- update the PHP matrix in the CI workflow to remove PHP 7.4

## Testing
- `pytest -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b332cd400832b8880ffb4d0c67174