### PR TITLE
Update help text for teams tab

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -23,7 +23,7 @@
   <ul id="adminTabs" uk-tab>
     <li class="uk-active" data-help="Allgemeine Einstellungen wie Logo, Texte und Farben der Veranstaltung."><a href="#">Veranstaltung konfigurieren</a></li>
     <li data-help="Fragenkataloge erstellen, benennen und beschreiben."><a href="#">Kataloge</a></li>
-    <li data-help="Liste der teilnehmenden Teams oder Personen verwalten."><a href="#">Teams/Personen</a></li>
+    <li data-help="Liste der teilnehmenden Teams oder Personen verwalten. Der Teamname wird beim Scannen an den Stationen verwendet. Die Option 'Nur Teams/Personen aus der Liste dürfen teilnehmen.' beschränkt die Teilnahme auf eingetragene Namen."><a href="#">Teams/Personen</a></li>
     <li data-help="Fragen eines Katalogs bearbeiten und neue Fragen hinzufügen."><a href="#">Fragen anpassen</a></li>
     <li data-help="Gespeicherte Quiz-Ergebnisse ansehen und herunterladen."><a href="#">Ergebnisse</a></li>
     <li data-help="Administrationspasswort festlegen."><a href="#">Passwort ändern</a></li>


### PR DESCRIPTION
## Summary
- clarify what team names are used for
- describe the effect of restricting participation to predefined teams

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd249016c832ba0486b561f3e8922