### PR TITLE
Hide admin tabs in print layout

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -213,6 +213,7 @@ body.dark-mode .sticky-actions {
   .bottombar,
   .sticky-tabs,
   .nav-placeholder,
+  #adminTabs,
   .footer-placeholder,
   .uk-footer,
   .uk-navbar-container,


### PR DESCRIPTION
## Summary
- hide admin tabs in print view so they don't clutter PDFs

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684c2316090c832b86a51fefe984fccb