### PR TITLE
Fix QR code block size mode constant

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -9,7 +9,7 @@ use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
-use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
+use Endroid\QrCode\BlockSizeMode\BlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -44,7 +44,7 @@ class QrController
         }
 
         $result = $builder
-            ->roundBlockSizeMode(RoundBlockSizeMode::ENLARGE)
+            ->roundBlockSizeMode(BlockSizeMode::ENLARGE)
             ->build();
 
         $data = $result->getString();

--- a/stubs/endroid_qr.stub
+++ b/stubs/endroid_qr.stub
@@ -1,9 +1,11 @@
 <?php
-namespace Endroid\QrCode\RoundBlockSizeMode;
+namespace Endroid\QrCode\BlockSizeMode;
 
-final class RoundBlockSizeMode
+final class BlockSizeMode
 {
+    public const MARGIN = 'margin';
     public const ENLARGE = 'enlarge';
     public const SHRINK = 'shrink';
-    public const MARGIN = 'margin';
+    public const NONE = 'none';
 }
+


### PR DESCRIPTION
## Summary
- use the new BlockSizeMode namespace from endroid/qr-code
- update the stub for phpstan

## Testing
- `vendor/bin/phpcs` *(fails: No such file or directory)*
- `vendor/bin/phpstan` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684de1ca2cd0832b998736cad874c326