### PR TITLE
Fix missing QR code class

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -9,7 +9,6 @@ use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
-use Endroid\QrCode\Label\Alignment\LabelAlignmentCenter;
 use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -23,7 +22,7 @@ class QrController
             return $response->withStatus(400);
         }
 
-        $result = Builder::create()
+        $builder = Builder::create()
             ->writer(new PngWriter())
             ->data($text)
             ->encoding(new Encoding('UTF-8'))
@@ -32,8 +31,13 @@ class QrController
             ->backgroundColor(new Color(255, 255, 255))
             ->foregroundColor(new Color(35, 180, 90))
             ->labelText($text)
-            ->labelFont(new NotoSans(20))
-            ->labelAlignment(new LabelAlignmentCenter())
+            ->labelFont(new NotoSans(20));
+
+        if (class_exists(\Endroid\QrCode\Label\Alignment\LabelAlignmentCenter::class)) {
+            $builder = $builder->labelAlignment(new \Endroid\QrCode\Label\Alignment\LabelAlignmentCenter());
+        }
+
+        $result = $builder
             ->roundBlockSizeMode(RoundBlockSizeMode::ENLARGE)
             ->build();
 

--- a/src/Service/PdfExportService.php
+++ b/src/Service/PdfExportService.php
@@ -9,7 +9,6 @@ use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
-use Endroid\QrCode\Label\Alignment\LabelAlignmentCenter;
 use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
 use FPDF;
 
@@ -77,7 +76,7 @@ class PdfExportService
      */
     private function createQrImage(string $text, array &$tmpFiles): string
     {
-        $result = Builder::create()
+        $builder = Builder::create()
             ->writer(new PngWriter())
             ->data($text)
             ->encoding(new Encoding('UTF-8'))
@@ -86,8 +85,13 @@ class PdfExportService
             ->backgroundColor(new Color(255, 255, 255))
             ->foregroundColor(new Color(35, 180, 90))
             ->labelText($text)
-            ->labelFont(new NotoSans(20))
-            ->labelAlignment(new LabelAlignmentCenter())
+            ->labelFont(new NotoSans(20));
+
+        if (class_exists(\Endroid\QrCode\Label\Alignment\LabelAlignmentCenter::class)) {
+            $builder = $builder->labelAlignment(new \Endroid\QrCode\Label\Alignment\LabelAlignmentCenter());
+        }
+
+        $result = $builder
             ->roundBlockSizeMode(RoundBlockSizeMode::ENLARGE)
             ->build();
 


### PR DESCRIPTION
## Summary
- fix error when QR label alignment class isn't available
- avoid failing if older endroid/qr-code versions are installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c16ab5058832ba9805ce5d3958cc4