### PR TITLE
Center logo on index page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -231,6 +231,8 @@ body.dark-mode .sticky-actions {
   height: 240px;
   object-fit: contain;
   display: block;
+  margin-left: auto;
+  margin-right: auto;
   max-width: 100%;
   max-height: 100%;
 }


### PR DESCRIPTION
## Summary
- center the logo image on the front page

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py` *(fails: pytest missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e020e56c4832bad0f86bd05d03286