### PR TITLE
Fix results table refresh

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -1,0 +1,58 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tbody = document.getElementById('resultsTableBody');
+  const refreshBtn = document.getElementById('resultsRefreshBtn');
+
+  function formatTime(ts) {
+    const d = new Date(ts * 1000);
+    const pad = n => n.toString().padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+
+  function render(rows) {
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    if (!rows.length) {
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = 5;
+      td.textContent = 'Keine Daten';
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+      return;
+    }
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      const cells = [
+        r.name,
+        r.attempt,
+        r.catalog,
+        `${r.correct}/${r.total}`,
+        formatTime(r.time)
+      ];
+      cells.forEach(c => {
+        const td = document.createElement('td');
+        td.textContent = c;
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+  }
+
+  function load() {
+    fetch('/results.json')
+      .then(r => r.json())
+      .then(render)
+      .catch(err => console.error(err));
+  }
+
+  refreshBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    load();
+  });
+
+  if (refreshBtn && typeof UIkit !== 'undefined') {
+    UIkit.icon(refreshBtn);
+  }
+
+  load();
+});

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -225,13 +225,16 @@
     </li>
     <li>
       <div class="uk-container uk-container-large">
-        <h2 class="uk-heading-bullet">Ergebnisse</h2>
+        <div class="uk-flex uk-flex-between uk-flex-middle">
+          <h2 class="uk-heading-bullet">Ergebnisse</h2>
+          <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="Aktualisieren" aria-label="Aktualisieren"></button>
+        </div>
         <div style="overflow-x: auto">
         <table class="uk-table uk-table-divider uk-table-responsive">
           <thead>
             <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th></tr>
           </thead>
-          <tbody>
+          <tbody id="resultsTableBody">
             {% for r in results %}
             <tr>
               <td>{{ r.name }}</td>
@@ -358,4 +361,5 @@
   </script>
   <script src="/js/admin.js"></script>
   <script src="/js/app.js"></script>
+  <script src="/js/results.js"></script>
 {% endblock %}

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -15,12 +15,15 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small">
-    <h2 class="uk-heading-bullet">Ergebnisse</h2>
+    <div class="uk-flex uk-flex-between uk-flex-middle">
+      <h2 class="uk-heading-bullet">Ergebnisse</h2>
+      <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="Aktualisieren" aria-label="Aktualisieren"></button>
+    </div>
     <table class="uk-table uk-table-divider">
       <thead>
         <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th></tr>
       </thead>
-      <tbody>
+      <tbody id="resultsTableBody">
         {% for r in results %}
         <tr>
           <td>{{ r.name }}</td>
@@ -40,4 +43,5 @@
 {% block scripts %}
   <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/app.js"></script>
+  <script src="/js/results.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a small refresh button above the results table
- reload results via `/results.json` when the page loads or the button is clicked
- share the same logic on the admin page

## Testing
- `pytest -q`
- `./vendor/bin/phpunit -c phpunit.xml tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2a1e86bc832bb1fb7a3f5c0c1dd0