### PR TITLE
Fix QR label alignment constant

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -9,7 +9,7 @@ use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
-use Endroid\QrCode\Label\Alignment\LabelAlignmentCenter;
+use Endroid\QrCode\Label\Alignment\LabelAlignment;
 use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -33,7 +33,7 @@ class QrController
             ->foregroundColor(new Color(35, 180, 90))
             ->labelText($text)
             ->labelFont(new NotoSans(20))
-            ->labelAlignment(new LabelAlignmentCenter())
+            ->labelAlignment(LabelAlignment::CENTER)
             ->roundBlockSizeMode(RoundBlockSizeMode::ENLARGE)
             ->build();
 

--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -9,7 +9,7 @@ use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
-use Endroid\QrCode\Label\Alignment\LabelAlignmentCenter;
+use Endroid\QrCode\Label\Alignment\LabelAlignment;
 use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
 use FPDF;
 
@@ -87,7 +87,7 @@ class PdfExportService
             ->foregroundColor(new Color(35, 180, 90))
             ->labelText($text)
             ->labelFont(new NotoSans(20))
-            ->labelAlignment(new LabelAlignmentCenter())
+            ->labelAlignment(LabelAlignment::CENTER)
             ->roundBlockSizeMode(RoundBlockSizeMode::ENLARGE)
             ->build();
 


### PR DESCRIPTION
## Summary
- update QR controller and PDF export service for new `endroid/qr-code` enum

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684c15e48abc832b983cb778931221ee