### PR TITLE
Add persistent data volume for slim service

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,14 @@ Das **Sommerfest-Quiz** ist eine sofort einsetzbare Web-App, mit der Sie Besuche
    ```bash
    php -S localhost:8080 -t public public/router.php
    ```
-   Anschließend ist das Quiz unter <http://localhost:8080> aufrufbar.
+  Anschließend ist das Quiz unter <http://localhost:8080> aufrufbar.
+
+## Docker Compose
+
+Das mitgelieferte `docker-compose.yml` startet das Quiz samt Reverse Proxy.
+Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
+`quizdata` gespeichert. So bleiben eingetragene Teams und Ergebnisse auch nach
+`docker-compose down` erhalten.
 
 ## Anpassung
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     working_dir: /var/www
     volumes:
       - ./:/var/www
+      - quizdata:/var/www/data
     environment:
       - VIRTUAL_HOST=${DOMAIN}
       - LETSENCRYPT_HOST=${DOMAIN}
@@ -53,3 +54,6 @@ services:
 networks:
   webproxy:
     external: false
+
+volumes:
+  quizdata:


### PR DESCRIPTION
## Summary
- mount `data/` on a named volume in docker-compose
- document persistent `quizdata` volume in README

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b64a5d360832bad6acba4043a61b4