### PR TITLE
Implement competition mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,12 @@ Alle wesentlichen Einstellungen finden sich in `data/config.json`. Hier lassen s
   "CheckAnswerButton": "no",
   "adminUser": "admin",
   "adminPass": "password",
-  "QRRestrict": false
+  "QRRestrict": false,
+  "competitionMode": false
 }
 ```
 
-Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage.
+Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus und verhindert Wiederholungen bereits abgeschlossener Kataloge.
 
 `ConfigService` liest und speichert diese Datei. Ein GET auf `/config.json` liefert den aktuellen Inhalt, ein POST auf dieselbe URL speichert geänderte Werte.
 

--- a/data/config.json
+++ b/data/config.json
@@ -10,5 +10,6 @@
   "CheckAnswerButton": "no",
   "adminUser": "admin",
   "adminPass": "password",
-  "QRRestrict": false
+  "QRRestrict": false,
+  "competitionMode": false
 }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -52,7 +52,8 @@ document.addEventListener('DOMContentLoaded', function () {
     buttonColor: document.getElementById('cfgButtonColor'),
     checkAnswerButton: document.getElementById('cfgCheckAnswerButton'),
     qrUser: document.getElementById('cfgQRUser'),
-    teamRestrict: document.getElementById('teamRestrict')
+    teamRestrict: document.getElementById('teamRestrict'),
+    competitionMode: document.getElementById('cfgCompetitionMode')
   };
   let logoUploaded = false;
   if (cfgFields.logoFile && cfgFields.logoPreview) {
@@ -104,6 +105,9 @@ document.addEventListener('DOMContentLoaded', function () {
     if (cfgFields.teamRestrict) {
       cfgFields.teamRestrict.checked = !!data.QRRestrict;
     }
+    if (cfgFields.competitionMode) {
+      cfgFields.competitionMode.value = String(data.competitionMode) || 'false';
+    }
   }
   renderCfg(cfgInitial);
   document.getElementById('cfgResetBtn').addEventListener('click', function (e) {
@@ -127,7 +131,8 @@ document.addEventListener('DOMContentLoaded', function () {
       buttonColor: cfgFields.buttonColor.value.trim(),
       CheckAnswerButton: cfgFields.checkAnswerButton.value,
       QRUser: cfgFields.qrUser.value === 'true',
-      QRRestrict: cfgFields.teamRestrict ? cfgFields.teamRestrict.checked : cfgInitial.QRRestrict
+      QRRestrict: cfgFields.teamRestrict ? cfgFields.teamRestrict.checked : cfgInitial.QRRestrict,
+      competitionMode: cfgFields.competitionMode ? cfgFields.competitionMode.value === 'true' : cfgInitial.competitionMode
     });
     fetch('/config.json', {
       method: 'POST',
@@ -137,6 +142,7 @@ document.addEventListener('DOMContentLoaded', function () {
       .then(r => {
         if (r.ok) {
           notify('Konfiguration gespeichert', 'success');
+          Object.assign(cfgInitial, data);
         } else if (r.status === 400) {
           notify('Ungültige Daten', 'danger');
         } else {

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -116,7 +116,8 @@
     }
   }
 
-  function showSelection(catalogs){
+  function showSelection(catalogs, solved){
+    solved = solved || new Set();
     const container = document.getElementById('quiz');
     if(!container) return;
     container.innerHTML = '';
@@ -129,6 +130,11 @@
       card.className = 'uk-card uk-card-default uk-card-body uk-card-hover';
       card.style.cursor = 'pointer';
       card.addEventListener('click', () => {
+        if((window.quizConfig || {}).competitionMode && solved.has(cat.id)){
+          const remaining = catalogs.filter(c => !solved.has(c.id)).map(c => c.name || c.id).join(', ');
+          alert('Der Katalog ' + (cat.name || cat.id) + ' wurde von eurem Team bereits abgeschlossen.' + (remaining ? '\nFolgende Fragenkataloge fehlen euch noch: ' + remaining : ''));
+          return;
+        }
         history.replaceState(null, '', '?katalog=' + cat.id);
         setSubHeader(cat.description || '');
         loadQuestions(cat.id, cat.file);
@@ -306,6 +312,23 @@
     applyConfig();
     updateUserName();
     const catalogs = await loadCatalogList();
+    let solved = new Set();
+    if(cfg.competitionMode){
+      try{
+        const r = await fetch('/results.json', {headers:{'Accept':'application/json'}});
+        if(r.ok){
+          const data = await r.json();
+          const user = sessionStorage.getItem('quizUser');
+          data.forEach(entry => {
+            if(entry.name === user){
+              solved.add(entry.catalog);
+            }
+          });
+        }
+      }catch(e){
+        console.warn('results not loaded', e);
+      }
+    }
     const params = new URLSearchParams(window.location.search);
     const id = params.get('katalog');
     const proceed = () => {
@@ -313,7 +336,7 @@
       if(selected){
         loadQuestions(selected.id, selected.file);
       }else{
-        showSelection(catalogs);
+        showSelection(catalogs, solved);
       }
     };
     if((window.quizConfig || {}).QRUser){

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -23,5 +23,8 @@ window.quizConfig = {
   QRUser: true,
 
   // Teilnahme auf bekannte Namen beschränken
-  QRRestrict: false
+  QRRestrict: false,
+
+  // Wettkampfmodus aktivieren
+  competitionMode: false
 };

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -675,21 +675,23 @@ function runQuiz(questions){
     const h = document.createElement('h3');
     h.textContent = '🎉 Danke fürs Mitmachen!';
     const p = document.createElement('p');
-    const restart = document.createElement('a');
-    restart.href = '/';
-    restart.textContent = 'Neu starten';
-    restart.className = 'uk-button uk-button-primary uk-margin-top';
-    styleButton(restart);
-    restart.addEventListener('click', () => {
-      sessionStorage.removeItem('quizUser');
-      const topbar = document.getElementById('topbar-title');
-      if(topbar){
-        topbar.textContent = topbar.dataset.defaultTitle || '';
-      }
-    });
     div.appendChild(h);
     div.appendChild(p);
-    div.appendChild(restart);
+    if(!cfg.competitionMode){
+      const restart = document.createElement('a');
+      restart.href = '/';
+      restart.textContent = 'Neu starten';
+      restart.className = 'uk-button uk-button-primary uk-margin-top';
+      styleButton(restart);
+      restart.addEventListener('click', () => {
+        sessionStorage.removeItem('quizUser');
+        const topbar = document.getElementById('topbar-title');
+        if(topbar){
+          topbar.textContent = topbar.dataset.defaultTitle || '';
+        }
+      });
+      div.appendChild(restart);
+    }
     return div;
   }
 }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -134,6 +134,19 @@
                 </div>
               </div>
             </div>
+            <div>
+              <div class="uk-margin">
+                <label class="uk-form-label" for="cfgCompetitionMode">Wettkampfmodus
+                  <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Blendet Neustart-Buttons aus und verhindert das Wiederholen bereits gelöster Kataloge.; pos: right"></span>
+                </label>
+                <div class="uk-form-controls">
+                  <select class="uk-select" id="cfgCompetitionMode">
+                    <option value="false">Nein</option>
+                    <option value="true">Ja</option>
+                  </select>
+                </div>
+              </div>
+            </div>
           </div>
         </form>
         <div class="uk-margin uk-flex uk-flex-between">


### PR DESCRIPTION
## Summary
- add `competitionMode` to config and docs
- expose Wettkampfmodus toggle in admin area
- disable restart button when Wettkampfmodus is active
- prevent repeating catalogs for completed teams

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1ac04434832bbc0f1eb785ec23be