### PR TITLE
Add UIkit admin layout with catalog page

### DIFF
--- a/src/Controller/AdminCatalogController.php
+++ b/src/Controller/AdminCatalogController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
+use App\Service\CatalogService;
+
+class AdminCatalogController
+{
+    private CatalogService $service;
+
+    public function __construct(CatalogService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $view = Twig::fromRequest($request);
+        $catalogsJson = $this->service->read('catalogs.json');
+        $catalogs = [];
+        if ($catalogsJson !== null) {
+            $catalogs = json_decode($catalogsJson, true) ?? [];
+        }
+
+        return $view->render($response, 'kataloge.twig', [
+            'kataloge' => $catalogs,
+        ]);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -7,6 +7,7 @@ use App\Controller\DatenschutzController;
 use App\Controller\ImpressumController;
 use App\Controller\LizenzController;
 use App\Controller\AdminController;
+use App\Controller\AdminCatalogController;
 use App\Controller\LoginController;
 use App\Controller\LogoutController;
 use App\Controller\ConfigController;
@@ -37,6 +38,7 @@ require_once __DIR__ . '/Controller/ResultController.php';
 require_once __DIR__ . '/Controller/TeamController.php';
 require_once __DIR__ . '/Controller/ExportController.php';
 require_once __DIR__ . '/Controller/PasswordController.php';
+require_once __DIR__ . '/Controller/AdminCatalogController.php';
 
 return function (\Slim\App $app) {
     $configService = new ConfigService(__DIR__ . '/../config/config.json');
@@ -70,6 +72,7 @@ return function (\Slim\App $app) {
     $app->post('/login', [LoginController::class, 'login']);
     $app->get('/logout', LogoutController::class);
     $app->get('/admin', AdminController::class)->add(new AdminAuthMiddleware());
+    $app->get('/admin/kataloge', AdminCatalogController::class)->add(new AdminAuthMiddleware());
     $app->get('/results', [$resultController, 'page']);
     $app->get('/results.json', [$resultController, 'get']);
     $app->get('/results/download', [$resultController, 'download']);

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Admin{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.19.3/dist/css/uikit.min.css" />
+    <script src="https://cdn.jsdelivr.net/npm/uikit@3.19.3/dist/js/uikit.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/uikit@3.19.3/dist/js/uikit-icons.min.js"></script>
+    <style>
+        body { background: #111; color: #fff; min-height: 100vh; }
+        .custom-card { background: #222; color: #fff; }
+        .uk-navbar { background: #181818; }
+        .sticky-tabs { position: sticky; top: 0; z-index: 10; background: #181818; }
+        .uk-footer { background: #222; color: #ccc; }
+    </style>
+</head>
+<body>
+    <nav class="uk-navbar-container uk-navbar sticky-tabs" uk-navbar>
+        <div class="uk-navbar-left">
+            <a class="uk-navbar-item uk-logo" href="#">Digitalisierung</a>
+        </div>
+        <div class="uk-navbar-center">
+            <ul class="uk-navbar-nav">
+                <li {% if tab == 'konfig' %}class="uk-active"{% endif %}><a href="/admin/konfig">Veranstaltung konfigurieren</a></li>
+                <li {% if tab == 'kataloge' %}class="uk-active"{% endif %}><a href="/admin/kataloge">Kataloge</a></li>
+                <li {% if tab == 'teams' %}class="uk-active"{% endif %}><a href="/admin/teams">Teams/Personen</a></li>
+                <li {% if tab == 'fragen' %}class="uk-active"{% endif %}><a href="/admin/fragen">Fragen anpassen</a></li>
+                <li {% if tab == 'ergebnisse' %}class="uk-active"{% endif %}><a href="/admin/ergebnisse">Ergebnisse</a></li>
+                <li {% if tab == 'pw' %}class="uk-active"{% endif %}><a href="/admin/pw">Passwort ändern</a></li>
+            </ul>
+        </div>
+        <div class="uk-navbar-right">
+            <a class="uk-navbar-toggle" href="#" uk-icon="icon: cog"></a>
+        </div>
+    </nav>
+
+    <main class="uk-section uk-section-small">
+        <div class="uk-container">
+            {% block content %}{% endblock %}
+        </div>
+    </main>
+
+    <footer class="uk-section uk-section-xsmall uk-footer">
+        <div class="uk-container uk-text-center">
+            <span>DATENSCHUTZ</span> | <span>IMPRESSUM</span> | <span>LIZENZ</span>
+        </div>
+    </footer>
+</body>
+</html>

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -1,0 +1,26 @@
+{% extends "base.twig" %}
+{% set tab = 'kataloge' %}
+
+{% block title %}Kataloge verwalten{% endblock %}
+
+{% block content %}
+<h2 class="uk-heading-divider uk-margin-medium-bottom">Kataloge</h2>
+<button class="uk-button uk-button-primary uk-margin-bottom">Neuer Katalog</button>
+
+<div class="uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid>
+    {% for katalog in kataloge %}
+    <div>
+        <div class="uk-card uk-card-default uk-card-body custom-card uk-flex uk-flex-middle">
+            <div class="uk-width-expand">
+                <div class="uk-text-bold">{{ katalog.name }}</div>
+                <div class="uk-text-small uk-margin-small-top">{{ katalog.beschreibung }}</div>
+            </div>
+            <div class="uk-flex uk-flex-column uk-flex-middle uk-flex-center uk-margin-left">
+                <img src="{{ katalog.qrcode_url }}" alt="QR" style="width:48px;height:48px;" class="uk-margin-small-bottom">
+                <button class="uk-button uk-button-danger uk-button-small">Löschen</button>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- provide `base.twig` layout for admin area with sticky navbar
- implement `kataloge.twig` using mobile-first UIkit grid
- create `AdminCatalogController` and route `/admin/kataloge`

## Testing
- `python3 -m pytest`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4757f194832b8c285c68ae9930ac