### PR TITLE
Ensure PDF temp files cleaned up on errors

### DIFF
--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -79,16 +79,19 @@ class PdfExportService
         $pdf = new \FPDF();
         $pdf->AddPage();
 
-        if ($header !== '') {
-            $pdf->SetFont('Arial', 'B', 16);
-            $pdf->Cell(0, 10, $header);
-            $pdf->Ln();
-        }
-        if ($subheader !== '') {
-            $pdf->SetFont('Arial', '', 12);
-            $pdf->Cell(0, 10, $subheader);
-            $pdf->Ln();
-        }
+        $tmpFiles = [];
+
+        try {
+            if ($header !== '') {
+                $pdf->SetFont('Arial', 'B', 16);
+                $pdf->Cell(0, 10, $header);
+                $pdf->Ln();
+            }
+            if ($subheader !== '') {
+                $pdf->SetFont('Arial', '', 12);
+                $pdf->Cell(0, 10, $subheader);
+                $pdf->Ln();
+            }
 
         $pdf->Ln(10);
         $pdf->SetFont('Arial', 'B', 14);
@@ -114,7 +117,6 @@ class PdfExportService
         $pdf->Ln();
 
         $pdf->SetFont('Arial', '', 12);
-        $tmpFiles = [];
         foreach ($catalogs as $catalog) {
             $name = $this->enc((string)($catalog['name'] ?? $catalog['id'] ?? ''));
             $desc = $this->enc((string)($catalog['description'] ?? $catalog['beschreibung'] ?? ''));
@@ -218,12 +220,13 @@ class PdfExportService
             }
         }
 
-        foreach ($tmpFiles as $f) {
-            @unlink($f);
-        }
-
         $content = $pdf->Output('', 'S');
 
         return $content;
+        } finally {
+            foreach ($tmpFiles as $f) {
+                @unlink($f);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- wrap `PdfExportService::build` contents in `try`/`finally`
- remove old cleanup logic and unlink temp files in `finally`
- add test to verify cleanup when an exception occurs
- implement minimal `FPDF` stub for tests

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b84166cbc832ba365bb06b67031d9