### PR TITLE
Improve drag-and-drop accessibility

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -212,8 +212,16 @@ function runQuiz(questions){
     const h = document.createElement('h4');
     h.textContent = q.prompt;
     div.appendChild(h);
+    const instr = document.createElement('p');
+    instr.id = 'sort-desc-' + idx;
+    instr.className = 'uk-hidden-visually';
+    instr.textContent = 'Benutze die Pfeiltasten hoch und runter, um Elemente in dieser Liste zu verschieben.';
+    div.appendChild(instr);
     const ul = document.createElement('ul');
     ul.className = 'uk-list uk-list-divider sortable-list uk-margin';
+    ul.setAttribute('aria-dropeffect', 'move');
+    ul.setAttribute('aria-label', 'Sortierbare Liste');
+    ul.setAttribute('aria-describedby', instr.id);
     const displayItems = shuffleArray(q.items);
     displayItems.forEach(text => {
       const li = document.createElement('li');
@@ -322,6 +330,7 @@ function runQuiz(questions){
       dz.className = 'dropzone';
       dz.setAttribute('role','listitem');
       dz.tabIndex = 0;
+      dz.setAttribute('aria-dropeffect', 'move');
       dz.dataset.term = t.term;
       dz.dataset.definition = t.definition;
       dz.setAttribute('aria-label', t.definition);

--- a/templates/vuequiz/index.html
+++ b/templates/vuequiz/index.html
@@ -128,7 +128,9 @@ createApp({
   template: `
     <div>
       <p class="mb-4">{{ question.question }}</p>
-      <draggable v-model="items" class="bg-white p-2" item-key="text" ghost-class="opacity-50">
+      <p id="sort-desc" class="uk-hidden-visually">Benutze die Pfeiltasten hoch und runter, um Elemente in dieser Liste zu verschieben.</p>
+      <draggable v-model="items" class="bg-white p-2" item-key="text" ghost-class="opacity-50"
+        aria-dropeffect="move" aria-label="Sortierbare Liste" aria-describedby="sort-desc">
         <template #item="{element}">
           <div class="p-2 mb-2 border bg-gray-100 cursor-move">{{ element }}</div>
         </template>
@@ -164,7 +166,9 @@ createApp({
       <div class="flex flex-col md:flex-row gap-4">
         <div class="md:w-1/3">
           <p class="font-semibold mb-2">Begriffe</p>
-          <draggable v-model="pool" group="items" class="min-h-[50px] p-2 bg-gray-100 rounded">
+          <p id="match-pool-desc" class="uk-hidden-visually">Benutze die Pfeiltasten hoch und runter, um Elemente in dieser Liste zu verschieben.</p>
+          <draggable v-model="pool" group="items" class="min-h-[50px] p-2 bg-gray-100 rounded"
+            aria-dropeffect="move" aria-label="Begriffe" aria-describedby="match-pool-desc">
             <template #item="{element}">
               <div class="p-2 m-1 bg-blue-200 rounded cursor-move">{{ element }}</div>
             </template>
@@ -174,7 +178,9 @@ createApp({
           <p class="font-semibold mb-2">Definitionen</p>
           <div v-for="(pair, idx) in question.pairs" :key="idx" class="mb-4">
             <div class="p-2 bg-gray-200 rounded mb-2">{{ pair.definition }}</div>
-            <draggable v-model="answers[idx]" group="items" :animation="150" class="min-h-[40px] p-2 border rounded">
+            <p :id="'match-drop-desc-' + idx" class="uk-hidden-visually">Benutze die Pfeiltasten hoch und runter, um Elemente in dieser Liste zu verschieben.</p>
+            <draggable v-model="answers[idx]" group="items" :animation="150" class="min-h-[40px] p-2 border rounded"
+              aria-dropeffect="move" :aria-label="'Ablagefeld ' + (idx + 1)" :aria-describedby="'match-drop-desc-' + idx">
               <template #item="{element}">
                 <div class="p-2 bg-blue-200 rounded cursor-move">{{ element }}</div>
               </template>


### PR DESCRIPTION
## Summary
- clarify drag instructions for Sortable Vue components
- expose screen reader hints for Sortable lists in JS quiz
- mark drop zones as move targets

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e01b49f30832b9f8faa4698d2fe7c