### PR TITLE
Fix header visibility in print layout

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -214,8 +214,6 @@ body.dark-mode .sticky-actions {
   .sticky-tabs,
   .nav-placeholder,
   #adminTabs,
-  h2.uk-heading-bullet,
-  h3.uk-heading-bullet,
   .footer-placeholder,
   .uk-footer,
   .uk-navbar-container,


### PR DESCRIPTION
## Summary
- remove rules that hide headings in print view

## Testing
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c3a4eb7b4832bbd0660038314672d