### PR TITLE
Install GD and FPDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:8.2-alpine
+
+RUN apk add --no-cache libpng-dev libjpeg-turbo-dev freetype-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install gd \
+    && apk del libpng-dev libjpeg-turbo-dev freetype-dev
+
+# install composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www
+COPY . /var/www
+RUN composer install --no-interaction --prefer-dist --no-progress
+
+CMD ["php", "-S", "0.0.0.0:8080", "-t", "public", "public/router.php"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Das **Sommerfest-Quiz** ist eine sofort einsetzbare Web-App, mit der Sie Besuche
    ```bash
    composer install
    ```
+   Das Docker-Setup installiert dabei automatisch die PHP-Erweiterung *gd*,
+   welche f"ur die Bibliothek `setasign/fpdf` ben"otigt wird.
 2. Server starten (z.B. für lokale Tests):
    ```bash
    php -S localhost:8080 -t public public/router.php

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "twig/twig": "^3.8",
         "slim/twig-view": "^3.3",
         "mpdf/mpdf": "^8.2",
-        "endroid/qr-code": "^5.0"
+        "endroid/qr-code": "^5.0",
+        "setasign/fpdf": "^1.8"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - webproxy
 
   slim:
-    image: php:8.2-alpine
+    build: .
     container_name: slim
     working_dir: /var/www
     volumes:


### PR DESCRIPTION
## Summary
- add a Dockerfile installing gd and composer dependencies
- build slim service using the custom Dockerfile
- require `setasign/fpdf` via composer
- note gd requirement in README

## Testing
- `pytest -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b57add348832ba5d7399a2529567b