### PR TITLE
Fix CSV encoding for Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ python3 tests/test_json_validity.py
 
 ## Datenschutz
 
-Ergebnisse werden serverseitig in einer CSV-Datei abgelegt. Der Dateiname orientiert sich am Veranstaltungsnamen (z.&nbsp;B. `Sommerfest 2025.csv`). Die Ablage erfolgt anonymisiert und entspricht den Vorgaben der DSGVO. Jede Zeile enthält ein Pseudonym, den verwendeten Katalog, die Versuchnummer und die Punktzahl. Alternativ lassen sich die Daten weiterhin lokal als `statistical.log` exportieren.
+Ergebnisse werden serverseitig in einer CSV-Datei abgelegt. Der Dateiname orientiert sich am Veranstaltungsnamen (z.&nbsp;B. `Sommerfest 2025.csv`). Die Ablage erfolgt anonymisiert und entspricht den Vorgaben der DSGVO. Jede Zeile enthält ein Pseudonym, den verwendeten Katalog, die Versuchnummer und die Punktzahl. Die exportierte Datei ist UTF‑8-kodiert und enthält eine BOM, damit Excel Sonderzeichen korrekt erkennt. Alternativ lassen sich die Daten weiterhin lokal als `statistical.log` exportieren.
 
 ## Barrierefreiheit
 

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -42,14 +42,15 @@ class ResultController
                 (int)($r['total'] ?? 0),
             ];
         }
-        $content = $this->buildCsv($rows);
+        // prepend UTF-8 BOM for better compatibility with spreadsheet tools
+        $content = "\xEF\xBB\xBF" . $this->buildCsv($rows);
         $response->getBody()->write($content);
 
         $cfg = $this->config->getConfig();
         $name = ($cfg['header'] ?? 'results') . '.csv';
 
         return $response
-            ->withHeader('Content-Type', 'text/csv')
+            ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
             ->withHeader('Content-Disposition', 'attachment; filename="' . $name . '"');
     }
 


### PR DESCRIPTION
## Summary
- ensure exported CSV uses UTF-8 with BOM for correct Excel import
- mention UTF-8 CSV in documentation

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3f73e024832ba97fc0287f03db95