### PR TITLE
Add QR codes and team table to PDF export

### DIFF
--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Service\CatalogService;
 use App\Service\ConfigService;
 use App\Service\PdfExportService;
+use App\Service\TeamService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -15,11 +16,13 @@ class ExportController
     private ConfigService $config;
     private CatalogService $catalogs;
     private PdfExportService $pdf;
+    private TeamService $teams;
 
-    public function __construct(ConfigService $config, CatalogService $catalogs, PdfExportService $pdf)
+    public function __construct(ConfigService $config, CatalogService $catalogs, TeamService $teams, PdfExportService $pdf)
     {
         $this->config = $config;
         $this->catalogs = $catalogs;
+        $this->teams = $teams;
         $this->pdf = $pdf;
     }
 
@@ -31,7 +34,8 @@ class ExportController
         if ($catJson !== null) {
             $cats = json_decode($catJson, true) ?? [];
         }
-        $content = $this->pdf->build($cfg, $cats);
+        $teams = $this->teams->getAll();
+        $content = $this->pdf->build($cfg, $cats, $teams);
         $response->getBody()->write($content);
         return $response
             ->withHeader('Content-Type', 'application/pdf')

--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -11,12 +11,13 @@ use FPDF;
 class PdfExportService
 {
     /**
-     * Build PDF listing catalogs with optional QR codes.
+     * Build PDF listing catalogs with optional QR codes and a team table.
      *
      * @param array<string,mixed> $config
      * @param array<int,array<string,mixed>> $catalogs
+     * @param list<string> $teams
      */
-    public function build(array $config, array $catalogs): string
+    public function build(array $config, array $catalogs, array $teams = []): string
     {
         $header = (string)($config['header'] ?? '');
         $subheader = (string)($config['subheader'] ?? '');
@@ -80,6 +81,50 @@ class PdfExportService
                 $pdf->Image($tmp, $x + 1, $y + 1, 8);
             }
             $pdf->Ln();
+        }
+
+        if ($teams !== []) {
+            $pdf->Ln(10);
+            $pdf->SetFont('Arial', 'B', 14);
+            $pdf->Cell(0, 10, 'Teams/Personen');
+            $pdf->Ln();
+
+            $pdf->SetFont('Arial', 'B', 12);
+            $pdf->Cell(60, 10, 'Name', 1);
+            if ($qrAvailable) {
+                $pdf->Cell(40, 10, 'QR-Code', 1);
+            }
+            $pdf->Ln();
+
+            $pdf->SetFont('Arial', '', 12);
+            foreach ($teams as $team) {
+                $name = (string)$team;
+                $pdf->Cell(60, 10, $name, 1);
+                if ($qrAvailable) {
+                    $url = $name;
+                    if (method_exists(QrCode::class, 'create')) {
+                        $qrCode = QrCode::create($url);
+                        $writer = new PngWriter();
+                        $tmp = sys_get_temp_dir() . '/' . uniqid('qr_', true) . '.png';
+                        $writer->write($qrCode)->saveToFile($tmp);
+                    } else {
+                        $qrCode = new QrCode($url);
+                        $writer = new PngWriter();
+                        $tmp = sys_get_temp_dir() . '/' . uniqid('qr_', true) . '.png';
+                        if (method_exists($writer, 'writeFile')) {
+                            $writer->writeFile($qrCode, $tmp);
+                        } else {
+                            $writer->write($qrCode)->saveToFile($tmp);
+                        }
+                    }
+                    $tmpFiles[] = $tmp;
+                    $x = $pdf->GetX();
+                    $y = $pdf->GetY();
+                    $pdf->Cell(40, 10, '', 1);
+                    $pdf->Image($tmp, $x + 1, $y + 1, 8);
+                }
+                $pdf->Ln();
+            }
         }
 
         foreach ($tmpFiles as $f) {

--- a/src/routes.php
+++ b/src/routes.php
@@ -52,7 +52,7 @@ return function (\Slim\App $app) {
     $catalogController = new CatalogController($catalogService);
     $resultController = new ResultController($resultService, $xlsxService);
     $teamController = new TeamController($teamService);
-    $exportController = new ExportController($configService, $catalogService, $pdfService);
+    $exportController = new ExportController($configService, $catalogService, $teamService, $pdfService);
     $passwordController = new PasswordController($configService);
 
     $app->get('/', HomeController::class);


### PR DESCRIPTION
## Summary
- extend `PdfExportService` to support teams and generate QR codes for them
- include `TeamService` in `ExportController`
- wire the service through routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b62270f98832bba43234517b1b776