### PR TITLE
Fix admin result download fallback

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -44,9 +44,15 @@ class ResultController
         }
         $content = $this->xlsx->build($rows);
         $response->getBody()->write($content);
+        if ($this->xlsx->isAvailable()) {
+            return $response
+                ->withHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+                ->withHeader('Content-Disposition', 'attachment; filename="results.xlsx"');
+        }
+
         return $response
-            ->withHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
-            ->withHeader('Content-Disposition', 'attachment; filename="results.xlsx"');
+            ->withHeader('Content-Type', 'text/csv')
+            ->withHeader('Content-Disposition', 'attachment; filename="results.csv"');
     }
 
     public function post(Request $request, Response $response): Response

--- a/src/Service/XlsxExportService.php
+++ b/src/Service/XlsxExportService.php
@@ -6,11 +6,26 @@ namespace App\Service;
 
 class XlsxExportService
 {
+    public function isAvailable(): bool
+    {
+        return class_exists(\ZipArchive::class);
+    }
+
     /**
      * @param list<array<string|int|float|null>> $rows
      */
     public function build(array $rows): string
     {
+        if (!$this->isAvailable()) {
+            $lines = [];
+            foreach ($rows as $row) {
+                $cells = array_map(static function ($v) {
+                    return '"' . str_replace('"', '""', (string) $v) . '"';
+                }, $row);
+                $lines[] = implode(';', $cells);
+            }
+            return implode("\n", $lines) . "\n";
+        }
         $sheetData = '';
         foreach ($rows as $i => $row) {
             $rowIndex = $i + 1;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -197,7 +197,7 @@
         </table>
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="resultsResetBtn" class="uk-button uk-button-default" uk-tooltip="title: Löscht alle gespeicherten Ergebnisse; pos: right">Zurücksetzen</button>
-          <button id="resultsDownloadBtn" class="uk-button uk-button-primary" uk-tooltip="title: Ergebnisse als CSV herunterladen; pos: right">Herunterladen</button>
+          <button id="resultsDownloadBtn" class="uk-button uk-button-primary" uk-tooltip="title: Ergebnisse herunterladen; pos: right">Herunterladen</button>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- allow admin result download without ZipArchive by falling back to CSV
- adjust controller headers based on export availability
- update tooltip wording on admin page

## Testing
- `pytest -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b84ecdf74832bafc2bfce8dd9893a