### PR TITLE
Ensure dependencies install on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,8 @@ WORKDIR /var/www
 COPY . /var/www
 RUN composer install --no-interaction --prefer-dist --no-progress
 
-CMD ["php", "-S", "0.0.0.0:8080", "-t", "public", "public/router.php"]
+# entrypoint to install dependencies if host volume lacks vendor/
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+

--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ Das mitgelieferte `docker-compose.yml` startet das Quiz samt Reverse Proxy.
 Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `quizdata` gespeichert. So bleiben eingetragene Teams und Ergebnisse auch nach
 `docker-compose down` erhalten. Die ACME-Konfiguration des Let's-Encrypt-
-Begleiters landet im Ordner `acme/` und wird dadurch ebenfalls 
+Begleiters landet im Ordner `acme/` und wird dadurch ebenfalls
 persistiert.
+Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
+Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.
+Ein vorheriges `composer install` ist somit nicht mehr erforderlich.
 
 ## Anpassung
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Install composer dependencies if vendor directory is missing
+if [ ! -d vendor ]; then
+    composer install --no-interaction --prefer-dist --no-progress
+fi
+
+exec "$@"
+


### PR DESCRIPTION
## Summary
- add `docker-entrypoint.sh` to install composer packages when the container starts
- wire entrypoint in Dockerfile
- document automatic dependency installation in README

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- ❌ `php` not available -> PHP unit tests skipped

------
https://chatgpt.com/codex/tasks/task_e_684c137886d0832ba12ce221ea587e1a