### PR TITLE
Remove Kataloge card and align admin layout

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -101,8 +101,8 @@
       </div>
     </li>
     <li>
-      <div class="uk-container uk-container-small">
-        <div class="uk-card uk-card-default uk-card-body tab-card">
+      <div class="uk-container uk-container-large">
+        <div>
           <h2 class="uk-heading-bullet">Kataloge</h2>
           <div class="uk-margin">
             <button id="newCatBtn" class="uk-button uk-button-default">Neuer Katalog</button>
@@ -115,7 +115,7 @@
       </div>
     </li>
     <li>
-      <div class="uk-container uk-container-small">
+      <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Teams/Personen</h2>
         <div id="teamsList" class="uk-margin"></div>
         <div class="uk-margin">
@@ -153,7 +153,7 @@
       </div>
     </li>
     <li>
-      <div class="uk-container uk-container-small">
+      <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Ergebnisse</h2>
         <table class="uk-table uk-table-divider">
           <thead>
@@ -179,7 +179,7 @@
       </div>
     </li>
     <li>
-      <div class="uk-container uk-container-small">
+      <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Passwort ändern</h2>
         <form id="passForm" class="uk-form-stacked">
           <div class="uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small" uk-grid>

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="uk-container uk-container-large">
-    <div class="uk-card uk-card-default uk-card-body tab-card">
+    <div>
         <h2 class="uk-heading-bullet">Kataloge</h2>
         <div class="uk-margin">
             <button class="uk-button uk-button-primary">Neuer Katalog</button>


### PR DESCRIPTION
## Summary
- remove UIkit card wrapper from admin catalog tab
- use consistent `uk-container-large` for all admin tabs
- drop card wrapper from standalone catalog page

## Testing
- `pytest -q`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b59582b38832b86a795ec7ab30c63