### PR TITLE
Swap Teams/Personen and Fragen tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Der Zugang zum Administrationsbereich erfolgt über `/login`. Nach erfolgreichem
 Unter `/admin` stehen folgende Tabs zur Verfügung:
 1. **Veranstaltung konfigurieren** – Einstellungen wie Logo, Farben und Texte.
 2. **Kataloge** – Fragenkataloge erstellen und verwalten.
-3. **Teams/Personen** – Teilnehmerlisten pflegen, optional als Login-Beschränkung.
-4. **Fragen anpassen** – Fragen eines Katalogs hinzufügen, bearbeiten oder löschen.
+3. **Fragen anpassen** – Fragen eines Katalogs hinzufügen, bearbeiten oder löschen.
+4. **Teams/Personen** – Teilnehmerlisten pflegen, optional als Login-Beschränkung.
 5. **Ergebnisse** – Spielstände einsehen und herunterladen.
 6. **Passwort ändern** – Administrationspasswort setzen.
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -23,8 +23,8 @@
   <ul id="adminTabs" uk-tab>
     <li class="uk-active" data-help="Allgemeine Einstellungen wie Logo, Texte und Farben der Veranstaltung."><a href="#">Veranstaltung konfigurieren</a></li>
     <li data-help="Fragenkataloge erstellen, benennen und beschreiben. Die drei Felder stehen für ID, Name und Beschreibung. Mit \"Hinzufügen\" legst du einen neuen Katalog an, \"Speichern\" übernimmt Änderungen und \"Löschen\" entfernt einen Eintrag."><a href="#">Kataloge</a></li>
-    <li data-help="Liste der teilnehmenden Teams oder Personen verwalten. Der Teamname wird beim Scannen an den Stationen verwendet. Die Option 'Nur Teams/Personen aus der Liste dürfen teilnehmen.' beschränkt die Teilnahme auf eingetragene Namen."><a href="#">Teams/Personen</a></li>
     <li data-help="Fragen eines Katalogs bearbeiten und neue Fragen hinzufügen."><a href="#">Fragen anpassen</a></li>
+    <li data-help="Liste der teilnehmenden Teams oder Personen verwalten. Der Teamname wird beim Scannen an den Stationen verwendet. Die Option 'Nur Teams/Personen aus der Liste dürfen teilnehmen.' beschränkt die Teilnahme auf eingetragene Namen."><a href="#">Teams/Personen</a></li>
     <li data-help="Gespeicherte Quiz-Ergebnisse ansehen und herunterladen."><a href="#">Ergebnisse</a></li>
     <li data-help="Administrationspasswort festlegen."><a href="#">Passwort ändern</a></li>
   </ul>
@@ -141,23 +141,6 @@
     </li>
     <li>
       <div class="uk-container uk-container-large">
-        <h2 class="uk-heading-bullet">Teams/Personen</h2>
-        <div id="teamsList" class="uk-margin"></div>
-        <div class="uk-margin">
-          <button id="teamAddBtn" class="uk-button uk-button-default" uk-tooltip="title: Neues Team oder Person hinzufügen; pos: right">Hinzufügen</button>
-        </div>
-        <div class="uk-margin">
-          <label><input class="uk-checkbox" type="checkbox" id="teamRestrict"> Nur Teams/Personen aus der Liste dürfen teilnehmen.
-            <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Aktiviert eine Zugangsbeschränkung auf eingetragene Teams; pos: right"></span>
-          </label>
-        </div>
-        <div class="uk-margin uk-flex uk-flex-right">
-          <button id="teamsSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Änderungen an Teams oder Personen speichern; pos: right">Speichern</button>
-        </div>
-      </div>
-    </li>
-    <li>
-      <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Fragen bearbeiten</h2>
         <div class="uk-margin">
           <label class="uk-form-label" for="catalogSelect">Fragenkatalog
@@ -179,6 +162,23 @@
         </div>
         <!-- Ende Hauptdatenbereich -->
 
+      </div>
+    </li>
+    <li>
+      <div class="uk-container uk-container-large">
+        <h2 class="uk-heading-bullet">Teams/Personen</h2>
+        <div id="teamsList" class="uk-margin"></div>
+        <div class="uk-margin">
+          <button id="teamAddBtn" class="uk-button uk-button-default" uk-tooltip="title: Neues Team oder Person hinzufügen; pos: right">Hinzufügen</button>
+        </div>
+        <div class="uk-margin">
+          <label><input class="uk-checkbox" type="checkbox" id="teamRestrict"> Nur Teams/Personen aus der Liste dürfen teilnehmen.
+            <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Aktiviert eine Zugangsbeschränkung auf eingetragene Teams; pos: right"></span>
+          </label>
+        </div>
+        <div class="uk-margin uk-flex uk-flex-right">
+          <button id="teamsSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Änderungen an Teams oder Personen speichern; pos: right">Speichern</button>
+        </div>
       </div>
     </li>
     <li>

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -24,8 +24,8 @@
             <ul class="uk-navbar-nav">
                 <li {% if tab == 'konfig' %}class="uk-active"{% endif %}><a href="/admin/konfig">Veranstaltung konfigurieren</a></li>
                 <li {% if tab == 'kataloge' %}class="uk-active"{% endif %}><a href="/admin/kataloge">Kataloge</a></li>
-                <li {% if tab == 'teams' %}class="uk-active"{% endif %}><a href="/admin/teams">Teams/Personen</a></li>
                 <li {% if tab == 'fragen' %}class="uk-active"{% endif %}><a href="/admin/fragen">Fragen anpassen</a></li>
+                <li {% if tab == 'teams' %}class="uk-active"{% endif %}><a href="/admin/teams">Teams/Personen</a></li>
                 <li {% if tab == 'ergebnisse' %}class="uk-active"{% endif %}><a href="/admin/ergebnisse">Ergebnisse</a></li>
                 <li {% if tab == 'pw' %}class="uk-active"{% endif %}><a href="/admin/pw">Passwort ändern</a></li>
             </ul>


### PR DESCRIPTION
## Summary
- swap the order of "Teams/Personen" and "Fragen anpassen" tabs
- update content sections to match new order
- correct documentation describing admin tab order

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684c02e12980832bbe41f8111c8016ee