### PR TITLE
Update team row layout for mobile

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -235,3 +235,19 @@ body.dark-mode .sticky-actions {
   margin-right: auto;
   margin-bottom: 8px;
 }
+
+/* Darstellung der Eingabefelder in der Team-Liste */
+.team-row {
+  display: flex;
+  align-items: center;
+}
+
+@media (max-width: 639px) {
+  .team-row {
+    flex-direction: column;
+  }
+  .team-row button.uk-button-danger {
+    margin-left: 0;
+    margin-top: 4px;
+  }
+}

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -748,7 +748,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function createTeamRow(name = ''){
     const div = document.createElement('div');
-    div.className = 'uk-flex uk-flex-middle uk-margin-small';
+    div.className = 'team-row uk-flex uk-flex-middle uk-margin-small';
     const input = document.createElement('input');
     input.type = 'text';
     input.className = 'uk-input uk-width-expand';


### PR DESCRIPTION
## Summary
- add `team-row` class in `createTeamRow`
- style `.team-row` to stack controls on small screens

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684dfeecd668832b92407debf1b234f9