### PR TITLE
Make catalogs section responsive

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -239,24 +239,27 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function createCatalogRow(cat) {
-    const row = document.createElement('div');
-    row.className = 'uk-flex uk-flex-middle uk-margin-small catalog-row';
+    const row = document.createElement('tr');
+    row.className = 'catalog-row';
     if (cat.new) row.dataset.new = 'true';
     row.dataset.id = cat.id || '';
     row.dataset.file = cat.file || '';
 
+    const idCell = document.createElement('td');
     const idInput = document.createElement('input');
     idInput.type = 'text';
-    idInput.className = 'uk-input uk-width-small cat-id';
+    idInput.className = 'uk-input cat-id';
     idInput.placeholder = 'ID';
     idInput.value = cat.id || '';
     if (cat.id && !cat.new) {
       idInput.disabled = true;
     }
+    idCell.appendChild(idInput);
 
+    const nameCell = document.createElement('td');
     const name = document.createElement('input');
     name.type = 'text';
-    name.className = 'uk-input uk-width-medium uk-margin-left cat-name';
+    name.className = 'uk-input cat-name';
     name.placeholder = 'Name';
     name.value = cat.name || '';
     name.addEventListener('input', () => {
@@ -265,19 +268,23 @@ document.addEventListener('DOMContentLoaded', function () {
         update();
       }
     });
+    nameCell.appendChild(name);
 
+    const descCell = document.createElement('td');
     const desc = document.createElement('input');
     desc.type = 'text';
-    desc.className = 'uk-input uk-width-expand uk-margin-left cat-desc';
+    desc.className = 'uk-input cat-desc';
     desc.placeholder = 'Beschreibung';
     desc.value = cat.description || '';
+    descCell.appendChild(desc);
 
-
+    const delCell = document.createElement('td');
     const del = document.createElement('button');
-    del.className = 'uk-button uk-button-danger uk-margin-left';
+    del.className = 'uk-button uk-button-danger';
     del.textContent = '×';
     del.setAttribute('aria-label', 'Löschen');
     del.addEventListener('click', () => deleteCatalog(cat, row));
+    delCell.appendChild(del);
 
     function update() {
       const id = idInput.value.trim();
@@ -287,10 +294,10 @@ document.addEventListener('DOMContentLoaded', function () {
     idInput.addEventListener('input', update);
     update();
 
-    row.appendChild(idInput);
-    row.appendChild(name);
-    row.appendChild(desc);
-    row.appendChild(del);
+    row.appendChild(idCell);
+    row.appendChild(nameCell);
+    row.appendChild(descCell);
+    row.appendChild(delCell);
 
     return row;
   }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -143,12 +143,19 @@
       <div class="uk-container uk-container-large">
         <div>
           <h2 class="uk-heading-bullet">Kataloge</h2>
-          <div class="uk-flex uk-margin-small">
-            <div class="uk-width-small"><strong>ID</strong></div>
-            <div class="uk-width-medium uk-margin-left"><strong>Name</strong></div>
-            <div class="uk-width-expand uk-margin-left"><strong>Beschreibung</strong></div>
+          <div class="uk-overflow-auto">
+            <table class="uk-table uk-table-divider uk-table-small">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Name</th>
+                  <th>Beschreibung</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="catalogList"></tbody>
+            </table>
           </div>
-          <div id="catalogList" class="uk-margin"></div>
           <div class="uk-margin">
             <button id="newCatBtn" class="uk-button uk-button-default" uk-tooltip="title: Neuen Fragenkatalog anlegen; pos: right">Hinzufügen</button>
           </div>


### PR DESCRIPTION
## Summary
- refactor admin "Kataloge" section to a table for stacking
- adjust JS to render catalog rows as table rows

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684dfc7bc070832b9fd6be9f837fc23a