### PR TITLE
Fix dark mode summary headings

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -6,6 +6,14 @@ body.dark-mode {
 body.dark-mode a {
   color: #9dc6ff;
 }
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3,
+body.dark-mode h4,
+body.dark-mode h5,
+body.dark-mode h6 {
+  color: #f5f5f5;
+}
 body.dark-mode .uk-card-default {
   background-color: #1e1e1e;
   color: #f5f5f5;


### PR DESCRIPTION
## Summary
- ensure dark mode headings are white

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c1e3a9900832bbeb8a021950c3ede