### PR TITLE
Fix PDF export headers and cleanup

### DIFF
--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -79,24 +79,7 @@ class PdfExportService
         $pdf = new \FPDF();
         $pdf->AddPage();
 
-        if ($header !== '') {
-            $pdf->SetFont('Arial', 'B', 16);
-            $pdf->Cell(0, 10, $header);
-            $pdf->Ln();
-        }
-        if ($subheader !== '') {
-            $pdf->SetFont('Arial', '', 12);
-            $pdf->Cell(0, 10, $subheader);
-            $pdf->Ln();
-        }
-
-        if ($catalogs !== []) {
-            $pdf->Ln(10);
-            $pdf->SetFont('Arial', 'B', 14);
-            $pdf->Cell(0, 10, $this->enc('Kataloge'));
-            $pdf->Ln();
-        }
-
+        $tmpFiles = [];
         $qrAvailable = class_exists(\Endroid\QrCode\QrCode::class)
             && class_exists(\Endroid\QrCode\Writer\PngWriter::class);
 
@@ -111,9 +94,6 @@ class PdfExportService
                 $pdf->Cell(0, 10, $subheader);
                 $pdf->Ln();
             }
-
-            $qrAvailable = class_exists(\Endroid\QrCode\QrCode::class)
-                && class_exists(\Endroid\QrCode\Writer\PngWriter::class);
 
             $loginUrl = (string)($config['loginUrl'] ?? $config['login_url'] ?? '');
             if ($loginUrl !== '' && $qrAvailable) {


### PR DESCRIPTION
## Summary
- fix PDF export by defining `$tmpFiles` before use
- remove duplicate headers so catalogs and teams render only once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd987ce7c832b8151adbf24eb413c