### PR TITLE
Show username in topbar while quiz is running

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -54,12 +54,22 @@
       nameEl.className = 'uk-text-lead';
       headerEl.appendChild(nameEl);
     }
+    const topbar = document.getElementById('topbar-title');
     if(user){
       nameEl.textContent = user;
       nameEl.classList.remove('uk-hidden');
+      if(topbar){
+        topbar.textContent = '';
+        topbar.appendChild(document.createTextNode('Jetzt spielt:'));
+        topbar.appendChild(document.createElement('br'));
+        topbar.appendChild(document.createTextNode(user));
+      }
     }else{
       nameEl.textContent = '';
       nameEl.classList.add('uk-hidden');
+      if(topbar){
+        topbar.textContent = topbar.dataset.defaultTitle || '';
+      }
     }
   }
   async function loadCatalogList(){

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -680,6 +680,13 @@ function runQuiz(questions){
     restart.textContent = 'Neu starten';
     restart.className = 'uk-button uk-button-primary uk-margin-top';
     styleButton(restart);
+    restart.addEventListener('click', () => {
+      sessionStorage.removeItem('quizUser');
+      const topbar = document.getElementById('topbar-title');
+      if(topbar){
+        topbar.textContent = topbar.dataset.defaultTitle || '';
+      }
+    });
     div.appendChild(h);
     div.appendChild(p);
     div.appendChild(restart);

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -16,7 +16,7 @@
       <a href="faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
     {% block center %}
-      <span class="uk-navbar-title">Sommerfest 2025</span>
+      <span id="topbar-title" class="uk-navbar-title" data-default-title="{{ config.header|default('Sommerfest 2025') }}">{{ config.header|default('Sommerfest 2025') }}</span>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">


### PR DESCRIPTION
## Summary
- display configured header in topbar with an id
- update user name in header and topbar when login occurs or quiz starts
- reset name in session storage on quiz restart
- show "Jetzt spielt: <name>" in topbar on two lines

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: `bash: vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684ef34bf504832baa16fde89f4a7afc