### PR TITLE
Remove QR code support from PDF export

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "slim/psr7": "^1.6",
         "twig/twig": "^3.8",
         "slim/twig-view": "^3.3",
-        "endroid/qr-code": "^5.0",
         "setasign/fpdf": "^1.8"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- drop `endroid/qr-code` library
- strip QR code generation from `PdfExportService`

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684b5ccbc42c832ba3df62bce5bc13dc