### PR TITLE
Increase logo size and update preview

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -227,7 +227,8 @@ body.dark-mode .sticky-actions {
 }
 
 .logo-placeholder {
-  height: 120px;
+  width: 160px;
+  height: 240px;
   object-fit: contain;
   display: block;
   margin-left: auto;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Füllt das Formular mit den Werten aus einem Konfigurationsobjekt
   function renderCfg(data) {
     if (cfgFields.logoPreview) {
-      cfgFields.logoPreview.src = data.logoPath || '';
+      cfgFields.logoPreview.src = data.logoPath ? data.logoPath + '?' + Date.now() : '';
     }
     cfgFields.pageTitle.value = data.pageTitle || '';
     cfgFields.header.value = data.header || '';

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -51,7 +51,7 @@
                     </div>
                   </div>
                   <progress id="cfgLogoProgress" class="uk-progress" value="0" max="100" hidden></progress>
-                  <img id="cfgLogoPreview" src="{{ config.logoPath|default('') }}" alt="Logo Vorschau" class="uk-margin-small-top" style="max-height:80px">
+                  <img id="cfgLogoPreview" src="{{ config.logoPath|default('') }}" alt="Logo Vorschau" class="uk-margin-small-top" style="max-height:160px">
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- enlarge logo CSS dimensions to 160x240
- add timestamp when displaying logo in admin to bypass cache
- enlarge logo preview in admin

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dea4ef258832bbbfb1714481efb88