### PR TITLE
Improve catalog admin layout

### DIFF
--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -4,28 +4,32 @@
 {% block title %}Kataloge verwalten{% endblock %}
 
 {% block content %}
-<div class="uk-container uk-container-small">
+<div class="uk-container uk-container-large">
     <div class="uk-card uk-card-default uk-card-body tab-card">
         <h2 class="uk-heading-bullet">Kataloge</h2>
         <div class="uk-margin">
             <button class="uk-button uk-button-primary">Neuer Katalog</button>
         </div>
 
-        <div class="uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid>
+        <div class="uk-overflow-auto">
+            <div class="uk-grid uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid>
             {% for katalog in kataloge %}
             <div>
-                <div class="uk-card uk-card-default uk-card-hover uk-card-body custom-card uk-flex uk-flex-middle">
-                    <div class="uk-width-expand">
-                        <div class="uk-text-bold">{{ katalog.name }}</div>
-                        <div class="uk-text-small uk-margin-small-top">{{ katalog.beschreibung }}</div>
-                    </div>
-                    <div class="uk-flex uk-flex-column uk-flex-middle uk-flex-center uk-margin-left">
-                        <img src="{{ katalog.qrcode_url }}" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
-                        <button class="uk-button uk-button-danger uk-button-small">Löschen</button>
+                <div class="uk-card uk-card-default uk-card-hover uk-card-body uk-padding-small custom-card uk-margin-small-bottom">
+                    <div class="uk-grid-small uk-flex-middle" uk-grid>
+                        <div class="uk-width-expand">
+                            <div class="uk-text-bold">{{ katalog.name }}</div>
+                            <div class="uk-text-small uk-margin-small-top">{{ katalog.beschreibung }}</div>
+                        </div>
+                        <div class="uk-width-auto@s uk-width-1-1">
+                            <img src="{{ katalog.qrcode_url }}" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
+                            <button class="uk-button uk-button-danger uk-button-small uk-width-1-1">Löschen</button>
+                        </div>
                     </div>
                 </div>
             </div>
             {% endfor %}
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- make catalog list a responsive grid using UIkit classes
- add padding and overflow scrolling for catalog cards

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b530e4900832b90596602e9e74b88