### PR TITLE
Fix QR code display in HTML export

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -43,6 +43,6 @@ class QrController
         $response->getBody()->write($data);
         return $response
             ->withHeader('Content-Type', 'image/png')
-            ->withHeader('Content-Disposition', 'attachment; filename="qr.png"');
+            ->withHeader('Content-Disposition', 'inline; filename="qr.png"');
     }
 }


### PR DESCRIPTION
## Summary
- fix `Content-Disposition` header so HTML export shows QR codes correctly

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c108681c0832b9a19da702e269a60