### PR TITLE
Add automatic deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execute remote deploy commands
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.DOMAIN }}
+          username: ${{ secrets.USER }}
+          password: ${{ secrets.PASSWORD }}
+          script: |
+            cd /var/sommerfest-quiz
+            git pull
+            docker-compose up -d


### PR DESCRIPTION
## Summary
- trigger deploy after PR merges
- deploy code over SSH using specified domain, user, and password

## Testing
- `python3 -m unittest discover -s tests`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c3cc133a8832ba7829494407b5a23