### PR TITLE
Fix admin save button alignment

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -111,7 +111,7 @@
           <div class="uk-margin">
             <button id="newCatBtn" class="uk-button uk-button-default">Hinzufügen</button>
           </div>
-          <div class="uk-margin">
+          <div class="uk-margin uk-flex uk-flex-right">
             <button id="catalogsSaveBtn" class="uk-button uk-button-primary">Speichern</button>
           </div>
         </div>
@@ -127,7 +127,7 @@
         <div class="uk-margin">
           <label><input class="uk-checkbox" type="checkbox" id="teamRestrict"> Nur Teams/Personen aus der Liste dürfen teilnehmen.</label>
         </div>
-        <div class="uk-margin">
+        <div class="uk-margin uk-flex uk-flex-right">
           <button id="teamsSaveBtn" class="uk-button uk-button-primary">Speichern</button>
         </div>
       </div>
@@ -199,7 +199,7 @@
               </div>
             </div>
           </div>
-          <div class="uk-margin">
+          <div class="uk-margin uk-flex uk-flex-right">
             <button id="passSaveBtn" class="uk-button uk-button-primary">Speichern</button>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- align save buttons right for catalog list, teams view and password change form

## Testing
- `pytest tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684b648bdd2c832ba2bcf1ab948be8d4