### PR TITLE
Add styled QR code example in admin summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier 
 QR-Codes können pro Eintrag über `qr_image` oder `qrcode_url` hinterlegt werden. Neben Data-URIs und lokalen Pfaden werden dabei nun auch HTTP- oder HTTPS-URLs unterstützt.
 Der PDF-Export platziert nun außerdem einen QR-Code für den Schnellzugriff auf das Quiz am Dokumentanfang.
 
+In der Zusammenfassung erscheint weiterhin der einfache QR-Code. Direkt daneben wird nun ein Beispiel angezeigt, das mit dem PHP-Paket *Endroid\\QrCode* farbig gestaltet und beschriftet ist.
+
 ## Tests
 
 PHP-Tests werden mit PHPUnit ausgeführt:

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -220,6 +220,7 @@
               <h4 class="uk-card-title">{{ c.name }}</h4>
               <p>{{ c.description }}</p>
               <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR" width="96" height="96">
+              <img src="/qr.png?t={{ ('?katalog=' ~ c.id)|url_encode }}" alt="QR Design" width="96" height="96">
             </div>
           </div>
           {% else %}
@@ -236,6 +237,7 @@
             <div class="export-card uk-card uk-card-default uk-card-body">
               <h4 class="uk-card-title">{{ t }}</h4>
               <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ t|url_encode }}" alt="QR" width="96" height="96">
+              <img src="/qr.png?t={{ t|url_encode }}" alt="QR Design" width="96" height="96">
             </div>
           </div>
           {% else %}


### PR DESCRIPTION
## Summary
- show an additional styled QR code in the summary tab
- document the new example in the README

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c22a0568c832ba6a208703eb66f8a