### PR TITLE
Fix base URL generation with DOMAIN env

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
 Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.
 Ein vorheriges `composer install` ist somit nicht mehr erforderlich.
 
+Die Anwendung lädt beim Start eine vorhandene `.env`-Datei ein, auch wenn sie
+ohne Docker betrieben wird. Ist `DOMAIN` dort gesetzt, wird für QR-Codes und
+Exportlinks diese Adresse verwendet. Enthält die Variable kein Schema, wird
+standardmäßig `https://` vorangestellt.
+
 ## Anpassung
 
 Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition enthält ein `id`, das dem Dateinamen ohne Endung entspricht. Bei neuen Katalogen generiert die Verwaltung dieses `id` nun automatisch aus dem eingegebenen Namen.

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,20 @@
 <?php
 require __DIR__ . '/../vendor/autoload.php';
 
+// Load environment variables from .env if available
+$envFile = __DIR__ . '/../.env';
+if (is_readable($envFile)) {
+    $vars = parse_ini_file($envFile, false, INI_SCANNER_RAW);
+    if (is_array($vars)) {
+        foreach ($vars as $key => $value) {
+            if (getenv($key) === false) {
+                putenv($key . '=' . $value);
+                $_ENV[$key] = $value;
+            }
+        }
+    }
+}
+
 use Slim\Views\Twig;
 use Slim\Views\TwigMiddleware;
 use App\Application\Middleware\SessionMiddleware;

--- a/src/Controller/AdminCatalogController.php
+++ b/src/Controller/AdminCatalogController.php
@@ -26,13 +26,17 @@ class AdminCatalogController
         if ($catalogsJson !== null) {
             $catalogs = json_decode($catalogsJson, true) ?? [];
         }
-        $uri = $request->getUri();
+        $uri    = $request->getUri();
         $domain = getenv('DOMAIN');
         if ($domain !== false && $domain !== '') {
-            $baseUrl = $uri->getScheme() . '://' . $domain;
+            if (preg_match('#^https?://#', $domain) === 1) {
+                $baseUrl = rtrim($domain, '/');
+            } else {
+                $baseUrl = 'https://' . $domain;
+            }
         } else {
             $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
-            $port = $uri->getPort();
+            $port    = $uri->getPort();
             if ($port !== null && !in_array($port, [80, 443], true)) {
                 $baseUrl .= ':' . $port;
             }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -29,13 +29,17 @@ class AdminController
             $catalogs = json_decode($catalogsJson, true) ?? [];
         }
 
-        $uri = $request->getUri();
+        $uri    = $request->getUri();
         $domain = getenv('DOMAIN');
         if ($domain !== false && $domain !== '') {
-            $baseUrl = $uri->getScheme() . '://' . $domain;
+            if (preg_match('#^https?://#', $domain) === 1) {
+                $baseUrl = rtrim($domain, '/');
+            } else {
+                $baseUrl = 'https://' . $domain;
+            }
         } else {
             $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
-            $port = $uri->getPort();
+            $port    = $uri->getPort();
             if ($port !== null && !in_array($port, [80, 443], true)) {
                 $baseUrl .= ':' . $port;
             }

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -28,14 +28,18 @@ class ExportController
 
     public function download(Request $request, Response $response): Response
     {
-        $cfg = $this->config->getConfig();
-        $uri = $request->getUri();
+        $cfg    = $this->config->getConfig();
+        $uri    = $request->getUri();
         $domain = getenv('DOMAIN');
         if ($domain !== false && $domain !== '') {
-            $baseUrl = $uri->getScheme() . '://' . $domain;
+            if (preg_match('#^https?://#', $domain) === 1) {
+                $baseUrl = rtrim($domain, '/');
+            } else {
+                $baseUrl = 'https://' . $domain;
+            }
         } else {
             $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
-            $port = $uri->getPort();
+            $port    = $uri->getPort();
             if ($port !== null && !in_array($port, [80, 443], true)) {
                 $baseUrl .= ':' . $port;
             }


### PR DESCRIPTION
## Summary
- load `.env` automatically when present
- prefer `https://` when DOMAIN env lacks scheme
- document DOMAIN behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c39cba924832bb70de1652cadf9ab