### PR TITLE
Add logo upload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Die Ergebnisse werden in `data/results.json` gespeichert. Wichtige Endpunkte:
 ### Passwort ändern
 Ein POST auf `/password` speichert ein neues Admin-Passwort in `config.json`.
 
+### Logo hochladen
+Das aktuelle Logo wird unter `/logo.png` bereitgestellt. Über einen POST auf dieselbe URL lässt sich eine neue PNG-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert.
+
 ### Sicherheit und Haftung
 Die Software wird unter der MIT-Lizenz bereitgestellt und erfolgt ohne Gewähr. Die Urheber haften nicht für Schäden, die aus der Nutzung entstehen.
 

--- a/data/config.json
+++ b/data/config.json
@@ -1,7 +1,7 @@
 {
   "displayErrorDetails": true,
   "QRUser": true,
-  "logoPath": "",
+  "logoPath": "/logo.png",
   "pageTitle": "Modernes Quiz mit UIkit",
   "header": "Sommerfest 2025",
   "subheader": "Willkommen beim Veranstaltungsquiz",

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -224,3 +224,12 @@ body.dark-mode .sticky-actions {
     display: none !important;
   }
 }
+
+.logo-placeholder {
+  height: 120px;
+  object-fit: contain;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 8px;
+}

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -17,20 +17,23 @@
     const cfg = window.quizConfig || {};
     const headerEl = document.getElementById('quiz-header');
     if(headerEl){
-      headerEl.innerHTML = '';
-      if(cfg.logoPath){
-        const img = document.createElement('img');
-        img.src = cfg.logoPath;
-        img.alt = cfg.header || 'Logo';
-        img.className = 'uk-margin-small-bottom';
-        headerEl.appendChild(img);
+      const img = headerEl.querySelector('img');
+      let title = headerEl.querySelector('h1');
+      if(img){
+        if(cfg.logoPath){
+          img.src = cfg.logoPath;
+          img.classList.remove('uk-hidden');
+        }else{
+          img.src = '';
+          img.classList.add('uk-hidden');
+        }
       }
-      if(cfg.header){
-        const h = document.createElement('h1');
-        h.textContent = cfg.header;
-        h.className = 'uk-margin-remove-bottom';
-        headerEl.appendChild(h);
+      if(!title){
+        title = document.createElement('h1');
+        title.className = 'uk-margin-remove-bottom';
+        headerEl.appendChild(title);
       }
+      title.textContent = cfg.header || '';
       setSubHeader(cfg.subheader || '');
       // Benutzername wird nach erfolgreichem Login ergänzt
     }

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\ConfigService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class LogoController
+{
+    private ConfigService $config;
+
+    public function __construct(ConfigService $config)
+    {
+        $this->config = $config;
+    }
+
+    public function get(Request $request, Response $response): Response
+    {
+        $path = __DIR__ . '/../../data/logo.png';
+        if (!file_exists($path)) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write((string)file_get_contents($path));
+        return $response->withHeader('Content-Type', 'image/png');
+    }
+
+    public function post(Request $request, Response $response): Response
+    {
+        $files = $request->getUploadedFiles();
+        if (!isset($files['file'])) {
+            return $response->withStatus(400);
+        }
+        $file = $files['file'];
+        if ($file->getError() !== UPLOAD_ERR_OK) {
+            return $response->withStatus(400);
+        }
+        $target = __DIR__ . '/../../data/logo.png';
+        $file->moveTo($target);
+
+        $cfg = $this->config->getConfig();
+        $cfg['logoPath'] = '/logo.png';
+        $this->config->saveConfig($cfg);
+
+        return $response->withStatus(204);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -22,6 +22,7 @@ use App\Controller\ResultController;
 use App\Controller\TeamController;
 use App\Controller\PasswordController;
 use App\Controller\QrController;
+use App\Controller\LogoController;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
@@ -38,6 +39,7 @@ require_once __DIR__ . '/Controller/TeamController.php';
 require_once __DIR__ . '/Controller/PasswordController.php';
 require_once __DIR__ . '/Controller/AdminCatalogController.php';
 require_once __DIR__ . '/Controller/QrController.php';
+require_once __DIR__ . '/Controller/LogoController.php';
 
 return function (\Slim\App $app) {
     $configService = new ConfigService(
@@ -54,6 +56,7 @@ return function (\Slim\App $app) {
     $teamController = new TeamController($teamService);
     $passwordController = new PasswordController($configService);
     $qrController = new QrController();
+    $logoController = new LogoController($configService);
 
     $app->get('/', HomeController::class);
     $app->get('/favicon.ico', function (Request $request, Response $response) {
@@ -90,4 +93,6 @@ return function (\Slim\App $app) {
     $app->post('/teams.json', [$teamController, 'post']);
     $app->post('/password', [$passwordController, 'post']);
     $app->get('/qr.png', [$qrController, 'image']);
+    $app->get('/logo.png', [$logoController, 'get']);
+    $app->post('/logo.png', [$logoController, 'post']);
 };

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -37,10 +37,13 @@
           <div class="uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small" uk-grid>
             <div>
               <div class="uk-margin">
-                <label class="uk-form-label" for="cfgLogoPath">Logo Pfad
-                  <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Pfad zur Bilddatei, die als Logo angezeigt wird.; pos: right"></span>
+                <label class="uk-form-label" for="cfgLogoFile">Logo hochladen
+                  <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: PNG-Datei als Logo für die Startseite hochladen.; pos: right"></span>
                 </label>
-                <div class="uk-form-controls"><input class="uk-input" type="text" id="cfgLogoPath"></div>
+                <div class="uk-form-controls">
+                  <input class="uk-input" type="file" id="cfgLogoFile" accept="image/png">
+                  <img id="cfgLogoPreview" src="{{ config.logoPath|default('') }}" alt="Logo Vorschau" class="uk-margin-small-top" style="max-height:80px">
+                </div>
               </div>
             </div>
             <div>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -25,7 +25,9 @@
   {% endembed %}
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin">
-      <div id="quiz-header" class="uk-text-center uk-margin"></div>
+      <div id="quiz-header" class="uk-text-center uk-margin">
+        <img id="quiz-logo" class="logo-placeholder" src="{{ config.logoPath|default('') }}" alt="Logo">
+      </div>
       <progress id="progress" class="uk-progress" value="0" max="1" aria-label="Fortschritt des Quiz"></progress>
       <div id="quiz"></div>
     </div>

--- a/tests/Controller/LogoControllerTest.php
+++ b/tests/Controller/LogoControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Controller\LogoController;
+use App\Service\ConfigService;
+use Tests\TestCase;
+use Slim\Psr7\Response;
+use Slim\Psr7\UploadedFile;
+
+class LogoControllerTest extends TestCase
+{
+    public function testGetNotFound(): void
+    {
+        $cfg = new ConfigService(sys_get_temp_dir() . '/cfg.json');
+        $controller = new LogoController($cfg);
+        $request = $this->createRequest('GET', '/logo.png');
+        $response = $controller->get($request, new Response());
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testPostAndGet(): void
+    {
+        $tmpConfig = tempnam(sys_get_temp_dir(), 'cfg');
+        $cfg = new ConfigService($tmpConfig);
+        $controller = new LogoController($cfg);
+        $logoFile = tempnam(sys_get_temp_dir(), 'logo');
+        imagepng(imagecreatetruecolor(10, 10), $logoFile);
+        $stream = fopen($logoFile, 'rb');
+        $uploaded = new UploadedFile($stream, filesize($logoFile), UPLOAD_ERR_OK, 'logo.png', 'image/png');
+        $request = $this->createRequest('POST', '/logo.png');
+        $request = $request->withUploadedFiles(['file' => $uploaded]);
+
+        $postResponse = $controller->post($request, new Response());
+        $this->assertEquals(204, $postResponse->getStatusCode());
+
+        $getResponse = $controller->get($this->createRequest('GET', '/logo.png'), new Response());
+        $this->assertEquals(200, $getResponse->getStatusCode());
+
+        unlink($tmpConfig);
+        unlink($logoFile);
+        unlink(sys_get_temp_dir() . '/logo.png');
+    }
+}


### PR DESCRIPTION
## Summary
- allow storing uploaded logo in persistent storage
- display logo placeholder above heading
- save uploaded path to `/logo.png`
- document the new logo upload endpoint
- add tests for the logo controller

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d70f974b4832ba85d79196bc33dee