### PR TITLE
Fix disclaimer display on direct catalog start

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -27,8 +27,7 @@ class HomeController
             $catalogs = json_decode($catalogsJson, true) ?? [];
         }
 
-        $params = $request->getQueryParams();
-        $showDisclaimer = empty($params['katalog']);
+        $showDisclaimer = true;
 
         return $view->render($response, 'index.twig', [
             'config' => $cfg,


### PR DESCRIPTION
## Summary
- always show the disclaimer on the start page

## Testing
- `python3 -m pytest -q`
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df90d7e5c832ba65d3da1742978dc