### PR TITLE
Fix direct link repeat in competition mode

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -337,6 +337,12 @@
     const proceed = () => {
       const selected = catalogs.find(c => c.id === id);
       if(selected){
+        if(cfg.competitionMode && solved.has(selected.id)){
+          const remaining = catalogs.filter(c => !solved.has(c.id)).map(c => c.name || c.id).join(', ');
+          alert('Der Katalog ' + (selected.name || selected.id) + ' wurde von eurem Team bereits abgeschlossen.' + (remaining ? '\nFolgende Fragenkataloge fehlen euch noch: ' + remaining : ''));
+          showSelection(catalogs, solved);
+          return;
+        }
         loadQuestions(selected.id, selected.file);
       }else{
         showSelection(catalogs, solved);


### PR DESCRIPTION
## Summary
- prevent replaying catalogs via direct link in competition mode

## Testing
- `python3 -m pytest tests/test_json_validity.py`
- `python3 -m pytest tests/test_html_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2a5906dc832b88a61042c0aac1d5