### PR TITLE
Fix centered camera in scanner modal

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -186,7 +186,7 @@
       modal.setAttribute('uk-modal', '');
       modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">'+
         '<h3 class="uk-modal-title uk-text-center">Who I AM</h3>'+
-        '<div id="login-qr" class="uk-margin" style="max-width:320px;width:100%"></div>'+
+        '<div id="login-qr" class="uk-margin" style="max-width:320px;margin:0 auto;width:100%"></div>'+
         '<button id="login-qr-stop" class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Abbrechen</button>'+
       '</div>';
       let scanner;

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -505,7 +505,7 @@ function runQuiz(questions){
       modal.setAttribute('uk-modal', '');
       modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">'+
         '<h3 class="uk-modal-title uk-text-center">Who I AM</h3>'+
-        '<div id="qr-reader" class="uk-margin" style="max-width:320px;width:100%"></div>'+
+        '<div id="qr-reader" class="uk-margin" style="max-width:320px;margin:0 auto;width:100%"></div>'+
         '<button id="qr-reader-stop" class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Abbrechen</button>'+
       '</div>';
       let scanner;


### PR DESCRIPTION
## Summary
- center the camera view in the QR scanning popups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6fa45820832bad8c92299eb5d6f7