### PR TITLE
Fix catalog delete button style

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -251,7 +251,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const del = document.createElement('button');
     del.className = 'uk-button uk-button-danger uk-margin-left';
-    del.textContent = 'Löschen';
+    del.textContent = '×';
+    del.setAttribute('aria-label', 'Löschen');
     del.addEventListener('click', () => deleteCatalog(cat, row));
 
     function update() {


### PR DESCRIPTION
## Summary
- update catalog deletion button to use the same design as in the team list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1c0d1264832b89fe337fa595eaaf