### PR TITLE
Add card layout for export page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -193,3 +193,15 @@ body.dark-mode .sticky-actions {
 .tab-card {
   margin-top: 16px;
 }
+
+/* Kartenlayout fuer Export-Seite */
+.card-grid > div {
+  break-inside: avoid;
+}
+
+.export-card {
+  border: 1px solid #ddd;
+  padding: 20px;
+  text-align: center;
+  page-break-inside: avoid;
+}

--- a/templates/export.twig
+++ b/templates/export.twig
@@ -19,39 +19,37 @@
   {% endembed %}
   <div class="uk-container uk-container-large">
     <h2 class="uk-heading-bullet">Kataloge</h2>
-    <table class="uk-table uk-table-divider">
-      <thead>
-        <tr><th>Name</th><th>Beschreibung</th><th>QR-Code</th></tr>
-      </thead>
-      <tbody>
-        {% for c in catalogs %}
-        <tr>
-          <td>{{ c.name }}</td>
-          <td>{{ c.description }}</td>
-          <td><img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="64" height="64"></td>
-        </tr>
-        {% else %}
-        <tr><td colspan="3">Keine Kataloge</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div class="card-grid" uk-grid>
+      {% for c in catalogs %}
+      <div class="uk-width-1-1 uk-width-1-2@s">
+        <div class="export-card uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">{{ c.name }}</h3>
+          <p>{{ c.description }}</p>
+          <img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+        </div>
+      </div>
+      {% else %}
+      <div class="uk-width-1-1">
+        <div class="export-card uk-card uk-card-default uk-card-body">Keine Kataloge</div>
+      </div>
+      {% endfor %}
+    </div>
 
     <h2 class="uk-heading-bullet">Teams/Personen</h2>
-    <table class="uk-table uk-table-divider">
-      <thead>
-        <tr><th>Name</th><th>QR-Code</th></tr>
-      </thead>
-      <tbody>
-        {% for t in teams %}
-        <tr>
-          <td>{{ t }}</td>
-          <td><img src="/qr.png?t={{ t|url_encode }}" alt="QR" width="64" height="64"></td>
-        </tr>
-        {% else %}
-        <tr><td colspan="2">Keine Daten</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div class="card-grid" uk-grid>
+      {% for t in teams %}
+      <div class="uk-width-1-1 uk-width-1-2@s">
+        <div class="export-card uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">{{ t }}</h3>
+          <img src="/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
+        </div>
+      </div>
+      {% else %}
+      <div class="uk-width-1-1">
+        <div class="export-card uk-card uk-card-default uk-card-body">Keine Daten</div>
+      </div>
+      {% endfor %}
+    </div>
   </div>
 {% endblock %}
 

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -69,6 +69,6 @@ class ExportControllerTest extends TestCase
         $request = $this->createRequest('GET', '/export.html');
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertStringContainsString('<table', (string) $response->getBody());
+        $this->assertStringContainsString('export-card', (string) $response->getBody());
     }
 }


### PR DESCRIPTION
## Summary
- redesign export template to show each record as card
- add CSS for printable card layout
- update export controller test

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b58aa08832ba6a97c1383148921