### PR TITLE
Add duplicate QR codes to summary exports

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -208,3 +208,9 @@ body.dark-mode .sticky-actions {
   text-align: center;
   page-break-inside: avoid;
 }
+
+.qr-pair {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -221,7 +221,10 @@
             <div class="export-card uk-card uk-card-default uk-card-body">
               <h4 class="uk-card-title">{{ c.name }}</h4>
               <p>{{ c.description }}</p>
-              <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+              <div class="qr-pair">
+                <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+                <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+              </div>
             </div>
           </div>
           {% else %}
@@ -237,7 +240,10 @@
           <div class="uk-width-1-1 uk-width-1-2@s">
             <div class="export-card uk-card uk-card-default uk-card-body">
               <h4 class="uk-card-title">{{ t }}</h4>
-              <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ t|url_encode }}" alt="QR" width="96" height="96">
+              <div class="qr-pair">
+                <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ t|url_encode }}" alt="QR" width="96" height="96">
+                <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ t|url_encode }}" alt="QR" width="96" height="96">
+              </div>
             </div>
           </div>
           {% else %}

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -222,8 +222,8 @@
               <h4 class="uk-card-title">{{ c.name }}</h4>
               <p>{{ c.description }}</p>
               <div class="qr-pair">
-                <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
-                <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+                <img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+                <img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
               </div>
             </div>
           </div>
@@ -241,8 +241,8 @@
             <div class="export-card uk-card uk-card-default uk-card-body">
               <h4 class="uk-card-title">{{ t }}</h4>
               <div class="qr-pair">
-                <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ t|url_encode }}" alt="QR" width="96" height="96">
-                <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ t|url_encode }}" alt="QR" width="96" height="96">
+                <img src="/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
+                <img src="/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
               </div>
             </div>
           </div>

--- a/templates/export.twig
+++ b/templates/export.twig
@@ -25,7 +25,10 @@
         <div class="export-card uk-card uk-card-default uk-card-body">
           <h3 class="uk-card-title">{{ c.name }}</h3>
           <p>{{ c.description }}</p>
-          <img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+          <div class="qr-pair">
+            <img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+            <img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+          </div>
         </div>
       </div>
       {% else %}
@@ -41,7 +44,10 @@
       <div class="uk-width-1-1 uk-width-1-2@s">
         <div class="export-card uk-card uk-card-default uk-card-body">
           <h3 class="uk-card-title">{{ t }}</h3>
-          <img src="/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
+          <div class="qr-pair">
+            <img src="/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
+            <img src="/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
+          </div>
         </div>
       </div>
       {% else %}


### PR DESCRIPTION
## Summary
- display two QR codes next to each other in export and admin summary pages
- add flexbox CSS helper

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1ff9509c832b8ab5316bbf1fb2dc