### PR TITLE
Improve progress accessibility

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -69,6 +69,7 @@ function runQuiz(questions){
 
   const container = document.getElementById('quiz');
   const progress = document.getElementById('progress');
+  const announcer = document.getElementById('question-announcer');
   // Vorhandene Inhalte entfernen (z.B. Katalogauswahl)
   if (container) container.innerHTML = '';
 
@@ -133,13 +134,19 @@ function runQuiz(questions){
     elements.forEach((el, idx) => el.classList.toggle('uk-hidden', idx !== i));
     if(i === 0){
       progress.classList.add('uk-hidden');
+      progress.setAttribute('aria-valuenow', 0);
+      if (announcer) announcer.textContent = '';
     } else if(i < questionCount){
       // Fragen anzeigen und Fortschritt aktualisieren
       progress.classList.remove('uk-hidden');
       progress.value = i;
+      progress.setAttribute('aria-valuenow', i);
+      if (announcer) announcer.textContent = `Frage ${i} von ${questionCount}`;
     } else if(i === questionCount){
       // Nach der letzten Frage Zusammenfassung anzeigen
       progress.value = questionCount;
+      progress.setAttribute('aria-valuenow', questionCount);
+      if (announcer) announcer.textContent = `Frage ${questionCount} von ${questionCount}`;
       progress.classList.add('uk-hidden');
       updateSummary();
     }

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -28,7 +28,8 @@
       <div id="quiz-header" class="uk-text-center uk-margin">
         <img id="quiz-logo" class="logo-placeholder" src="{{ config.logoPath|default('') }}" alt="Logo">
       </div>
-      <progress id="progress" class="uk-progress" value="0" max="1" aria-label="Fortschritt des Quiz"></progress>
+      <progress id="progress" class="uk-progress" value="0" max="1" aria-label="Fortschritt des Quiz" aria-valuenow="0"></progress>
+      <span id="question-announcer" class="uk-hidden-visually" aria-live="polite"></span>
       <div id="quiz"></div>
     </div>
     {% if showDisclaimer %}


### PR DESCRIPTION
## Summary
- add aria-valuenow to progress bar
- provide a live region for announcing the current question
- update quiz script to set aria-valuenow and update announcer during progress

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e0039a2f0832bb91e74c2b2046ea4