### PR TITLE
Add timestamp column to results tables and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python3 tests/test_json_validity.py
 
 ## Datenschutz
 
-Ergebnisse werden serverseitig in einer CSV-Datei abgelegt. Der Dateiname orientiert sich am Veranstaltungsnamen (z.&nbsp;B. `Sommerfest 2025.csv`). Die Ablage erfolgt anonymisiert und entspricht den Vorgaben der DSGVO. Jede Zeile enthält ein Pseudonym, den verwendeten Katalog, die Versuchnummer und die Punktzahl. Die exportierte Datei ist UTF‑8-kodiert und enthält eine BOM, damit Excel Sonderzeichen korrekt erkennt. Alternativ lassen sich die Daten weiterhin lokal als `statistical.log` exportieren.
+Ergebnisse werden serverseitig in einer CSV-Datei abgelegt. Der Dateiname orientiert sich am Veranstaltungsnamen (z.&nbsp;B. `Sommerfest 2025.csv`). Die Ablage erfolgt anonymisiert und entspricht den Vorgaben der DSGVO. Jede Zeile enthält ein Pseudonym, den verwendeten Katalog, die Versuchnummer, die Punktzahl und den Zeitpunkt des Eintrags. Die exportierte Datei ist UTF‑8-kodiert und enthält eine BOM, damit Excel Sonderzeichen korrekt erkennt. Alternativ lassen sich die Daten weiterhin lokal als `statistical.log` exportieren.
 
 ## Barrierefreiheit
 

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -32,7 +32,7 @@ class ResultController
     {
         $data = $this->service->getAll();
         $rows = [];
-        $rows[] = ['Name', 'Versuch', 'Katalog', 'Richtige', 'Gesamt'];
+        $rows[] = ['Name', 'Versuch', 'Katalog', 'Richtige', 'Gesamt', 'Zeit'];
         foreach ($data as $r) {
             $rows[] = [
                 (string)($r['name'] ?? ''),
@@ -40,6 +40,7 @@ class ResultController
                 (string)($r['catalog'] ?? ''),
                 (int)($r['correct'] ?? 0),
                 (int)($r['total'] ?? 0),
+                date('Y-m-d H:i', (int)($r['time'] ?? 0)),
             ];
         }
         // prepend UTF-8 BOM for better compatibility with spreadsheet tools

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -198,7 +198,7 @@
         <h2 class="uk-heading-bullet">Ergebnisse</h2>
         <table class="uk-table uk-table-divider">
           <thead>
-            <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th></tr>
+            <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th></tr>
           </thead>
           <tbody>
             {% for r in results %}
@@ -207,9 +207,10 @@
               <td>{{ r.attempt }}</td>
               <td>{{ r.catalog }}</td>
               <td>{{ r.correct }}/{{ r.total }}</td>
+              <td>{{ r.time | date('Y-m-d H:i') }}</td>
             </tr>
             {% else %}
-            <tr><td colspan="4">Keine Daten</td></tr>
+            <tr><td colspan="5">Keine Daten</td></tr>
             {% endfor %}
           </tbody>
         </table>

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -36,7 +36,7 @@
     <h2 class="uk-heading-bullet">3. Art und Umfang der erhobenen Daten</h2>
     <p><strong>Keine Erhebung personenbezogener Daten:</strong> Es werden keinerlei personenbezogene Daten (wie Name, E-Mail, Adresse etc.) abgefragt, gespeichert oder verarbeitet.</p>
     <p><strong>Quiz-Daten:</strong> Bei der Nutzung der App werden lediglich pseudonymisierte Daten wie frei gewählte Benutzernamen, erzielte Punktzahlen und ggf. technische Informationen zum Ablauf des Quiz verarbeitet.</p>
-    <p><strong>Serverdatei ([Veranstaltungsname].csv):</strong> Bei aktivierter Speicherung werden Pseudonyme, Katalogname, Versuch und Punktzahl serverseitig gesichert. Die Ablage erfolgt anonymisiert und konform zur DSGVO.</p>
+    <p><strong>Serverdatei ([Veranstaltungsname].csv):</strong> Bei aktivierter Speicherung werden Pseudonyme, Katalogname, Versuch, Punktzahl und Zeitpunkt serverseitig gesichert. Die Ablage erfolgt anonymisiert und konform zur DSGVO.</p>
     <p><strong>Protokolldatei (statistical.log):</strong> Beim optionalen Export werden ausschließlich Pseudonyme und Punktzahlen gespeichert.</p>
 
     <h2 class="uk-heading-bullet">4. Speicherung und Löschung</h2>

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -18,7 +18,7 @@
     <h2 class="uk-heading-bullet">Ergebnisse</h2>
     <table class="uk-table uk-table-divider">
       <thead>
-        <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th></tr>
+        <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th></tr>
       </thead>
       <tbody>
         {% for r in results %}
@@ -27,9 +27,10 @@
           <td>{{ r.attempt }}</td>
           <td>{{ r.catalog }}</td>
           <td>{{ r.correct }}/{{ r.total }}</td>
+          <td>{{ r.time | date('Y-m-d H:i') }}</td>
         </tr>
         {% else %}
-        <tr><td colspan="4">Keine Daten</td></tr>
+        <tr><td colspan="5">Keine Daten</td></tr>
         {% endfor %}
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- add time column to "Ergebnisse" tables
- include timestamp in CSV export
- document timestamp in README and Datenschutz page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dddf741ac832bb415970e9c06c2af