### PR TITLE
Add UIkit i18n support

### DIFF
--- a/public/js/i18n/de-de.js
+++ b/public/js/i18n/de-de.js
@@ -1,0 +1,32 @@
+(function(UIkit){
+  const i18n = {
+    close: { label: 'Schließen' },
+    totop: { label: 'Nach oben' },
+    marker: { label: 'Öffnen' },
+    navbarToggleIcon: { label: 'Menü öffnen' },
+    paginationPrevious: { label: 'Vorherige Seite' },
+    paginationNext: { label: 'Nächste Seite' },
+    slider: {
+      next: 'Nächste Folie',
+      previous: 'Vorherige Folie',
+      slideX: 'Folie %s',
+      slideLabel: '%s von %s'
+    },
+    slideshow: {
+      next: 'Nächste Folie',
+      previous: 'Vorherige Folie',
+      slideX: 'Folie %s',
+      slideLabel: '%s von %s'
+    },
+    lightboxPanel: {
+      next: 'Nächste Folie',
+      previous: 'Vorherige Folie',
+      slideLabel: '%s von %s',
+      close: 'Schließen'
+    }
+  };
+
+  for (const component in i18n) {
+    UIkit.mixin({ i18n: i18n[component] }, component);
+  }
+})(UIkit);

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -21,6 +21,7 @@
     </div>
   </nav>
   <script src="/js/uikit.min.js"></script>
+  <script src="/js/i18n/de-de.js"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add german UIkit translation script
- load translation in layout

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684dd7854f50832bbaa6fc95af429d93