### PR TITLE
Show team restriction option in config tab

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', function () {
     buttonColor: document.getElementById('cfgButtonColor'),
     checkAnswerButton: document.getElementById('cfgCheckAnswerButton'),
     qrUser: document.getElementById('cfgQRUser'),
-    teamRestrict: document.getElementById('teamRestrict'),
+    teamRestrict: document.getElementById('cfgTeamRestrict'),
     competitionMode: document.getElementById('cfgCompetitionMode')
   };
   let logoUploaded = false;
@@ -778,7 +778,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const teamListEl = document.getElementById('teamsList');
   const teamAddBtn = document.getElementById('teamAddBtn');
   const teamSaveBtn = document.getElementById('teamsSaveBtn');
-  const teamRestrict = cfgFields.teamRestrict;
+  const teamRestrictTeams = document.getElementById('teamRestrict');
 
 
   function createTeamRow(name = ''){
@@ -816,7 +816,7 @@ document.addEventListener('DOMContentLoaded', function () {
       .then(r => r.json())
       .then(data => { renderTeams(data); })
       .catch(()=>{});
-    teamRestrict.checked = !!cfgInitial.QRRestrict;
+    teamRestrictTeams.checked = !!cfgInitial.QRRestrict;
   }
 
   teamAddBtn?.addEventListener('click', e => {
@@ -840,7 +840,7 @@ document.addEventListener('DOMContentLoaded', function () {
       console.error(err);
       notify('Fehler beim Speichern','danger');
     });
-    cfgInitial.QRRestrict = teamRestrict.checked;
+    cfgInitial.QRRestrict = teamRestrictTeams.checked;
     fetch('/config.json', {
       method:'POST',
       headers:{'Content-Type':'application/json'},

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -136,6 +136,13 @@
             </div>
             <div>
               <div class="uk-margin">
+                <label><input class="uk-checkbox" type="checkbox" id="cfgTeamRestrict"> Nur Teams/Personen aus der Liste dürfen teilnehmen.
+                  <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Aktiviert eine Zugangsbeschränkung auf eingetragene Teams; pos: right"></span>
+                </label>
+              </div>
+            </div>
+            <div>
+              <div class="uk-margin">
                 <label class="uk-form-label" for="cfgCompetitionMode">Wettkampfmodus
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Blendet Neustart-Buttons aus und verhindert das Wiederholen bereits gelöster Kataloge.; pos: right"></span>
                 </label>


### PR DESCRIPTION
## Summary
- expose QR restriction option on configuration tab
- adjust admin JS to handle separate config and teams checkboxes

## Testing
- `python3 -m pytest -q tests/test_json_validity.py`
- `python3 -m pytest -q tests/test_html_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684f1dd7dbc0832baae8f9e7be3c1ee0