### PR TITLE
Remove stray team restriction checkbox

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -816,7 +816,9 @@ document.addEventListener('DOMContentLoaded', function () {
       .then(r => r.json())
       .then(data => { renderTeams(data); })
       .catch(()=>{});
-    teamRestrictTeams.checked = !!cfgInitial.QRRestrict;
+    if (teamRestrictTeams) {
+      teamRestrictTeams.checked = !!cfgInitial.QRRestrict;
+    }
   }
 
   teamAddBtn?.addEventListener('click', e => {
@@ -840,12 +842,14 @@ document.addEventListener('DOMContentLoaded', function () {
       console.error(err);
       notify('Fehler beim Speichern','danger');
     });
-    cfgInitial.QRRestrict = teamRestrictTeams.checked;
-    fetch('/config.json', {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify(cfgInitial)
-    }).catch(()=>{});
+    if (teamRestrictTeams) {
+      cfgInitial.QRRestrict = teamRestrictTeams.checked;
+      fetch('/config.json', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify(cfgInitial)
+      }).catch(()=>{});
+    }
   });
 
   // --------- Passwort ändern ---------

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -233,11 +233,6 @@
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-button uk-button-default" uk-tooltip="title: Neues Team oder Person hinzufügen; pos: right">Hinzufügen</button>
         </div>
-        <div class="uk-margin">
-          <label><input class="uk-checkbox" type="checkbox" id="teamRestrict"> Nur Teams/Personen aus der Liste dürfen teilnehmen.
-            <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Aktiviert eine Zugangsbeschränkung auf eingetragene Teams; pos: right"></span>
-          </label>
-        </div>
         <div class="uk-margin uk-flex uk-flex-right">
           <button id="teamsSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Änderungen an Teams oder Personen speichern; pos: right">Speichern</button>
         </div>


### PR DESCRIPTION
## Summary
- remove duplicate team restriction option from Teams admin tab
- guard JS with `teamRestrictTeams` checks so missing element doesn't error

## Testing
- `pytest -q`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f20ff89c4832b81f8306027d6bc3b