### PR TITLE
Fix PDF font encoding

### DIFF
--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -47,9 +47,10 @@ class PdfExportService
         $objects[] = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>"; // 2
         $objects[] = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>"; //3
         $objects[] = "<< /Length " . strlen($stream) . " >>\nstream\n" . $stream . "\nendstream"; //4
-        $objects[] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"; //5
+        // Use WinAnsiEncoding so encoded text renders correctly
+        $objects[] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"; //5
 
-        $pdf = "%PDF-1.4\n";
+        $pdf = "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n";
         $offsets = [];
         foreach ($objects as $i => $obj) {
             $offsets[$i + 1] = strlen($pdf);
@@ -62,7 +63,7 @@ class PdfExportService
             $pdf .= sprintf('%010d 00000 n \n', $off);
         }
         $pdf .= "trailer << /Root 1 0 R /Size " . (count($objects) + 1) . " >>\n";
-        $pdf .= "startxref\n" . $xrefPos . "\n%%EOF";
+        $pdf .= "startxref\n" . $xrefPos . "\n%%EOF\n";
 
         return $pdf;
     }


### PR DESCRIPTION
## Summary
- use WinAnsiEncoding with Helvetica to fix PDF rendering

## Testing
- `pytest -q`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b429f87a4832b9f55a7b633c62c47