### PR TITLE
Add workflow to require phpcs

### DIFF
--- a/.github/workflows/composer-require-phpcs.yml
+++ b/.github/workflows/composer-require-phpcs.yml
@@ -1,0 +1,34 @@
+name: Add PHPCS Package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  require-phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Require squizlabs/php_codesniffer
+        run: composer require --dev squizlabs/php_codesniffer --no-interaction --no-progress
+
+      - name: Commit updated composer files
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          if [ -n "$(git status --porcelain composer.json composer.lock)" ]; then
+            git add composer.json composer.lock
+            git commit -m "Add squizlabs/php_codesniffer via workflow"
+            git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
## Summary
- add workflow that installs `squizlabs/php_codesniffer` and commits composer updates

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c451de860832b8d6351ece53c37bf