### PR TITLE
Improve admin catalog tab layout

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -69,6 +69,12 @@ body.dark-mode .mc-option input {
   margin-right: 8px;
 }
 
+/* Einheitlicher Kartenrahmen fuer Admin-Tabs im Dunkelmodus */
+body.dark-mode .tab-card {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+
 body.dark-mode .topbar {
   background-color: #1e1e1e;
   border-color: #444;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -188,3 +188,8 @@ body.dark-mode .sticky-actions {
 .question-preview {
   min-height: 100px;
 }
+
+/* Einheitlicher Kartenrahmen fuer Admin-Tabs */
+.tab-card {
+  margin-top: 16px;
+}

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -102,13 +102,15 @@
     </li>
     <li>
       <div class="uk-container uk-container-small">
-        <h2 class="uk-heading-bullet">Kataloge</h2>
-        <div class="uk-margin">
-          <button id="newCatBtn" class="uk-button uk-button-default">Neuer Katalog</button>
-        </div>
-        <div id="catalogList" class="uk-margin"></div>
-        <div class="uk-margin">
-          <button id="catalogsSaveBtn" class="uk-button uk-button-primary">Speichern</button>
+        <div class="uk-card uk-card-default uk-card-body tab-card">
+          <h2 class="uk-heading-bullet">Kataloge</h2>
+          <div class="uk-margin">
+            <button id="newCatBtn" class="uk-button uk-button-default">Neuer Katalog</button>
+          </div>
+          <div id="catalogList" class="uk-margin"></div>
+          <div class="uk-margin">
+            <button id="catalogsSaveBtn" class="uk-button uk-button-primary">Speichern</button>
+          </div>
         </div>
       </div>
     </li>

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -4,23 +4,29 @@
 {% block title %}Kataloge verwalten{% endblock %}
 
 {% block content %}
-<h2 class="uk-heading-divider uk-margin-medium-bottom">Kataloge</h2>
-<button class="uk-button uk-button-primary uk-margin-bottom">Neuer Katalog</button>
+<div class="uk-container uk-container-small">
+    <div class="uk-card uk-card-default uk-card-body tab-card">
+        <h2 class="uk-heading-bullet">Kataloge</h2>
+        <div class="uk-margin">
+            <button class="uk-button uk-button-primary">Neuer Katalog</button>
+        </div>
 
-<div class="uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid>
-    {% for katalog in kataloge %}
-    <div>
-        <div class="uk-card uk-card-default uk-card-body custom-card uk-flex uk-flex-middle">
-            <div class="uk-width-expand">
-                <div class="uk-text-bold">{{ katalog.name }}</div>
-                <div class="uk-text-small uk-margin-small-top">{{ katalog.beschreibung }}</div>
+        <div class="uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid>
+            {% for katalog in kataloge %}
+            <div>
+                <div class="uk-card uk-card-default uk-card-hover uk-card-body custom-card uk-flex uk-flex-middle">
+                    <div class="uk-width-expand">
+                        <div class="uk-text-bold">{{ katalog.name }}</div>
+                        <div class="uk-text-small uk-margin-small-top">{{ katalog.beschreibung }}</div>
+                    </div>
+                    <div class="uk-flex uk-flex-column uk-flex-middle uk-flex-center uk-margin-left">
+                        <img src="{{ katalog.qrcode_url }}" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
+                        <button class="uk-button uk-button-danger uk-button-small">Löschen</button>
+                    </div>
+                </div>
             </div>
-            <div class="uk-flex uk-flex-column uk-flex-middle uk-flex-center uk-margin-left">
-                <img src="{{ katalog.qrcode_url }}" alt="QR" style="width:48px;height:48px;" class="uk-margin-small-bottom">
-                <button class="uk-button uk-button-danger uk-button-small">Löschen</button>
-            </div>
+            {% endfor %}
         </div>
     </div>
-    {% endfor %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- redesign `kataloge.twig` using a card container for consistent heading placement
- wrap the "Kataloge" tab in `admin.twig` in the same card container
- add `.tab-card` helper class in main and dark CSS

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684b5055d2c0832b88fc2bfa8b292727