### PR TITLE
Implement HTML export with new button

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -126,6 +126,12 @@ document.addEventListener('DOMContentLoaded', function () {
       });
   });
 
+  const cfgHtmlBtn = document.getElementById('cfgHtmlBtn');
+  cfgHtmlBtn?.addEventListener('click', function (e) {
+    e.preventDefault();
+    window.open('/export.html', '_blank');
+  });
+
   // --------- Fragen bearbeiten ---------
   const container = document.getElementById('questions');
   const addBtn = document.getElementById('addBtn');

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -8,6 +8,7 @@ use App\Service\CatalogService;
 use App\Service\ConfigService;
 use App\Service\PdfExportService;
 use App\Service\TeamService;
+use Slim\Views\Twig;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -40,5 +41,23 @@ class ExportController
         return $response
             ->withHeader('Content-Type', 'application/pdf')
             ->withHeader('Content-Disposition', 'attachment; filename="export.pdf"');
+    }
+
+    public function page(Request $request, Response $response): Response
+    {
+        $view = Twig::fromRequest($request);
+        $cfg = $this->config->getConfig();
+        $catJson = $this->catalogs->read('catalogs.json');
+        $cats = [];
+        if ($catJson !== null) {
+            $cats = json_decode($catJson, true) ?? [];
+        }
+        $teams = $this->teams->getAll();
+
+        return $view->render($response, 'export.twig', [
+            'config' => $cfg,
+            'catalogs' => $cats,
+            'teams' => $teams,
+        ]);
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -85,6 +85,7 @@ return function (\Slim\App $app) {
     $app->post('/results', [$resultController, 'post']);
     $app->delete('/results', [$resultController, 'delete']);
     $app->get('/export.pdf', [$exportController, 'download']);
+    $app->get('/export.html', [$exportController, 'page']);
     $app->get('/config.json', [$configController, 'get']);
     $app->post('/config.json', [$configController, 'post']);
     $app->get('/kataloge/{file}', [$catalogController, 'get']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -114,6 +114,7 @@
           <button id="cfgResetBtn" class="uk-button uk-button-default" uk-tooltip="title: Setzt alle Felder auf gespeicherte Werte zurück; pos: right">Zurücksetzen</button>
           <div>
             <button id="cfgExportBtn" class="uk-button uk-button-secondary uk-margin-right" uk-tooltip="title: PDF mit QR-Codes erzeugen; pos: right">PDF Export</button>
+            <button id="cfgHtmlBtn" class="uk-button uk-button-secondary uk-margin-right" uk-tooltip="title: HTML-Seite mit QR-Codes anzeigen; pos: right">HTML Export</button>
             <button id="cfgSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Einstellungen speichern; pos: right">Speichern</button>
           </div>
         </div>

--- a/templates/export.twig
+++ b/templates/export.twig
@@ -1,0 +1,61 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Export Vorschau{% endblock %}
+
+{% block head %}
+  <link rel="stylesheet" href="/css/main.css">
+{% endblock %}
+
+{% block body_class %}uk-background-muted uk-padding{% endblock %}
+
+{% block body %}
+  {% embed 'topbar.twig' %}
+    {% block left %}
+      <a href="/admin" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+    {% endblock %}
+    {% block center %}
+      <span class="uk-navbar-title">Export</span>
+    {% endblock %}
+  {% endembed %}
+  <div class="uk-container uk-container-large">
+    <h2 class="uk-heading-bullet">Kataloge</h2>
+    <table class="uk-table uk-table-divider">
+      <thead>
+        <tr><th>Name</th><th>Beschreibung</th><th>QR-Code</th></tr>
+      </thead>
+      <tbody>
+        {% for c in catalogs %}
+        <tr>
+          <td>{{ c.name }}</td>
+          <td>{{ c.description }}</td>
+          <td><img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="64" height="64"></td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3">Keine Kataloge</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <h2 class="uk-heading-bullet">Teams/Personen</h2>
+    <table class="uk-table uk-table-divider">
+      <thead>
+        <tr><th>Name</th><th>QR-Code</th></tr>
+      </thead>
+      <tbody>
+        {% for t in teams %}
+        <tr>
+          <td>{{ t }}</td>
+          <td><img src="/qr.png?t={{ t|url_encode }}" alt="QR" width="64" height="64"></td>
+        </tr>
+        {% else %}
+        <tr><td colspan="2">Keine Daten</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="/js/uikit-icons.min.js"></script>
+  <script src="/js/app.js"></script>
+{% endblock %}

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -62,4 +62,13 @@ class ExportControllerTest extends TestCase
         $this->assertEquals('application/pdf', $response->getHeaderLine('Content-Type'));
         $this->assertStringContainsString('PNG', $content);
     }
+
+    public function testExportHtml(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/export.html');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('<table', (string) $response->getBody());
+    }
 }

--- a/tests/test_html_validity.py
+++ b/tests/test_html_validity.py
@@ -56,5 +56,9 @@ class TestHTMLValidity(unittest.TestCase):
         errors = validate_html_file('templates/lizenz.twig')
         self.assertEqual(errors, [], msg='\n'.join(errors))
 
+    def test_export_html_is_valid(self):
+        errors = validate_html_file('templates/export.twig')
+        self.assertEqual(errors, [], msg='\n'.join(errors))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add HTML export preview template and controller method
- hook up new `/export.html` route
- include button for HTML export in admin page
- open new window via JS on click
- extend tests for new export and validate HTML

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0dff0128832ba94ca2d34ed97ea9