### PR TITLE
Fix login layout spacing

### DIFF
--- a/templates/login.twig
+++ b/templates/login.twig
@@ -20,11 +20,9 @@
       </div>
     {% endblock %}
   {% endembed %}
-<div class="uk-width-1-1">
-  <div class="uk-container">
-    <div class="uk-grid-margin uk-grid uk-grid-stack" uk-grid>
-      <div class="uk-width-1-1@m">
-        <div class="uk-margin uk-width-large uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+<div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
+  <div class="uk-width-1-1@m">
+    <div class="uk-width-large uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
           <h3 class="uk-card-title uk-text-center">Admin Login</h3>
           {% if error %}
           <div class="uk-alert-danger" uk-alert>
@@ -48,11 +46,9 @@
               <button class="uk-button uk-button-primary uk-button-large uk-width-1-1">Login</button>
             </div>
           </form>
-        </div>
       </div>
     </div>
   </div>
-</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- center login block horizontally
- add spacing below the fixed topbar

## Testing
- `php -l templates/login.twig` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6a547ff8832b955a1692d6c0683c