### PR TITLE
Improve logo preview styling

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -231,9 +231,28 @@ body.dark-mode .sticky-actions {
   height: 240px;
   object-fit: contain;
   display: block;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.logo-frame {
+  width: 160px;
+  height: 240px;
+  border: 1px solid #e5e5e5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin-left: auto;
   margin-right: auto;
   margin-bottom: 8px;
+  background-color: #fff;
+}
+
+.js-upload {
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Darstellung der Eingabefelder in der Team-Liste */

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -58,7 +58,9 @@
               <div class="uk-margin">
                 <label class="uk-form-label" for="cfgLogoPreview">Logo Vorschau</label>
                 <div class="uk-form-controls">
-                  <img id="cfgLogoPreview" src="{{ config.logoPath|default('') }}" alt="Logo Vorschau" class="uk-margin-small-top" style="max-height:120px">
+                  <div class="logo-frame uk-margin-small-top">
+                    <img id="cfgLogoPreview" src="{{ config.logoPath|default('') }}" alt="Logo Vorschau" class="logo-placeholder">
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- show logo preview inside a framed window
- keep the upload area as tall as the preview

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e002bf6b8832b9415127541e67993