### PR TITLE
Add PHP dev tools

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,9 @@ jobs:
             - name: Install dependencies with Composer
               uses: ramsey/composer-install@v2
 
+            - name: Debug Composer installation
+              run: ls -la vendor/bin
+
             - name: Coding standards
               if: matrix.analysis
               run: vendor/bin/phpcs

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
         "psr-4": {
             "App\\": "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0",
+        "phpstan/phpstan": "^2.1",
+        "squizlabs/php_codesniffer": "^3.9"
     }
 }


### PR DESCRIPTION
## Summary
- add PHP dev dependencies to composer.json for CI tools
- show vendor bin contents for debugging in CI workflow

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_684c401219f0832b95a05c9d0cb835c8