### PR TITLE
Fix results text

### DIFF
--- a/templates/vuequiz/index.html
+++ b/templates/vuequiz/index.html
@@ -24,10 +24,10 @@
     </div>
     <div v-else>
       <h2 class="text-xl font-bold mb-4">Auswertung</h2>
-      <p class="mb-4">Du hast {{ score }} von {{ questions.length }} Punkten erreicht.</p>
+      <p class="mb-4">Es wurden {{ score }} von {{ questions.length }} Punkten erreicht.</p>
       <div v-for="(q, idx) in questions" :key="idx" class="mb-4">
         <p class="font-semibold">{{ q.question }}</p>
-        <p>Deine Antwort: {{ formatAnswer(userAnswers[idx]) }}</p>
+        <p>Gegebene Antwort: {{ formatAnswer(userAnswers[idx]) }}</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- tweak result line wording in vue quiz
- rename answer label

## Testing
- `pytest -q`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f45509814832b990a3cbeecd7521f