### PR TITLE
Improve admin UI responsiveness

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -169,3 +169,22 @@ a.uk-accordion-title {
     padding-right: 8px;
   }
 }
+
+/* Fester Bedienbereich im Admin-Editor */
+.sticky-actions {
+  position: sticky;
+  bottom: 72px;
+  z-index: 900;
+  background: rgba(255, 255, 255, 0.95);
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+body.dark-mode .sticky-actions {
+  background: rgba(0, 0, 0, 0.95);
+}
+
+/* Vorschau innerhalb der Fragekarte */
+.question-preview {
+  min-height: 100px;
+}

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -405,11 +405,67 @@ document.addEventListener('DOMContentLoaded', function () {
 
     renderFields();
 
-    card.appendChild(typeSelect);
-    card.appendChild(typeInfo);
-    card.appendChild(prompt);
-    card.appendChild(fields);
-    card.appendChild(removeBtn);
+    // Vorschau-Bereich anlegen
+    const preview = document.createElement('div');
+    preview.className = 'uk-card uk-card-muted uk-card-body question-preview';
+
+    const formCol = document.createElement('div');
+    formCol.appendChild(typeSelect);
+    formCol.appendChild(typeInfo);
+    formCol.appendChild(prompt);
+    formCol.appendChild(fields);
+    formCol.appendChild(removeBtn);
+
+    const previewCol = document.createElement('div');
+    previewCol.appendChild(preview);
+
+    const grid = document.createElement('div');
+    grid.className = 'uk-grid-small uk-child-width-1-1 uk-child-width-1-2@m';
+    grid.setAttribute('uk-grid', '');
+    grid.appendChild(formCol);
+    grid.appendChild(previewCol);
+
+    card.appendChild(grid);
+
+    function updatePreview() {
+      preview.innerHTML = '';
+      const h = document.createElement('h4');
+      h.textContent = prompt.value || 'Vorschau';
+      preview.appendChild(h);
+      if (typeSelect.value === 'sort') {
+        const ul = document.createElement('ul');
+        Array.from(fields.querySelectorAll('.item')).forEach(i => {
+          const li = document.createElement('li');
+          li.textContent = i.value;
+          ul.appendChild(li);
+        });
+        preview.appendChild(ul);
+      } else if (typeSelect.value === 'assign') {
+        const ul = document.createElement('ul');
+        Array.from(fields.querySelectorAll('.term-row')).forEach(r => {
+          const term = r.querySelector('.term').value;
+          const def = r.querySelector('.definition').value;
+          const li = document.createElement('li');
+          li.textContent = term + ' – ' + def;
+          ul.appendChild(li);
+        });
+        preview.appendChild(ul);
+      } else {
+        const ul = document.createElement('ul');
+        Array.from(fields.querySelectorAll('.option')).forEach(o => {
+          const li = document.createElement('li');
+          li.textContent = o.value;
+          ul.appendChild(li);
+        });
+        preview.appendChild(ul);
+      }
+    }
+
+    prompt.addEventListener('input', updatePreview);
+    fields.addEventListener('input', updatePreview);
+    typeSelect.addEventListener('change', updatePreview);
+    updatePreview();
+
     cardIndex++;
     return card;
   }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -118,14 +118,17 @@
             <select id="catalogSelect" class="uk-select"></select>
           </div>
         </div>
-        <div id="questions"></div>
-        <div class="uk-margin">
+        <!-- Hauptdatenbereich: Frageneditor -->
+        <div id="questions" class="uk-margin"></div>
+        <!-- Bedienleiste fuer Frageneditor -->
+        <div id="questionActions" class="sticky-actions uk-flex uk-flex-between uk-flex-middle uk-margin">
           <button id="addBtn" class="uk-button uk-button-default">Neue Frage</button>
+          <div>
+            <button id="resetBtn" class="uk-button uk-button-default uk-margin-right">Zurücksetzen</button>
+            <button id="saveBtn" class="uk-button uk-button-primary">Speichern</button>
+          </div>
         </div>
-        <div class="uk-margin uk-flex uk-flex-between">
-          <button id="resetBtn" class="uk-button uk-button-default">Zurücksetzen</button>
-          <button id="saveBtn" class="uk-button uk-button-primary">Speichern</button>
-        </div>
+        <!-- Ende Hauptdatenbereich -->
 
       </div>
     </li>


### PR DESCRIPTION
## Summary
- keep quiz admin controls visible with sticky action bar
- reorganize question editor with a responsive grid and live preview
- style sticky button bar and preview card

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b437850d4832b81cc66c7110dac9d