### PR TITLE
Fix catalog save issue and auto-generate IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ persistiert.
 
 ## Anpassung
 
-Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden.
+Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition enthält ein `id`, das dem Dateinamen ohne Endung entspricht. Bei neuen Katalogen generiert die Verwaltung dieses `id` nun automatisch aus dem eingegebenen Namen.
 
 ## Tests
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -6,6 +6,17 @@ document.addEventListener('DOMContentLoaded', function () {
       alert(msg);
     }
   }
+
+  function slugify(text) {
+    return text
+      .toString()
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/ß/g, 'ss')
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '');
+  }
   // --------- Konfiguration bearbeiten ---------
   // Ausgangswerte aus der bestehenden Konfiguration
   const cfgInitial = window.quizConfig || {};
@@ -192,6 +203,12 @@ document.addEventListener('DOMContentLoaded', function () {
     name.className = 'uk-input uk-width-medium uk-margin-left cat-name';
     name.placeholder = 'Name';
     name.value = cat.name || '';
+    name.addEventListener('input', () => {
+      if (row.dataset.new === 'true' && idInput.value.trim() === '') {
+        idInput.value = slugify(name.value);
+        update();
+      }
+    });
 
     const desc = document.createElement('input');
     desc.type = 'text';
@@ -576,7 +593,14 @@ document.addEventListener('DOMContentLoaded', function () {
     const rows = Array.from(catalogList.querySelectorAll('.catalog-row'));
     for (const row of rows) {
       if (row.dataset.new === 'true') {
-        const id = row.querySelector('.cat-id').value.trim();
+        let id = row.querySelector('.cat-id').value.trim();
+        if (!id) {
+          const nameEl = row.querySelector('.cat-name');
+          if (nameEl) {
+            id = slugify(nameEl.value);
+            row.querySelector('.cat-id').value = id;
+          }
+        }
         if (!id) continue;
         try {
           await fetch('/kataloge/' + id + '.json', {


### PR DESCRIPTION
## Summary
- add `slugify()` helper in admin.js
- auto-generate catalog IDs from entered names
- ensure missing IDs are generated when saving
- document automatic ID generation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6e233420832b8151865a22237229