### PR TITLE
Fix PSR-12 spacing in routes file

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -1,4 +1,5 @@
 <?php
+
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use App\Controller\HomeController;


### PR DESCRIPTION
## Summary
- add missing blank line after `<?php` in `routes.php`

## Testing
- `python3 -m pytest -q tests/test_json_validity.py`
- `python3 -m pytest -q tests/test_html_validity.py`
- ❌ `vendor/bin/phpcs` *(fails: command not found)*
- ❌ `vendor/bin/phpunit --coverage-clover clover.xml` *(fails: command not found)*
- ❌ `vendor/bin/phpstan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c46bd7f50832bbd53e484c7bff9f5