### PR TITLE
Update admin help text

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -21,7 +21,7 @@
     </div>
   </div>
   <ul id="adminTabs" uk-tab>
-    <li class="uk-active" data-help="Allgemeine Einstellungen wie Logo, Texte und Farben der Veranstaltung."><a href="#">Veranstaltung konfigurieren</a></li>
+    <li class="uk-active" data-help="Hier lädst du ein Logo hoch (mit Vorschau), legst Titel im Browser-Tab, Überschrift und Untertitel fest und wählst Hintergrund- sowie Buttonfarbe. Du kannst den Button Antwort prüfen und den QR-Code-Login einblenden. Zurück führt zurück, Speichern übernimmt alles."><a href="#">Veranstaltung konfigurieren</a></li>
     <li data-help="Fragenkataloge erstellen, benennen und beschreiben. Die drei Felder stehen für ID, Name und Beschreibung. Mit \"Hinzufügen\" legst du einen neuen Katalog an, \"Speichern\" übernimmt Änderungen und \"Löschen\" entfernt einen Eintrag."><a href="#">Kataloge</a></li>
     <li data-help="Fragen eines Katalogs bearbeiten und neue Fragen hinzufügen."><a href="#">Fragen anpassen</a></li>
     <li data-help="Liste der teilnehmenden Teams oder Personen verwalten. Der Teamname wird beim Scannen an den Stationen verwendet. Die Option 'Nur Teams/Personen aus der Liste dürfen teilnehmen.' beschränkt die Teilnahme auf eingetragene Namen."><a href="#">Teams/Personen</a></li>


### PR DESCRIPTION
## Summary
- fix truncated text for the configuration tab in admin sidebar

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684de3ef2f00832bbbf99c45d73a4ede