### PR TITLE
Add catalog heading in PDF export

### DIFF
--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -47,6 +47,13 @@ class PdfExportService
             $pdf->Ln();
         }
 
+        if ($catalogs !== []) {
+            $pdf->Ln(10);
+            $pdf->SetFont('Arial', 'B', 14);
+            $pdf->Cell(0, 10, $this->enc('Kataloge'));
+            $pdf->Ln();
+        }
+
         $qrAvailable = class_exists(\Endroid\QrCode\QrCode::class)
             && class_exists(\Endroid\QrCode\Writer\PngWriter::class);
 


### PR DESCRIPTION
## Summary
- show heading "Kataloge" in the exported PDF
- leave teams section intact

## Testing
- `python3 -m pytest -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b6b3aa5dc832b93ae8d6672b8ed80