### PR TITLE
Ensure card titles are white in dark mode

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -14,6 +14,9 @@ body.dark-mode h5,
 body.dark-mode h6 {
   color: #f5f5f5;
 }
+body.dark-mode .uk-card-title {
+  color: #f5f5f5;
+}
 body.dark-mode .uk-card-default {
   background-color: #1e1e1e;
   color: #f5f5f5;


### PR DESCRIPTION
## Summary
- keep `.uk-card-title` readable in dark mode by forcing white text

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c20d8b0a8832ba4194afeba6ddd02