### PR TITLE
Add logout button to admin

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -12,8 +12,11 @@
 {% block body %}
   <div class="uk-flex uk-flex-between uk-margin-small-bottom">
     <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
-    <div class="theme-switch">
-      <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+    <div class="uk-flex">
+      <a href="/logout" class="uk-button uk-button-danger uk-margin-right">Logout</a>
+      <div class="theme-switch">
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
     </div>
   </div>
   <ul uk-tab>

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -31,6 +31,7 @@
             </ul>
         </div>
         <div class="uk-navbar-right">
+            <a href="/logout" class="uk-button uk-button-danger uk-margin-small-right">Logout</a>
             <a class="uk-navbar-toggle" href="#" uk-icon="icon: cog"></a>
         </div>
     </nav>

--- a/tests/Controller/LogoutControllerTest.php
+++ b/tests/Controller/LogoutControllerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class LogoutControllerTest extends TestCase
+{
+    public function testLogoutRedirectsToLogin(): void
+    {
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['admin'] = true;
+        $request = $this->createRequest('GET', '/logout');
+        $response = $app->handle($request);
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('/login', $response->getHeaderLine('Location'));
+        session_destroy();
+    }
+}


### PR DESCRIPTION
## Summary
- add a Logout link to the new admin base template
- allow logging out from the old admin template as well
- test logout controller behavior

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b625eb1c4832ba687f94bf86141c3