### PR TITLE
Fix admin logo preview size

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -58,7 +58,7 @@
               <div class="uk-margin">
                 <label class="uk-form-label" for="cfgLogoPreview">Logo Vorschau</label>
                 <div class="uk-form-controls">
-                  <img id="cfgLogoPreview" src="{{ config.logoPath|default('') }}" alt="Logo Vorschau" class="uk-margin-small-top" style="max-height:240px">
+                  <img id="cfgLogoPreview" src="{{ config.logoPath|default('') }}" alt="Logo Vorschau" class="uk-margin-small-top" style="max-height:120px">
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- shrink the logo preview on the admin page to reduce vertical space

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684dfd4318a4832b8ba3291949440d30