### PR TITLE
Adjust logo preview position

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -51,6 +51,13 @@
                     </div>
                   </div>
                   <progress id="cfgLogoProgress" class="uk-progress" value="0" max="100" hidden></progress>
+                </div>
+              </div>
+            </div>
+            <div>
+              <div class="uk-margin">
+                <label class="uk-form-label" for="cfgLogoPreview">Logo Vorschau</label>
+                <div class="uk-form-controls">
                   <img id="cfgLogoPreview" src="{{ config.logoPath|default('') }}" alt="Logo Vorschau" class="uk-margin-small-top" style="max-height:240px">
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- show logo preview in a separate field next to the upload control in the admin interface

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684def85921c832b859f62ca8c6d8ac7