### PR TITLE
Fix sticky actions offset

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -174,7 +174,7 @@ a.uk-accordion-title {
 /* Fester Bedienbereich im Admin-Editor */
 .sticky-actions {
   position: sticky;
-  bottom: 72px;
+  bottom: calc(56px + 1rem);
   z-index: 900;
   background: rgba(255, 255, 255, 0.95);
   padding-top: 8px;


### PR DESCRIPTION
## Summary
- adjust admin editor sticky bar to respect bottom bar height

## Testing
- `pytest tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfde8fa40832bafe742171c368088