### PR TITLE
Disable leftover random names in restricted mode

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -269,6 +269,10 @@
   }
 
   async function init(){
+    const cfg = window.quizConfig || {};
+    if(cfg.QRRestrict){
+      sessionStorage.removeItem('quizUser');
+    }
     applyConfig();
     updateUserName();
     const catalogs = await loadCatalogList();


### PR DESCRIPTION
## Summary
- clear stored random usernames when team restriction is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3df2a8a0832b975c1a6c2880f953