### PR TITLE
Implement QR-code PDF export

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,9 @@
         "slim/slim": "^4.12",
         "slim/psr7": "^1.6",
         "twig/twig": "^3.8",
-        "slim/twig-view": "^3.3"
+        "slim/twig-view": "^3.3",
+        "mpdf/mpdf": "^8.2",
+        "endroid/qr-code": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -4,81 +4,63 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use Mpdf\Mpdf;
+use function class_exists;
+use function strlen;
+
 class PdfExportService
 {
     /**
-     * @param array<string, mixed> $config
-     * @param array<int, array<string, mixed>> $catalogs
+     * Build PDF listing catalogs with optional QR codes.
+     *
+     * @param array<string,mixed> $config
+     * @param array<int,array<string,mixed>> $catalogs
      */
     public function build(array $config, array $catalogs): string
     {
         $header = (string)($config['header'] ?? '');
         $subheader = (string)($config['subheader'] ?? '');
 
-        $y = 770.0;
-        $lines = [];
-        $lines[] = 'BT';
+        $html = '';
         if ($header !== '') {
-            $lines[] = '/F1 24 Tf';
-            $lines[] = sprintf('1 0 0 1 72 %.1f Tm (%s) Tj', $y, $this->encode($header));
-            $y -= 32.0;
+            $html .= '<h1>' . htmlspecialchars($header) . '</h1>';
         }
         if ($subheader !== '') {
-            $lines[] = '/F1 16 Tf';
-            $lines[] = sprintf('1 0 0 1 72 %.1f Tm (%s) Tj', $y, $this->encode($subheader));
-            $y -= 40.0;
+            $html .= '<h2>' . htmlspecialchars($subheader) . '</h2>';
         }
-        $lines[] = '/F1 12 Tf';
-        foreach ($catalogs as $cat) {
-            $name = (string)($cat['name'] ?? $cat['id'] ?? '');
-            $lines[] = sprintf(
-                '1 0 0 1 72 %.1f Tm (%s) Tj',
-                $y,
-                $this->encode('• ' . $name)
-            );
-            $y -= 20.0;
+
+        $html .= '<table border="1" cellpadding="8" style="width:100%; border-collapse:collapse;">';
+        $html .= '<tr><th>Name</th><th>Beschreibung</th><th>QR-Code</th></tr>';
+
+        foreach ($catalogs as $catalog) {
+            $name = (string)($catalog['name'] ?? $catalog['id'] ?? '');
+            $desc = (string)($catalog['description'] ?? $catalog['beschreibung'] ?? '');
+            $url = '?katalog=' . urlencode((string)($catalog['id'] ?? ''));
+
+            $qrImg = '';
+            if (class_exists('Endroid\\QrCode\\QrCode') && class_exists('Endroid\\QrCode\\Writer\\PngWriter')) {
+                $qrCode = \Endroid\QrCode\QrCode::create($url);
+                $writer = new \Endroid\QrCode\Writer\PngWriter();
+                $qrImg = $writer->write($qrCode)->getDataUri();
+            }
+
+            $html .= '<tr>';
+            $html .= '<td>' . htmlspecialchars($name) . '</td>';
+            $html .= '<td>' . htmlspecialchars($desc) . '</td>';
+            if ($qrImg !== '') {
+                $html .= '<td><img src="' . $qrImg . '" width="60"/></td>';
+            } else {
+                $html .= '<td></td>';
+            }
+            $html .= '</tr>';
         }
-        $lines[] = 'ET';
 
-        $stream = implode("\n", $lines);
+        $html .= '</table>';
 
-        $objects = [];
-        $objects[] = "<< /Type /Catalog /Pages 2 0 R >>"; // 1
-        $objects[] = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>"; // 2
-        $objects[] = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>"; //3
-        $objects[] = "<< /Length " . strlen($stream) . " >>\nstream\n" . $stream . "\nendstream"; //4
-        // Use WinAnsiEncoding so encoded text renders correctly
-        $objects[] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"; //5
+        $mpdf = new Mpdf(['tempDir' => sys_get_temp_dir()]);
+        $mpdf->WriteHTML($html);
+        $content = $mpdf->Output('', 'S');
 
-        $pdf = "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n";
-        $offsets = [];
-        foreach ($objects as $i => $obj) {
-            $offsets[$i + 1] = strlen($pdf);
-            $pdf .= ($i + 1) . " 0 obj\n" . $obj . "\nendobj\n";
-        }
-        $xrefPos = strlen($pdf);
-        $pdf .= "xref\n0 " . (count($objects) + 1) . "\n";
-        $pdf .= "0000000000 65535 f \n";
-        foreach ($offsets as $off) {
-            $pdf .= sprintf('%010d 00000 n \n', $off);
-        }
-        $pdf .= "trailer << /Root 1 0 R /Size " . (count($objects) + 1) . " >>\n";
-        $pdf .= "startxref\n" . $xrefPos . "\n%%EOF\n";
-
-        return $pdf;
-    }
-
-    private function escape(string $text): string
-    {
-        return str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $text);
-    }
-
-    private function encode(string $text): string
-    {
-        $encoded = @iconv('UTF-8', 'windows-1252//TRANSLIT', $text);
-        if ($encoded === false) {
-            $encoded = '';
-        }
-        return $this->escape($encoded);
+        return $content;
     }
 }


### PR DESCRIPTION
## Summary
- add mpdf/mpdf and endroid/qr-code to dependencies
- replace custom PDF code with mpdf version that embeds dynamic QR codes for each catalog
- inline QR code generation to avoid temporary files

## Testing
- `python3 -m pytest tests/test_html_validity.py tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b48fdb274832b8165afd2fc559381