### PR TITLE
Fix team restriction persistence

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   document.getElementById('cfgSaveBtn').addEventListener('click', function (e) {
     e.preventDefault();
-    const data = {
+    const data = Object.assign({}, cfgInitial, {
       logoPath: cfgFields.logoPath.value.trim(),
       pageTitle: cfgFields.pageTitle.value.trim(),
       header: cfgFields.header.value.trim(),
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', function () {
       buttonColor: cfgFields.buttonColor.value.trim(),
       CheckAnswerButton: cfgFields.checkAnswerButton.value,
       QRUser: cfgFields.qrUser.value === 'true'
-    };
+    });
     fetch('/config.json', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- preserve unused config values when saving global configuration

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_684b6f027150832b878195791d4bfbff