### PR TITLE
Fix footer spacing on iPad

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -100,6 +100,7 @@ body.dark-mode .uk-icon-button {
 body.dark-mode .bottombar {
   background-color: #1e1e1e;
   border-color: #444;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 body.dark-mode .uk-icon-button {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -126,6 +126,7 @@ body.uk-padding {
   left: 0;
   width: 100%;
   z-index: 1000;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .bottombar .uk-navbar-item {

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{% block title %}Admin{% endblock %}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.19.3/dist/css/uikit.min.css" />
     <script src="https://cdn.jsdelivr.net/npm/uikit@3.19.3/dist/js/uikit.min.js"></script>

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <title>{% block title %}Quiz{% endblock %}</title>
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/css/uikit.min.css">

--- a/templates/vuequiz/index.html
+++ b/templates/vuequiz/index.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Quiz App</title>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>


### PR DESCRIPTION
## Summary
- ensure iPad uses entire viewport by adding `viewport-fit=cover`
- keep fixed footer flush to the bottom

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e87efbbdc832b8723d36e98752fd1