### PR TITLE
Add URL QR images in PDF exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ persistiert.
 
 Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition enthält ein `id`, das dem Dateinamen ohne Endung entspricht. Bei neuen Katalogen generiert die Verwaltung dieses `id` nun automatisch aus dem eingegebenen Namen.
 
+QR-Codes können pro Eintrag über `qr_image` oder `qrcode_url` hinterlegt werden. Neben Data-URIs und lokalen Pfaden werden dabei nun auch HTTP- oder HTTPS-URLs unterstützt.
+
 ## Tests
 
 PHP-Tests werden mit PHPUnit ausgeführt:

--- a/tests/Service/PdfExportServiceTest.php
+++ b/tests/Service/PdfExportServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\PdfExportService;
+use PHPUnit\Framework\TestCase;
+
+class PdfExportServiceTest extends TestCase
+{
+    private string $img;
+
+    protected function setUp(): void
+    {
+        $this->img = sys_get_temp_dir() . '/qr_' . uniqid() . '.png';
+        $data = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQI12NgYGBgAAAABAABJzQnKgAAAABJRU5ErkJggg==');
+        file_put_contents($this->img, $data);
+
+        stream_wrapper_unregister('http');
+        stream_wrapper_register('http', DummyHttpStream::class);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->img);
+        stream_wrapper_restore('http');
+    }
+
+    public function testRemoteQrImageIsEmbedded(): void
+    {
+        global $dummyImagePath;
+        $dummyImagePath = $this->img;
+
+        $service = new PdfExportService();
+        $config = ['header' => 'h'];
+        $catalogs = [
+            [
+                'id' => 1,
+                'name' => 'Test',
+                'description' => '',
+                'qr_image' => 'http://example.com/qr.png',
+            ],
+        ];
+
+        $pdf = $service->build($config, $catalogs);
+        $this->assertNotEmpty($pdf);
+        $this->assertStringContainsString('PNG', $pdf);
+    }
+}
+
+class DummyHttpStream
+{
+    public $context;
+    private $handle;
+
+    public function stream_open($path, $mode, $options, &$opened_path): bool
+    {
+        global $dummyImagePath;
+        $this->handle = fopen($dummyImagePath, 'rb');
+        return $this->handle !== false;
+    }
+
+    public function stream_read($count)
+    {
+        return fread($this->handle, $count);
+    }
+
+    public function stream_eof(): bool
+    {
+        return feof($this->handle);
+    }
+
+    public function stream_stat()
+    {
+        return fstat($this->handle);
+    }
+
+    public function stream_close(): void
+    {
+        fclose($this->handle);
+    }
+}


### PR DESCRIPTION
## Summary
- support loading QR images from HTTP URLs
- factor out QR image resolver
- document remote QR sources
- add PDF export test with mocked HTTP fetch

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml tests/Service/PdfExportServiceTest.php` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684b7f637f3c832b8654af1776eb7f03