### PR TITLE
Add color picker inputs

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -70,7 +70,7 @@
                 <label class="uk-form-label" for="cfgBackgroundColor">Hintergrundfarbe
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: CSS-Farbwert für die Seite.; pos: right"></span>
                 </label>
-                <div class="uk-form-controls"><input class="uk-input" type="text" id="cfgBackgroundColor"></div>
+                <div class="uk-form-controls"><input class="uk-input" type="color" id="cfgBackgroundColor"></div>
               </div>
             </div>
             <div>
@@ -78,7 +78,7 @@
                 <label class="uk-form-label" for="cfgButtonColor">Buttonfarbe
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: CSS-Farbwert für alle Buttons.; pos: right"></span>
                 </label>
-                <div class="uk-form-controls"><input class="uk-input" type="text" id="cfgButtonColor"></div>
+                <div class="uk-form-controls"><input class="uk-input" type="color" id="cfgButtonColor"></div>
               </div>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- use color inputs for background and button color in admin page

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b82e20124832baf9ce4ee997afc9b