### PR TITLE
Add webp support for logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Die Ergebnisse werden in `data/results.json` gespeichert. Wichtige Endpunkte:
 Ein POST auf `/password` speichert ein neues Admin-Passwort in `config.json`.
 
 ### Logo hochladen
-Das aktuelle Logo wird unter `/logo.png` bereitgestellt. Über einen POST auf dieselbe URL lässt sich eine neue PNG-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert.
+Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue PNG- oder WebP-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert.
 
 ### Sicherheit und Haftung
 Die Software wird unter der MIT-Lizenz bereitgestellt und erfolgt ohne Gewähr. Die Urheber haften nicht für Schäden, die aus der Nutzung entstehen.

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -81,7 +81,9 @@ document.addEventListener('DOMContentLoaded', function () {
         setTimeout(function () {
           bar.setAttribute('hidden', 'hidden');
         }, 1000);
-        cfgFields.logoPreview.src = '/logo.png?' + Date.now();
+        const file = cfgFields.logoFile.files && cfgFields.logoFile.files[0];
+        const ext = file && file.name.toLowerCase().endsWith('.webp') ? 'webp' : 'png';
+        cfgFields.logoPreview.src = '/logo.' + ext + '?' + Date.now();
         logoUploaded = true;
         notify('Logo hochgeladen', 'success');
       }
@@ -111,7 +113,13 @@ document.addEventListener('DOMContentLoaded', function () {
   document.getElementById('cfgSaveBtn').addEventListener('click', function (e) {
     e.preventDefault();
     const data = Object.assign({}, cfgInitial, {
-      logoPath: cfgFields.logoPreview && cfgFields.logoPreview.src ? '/logo.png' : cfgInitial.logoPath,
+      logoPath: (function () {
+        if (cfgFields.logoPreview && cfgFields.logoPreview.src) {
+          const m = cfgFields.logoPreview.src.match(/\/logo\.(png|webp)/);
+          if (m) return '/logo.' + m[1];
+        }
+        return cfgInitial.logoPath;
+      })(),
       pageTitle: cfgFields.pageTitle.value.trim(),
       header: cfgFields.header.value.trim(),
       subheader: cfgFields.subheader.value.trim(),

--- a/src/routes.php
+++ b/src/routes.php
@@ -93,6 +93,8 @@ return function (\Slim\App $app) {
     $app->post('/teams.json', [$teamController, 'post']);
     $app->post('/password', [$passwordController, 'post']);
     $app->get('/qr.png', [$qrController, 'image']);
-    $app->get('/logo.png', [$logoController, 'get']);
+    $app->get('/logo.png', [$logoController, 'get'])->setArgument('ext', 'png');
     $app->post('/logo.png', [$logoController, 'post']);
+    $app->get('/logo.webp', [$logoController, 'get'])->setArgument('ext', 'webp');
+    $app->post('/logo.webp', [$logoController, 'post']);
 };

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -46,7 +46,7 @@
                     <span uk-icon="icon: cloud-upload"></span>
                     <span class="uk-text-middle">Datei hierher ziehen oder </span>
                     <div uk-form-custom>
-                      <input type="file" id="cfgLogoFile" accept="image/png">
+                      <input type="file" id="cfgLogoFile" accept="image/png,image/webp">
                       <span class="uk-link">auswählen</span>
                     </div>
                   </div>

--- a/tests/Controller/LogoControllerTest.php
+++ b/tests/Controller/LogoControllerTest.php
@@ -44,4 +44,27 @@ class LogoControllerTest extends TestCase
         unlink($logoFile);
         unlink(sys_get_temp_dir() . '/logo.png');
     }
+
+    public function testPostAndGetWebp(): void
+    {
+        $tmpConfig = tempnam(sys_get_temp_dir(), 'cfg');
+        $cfg = new ConfigService($tmpConfig);
+        $controller = new LogoController($cfg);
+        $logoFile = tempnam(sys_get_temp_dir(), 'logo');
+        file_put_contents($logoFile, 'dummy');
+        $stream = fopen($logoFile, 'rb');
+        $uploaded = new UploadedFile($stream, filesize($logoFile), UPLOAD_ERR_OK, 'logo.webp', 'image/webp');
+        $request = $this->createRequest('POST', '/logo.png');
+        $request = $request->withUploadedFiles(['file' => $uploaded]);
+
+        $postResponse = $controller->post($request, new Response());
+        $this->assertEquals(204, $postResponse->getStatusCode());
+
+        $getResponse = $controller->get($this->createRequest('GET', '/logo.webp'), new Response());
+        $this->assertEquals(200, $getResponse->getStatusCode());
+
+        unlink($tmpConfig);
+        unlink($logoFile);
+        unlink(sys_get_temp_dir() . '/logo.webp');
+    }
 }


### PR DESCRIPTION
## Summary
- allow uploading WebP logos
- handle PNG or WebP logo serving
- update admin interface for WebP preview and config
- document WebP support
- test controller with WebP logos

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de67906c8832b9621ef9981d5562d