### PR TITLE
Add high contrast mode

### DIFF
--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -1,0 +1,56 @@
+/* High contrast mode styles */
+body.high-contrast {
+  background-color: #ffffff !important;
+  color: #000000 !important;
+}
+body.high-contrast a {
+  color: #0000ee;
+  text-decoration: underline;
+}
+body.high-contrast .uk-card-default {
+  background-color: #ffffff;
+  color: #000000;
+  border-color: #000000;
+}
+body.high-contrast .uk-button-primary {
+  background-color: #000000;
+  border-color: #000000;
+  color: #ffffff;
+}
+body.high-contrast .uk-button,
+body.high-contrast .uk-button-default {
+  background-color: #ffffff;
+  color: #000000;
+  border-color: #000000;
+}
+body.high-contrast input,
+body.high-contrast textarea,
+body.high-contrast select {
+  background-color: #ffffff;
+  color: #000000;
+  border-color: #000000;
+}
+body.high-contrast .sortable-list li,
+body.high-contrast .terms li,
+body.high-contrast .dropzone,
+body.high-contrast .mc-option {
+  background: #ffffff;
+  border: 2px solid #000000;
+  color: #000000;
+}
+body.high-contrast .dropzone.over {
+  background: #ffffcc;
+  border-color: #000000;
+}
+body.high-contrast .uk-alert-success {
+  background-color: #006400;
+  color: #ffffff;
+}
+body.high-contrast .uk-alert-danger {
+  background-color: #8b0000;
+  color: #ffffff;
+}
+body.high-contrast .uk-alert-primary {
+  background-color: #00008b;
+  color: #ffffff;
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -97,6 +97,17 @@ body.uk-padding {
   background: transparent;
 }
 
+.contrast-switch {
+  display: inline-block;
+  margin-left: 8px;
+  margin-top: 0;
+}
+
+.contrast-switch button {
+  border: none;
+  background: transparent;
+}
+
 .topbar .uk-navbar-item {
   margin: 0;
   padding-left: 0.5rem;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,28 +1,41 @@
 document.addEventListener('DOMContentLoaded', function () {
-  const toggle = document.getElementById('theme-toggle');
-  if (!toggle) return;
-  const isDark = localStorage.getItem('darkMode') === 'true';
-  if (isDark) {
-    document.body.classList.add('dark-mode', 'uk-light');
-    // show sun icon when dark mode is active
-    toggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
-  } else {
-    // show moon icon when light mode is active
-    toggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
-  }
-  UIkit.icon(toggle);
-  toggle.addEventListener('click', function () {
-    const dark = document.body.classList.toggle('dark-mode');
-    document.body.classList.toggle('uk-light', dark);
-    if (dark) {
-      localStorage.setItem('darkMode', 'true');
-      // after enabling dark mode show sun icon
-      toggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
+  const themeToggle = document.getElementById('theme-toggle');
+  const contrastToggle = document.getElementById('contrast-toggle');
+
+  if (themeToggle) {
+    const isDark = localStorage.getItem('darkMode') === 'true';
+    if (isDark) {
+      document.body.classList.add('dark-mode', 'uk-light');
+      // show sun icon when dark mode is active
+      themeToggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
     } else {
-      localStorage.setItem('darkMode', 'false');
-      // after disabling dark mode show moon icon
-      toggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
+      // show moon icon when light mode is active
+      themeToggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
     }
-    UIkit.icon(toggle);
-  });
+    UIkit.icon(themeToggle);
+    themeToggle.addEventListener('click', function () {
+      const dark = document.body.classList.toggle('dark-mode');
+      document.body.classList.toggle('uk-light', dark);
+      if (dark) {
+        localStorage.setItem('darkMode', 'true');
+        themeToggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
+      } else {
+        localStorage.setItem('darkMode', 'false');
+        themeToggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
+      }
+      UIkit.icon(themeToggle);
+    });
+  }
+
+  if (contrastToggle) {
+    const isHigh = localStorage.getItem('highContrast') === 'true';
+    if (isHigh) {
+      document.body.classList.add('high-contrast');
+    }
+    UIkit.icon(contrastToggle);
+    contrastToggle.addEventListener('click', function () {
+      const hc = document.body.classList.toggle('high-contrast');
+      localStorage.setItem('highContrast', hc ? 'true' : 'false');
+    });
+  }
 });

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -5,6 +5,7 @@
 {% block head %}
   <link rel="stylesheet" href="/css/dark.css">
   <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/highcontrast.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -16,6 +17,9 @@
       <a href="/logout" class="uk-button uk-button-danger uk-margin-right">Logout</a>
       <div class="theme-switch uk-margin-right">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-right">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
       <button id="helpBtn" class="uk-icon-button" uk-icon="icon: question; ratio: 2" aria-label="Hilfe"></button>
     </div>

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -5,6 +5,7 @@
 {% block head %}
   <link rel="stylesheet" href="/css/dark.css">
   <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/highcontrast.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -17,6 +18,9 @@
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
     {% endblock %}
   {% endembed %}

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -5,6 +5,7 @@
 {% block head %}
   <link rel="stylesheet" href="/css/dark.css">
   <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/highcontrast.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -17,6 +18,9 @@
       {% block right %}
         <div class="theme-switch">
           <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+        </div>
+        <div class="contrast-switch uk-margin-small-left">
+          <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
         </div>
       {% endblock %}
     {% endembed %}

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -5,6 +5,7 @@
 {% block head %}
   <link rel="stylesheet" href="/css/dark.css">
   <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/highcontrast.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -17,6 +18,9 @@
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
     {% endblock %}
   {% endembed %}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -5,6 +5,7 @@
 {% block head %}
   <link rel="stylesheet" href="/css/dark.css">
   <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/highcontrast.css">
 {% endblock %}
 
 {% block body_class %}index-page uk-padding{% endblock %}
@@ -20,6 +21,9 @@
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
     {% endblock %}
   {% endembed %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -5,6 +5,7 @@
 {% block head %}
   <link rel="stylesheet" href="/css/dark.css">
   <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/highcontrast.css">
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -17,6 +18,9 @@
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
     {% endblock %}
   {% endembed %}

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -5,6 +5,7 @@
 {% block head %}
   <link rel="stylesheet" href="/css/dark.css">
   <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/highcontrast.css">
 {% endblock %}
 
 {% block body_class %}uk-padding{% endblock %}
@@ -17,6 +18,9 @@
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
     {% endblock %}
   {% endembed %}


### PR DESCRIPTION
## Summary
- add new `public/css/highcontrast.css` with improved contrast colors
- include `highcontrast.css` in page templates
- add high contrast toggle UI next to the existing dark mode switch
- remember high contrast selection in localStorage

## Testing
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e023d3f44832bba66699193b1478b