### PR TITLE
Adjust quiz summary text

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -182,9 +182,9 @@ function runQuiz(questions){
       user = generateUserName();
     }
     const p = summaryEl.querySelector('p');
-    if(p) p.textContent = `${user} hat ${score} von ${questionCount} Punkten erreicht.`;
+    if(p) p.textContent = `${score} von ${questionCount} Punkten erreicht.`;
     const heading = summaryEl.querySelector('h3');
-    if(heading) heading.textContent = `🎉 Danke fürs Mitmachen ${user}!`;
+    if(heading) heading.textContent = '🎉 Danke fürs Mitmachen!';
     if(score === questionCount && typeof window.startConfetti === 'function'){
       window.startConfetti();
     }


### PR DESCRIPTION
## Summary
- fix summary text in quiz by removing username

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_684f4505359c832ba0e57bc655daff18