### PR TITLE
Add password change tab for admin

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -672,6 +672,41 @@ document.addEventListener('DOMContentLoaded', function () {
     }).catch(()=>{});
   });
 
+  // --------- Passwort ändern ---------
+  const passSaveBtn = document.getElementById('passSaveBtn');
+  const newPass = document.getElementById('newPass');
+  const newPassRepeat = document.getElementById('newPassRepeat');
+
+  passSaveBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    if (!newPass || !newPassRepeat) return;
+    const p1 = newPass.value;
+    const p2 = newPassRepeat.value;
+    if (p1 === '' || p2 === '') {
+      notify('Passwort darf nicht leer sein', 'danger');
+      return;
+    }
+    if (p1 !== p2) {
+      notify('Passwörter stimmen nicht überein', 'danger');
+      return;
+    }
+    fetch('/password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: p1 })
+    })
+      .then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        notify('Passwort geändert', 'success');
+        newPass.value = '';
+        newPassRepeat.value = '';
+      })
+      .catch(err => {
+        console.error(err);
+        notify('Fehler beim Speichern', 'danger');
+      });
+  });
+
   // Zähler für eindeutige Namen von Eingabefeldern
   let cardIndex = 0;
 });

--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\ConfigService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class PasswordController
+{
+    private ConfigService $service;
+
+    public function __construct(ConfigService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function post(Request $request, Response $response): Response
+    {
+        $data = $request->getParsedBody();
+        if ($request->getHeaderLine('Content-Type') === 'application/json') {
+            $data = json_decode((string) $request->getBody(), true);
+            if (!is_array($data)) {
+                return $response->withStatus(400);
+            }
+        } elseif (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+
+        $pass = $data['password'] ?? '';
+        if (!is_string($pass) || $pass === '') {
+            return $response->withStatus(400);
+        }
+
+        $cfg = $this->service->getConfig();
+        $cfg['adminPass'] = $pass;
+        $this->service->saveConfig($cfg);
+
+        return $response->withStatus(204);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -21,6 +21,7 @@ use App\Controller\ResultController;
 use App\Controller\TeamController;
 use App\Controller\ExportController;
 use App\Service\PdfExportService;
+use App\Controller\PasswordController;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
@@ -35,6 +36,7 @@ require_once __DIR__ . '/Controller/CatalogController.php';
 require_once __DIR__ . '/Controller/ResultController.php';
 require_once __DIR__ . '/Controller/TeamController.php';
 require_once __DIR__ . '/Controller/ExportController.php';
+require_once __DIR__ . '/Controller/PasswordController.php';
 
 return function (\Slim\App $app) {
     $configService = new ConfigService(__DIR__ . '/../config/config.json');
@@ -49,6 +51,7 @@ return function (\Slim\App $app) {
     $resultController = new ResultController($resultService, $xlsxService);
     $teamController = new TeamController($teamService);
     $exportController = new ExportController($configService, $catalogService, $pdfService);
+    $passwordController = new PasswordController($configService);
 
     $app->get('/', HomeController::class);
     $app->get('/favicon.ico', function (Request $request, Response $response) {
@@ -83,4 +86,5 @@ return function (\Slim\App $app) {
 
     $app->get('/teams.json', [$teamController, 'get']);
     $app->post('/teams.json', [$teamController, 'post']);
+    $app->post('/password', [$passwordController, 'post']);
 };

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -22,6 +22,7 @@
     <li><a href="#">Teams/Personen</a></li>
     <li><a href="#">Fragen anpassen</a></li>
     <li><a href="#">Ergebnisse</a></li>
+    <li><a href="#">Passwort ändern</a></li>
   </ul>
   <ul class="uk-switcher uk-margin">
     <li>
@@ -152,6 +153,24 @@
           <button id="resultsResetBtn" class="uk-button uk-button-default">Zurücksetzen</button>
           <button id="resultsDownloadBtn" class="uk-button uk-button-primary">Herunterladen</button>
         </div>
+      </div>
+    </li>
+    <li>
+      <div class="uk-container uk-container-small">
+        <h2 class="uk-heading-bullet">Passwort ändern</h2>
+        <form id="passForm" class="uk-form-stacked">
+          <div class="uk-margin">
+            <label class="uk-form-label" for="newPass">Neues Passwort</label>
+            <div class="uk-form-controls"><input class="uk-input" type="password" id="newPass"></div>
+          </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="newPassRepeat">Passwort wiederholen</label>
+            <div class="uk-form-controls"><input class="uk-input" type="password" id="newPassRepeat"></div>
+          </div>
+          <div class="uk-margin">
+            <button id="passSaveBtn" class="uk-button uk-button-primary">Speichern</button>
+          </div>
+        </form>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
## Summary
- add `PasswordController` and routes
- support password update in admin.js
- add new tab in admin.twig for password changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3efdefdc832ba719fe3857a4993f