### PR TITLE
Move config migration to data

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -16,7 +16,10 @@ class AdminController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        $cfg = (new ConfigService(__DIR__ . '/../../data/config.json'))->getConfig();
+        $cfg = (new ConfigService(
+            __DIR__ . '/../../data/config.json',
+            __DIR__ . '/../../config/config.json'
+        ))->getConfig();
         $results = (new ResultService(__DIR__ . '/../../data/results.json'))->getAll();
         $catalogSvc = new CatalogService(__DIR__ . '/../../data/kataloge');
         $catalogsJson = $catalogSvc->read('catalogs.json');

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -14,7 +14,10 @@ class HomeController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        $cfg = (new ConfigService(__DIR__ . '/../../data/config.json'))->getConfig();
+        $cfg = (new ConfigService(
+            __DIR__ . '/../../data/config.json',
+            __DIR__ . '/../../config/config.json'
+        ))->getConfig();
         return $view->render($response, 'index.twig', ['config' => $cfg]);
     }
 }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -24,7 +24,10 @@ class LoginController
             $data = json_decode((string) $request->getBody(), true);
         }
 
-        $config = (new ConfigService(__DIR__ . '/../../data/config.json'))->getConfig();
+        $config = (new ConfigService(
+            __DIR__ . '/../../data/config.json',
+            __DIR__ . '/../../config/config.json'
+        ))->getConfig();
         $user = $config['adminUser'] ?? 'admin';
         $pass = $config['adminPass'] ?? 'password';
 

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -7,15 +7,24 @@ namespace App\Service;
 class ConfigService
 {
     private string $path;
+    private ?string $fallbackPath = null;
 
-    public function __construct(string $path)
+    public function __construct(string $path, ?string $fallbackPath = null)
     {
         $this->path = $path;
+        $this->fallbackPath = $fallbackPath;
     }
 
     public function getJson(): ?string
     {
         if (!file_exists($this->path)) {
+            if ($this->fallbackPath !== null && file_exists($this->fallbackPath)) {
+                $content = file_get_contents($this->fallbackPath);
+                if ($content !== false) {
+                    file_put_contents($this->path, $content);
+                    return $content;
+                }
+            }
             return null;
         }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -41,7 +41,10 @@ require_once __DIR__ . '/Controller/PasswordController.php';
 require_once __DIR__ . '/Controller/AdminCatalogController.php';
 
 return function (\Slim\App $app) {
-    $configService = new ConfigService(__DIR__ . '/../data/config.json');
+    $configService = new ConfigService(
+        __DIR__ . '/../data/config.json',
+        __DIR__ . '/../config/config.json'
+    );
     $catalogService = new CatalogService(__DIR__ . '/../data/kataloge');
     $resultService = new ResultService(__DIR__ . '/../data/results.json');
     $xlsxService = new XlsxExportService();


### PR DESCRIPTION
## Summary
- allow `ConfigService` to migrate legacy `config/config.json`
- update controllers to provide fallback path
- persist config via `routes.php`

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6d60c324832b81cddff4a43f1584