### PR TITLE
Remove QR code features from admin UI

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -248,15 +248,6 @@ document.addEventListener('DOMContentLoaded', function () {
     desc.placeholder = 'Beschreibung';
     desc.value = cat.description || '';
 
-    const qr = document.createElement('img');
-    qr.className = 'uk-margin-left';
-    qr.width = 64;
-    qr.height = 64;
-
-    const dl = document.createElement('button');
-    dl.className = 'uk-button uk-button-default uk-margin-left';
-    dl.innerHTML = '<span uk-icon="download"></span>';
-    dl.setAttribute('aria-label', 'QR-Code herunterladen');
 
     const del = document.createElement('button');
     del.className = 'uk-button uk-button-danger uk-margin-left';
@@ -267,16 +258,6 @@ document.addEventListener('DOMContentLoaded', function () {
       const id = idInput.value.trim();
       row.dataset.id = id;
       row.dataset.file = id ? id + '.json' : '';
-      if (id) {
-        const link = window.location.origin + '/kataloge/' + row.dataset.file;
-        qr.src = qrSrc(link);
-        dl.disabled = false;
-        dl.onclick = e => { e.preventDefault(); downloadQr(link); };
-      } else {
-        qr.src = '';
-        dl.disabled = true;
-        dl.onclick = null;
-      }
     }
     idInput.addEventListener('input', update);
     update();
@@ -284,8 +265,6 @@ document.addEventListener('DOMContentLoaded', function () {
     row.appendChild(idInput);
     row.appendChild(name);
     row.appendChild(desc);
-    row.appendChild(qr);
-    row.appendChild(dl);
     row.appendChild(del);
 
     return row;
@@ -733,26 +712,6 @@ document.addEventListener('DOMContentLoaded', function () {
   const teamSaveBtn = document.getElementById('teamsSaveBtn');
   const teamRestrict = cfgFields.teamRestrict;
 
-  function qrSrc(text){
-    return '/qr.png?t=' + encodeURIComponent(text);
-  }
-
-  function downloadQr(text){
-    return fetch('/qr.png?t=' + encodeURIComponent(text))
-      .then(r => {
-        if(!r.ok) throw new Error(r.statusText);
-        return r.blob();
-      })
-      .then(blob => {
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = text + '.png';
-        a.click();
-        URL.revokeObjectURL(url);
-      })
-      .catch(err => console.error(err));
-  }
 
   function createTeamRow(name = ''){
     const div = document.createElement('div');
@@ -761,36 +720,12 @@ document.addEventListener('DOMContentLoaded', function () {
     input.type = 'text';
     input.className = 'uk-input uk-width-expand';
     input.value = name;
-  const img = document.createElement('img');
-  img.className = 'uk-margin-left';
-  img.width = 64;
-  img.height = 64;
-  const dl = document.createElement('button');
-  dl.className = 'uk-button uk-button-default uk-margin-left';
-  dl.innerHTML = '<span uk-icon="download"></span>';
-  dl.setAttribute('aria-label', 'QR-Code herunterladen');
-  function update() {
-    const val = input.value.trim();
-    if (val) {
-      img.src = qrSrc(val);
-      dl.disabled = false;
-      dl.onclick = e => { e.preventDefault(); downloadQr(val); };
-    } else {
-      img.src = '';
-      dl.disabled = true;
-      dl.onclick = null;
-    }
-  }
-  input.addEventListener('input', update);
-  update();
-  const del = document.createElement('button');
-  del.className = 'uk-button uk-button-danger uk-margin-left';
-  del.textContent = '×';
-  del.onclick = () => div.remove();
-  div.appendChild(input);
-  div.appendChild(img);
-  div.appendChild(dl);
-  div.appendChild(del);
+    const del = document.createElement('button');
+    del.className = 'uk-button uk-button-danger uk-margin-left';
+    del.textContent = '×';
+    del.onclick = () => div.remove();
+    div.appendChild(input);
+    div.appendChild(del);
     return div;
   }
 


### PR DESCRIPTION
## Summary
- remove QR code download and preview controls from catalog and team admin sections

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1a4743f8832b9d45ed1265319506