### PR TITLE
Improve QR generation styling

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -734,7 +734,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const teamRestrict = cfgFields.teamRestrict;
 
   function qrSrc(text){
-    return 'https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=' + encodeURIComponent(text);
+    return '/qr.png?t=' + encodeURIComponent(text);
   }
 
   function downloadQr(text){

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Builder\Builder;
 use Endroid\QrCode\Writer\PngWriter;
+use Endroid\QrCode\Color\Color;
+use Endroid\QrCode\Encoding\Encoding;
+use Endroid\QrCode\Label\Font\NotoSans;
+use Endroid\QrCode\Label\Alignment\LabelAlignmentCenter;
+use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -18,27 +23,21 @@ class QrController
             return $response->withStatus(400);
         }
 
-        if (method_exists(QrCode::class, 'create')) {
-            $qrCode = QrCode::create($text);
-        } else {
-            $qrCode = new QrCode($text);
-        }
-        $writer = new PngWriter();
+        $result = Builder::create()
+            ->writer(new PngWriter())
+            ->data($text)
+            ->encoding(new Encoding('UTF-8'))
+            ->size(300)
+            ->margin(20)
+            ->backgroundColor(new Color(255, 255, 255))
+            ->foregroundColor(new Color(35, 180, 90))
+            ->labelText($text)
+            ->labelFont(new NotoSans(20))
+            ->labelAlignment(new LabelAlignmentCenter())
+            ->roundBlockSizeMode(RoundBlockSizeMode::ENLARGE)
+            ->build();
 
-        if (method_exists($writer, 'write')) {
-            $data = $writer->write($qrCode)->getString();
-        } elseif (method_exists($writer, 'writeString')) {
-            $data = $writer->writeString($qrCode);
-        } else {
-            $tmp = sys_get_temp_dir() . '/' . uniqid('qr_', true) . '.png';
-            if (method_exists($writer, 'writeFile')) {
-                $writer->writeFile($qrCode, $tmp);
-            } else {
-                $writer->write($qrCode)->saveToFile($tmp);
-            }
-            $data = file_get_contents($tmp) ?: '';
-            @unlink($tmp);
-        }
+        $data = $result->getString();
 
         $response->getBody()->write($data);
         return $response


### PR DESCRIPTION
## Summary
- customize in-app QR code generation with Endroid builder
- display generated team QR codes using the server endpoint
- update PDF export to draw styled QR codes for catalogs and teams

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1140c45c832ba90dbf574f152d22