### PR TITLE
Implement direct QR code downloads

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -711,12 +711,20 @@ document.addEventListener('DOMContentLoaded', function () {
   dl.innerHTML = '<span uk-icon="download"></span>';
   dl.setAttribute('aria-label', 'QR-Code herunterladen');
   function triggerDownload(text) {
-    const a = document.createElement('a');
-    a.href = qrSrc(text);
-    a.download = text + '.png';
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
+    fetch('/qr.png?t=' + encodeURIComponent(text))
+      .then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        return r.blob();
+      })
+      .then(blob => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = text + '.png';
+        a.click();
+        URL.revokeObjectURL(url);
+      })
+      .catch(err => console.error(err));
   }
   function update() {
     const val = input.value.trim();

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Writer\PngWriter;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class QrController
+{
+    public function image(Request $request, Response $response): Response
+    {
+        $text = (string)($request->getQueryParams()['t'] ?? '');
+        if ($text === '') {
+            return $response->withStatus(400);
+        }
+
+        if (method_exists(QrCode::class, 'create')) {
+            $qrCode = QrCode::create($text);
+        } else {
+            $qrCode = new QrCode($text);
+        }
+        $writer = new PngWriter();
+
+        if (method_exists($writer, 'write')) {
+            $data = $writer->write($qrCode)->getString();
+        } elseif (method_exists($writer, 'writeString')) {
+            $data = $writer->writeString($qrCode);
+        } else {
+            $tmp = sys_get_temp_dir() . '/' . uniqid('qr_', true) . '.png';
+            if (method_exists($writer, 'writeFile')) {
+                $writer->writeFile($qrCode, $tmp);
+            } else {
+                $writer->write($qrCode)->saveToFile($tmp);
+            }
+            $data = file_get_contents($tmp) ?: '';
+            @unlink($tmp);
+        }
+
+        $response->getBody()->write($data);
+        return $response
+            ->withHeader('Content-Type', 'image/png')
+            ->withHeader('Content-Disposition', 'attachment; filename="qr.png"');
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -23,6 +23,7 @@ use App\Controller\TeamController;
 use App\Controller\ExportController;
 use App\Service\PdfExportService;
 use App\Controller\PasswordController;
+use App\Controller\QrController;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
@@ -39,6 +40,7 @@ require_once __DIR__ . '/Controller/TeamController.php';
 require_once __DIR__ . '/Controller/ExportController.php';
 require_once __DIR__ . '/Controller/PasswordController.php';
 require_once __DIR__ . '/Controller/AdminCatalogController.php';
+require_once __DIR__ . '/Controller/QrController.php';
 
 return function (\Slim\App $app) {
     $configService = new ConfigService(
@@ -57,6 +59,7 @@ return function (\Slim\App $app) {
     $teamController = new TeamController($teamService);
     $exportController = new ExportController($configService, $catalogService, $teamService, $pdfService);
     $passwordController = new PasswordController($configService);
+    $qrController = new QrController();
 
     $app->get('/', HomeController::class);
     $app->get('/favicon.ico', function (Request $request, Response $response) {
@@ -93,4 +96,5 @@ return function (\Slim\App $app) {
     $app->get('/teams.json', [$teamController, 'get']);
     $app->post('/teams.json', [$teamController, 'post']);
     $app->post('/password', [$passwordController, 'post']);
+    $app->get('/qr.png', [$qrController, 'image']);
 };


### PR DESCRIPTION
## Summary
- add `QrController` serving QR code images as attachments
- expose new `/qr.png` endpoint
- update admin panel downloads to call the endpoint

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684bd290b76c832ba99157127656233b