### PR TITLE
Hide frontpage disclaimer when catalog selected

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -113,6 +113,10 @@ function runQuiz(questions){
     headerEl.innerHTML = '';
     headerEl.classList.add('uk-hidden');
   }
+  const disclaimerEl = document.getElementById('front-disclaimer');
+  if (disclaimerEl) {
+    disclaimerEl.classList.add('uk-hidden');
+  }
 
   elements.forEach((el, i) => {
     if (i !== 0) el.classList.add('uk-hidden');

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -27,9 +27,13 @@ class HomeController
             $catalogs = json_decode($catalogsJson, true) ?? [];
         }
 
+        $params = $request->getQueryParams();
+        $showDisclaimer = empty($params['katalog']);
+
         return $view->render($response, 'index.twig', [
             'config' => $cfg,
             'catalogs' => $catalogs,
+            'showDisclaimer' => $showDisclaimer,
         ]);
     }
 }

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -31,12 +31,14 @@
       <progress id="progress" class="uk-progress" value="0" max="1" aria-label="Fortschritt des Quiz"></progress>
       <div id="quiz"></div>
     </div>
-    <div class="uk-card uk-card-default uk-card-body uk-margin">
+    {% if showDisclaimer %}
+    <div id="front-disclaimer" class="uk-card uk-card-default uk-card-body uk-margin">
       <h3 class="uk-heading-bullet">Informationen zur Quiz-Anwendung</h3>
       <p>Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer engen Zusammenarbeit von menschlicher Erfahrung und k&uuml;nstlicher Intelligenz. Die Ideen, das Projektmanagement und die Praxiserfahrung aus vielen Softwareprojekten stammen von Menschenhand &ndash; alle Codezeilen und Optimierungen wurden jedoch zu Erprobungszwecken bewusst vollst&auml;ndig von OpenAI Codex generiert. Menschliche Sprache wurde direkt in Code verwandelt.</p>
       <p>F&uuml;r die Fehleranalyse kam GitHub Copilot zum Einsatz, f&uuml;r Best-Practice-L&ouml;sungen und Inspirationen wurde GPT-4.1 von ChatGPT genutzt. Das Projekt ist damit nicht nur ein innovatives Quiz, sondern auch ein anschauliches Beispiel f&uuml;r die erfolgreiche Kooperation zwischen menschlicher Expertise und modernen KI-Werkzeugen.</p>
       <p>Das aktuelle Logo wurde mit SORA von OpenAI erstellt.</p>
       </div>
+    {% endif %}
   </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- don't render the frontpage disclaimer when a catalog ID is provided in the URL
- keep hiding the disclaimer once the quiz starts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df393ce1c832b8d44fbd6379774fb