### PR TITLE
Update default colors and label

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -5,7 +5,7 @@
   "pageTitle": "Modernes Quiz mit UIkit",
   "header": "Sommerfest 2025",
   "subheader": "Willkommen beim Veranstaltungsquiz",
-  "backgroundColor": "#f8f8f8",
+  "backgroundColor": "#ffffff",
   "buttonColor": "#1e87f0",
   "CheckAnswerButton": "no",
   "adminUser": "admin",

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -35,7 +35,7 @@
       // Benutzername wird nach erfolgreichem Login ergänzt
     }
     const styleEl = document.createElement('style');
-    styleEl.textContent = `\n      body { background-color: ${cfg.backgroundColor || '#f8f8f8'}; }\n      .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n    `;
+    styleEl.textContent = `\n      body { background-color: ${cfg.backgroundColor || '#ffffff'}; }\n      .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n    `;
     document.head.appendChild(styleEl);
   }
 

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -13,7 +13,7 @@ window.quizConfig = {
   subheader: 'Willkommen beim Veranstaltungsquiz',
 
   // Farbschema der Anwendung
-  backgroundColor: '#f8f8f8',
+  backgroundColor: '#ffffff',
   buttonColor: '#1e87f0',
 
   // Falls "no", wird der Button "Antwort prüfen" ausgeblendet

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -104,7 +104,7 @@ function runQuiz(questions){
 
   // konfigurierbare Farben dynamisch in ein Style-Tag schreiben
   const styleEl = document.createElement('style');
-  styleEl.textContent = `\n    body { background-color: ${cfg.backgroundColor || '#f8f8f8'}; }\n    .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n  `;
+  styleEl.textContent = `\n    body { background-color: ${cfg.backgroundColor || '#ffffff'}; }\n    .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n  `;
   document.head.appendChild(styleEl);
 
   // hide header once the quiz starts

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -77,7 +77,7 @@
             </div>
             <div>
               <div class="uk-margin">
-                <label class="uk-form-label" for="cfgButtonColor">Buttonfarbe
+                <label class="uk-form-label" for="cfgButtonColor">Farbe der Schaltflächen
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: CSS-Farbwert für alle Buttons.; pos: right"></span>
                 </label>
                 <div class="uk-form-controls"><input class="uk-input" type="color" id="cfgButtonColor"></div>


### PR DESCRIPTION
## Summary
- update default background color to white
- adjust JS fallbacks for light theme
- rename button color label

## Testing
- `pytest -q`
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3b5519a8832b90a41b330d20305b