### PR TITLE
Adjust spacing for admin catalog select

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -179,7 +179,7 @@
             <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Hier den zu bearbeitenden Katalog wählen.; pos: right"></span>
           </label>
           <div class="uk-form-controls">
-            <select id="catalogSelect" class="uk-select"></select>
+            <select id="catalogSelect" class="uk-select uk-margin-small-top"></select>
           </div>
         </div>
         <!-- Hauptdatenbereich: Frageneditor -->


### PR DESCRIPTION
## Summary
- tweak spacing for catalog dropdown in admin panel

## Testing
- `pytest -q`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1c6a7a3c832bb7da14f0d121e4a5