### PR TITLE
Enhance PDF export with QR text column

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Die Ergebnisse werden in `data/results.json` gespeichert. Wichtige Endpunkte:
 - `GET /results/download` – erzeugt eine XLSX-Datei (oder CSV) mit allen Resultaten.
 
 ### PDF-Export
-`GET /export.pdf` erzeugt eine PDF-Datei mit QR-Codes zu jedem Katalog und optional einer Teamliste. Der `PdfExportService` baut diese Datei auf und unterstützt auch externe QR-Code-Grafiken.
+`GET /export.pdf` erzeugt eine PDF-Datei mit QR-Codes zu jedem Katalog und optional einer Teamliste. Der `PdfExportService` baut diese Datei auf, unterstützt externe QR-Code-Grafiken und zeigt in einer zusätzlichen Spalte auch den Text, aus dem der QR-Code generiert wird.
 
 ### Passwort ändern
 Ein POST auf `/password` speichert ein neues Admin-Passwort in `config.json`.

--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -132,9 +132,10 @@ class PdfExportService
         $rowHeight = 20; // allow enough space for scannable QR codes
         $qrSize = 18;
 
-        $pdf->Cell(60, $rowHeight, $this->enc('Name'), 1);
-        $pdf->Cell(80, $rowHeight, $this->enc('Beschreibung'), 1);
+        $pdf->Cell(40, $rowHeight, $this->enc('Name'), 1);
+        $pdf->Cell(70, $rowHeight, $this->enc('Beschreibung'), 1);
         if ($qrEnabled) {
+            $pdf->Cell(40, $rowHeight, $this->enc('QR-Text'), 1);
             $pdf->Cell(40, $rowHeight, $this->enc('QR-Code'), 1);
         }
         $pdf->Ln();
@@ -144,8 +145,8 @@ class PdfExportService
             $name = $this->enc((string)($catalog['name'] ?? $catalog['id'] ?? ''));
             $desc = $this->enc((string)($catalog['description'] ?? $catalog['beschreibung'] ?? ''));
 
-            $pdf->Cell(60, $rowHeight, $name, 1);
-            $pdf->Cell(80, $rowHeight, $desc, 1);
+            $pdf->Cell(40, $rowHeight, $name, 1);
+            $pdf->Cell(70, $rowHeight, $desc, 1);
 
             if ($qrEnabled) {
                 $qrImage = $catalog['qr_image']
@@ -154,6 +155,8 @@ class PdfExportService
                     ?? $catalog['qrcode']
                     ?? null;
                 $qrImage = $this->loadQrImage($qrImage, $tmpFiles);
+                $qrData = '?katalog=' . urlencode((string)($catalog['id'] ?? ''));
+                $pdf->Cell(40, $rowHeight, $this->enc($qrData), 1);
                 if ($qrImage === null && $qrAvailable) {
                     $url = '?katalog=' . urlencode((string)($catalog['id'] ?? ''));
                     if (method_exists(QrCode::class, 'create')) {
@@ -192,16 +195,17 @@ class PdfExportService
             $pdf->Ln();
 
             $pdf->SetFont('Arial', 'B', 12);
-            $pdf->Cell(60, $rowHeight, $this->enc('Name'), 1);
+            $pdf->Cell(70, $rowHeight, $this->enc('Name'), 1);
             if ($qrEnabled) {
+                $pdf->Cell(80, $rowHeight, $this->enc('QR-Text'), 1);
                 $pdf->Cell(40, $rowHeight, $this->enc('QR-Code'), 1);
             }
             $pdf->Ln();
 
             $pdf->SetFont('Arial', '', 12);
             foreach ($teams as $team) {
-            $name = $this->enc((string)$team);
-            $pdf->Cell(60, $rowHeight, $name, 1);
+            $name = is_array($team) ? $this->enc((string)($team['name'] ?? '')) : $this->enc((string)$team);
+            $pdf->Cell(70, $rowHeight, $name, 1);
                 if ($qrEnabled) {
                     $qrImage = null;
                     if (is_array($team)) {
@@ -212,6 +216,8 @@ class PdfExportService
                             ?? null;
                     }
                     $qrImage = $this->loadQrImage($qrImage, $tmpFiles);
+                    $qrData = is_array($team) ? (string)($team['name'] ?? '') : (string)$team;
+                    $pdf->Cell(80, $rowHeight, $this->enc($qrData), 1);
                     if ($qrImage === null && $qrAvailable) {
                         $url = is_array($team) ? (string)($team['name'] ?? '') : (string)$team;
                         if (method_exists(QrCode::class, 'create')) {


### PR DESCRIPTION
## Summary
- show the encoded text in the PDF export
- document QR text column in README

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0c21d66c832b925332b9b9114dab