### PR TITLE
Add QR-Code Samples tab

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -28,6 +28,7 @@
     <li data-help="Gespeicherte Quiz-Ergebnisse ansehen und herunterladen."><a href="#">Ergebnisse</a></li>
     <li data-help="Übersicht aller QR-Codes"><a href="#">Zusammenfassung</a></li>
     <li data-help="Administrationspasswort festlegen."><a href="#">Passwort ändern</a></li>
+    <li data-help="Beispiele moderner QR-Codes"><a href="#">QR-Code Samples</a></li>
   </ul>
   <ul class="uk-switcher uk-margin">
     <li>
@@ -289,6 +290,21 @@
             <button id="passSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Neues Passwort speichern; pos: right">Speichern</button>
           </div>
         </form>
+      </div>
+    </li>
+    <li>
+      <div class="uk-container uk-container-large">
+        <h2 class="uk-heading-bullet">QR-Code Samples</h2>
+        <div class="card-grid" uk-grid>
+          {% for i in 1..10 %}
+          <div class="uk-width-1-1 uk-width-1-2@s">
+            <div class="export-card uk-card uk-card-default uk-card-body">
+              <h4 class="uk-card-title">Sample {{ i }}</h4>
+              <img src="/qr.png?t={{ ('Sample ' ~ i)|url_encode }}" alt="Sample {{ i }}" width="200" height="200">
+            </div>
+          </div>
+          {% endfor %}
+        </div>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
## Summary
- extend admin navigation with a new **QR-Code Samples** tab
- showcase ten QR codes generated via `/qr.png`

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684dd513e440832b8e34dfbbc04818f9