### PR TITLE
Improve sidebar help texts

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -25,14 +25,14 @@
     </div>
   </div>
   <ul id="adminTabs" uk-tab>
-    <li class="uk-active" data-help="Hier lädst du ein Logo hoch (mit Vorschau), legst Titel im Browser-Tab, Überschrift und Untertitel fest und wählst Hintergrund- sowie Buttonfarbe. Du kannst den Button Antwort prüfen und den QR-Code-Login einblenden. Zurück führt zurück, Speichern übernimmt alles."><a href="#">Veranstaltung konfigurieren</a></li>
-    <li data-help="Fragenkataloge erstellen, benennen und beschreiben. Die drei Felder stehen für ID, Name und Beschreibung. Mit \"Hinzufügen\" legst du einen neuen Katalog an, \"Speichern\" übernimmt Änderungen und \"Löschen\" entfernt einen Eintrag."><a href="#">Kataloge</a></li>
-    <li data-help="Fragen eines Katalogs bearbeiten und neue Fragen hinzufügen."><a href="#">Fragen anpassen</a></li>
-    <li data-help="Liste der teilnehmenden Teams oder Personen verwalten. Der Teamname wird beim Scannen an den Stationen verwendet. Die Option 'Nur Teams/Personen aus der Liste dürfen teilnehmen.' beschränkt die Teilnahme auf eingetragene Namen."><a href="#">Teams/Personen</a></li>
-    <li data-help="Gespeicherte Quiz-Ergebnisse ansehen und herunterladen."><a href="#">Ergebnisse</a></li>
-    <li data-help="Übersicht aller QR-Codes"><a href="#">Zusammenfassung</a></li>
-    <li data-help="Administrationspasswort festlegen."><a href="#">Passwort ändern</a></li>
-    <li data-help="Beispiele moderner QR-Codes"><a href="#">QR-Code Samples</a></li>
+    <li class="uk-active" data-help="Logo hochladen und Vorschau ansehen. Seitentitel, Überschrift und Untertitel festlegen. Hintergrund- und Buttonfarbe wählen. Optional den Button 'Antwort prüfen' und den QR-Code-Login aktivieren. 'Zurücksetzen' lädt gespeicherte Werte, 'Speichern' übernimmt Änderungen."><a href="#">Veranstaltung konfigurieren</a></li>
+    <li data-help="Fragenkataloge anlegen oder bearbeiten. Jede Zeile enthält ID, Name und Beschreibung. 'Hinzufügen' erstellt einen neuen Katalog, das rote × entfernt einen Eintrag. Speichern übernimmt die Änderungen."><a href="#">Kataloge</a></li>
+    <li data-help="Nach Auswahl eines Katalogs einzelne Fragen bearbeiten oder neue anlegen. 'Neue Frage' fügt eine weitere hinzu, 'Zurücksetzen' verwirft Änderungen, 'Speichern' sichert den gesamten Katalog."><a href="#">Fragen anpassen</a></li>
+    <li data-help="Teilnehmerliste pflegen. Über 'Hinzufügen' Teams oder Personen ergänzen. Die Checkbox beschränkt die Teilnahme auf gelistete Namen. Speichern aktualisiert die Liste."><a href="#">Teams/Personen</a></li>
+    <li data-help="Gespeicherte Ergebnisse mit richtigen Antworten und Zeit einsehen. 'Zurücksetzen' löscht alle Daten, 'Herunterladen' exportiert sie als CSV."><a href="#">Ergebnisse</a></li>
+    <li data-help="QR-Codes für alle Kataloge und Teams anzeigen, um Quizlinks oder Anmeldungen weiterzugeben. 'Drucken' erstellt eine übersichtliche Liste."><a href="#">Zusammenfassung</a></li>
+    <li data-help="Neues Administrationspasswort eingeben, wiederholen und speichern."><a href="#">Passwort ändern</a></li>
+    <li data-help="Farbige Beispiel-QR-Codes als Designvorlage."><a href="#">QR-Code Samples</a></li>
   </ul>
   <ul class="uk-switcher uk-margin">
     <li>


### PR DESCRIPTION
## Summary
- update help-text attributes for admin tabs with concise explanations

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e15452e6c832ba91556e00bdadbf5