### PR TITLE
Group results by team

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -8,10 +8,10 @@ document.addEventListener('DOMContentLoaded', () => {
     return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
   }
 
-  function render(rows) {
+  function render(groups) {
     if (!tbody) return;
     tbody.innerHTML = '';
-    if (!rows.length) {
+    if (!groups.length) {
       const tr = document.createElement('tr');
       const td = document.createElement('td');
       td.colSpan = 5;
@@ -20,28 +20,53 @@ document.addEventListener('DOMContentLoaded', () => {
       tbody.appendChild(tr);
       return;
     }
-    rows.forEach(r => {
-      const tr = document.createElement('tr');
-      const cells = [
-        r.name,
-        r.attempt,
-        r.catalog,
-        `${r.correct}/${r.total}`,
-        formatTime(r.time)
-      ];
-      cells.forEach(c => {
-        const td = document.createElement('td');
-        td.textContent = c;
-        tr.appendChild(td);
+    groups.forEach(g => {
+      const head = document.createElement('tr');
+      const th = document.createElement('th');
+      th.colSpan = 5;
+      th.textContent = g.name;
+      head.appendChild(th);
+      tbody.appendChild(head);
+
+      g.entries.forEach(r => {
+        const tr = document.createElement('tr');
+        const cells = [
+          r.attempt,
+          r.catalog,
+          `${r.correct}/${r.total}`,
+          formatTime(r.time)
+        ];
+        const nameCell = document.createElement('td');
+        nameCell.textContent = r.name;
+        tr.appendChild(nameCell);
+        cells.forEach(c => {
+          const td = document.createElement('td');
+          td.textContent = c;
+          tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
       });
-      tbody.appendChild(tr);
     });
   }
 
   function load() {
     fetch('/results.json')
       .then(r => r.json())
-      .then(render)
+      .then(rows => {
+        const map = new Map();
+        rows.forEach(row => {
+          if (!map.has(row.name)) {
+            map.set(row.name, []);
+          }
+          map.get(row.name).push(row);
+        });
+        const groups = Array.from(map.entries()).map(([name, list]) => {
+          list.sort((a, b) => b.time - a.time);
+          return { name, time: list[0]?.time || 0, entries: list };
+        });
+        groups.sort((a, b) => b.time - a.time);
+        render(groups);
+      })
       .catch(err => console.error(err));
   }
 


### PR DESCRIPTION
## Summary
- group JSON results by team in `results.js`
- show each team with entries sorted by time in descending order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3c82f2a0832bb78fd9b2a5fe6eef