### PR TITLE
Add responsive table class in admin results

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -203,7 +203,8 @@
     <li>
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Ergebnisse</h2>
-        <table class="uk-table uk-table-divider">
+        <div style="overflow-x: auto">
+        <table class="uk-table uk-table-divider uk-table-responsive">
           <thead>
             <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th></tr>
           </thead>
@@ -221,6 +222,7 @@
             {% endfor %}
           </tbody>
         </table>
+        </div>
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="resultsResetBtn" class="uk-button uk-button-default" uk-tooltip="title: Löscht alle gespeicherten Ergebnisse; pos: right">Zurücksetzen</button>
           <button id="resultsDownloadBtn" class="uk-button uk-button-primary" uk-tooltip="title: Ergebnisse herunterladen; pos: right">Herunterladen</button>


### PR DESCRIPTION
## Summary
- make results table responsive in `admin.twig`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684dfbc2e9a0832b84ce948fc01f9c72