### PR TITLE
Fix catalog list fallback

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use App\Service\ConfigService;
+use App\Service\CatalogService;
 use Slim\Views\Twig;
 
 class HomeController
@@ -18,6 +19,17 @@ class HomeController
             __DIR__ . '/../../data/config.json',
             __DIR__ . '/../../config/config.json'
         ))->getConfig();
-        return $view->render($response, 'index.twig', ['config' => $cfg]);
+
+        $catalogService = new CatalogService(__DIR__ . '/../../data/kataloge');
+        $catalogsJson = $catalogService->read('catalogs.json');
+        $catalogs = [];
+        if ($catalogsJson !== null) {
+            $catalogs = json_decode($catalogsJson, true) ?? [];
+        }
+
+        return $view->render($response, 'index.twig', [
+            'config' => $cfg,
+            'catalogs' => $catalogs,
+        ]);
     }
 }

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -48,56 +48,7 @@
     window.quizConfig = {{ config|json_encode|raw }};
   </script>
   <script id="catalogs-data" type="application/json">
-    [
-      {
-        "id": "station_1",
-        "file": "station_1.json",
-        "name": "Station-1",
-        "description": "Speicher und Geraete"
-      },
-      {
-        "id": "station_2",
-        "file": "station_2.json",
-        "name": "Station-2",
-        "description": "Bedienung und Symbole"
-      },
-      {
-        "id": "station_3",
-        "file": "station_3.json",
-        "name": "Station-3",
-        "description": "WWW und Speicherarten"
-      },
-      {
-        "id": "station_4",
-        "file": "station_4.json",
-        "name": "Station-4",
-        "description": "Begriffe und Geraetegroessen"
-      },
-      {
-        "id": "station_5",
-        "file": "station_5.json",
-        "name": "Station-5",
-        "description": "Programme und Binaersystem"
-      },
-      {
-        "id": "station_6",
-        "file": "station_6.json",
-        "name": "Station-6",
-        "description": "Dateien und URLs"
-      },
-      {
-        "id": "station_7",
-        "file": "station_7.json",
-        "name": "Station-7",
-        "description": "Netzwerke und Kuerzel"
-      },
-      {
-        "id": "station_8",
-        "file": "station_8.json",
-        "name": "Station-8",
-        "description": "Cloud und Steuerung"
-      }
-    ]
+    {{ catalogs|json_encode|raw }}
   </script>
   <script src="/js/catalog.js"></script>
   <script src="/js/confetti.js"></script>


### PR DESCRIPTION
## Summary
- read catalogs at runtime in `HomeController`
- expose catalog data as JSON in `index.twig`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b756c3798832ba4e55b9c97198510