### PR TITLE
Fix catalog persistence

### DIFF
--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -29,16 +29,28 @@ class CatalogService
     }
 
     /**
+     * Persist a catalog JSON file.
+     *
+     * The target directory is created automatically if it does not exist.
+     * When an array is provided it will be encoded as pretty printed JSON with
+     * a trailing newline to avoid truncated files.
+     *
      * @param array|string $data
      */
     public function write(string $file, $data): void
     {
         $path = $this->path($file);
-        if (is_array($data)) {
-            $data = json_encode($data, JSON_PRETTY_PRINT);
+
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
         }
 
-        file_put_contents($path, (string) $data);
+        if (is_array($data)) {
+            $data = json_encode($data, JSON_PRETTY_PRINT) . "\n";
+        }
+
+        file_put_contents($path, (string) $data, LOCK_EX);
     }
 
     public function delete(string $file): void


### PR DESCRIPTION
## Summary
- ensure catalog JSON files are saved correctly
- create directory on demand, use file lock, and append newline

## Testing
- `python3 tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_684b73108070832b98328f52cb9cf2fa