### PR TITLE
Fix Dockerfile GD dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM php:8.2-alpine
 
-RUN apk add --no-cache libpng-dev libjpeg-turbo-dev freetype-dev \
+RUN apk add --no-cache libpng libjpeg-turbo freetype \
+    && apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install gd \
-    && apk del libpng-dev libjpeg-turbo-dev freetype-dev
+    && apk del .build-deps
 
 # install composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
## Summary
- ensure GD runtime dependencies are present when building Docker

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c187d9e0c832bb8bb937a20f5723c