### PR TITLE
Show dropped term in assignment dropzones

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -58,6 +58,7 @@ body.dark-mode .mc-option {
   color: #f5f5f5;
   font-size: 1rem;
   padding: 16px;
+  white-space: normal;
 }
 body.dark-mode .dropzone.over {
   background-color: #2a2a2a;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -46,6 +46,7 @@ body.uk-padding {
   display: flex;
   align-items: center;
   padding: 8px 12px;
+  white-space: normal;
 }
 
 .dropzone.over {

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -372,9 +372,9 @@ function runQuiz(questions){
           group: { name: group, pull: false, put: true },
           sort: false,
           animation: 150,
-          onAdd: evt => {
+            onAdd: evt => {
             const item = evt.item;
-            zone.textContent = item.textContent;
+            zone.textContent = zone.dataset.definition + ' \u2013 ' + item.textContent;
             zone.dataset.dropped = item.dataset.term;
             item.remove();
           }
@@ -395,7 +395,7 @@ function runQuiz(questions){
     div.querySelectorAll('.dropzone').forEach(zone => {
       zone.addEventListener('keydown', e => {
         if((e.key === 'Enter' || e.key === ' ') && div._selectedTerm){
-          zone.textContent = div._selectedTerm.textContent;
+          zone.textContent = zone.dataset.definition + ' \u2013 ' + div._selectedTerm.textContent;
           zone.dataset.dropped = div._selectedTerm.dataset.term;
           div._selectedTerm.style.visibility = 'hidden';
           div._selectedTerm.setAttribute('aria-grabbed','false');
@@ -410,7 +410,9 @@ function runQuiz(questions){
   function checkAssign(div, feedback, idx){
     let allCorrect = true;
     div.querySelectorAll('.dropzone').forEach(zone => {
-      if(zone.dataset.term !== zone.dataset.dropped) allCorrect = false;
+      const parts = zone.textContent.split(' \u2013 ');
+      const dropped = parts.length > 1 ? parts[1].trim() : '';
+      if(zone.dataset.term !== dropped) allCorrect = false;
     });
     results[idx] = allCorrect;
     feedback.innerHTML = allCorrect


### PR DESCRIPTION
## Summary
- show definition and term in assignment drop zones after a drop
- parse the dropped term from the displayed text when checking answers
- allow wrapping text in drop zones

## Testing
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684dd8289ed0832b8b42dcebde306c90