### PR TITLE
Improve admin team table

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -268,18 +268,3 @@ body.dark-mode .sticky-actions {
   justify-content: center;
 }
 
-/* Darstellung der Eingabefelder in der Team-Liste */
-.team-row {
-  display: flex;
-  align-items: center;
-}
-
-@media (max-width: 639px) {
-  .team-row {
-    flex-direction: column;
-  }
-  .team-row button.uk-button-danger {
-    margin-left: 0;
-    margin-top: 4px;
-  }
-}

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -771,20 +771,28 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
   function createTeamRow(name = ''){
-    const div = document.createElement('div');
-    div.className = 'team-row uk-flex uk-flex-middle uk-margin-small';
+    const row = document.createElement('tr');
+    row.className = 'team-row';
+
+    const nameCell = document.createElement('td');
     const input = document.createElement('input');
     input.type = 'text';
-    input.className = 'uk-input uk-width-expand';
+    input.className = 'uk-input team-name';
     input.value = name;
     input.setAttribute('aria-label', 'Name');
+    nameCell.appendChild(input);
+
+    const delCell = document.createElement('td');
     const del = document.createElement('button');
-    del.className = 'uk-button uk-button-danger uk-margin-left';
+    del.className = 'uk-button uk-button-danger';
     del.textContent = '×';
-    del.onclick = () => div.remove();
-    div.appendChild(input);
-    div.appendChild(del);
-    return div;
+    del.setAttribute('aria-label', 'Löschen');
+    del.onclick = () => row.remove();
+    delCell.appendChild(del);
+
+    row.appendChild(nameCell);
+    row.appendChild(delCell);
+    return row;
   }
 
   function renderTeams(list){

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -199,7 +199,17 @@
     <li>
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Teams/Personen</h2>
-        <div id="teamsList" class="uk-margin"></div>
+        <div class="uk-overflow-auto">
+          <table class="uk-table uk-table-divider uk-table-small">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="teamsList"></tbody>
+          </table>
+        </div>
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-button uk-button-default" uk-tooltip="title: Neues Team oder Person hinzufügen; pos: right">Hinzufügen</button>
         </div>


### PR DESCRIPTION
## Summary
- adjust team management layout to use responsive table
- update JS to render table rows for teams
- drop obsolete team-row styles

## Testing
- `pytest -q tests/test_json_validity.py`
- `pytest -q tests/test_html_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e0ccfee9c832ba2c54ebe2224bc75