### PR TITLE
Fix PDF export with optional QR codes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "slim/psr7": "^1.6",
         "twig/twig": "^3.8",
         "slim/twig-view": "^3.3",
-        "setasign/fpdf": "^1.8"
+        "setasign/fpdf": "^1.8",
+        "endroid/qr-code": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Writer\PngWriter;
 use FPDF;
 
 class PdfExportService
 {
     /**
-     * Build PDF listing catalogs.
+     * Build PDF listing catalogs with optional QR codes.
      *
      * @param array<string,mixed> $config
      * @param array<int,array<string,mixed>> $catalogs
@@ -33,19 +35,55 @@ class PdfExportService
             $pdf->Ln();
         }
 
+        $qrAvailable = class_exists(\Endroid\QrCode\QrCode::class)
+            && class_exists(\Endroid\QrCode\Writer\PngWriter::class);
+
         $pdf->SetFont('Arial', 'B', 12);
         $pdf->Cell(60, 10, 'Name', 1);
         $pdf->Cell(80, 10, 'Beschreibung', 1);
+        if ($qrAvailable) {
+            $pdf->Cell(40, 10, 'QR-Code', 1);
+        }
         $pdf->Ln();
 
         $pdf->SetFont('Arial', '', 12);
+        $tmpFiles = [];
         foreach ($catalogs as $catalog) {
             $name = (string)($catalog['name'] ?? $catalog['id'] ?? '');
             $desc = (string)($catalog['description'] ?? $catalog['beschreibung'] ?? '');
 
             $pdf->Cell(60, 10, $name, 1);
             $pdf->Cell(80, 10, $desc, 1);
+
+            if ($qrAvailable) {
+                $url = '?katalog=' . urlencode((string)($catalog['id'] ?? ''));
+                if (method_exists(QrCode::class, 'create')) {
+                    $qrCode = QrCode::create($url);
+                    $writer = new PngWriter();
+                    $tmp = sys_get_temp_dir() . '/' . uniqid('qr_', true) . '.png';
+                    $writer->write($qrCode)->saveToFile($tmp);
+                } else {
+                    $qrCode = new QrCode($url);
+                    $writer = new PngWriter();
+                    $tmp = sys_get_temp_dir() . '/' . uniqid('qr_', true) . '.png';
+                    if (method_exists($writer, 'writeFile')) {
+                        $writer->writeFile($qrCode, $tmp);
+                    } else {
+                        $writer->write($qrCode)->saveToFile($tmp);
+                    }
+                }
+                $tmpFiles[] = $tmp;
+
+                $x = $pdf->GetX();
+                $y = $pdf->GetY();
+                $pdf->Cell(40, 10, '', 1);
+                $pdf->Image($tmp, $x + 1, $y + 1, 8);
+            }
             $pdf->Ln();
+        }
+
+        foreach ($tmpFiles as $f) {
+            @unlink($f);
         }
 
         $content = $pdf->Output('', 'S');


### PR DESCRIPTION
## Summary
- handle both old and new QR code library versions
- reintroduce `endroid/qr-code` dependency

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b5e32cbbc832b9c76db996ebe73d1