### PR TITLE
Fix login width

### DIFF
--- a/templates/login.twig
+++ b/templates/login.twig
@@ -21,7 +21,7 @@
     {% endblock %}
   {% endembed %}
 <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
-  <div class="uk-width-1-1@m">
+  <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
     <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
           <h3 class="uk-card-title uk-text-center">Admin Login</h3>
           {% if error %}


### PR DESCRIPTION
## Summary
- resize the admin login card so it isn't overly wide

## Testing
- `python3 -m pytest tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `vendor/bin/phpunit tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e02ac6dd4832b815e55e1640c2446