### PR TITLE
Fix QrController namespace

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -10,7 +10,7 @@ use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
 use Endroid\QrCode\Label\Alignment\LabelAlignment;
-use Endroid\QrCode\RoundBlockSizeMode;
+use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 


### PR DESCRIPTION
## Summary
- import correct class for Endroid QR code constants

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dd1f39340832b8120bdb8d4f0ffa2