### PR TITLE
Add summary tab to admin panel

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -10,6 +10,7 @@ use Slim\Views\Twig;
 use App\Service\ConfigService;
 use App\Service\ResultService;
 use App\Service\CatalogService;
+use App\Service\TeamService;
 
 class AdminController
 {
@@ -28,10 +29,13 @@ class AdminController
             $catalogs = json_decode($catalogsJson, true) ?? [];
         }
 
+        $teams = (new TeamService(__DIR__ . '/../../data/teams.json'))->getAll();
+
         return $view->render($response, 'admin.twig', [
             'config' => $cfg,
             'results' => $results,
             'catalogs' => $catalogs,
+            'teams' => $teams,
         ]);
     }
 }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -27,6 +27,7 @@
     <li data-help="Liste der teilnehmenden Teams oder Personen verwalten. Der Teamname wird beim Scannen an den Stationen verwendet. Die Option 'Nur Teams/Personen aus der Liste dürfen teilnehmen.' beschränkt die Teilnahme auf eingetragene Namen."><a href="#">Teams/Personen</a></li>
     <li data-help="Gespeicherte Quiz-Ergebnisse ansehen und herunterladen."><a href="#">Ergebnisse</a></li>
     <li data-help="Administrationspasswort festlegen."><a href="#">Passwort ändern</a></li>
+    <li data-help="Übersicht aller QR-Codes"><a href="#">Zusammenfassung</a></li>
   </ul>
   <ul class="uk-switcher uk-margin">
     <li>
@@ -234,6 +235,47 @@
             <button id="passSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Neues Passwort speichern; pos: right">Speichern</button>
           </div>
         </form>
+      </div>
+    </li>
+    <li>
+      <div class="uk-container uk-container-large">
+        <h2 class="uk-heading-bullet">{{ config.header }}</h2>
+        <p>{{ config.subheader }}</p>
+
+        <h3 class="uk-heading-bullet">Kataloge</h3>
+        <table class="uk-table uk-table-divider">
+          <thead>
+            <tr><th>Name</th><th>Beschreibung</th><th>QR-Code</th></tr>
+          </thead>
+          <tbody>
+            {% for c in catalogs %}
+            <tr>
+              <td>{{ c.name }}</td>
+              <td>{{ c.description }}</td>
+              <td><img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="64" height="64"></td>
+            </tr>
+            {% else %}
+            <tr><td colspan="3">Keine Kataloge</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+
+        <h3 class="uk-heading-bullet">Teams/Personen</h3>
+        <table class="uk-table uk-table-divider">
+          <thead>
+            <tr><th>Name</th><th>QR-Code</th></tr>
+          </thead>
+          <tbody>
+            {% for t in teams %}
+            <tr>
+              <td>{{ t }}</td>
+              <td><img src="/qr.png?t={{ t|url_encode }}" alt="QR" width="64" height="64"></td>
+            </tr>
+            {% else %}
+            <tr><td colspan="2">Keine Daten</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
## Summary
- extend AdminController to load teams for templates
- add a new "Zusammenfassung" tab in admin view
- show header, subheader, catalogs and teams with QR codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c102f0cfc832bb57bf524f6f0a76b