### PR TITLE
Update README about composer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
    sodass stets die neuesten kompatiblen Abhängigkeiten installiert werden.
    Das Docker-Setup installiert dabei automatisch die PHP-Erweiterung *gd*,
    welche für die Bibliothek `setasign/fpdf` benötigt wird.
+   Eine Aktualisierung der `composer.lock` kann alternativ 
+   über den GitHub-Workflow **Manual Composer Install** erfolgen
+   (siehe `.github/workflows/composer-install.yml`).
+   Dieser lässt sich im Reiter **Actions** über den Button
+   „Run workflow“ manuell starten und committet bei Bedarf die
+   aktualisierte Datei.
 2. Server starten (z.B. für lokale Tests):
    ```bash
    php -S localhost:8080 -t public public/router.php


### PR DESCRIPTION
## Summary
- document the optional *Manual Composer Install* workflow in the Quickstart section

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e9485588c832b80d5b98864de6bfe