### PR TITLE
Add stub for phpstan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,3 +2,5 @@ parameters:
   level: 4
   paths:
     - src
+  stubFiles:
+    - stubs/endroid_qr.stub

--- a/stubs/endroid_qr.stub
+++ b/stubs/endroid_qr.stub
@@ -1,0 +1,9 @@
+<?php
+namespace Endroid\QrCode\RoundBlockSizeMode;
+
+final class RoundBlockSizeMode
+{
+    public const ENLARGE = 'enlarge';
+    public const SHRINK = 'shrink';
+    public const MARGIN = 'margin';
+}


### PR DESCRIPTION
## Summary
- provide a phpstan stub for `Endroid\QrCode\RoundBlockSizeMode`
- configure phpstan to load the stub

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684dd7ce2888832bad96d955e90eafe2