### PR TITLE
Add result service tests and competition mode check

### DIFF
--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\ResultService;
+use Tests\TestCase;
+
+class ResultServiceTest extends TestCase
+{
+    public function testAddIncrementsAttemptForSameCatalog(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'results');
+        $service = new ResultService($tmp);
+
+        $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
+        $this->assertSame(1, $first['attempt']);
+
+        $second = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
+        $this->assertSame(2, $second['attempt']);
+
+        unlink($tmp);
+    }
+
+    public function testAddDoesNotIncrementAcrossCatalogs(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'results');
+        $service = new ResultService($tmp);
+
+        $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
+        $this->assertSame(1, $first['attempt']);
+
+        $other = $service->add(['name' => 'TeamA', 'catalog' => 'cat2']);
+        $this->assertSame(1, $other['attempt']);
+
+        unlink($tmp);
+    }
+}

--- a/tests/test_competition_mode.js
+++ b/tests/test_competition_mode.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const code = fs.readFileSync('public/js/catalog.js', 'utf8');
+const match = code.match(/async function buildSolvedSet\(cfg\)\{[\s\S]*?return solved;\n\s*\}/);
+if (!match) {
+  throw new Error('buildSolvedSet not found');
+}
+
+const context = {
+  sessionStorage: {
+    _data: {},
+    getItem(key) { return Object.prototype.hasOwnProperty.call(this._data, key) ? this._data[key] : null; },
+    setItem(key, val) { this._data[key] = String(val); },
+    removeItem(key) { delete this._data[key]; }
+  },
+  fetch: async () => ({
+    ok: true,
+    json: async () => [{ name: 'Team1', catalog: 'cat1' }]
+  }),
+  console
+};
+
+const buildSolvedSet = vm.runInNewContext('(' + match[0] + ')', context);
+context.sessionStorage.setItem('quizUser', 'Team1');
+
+(async () => {
+  const res = await buildSolvedSet({ competitionMode: true });
+  assert(res.has('cat1'));
+  assert.deepStrictEqual(JSON.parse(context.sessionStorage.getItem('quizSolved')), ['cat1']);
+  console.log('ok');
+})().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- ensure attempts increase in `ResultService::add`
- verify competition mode prevents repeat catalogs using a JS integration test

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py -q`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_684f3cf24054832b8bd208e5b81e3d25