### PR TITLE
Add PHPStan check during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ WORKDIR /var/www
 COPY . /var/www
 RUN composer install --no-interaction --prefer-dist --no-progress
 
+# run static analysis during image build
+RUN if [ -f vendor/bin/phpstan ]; then \
+        vendor/bin/phpstan --no-progress; \
+    fi
+
 # entrypoint to install dependencies if host volume lacks vendor/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- run PHPStan during Docker image build to verify sources

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_684e02f7a0f4832bbbc842ec5c1eb3d0