### PR TITLE
Persist acme config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Das **Sommerfest-Quiz** ist eine sofort einsetzbare Web-App, mit der Sie Besuche
 Das mitgelieferte `docker-compose.yml` startet das Quiz samt Reverse Proxy.
 Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `quizdata` gespeichert. So bleiben eingetragene Teams und Ergebnisse auch nach
-`docker-compose down` erhalten.
+`docker-compose down` erhalten. Die ACME-Konfiguration des Let's-Encrypt-
+Begleiters landet im Ordner `acme/` und wird dadurch ebenfalls 
+persistiert.
 
 ## Anpassung
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - DEFAULT_EMAIL=${LETSENCRYPT_EMAIL}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./acme:/etc/acme.sh
       - ./certs:/etc/nginx/certs:rw
       - ./vhost.d:/etc/nginx/vhost.d
       - ./html:/usr/share/nginx/html


### PR DESCRIPTION
## Summary
- persist ACME data for acme-companion
- describe the new folder in the readme

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684b6907df5c832bacb5eda71550a696