### PR TITLE
Group game settings as checkboxes

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -100,13 +100,13 @@ document.addEventListener('DOMContentLoaded', function () {
     cfgFields.subheader.value = data.subheader || '';
     cfgFields.backgroundColor.value = data.backgroundColor || '';
     cfgFields.buttonColor.value = data.buttonColor || '';
-    cfgFields.checkAnswerButton.value = data.CheckAnswerButton || 'yes';
-    cfgFields.qrUser.value = String(data.QRUser) || 'false';
+    cfgFields.checkAnswerButton.checked = data.CheckAnswerButton !== 'no';
+    cfgFields.qrUser.checked = !!data.QRUser;
     if (cfgFields.teamRestrict) {
       cfgFields.teamRestrict.checked = !!data.QRRestrict;
     }
     if (cfgFields.competitionMode) {
-      cfgFields.competitionMode.value = String(data.competitionMode) || 'false';
+      cfgFields.competitionMode.checked = !!data.competitionMode;
     }
   }
   renderCfg(cfgInitial);
@@ -129,10 +129,10 @@ document.addEventListener('DOMContentLoaded', function () {
       subheader: cfgFields.subheader.value.trim(),
       backgroundColor: cfgFields.backgroundColor.value.trim(),
       buttonColor: cfgFields.buttonColor.value.trim(),
-      CheckAnswerButton: cfgFields.checkAnswerButton.value,
-      QRUser: cfgFields.qrUser.value === 'true',
+      CheckAnswerButton: cfgFields.checkAnswerButton.checked ? 'yes' : 'no',
+      QRUser: cfgFields.qrUser.checked,
       QRRestrict: cfgFields.teamRestrict ? cfgFields.teamRestrict.checked : cfgInitial.QRRestrict,
-      competitionMode: cfgFields.competitionMode ? cfgFields.competitionMode.value === 'true' : cfgInitial.competitionMode
+      competitionMode: cfgFields.competitionMode ? cfgFields.competitionMode.checked : cfgInitial.competitionMode
     });
     fetch('/config.json', {
       method: 'POST',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -108,30 +108,21 @@
                 </div>
               </div>
             </div>
+            <div class="uk-width-1-1">
+              <h3 class="uk-heading-bullet">Spieloptionen</h3>
+            </div>
             <div>
               <div class="uk-margin">
-                <label class="uk-form-label" for="cfgCheckAnswerButton">Antwort-Prüfen-Button anzeigen
+                <label><input class="uk-checkbox" type="checkbox" id="cfgCheckAnswerButton"> Antwort-Prüfen-Button anzeigen
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Zeigt beim Quiz einen Button zum Prüfen der Antwort.; pos: right"></span>
                 </label>
-                <div class="uk-form-controls">
-                  <select class="uk-select" id="cfgCheckAnswerButton">
-                    <option value="yes">Ja</option>
-                    <option value="no">Nein</option>
-                  </select>
-                </div>
               </div>
             </div>
             <div>
               <div class="uk-margin">
-                <label class="uk-form-label" for="cfgQRUser">QR-Code-Login verwenden
+                <label><input class="uk-checkbox" type="checkbox" id="cfgQRUser"> QR-Code-Login verwenden
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Aktiviert den Button 'Name mit QR-Code scannen' auf der Startseite, um den Namen aus einem QR-Code zu übernehmen.; pos: right"></span>
                 </label>
-                <div class="uk-form-controls">
-                  <select class="uk-select" id="cfgQRUser">
-                    <option value="false">Nein</option>
-                    <option value="true">Ja</option>
-                  </select>
-                </div>
               </div>
             </div>
             <div>
@@ -143,15 +134,9 @@
             </div>
             <div>
               <div class="uk-margin">
-                <label class="uk-form-label" for="cfgCompetitionMode">Wettkampfmodus
+                <label><input class="uk-checkbox" type="checkbox" id="cfgCompetitionMode"> Wettkampfmodus
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Blendet Neustart-Buttons aus und verhindert das Wiederholen bereits gelöster Kataloge.; pos: right"></span>
                 </label>
-                <div class="uk-form-controls">
-                  <select class="uk-select" id="cfgCompetitionMode">
-                    <option value="false">Nein</option>
-                    <option value="true">Ja</option>
-                  </select>
-                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- convert binary selects on admin page to checkboxes
- introduce a new "Spieloptionen" section grouping the game settings
- update JavaScript to handle checkbox states

## Testing
- `pytest -q tests/test_json_validity.py tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_684f20aaa7bc832bbe85253472786d83