### PR TITLE
Add global PDF export

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -67,6 +67,27 @@ document.addEventListener('DOMContentLoaded', function () {
         notify('Fehler beim Speichern', 'danger');
       });
   });
+  const cfgExportBtn = document.getElementById('cfgExportBtn');
+  cfgExportBtn?.addEventListener('click', function (e) {
+    e.preventDefault();
+    fetch('/export.pdf')
+      .then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        return r.blob();
+      })
+      .then(blob => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'export.pdf';
+        a.click();
+        URL.revokeObjectURL(url);
+      })
+      .catch(err => {
+        console.error(err);
+        notify('Fehler beim Export', 'danger');
+      });
+  });
 
   // --------- Fragen bearbeiten ---------
   const container = document.getElementById('questions');

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\CatalogService;
+use App\Service\ConfigService;
+use App\Service\PdfExportService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class ExportController
+{
+    private ConfigService $config;
+    private CatalogService $catalogs;
+    private PdfExportService $pdf;
+
+    public function __construct(ConfigService $config, CatalogService $catalogs, PdfExportService $pdf)
+    {
+        $this->config = $config;
+        $this->catalogs = $catalogs;
+        $this->pdf = $pdf;
+    }
+
+    public function download(Request $request, Response $response): Response
+    {
+        $cfg = $this->config->getConfig();
+        $catJson = $this->catalogs->read('catalogs.json');
+        $cats = [];
+        if ($catJson !== null) {
+            $cats = json_decode($catJson, true) ?? [];
+        }
+        $content = $this->pdf->build($cfg, $cats);
+        $response->getBody()->write($content);
+        return $response
+            ->withHeader('Content-Type', 'application/pdf')
+            ->withHeader('Content-Disposition', 'attachment; filename="export.pdf"');
+    }
+}

--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class PdfExportService
+{
+    /**
+     * @param array<string, mixed> $config
+     * @param array<int, array<string, mixed>> $catalogs
+     */
+    public function build(array $config, array $catalogs): string
+    {
+        $header = (string)($config['header'] ?? '');
+        $subheader = (string)($config['subheader'] ?? '');
+
+        $y = 770.0;
+        $lines = [];
+        $lines[] = 'BT';
+        if ($header !== '') {
+            $lines[] = '/F1 24 Tf';
+            $lines[] = sprintf('1 0 0 1 72 %.1f Tm (%s) Tj', $y, $this->escape($header));
+            $y -= 32.0;
+        }
+        if ($subheader !== '') {
+            $lines[] = '/F1 16 Tf';
+            $lines[] = sprintf('1 0 0 1 72 %.1f Tm (%s) Tj', $y, $this->escape($subheader));
+            $y -= 40.0;
+        }
+        $lines[] = '/F1 12 Tf';
+        foreach ($catalogs as $cat) {
+            $name = (string)($cat['name'] ?? $cat['id'] ?? '');
+            $lines[] = sprintf('1 0 0 1 72 %.1f Tm (%s) Tj', $y, $this->escape('• ' . $name));
+            $y -= 20.0;
+        }
+        $lines[] = 'ET';
+
+        $stream = implode("\n", $lines);
+
+        $objects = [];
+        $objects[] = "<< /Type /Catalog /Pages 2 0 R >>"; // 1
+        $objects[] = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>"; // 2
+        $objects[] = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>"; //3
+        $objects[] = "<< /Length " . strlen($stream) . " >>\nstream\n" . $stream . "\nendstream"; //4
+        $objects[] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"; //5
+
+        $pdf = "%PDF-1.4\n";
+        $offsets = [];
+        foreach ($objects as $i => $obj) {
+            $offsets[$i + 1] = strlen($pdf);
+            $pdf .= ($i + 1) . " 0 obj\n" . $obj . "\nendobj\n";
+        }
+        $xrefPos = strlen($pdf);
+        $pdf .= "xref\n0 " . (count($objects) + 1) . "\n";
+        $pdf .= "0000000000 65535 f \n";
+        foreach ($offsets as $off) {
+            $pdf .= sprintf('%010d 00000 n \n', $off);
+        }
+        $pdf .= "trailer << /Root 1 0 R /Size " . (count($objects) + 1) . " >>\n";
+        $pdf .= "startxref\n" . $xrefPos . "\n%%EOF";
+
+        return $pdf;
+    }
+
+    private function escape(string $text): string
+    {
+        return str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $text);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -19,6 +19,8 @@ use App\Service\XlsxExportService;
 use App\Service\TeamService;
 use App\Controller\ResultController;
 use App\Controller\TeamController;
+use App\Controller\ExportController;
+use App\Service\PdfExportService;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
@@ -32,6 +34,7 @@ require_once __DIR__ . '/Controller/ConfigController.php';
 require_once __DIR__ . '/Controller/CatalogController.php';
 require_once __DIR__ . '/Controller/ResultController.php';
 require_once __DIR__ . '/Controller/TeamController.php';
+require_once __DIR__ . '/Controller/ExportController.php';
 
 return function (\Slim\App $app) {
     $configService = new ConfigService(__DIR__ . '/../config/config.json');
@@ -39,11 +42,13 @@ return function (\Slim\App $app) {
     $resultService = new ResultService(__DIR__ . '/../data/results.json');
     $xlsxService = new XlsxExportService();
     $teamService = new TeamService(__DIR__ . '/../data/teams.json');
+    $pdfService = new PdfExportService();
 
     $configController = new ConfigController($configService);
     $catalogController = new CatalogController($catalogService);
     $resultController = new ResultController($resultService, $xlsxService);
     $teamController = new TeamController($teamService);
+    $exportController = new ExportController($configService, $catalogService, $pdfService);
 
     $app->get('/', HomeController::class);
     $app->get('/favicon.ico', function (Request $request, Response $response) {
@@ -67,6 +72,7 @@ return function (\Slim\App $app) {
     $app->get('/results/download', [$resultController, 'download']);
     $app->post('/results', [$resultController, 'post']);
     $app->delete('/results', [$resultController, 'delete']);
+    $app->get('/export.pdf', [$exportController, 'download']);
     $app->get('/config.json', [$configController, 'get']);
     $app->post('/config.json', [$configController, 'post']);
     $app->get('/kataloge/{file}', [$catalogController, 'get']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -73,7 +73,10 @@
         </form>
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="cfgResetBtn" class="uk-button uk-button-default">Zurücksetzen</button>
-          <button id="cfgSaveBtn" class="uk-button uk-button-primary">Speichern</button>
+          <div>
+            <button id="cfgExportBtn" class="uk-button uk-button-secondary uk-margin-right">PDF Export</button>
+            <button id="cfgSaveBtn" class="uk-button uk-button-primary">Speichern</button>
+          </div>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- add simple PDF builder service
- create ExportController for PDF downloads
- expose `/export.pdf` route and use in admin
- include button and event handler for PDF export in admin panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3a9bf0e8832b8de602c8559d0fea