### PR TITLE
Fix RoundBlockSizeMode stub for phpstan

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -9,7 +9,7 @@ use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
-use Endroid\QrCode\BlockSizeMode\BlockSizeMode;
+use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -44,7 +44,7 @@ class QrController
         }
 
         $result = $builder
-            ->roundBlockSizeMode(BlockSizeMode::ENLARGE)
+            ->roundBlockSizeMode(RoundBlockSizeMode::ENLARGE)
             ->build();
 
         $data = $result->getString();

--- a/stubs/endroid_qr.stub
+++ b/stubs/endroid_qr.stub
@@ -1,11 +1,11 @@
 <?php
-namespace Endroid\QrCode\BlockSizeMode;
+namespace Endroid\QrCode\RoundBlockSizeMode;
 
-final class BlockSizeMode
+final class RoundBlockSizeMode
 {
-    public const MARGIN = 'margin';
     public const ENLARGE = 'enlarge';
     public const SHRINK = 'shrink';
+    public const MARGIN = 'margin';
     public const NONE = 'none';
 }
 


### PR DESCRIPTION
## Summary
- restore correct namespace for QR code block size enum stub
- use `RoundBlockSizeMode` in `QrController`

## Testing
- `php` not installed
- `composer` not installed

------
https://chatgpt.com/codex/tasks/task_e_684f0069e05c832b94fbc0c537ccf414