### PR TITLE
Add team results toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,12 @@ Alle wesentlichen Einstellungen finden sich in `data/config.json`. Hier lassen s
   "adminUser": "admin",
   "adminPass": "password",
   "QRRestrict": false,
-  "competitionMode": false
+  "competitionMode": false,
+  "teamResults": true
 }
 ```
 
-Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus, verhindert Wiederholungen bereits abgeschlossener Kataloge und unterbindet die Anzeige der Katalogübersicht. Ein Fragenkatalog kann dann nur über einen direkten QR-Code-Link gestartet werden.
+Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus, verhindert Wiederholungen bereits abgeschlossener Kataloge und unterbindet die Anzeige der Katalogübersicht. Ein Fragenkatalog kann dann nur über einen direkten QR-Code-Link gestartet werden. Über `teamResults` lässt sich steuern, ob Teams nach Abschluss aller Kataloge ihre eigene Ergebnisübersicht angezeigt bekommen.
 
 `ConfigService` liest und speichert diese Datei. Ein GET auf `/config.json` liefert den aktuellen Inhalt, ein POST auf dieselbe URL speichert geänderte Werte.
 

--- a/data/config.json
+++ b/data/config.json
@@ -11,5 +11,6 @@
   "adminUser": "admin",
   "adminPass": "password",
   "QRRestrict": false,
-  "competitionMode": false
+  "competitionMode": false,
+  "teamResults": true
 }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -53,7 +53,8 @@ document.addEventListener('DOMContentLoaded', function () {
     checkAnswerButton: document.getElementById('cfgCheckAnswerButton'),
     qrUser: document.getElementById('cfgQRUser'),
     teamRestrict: document.getElementById('cfgTeamRestrict'),
-    competitionMode: document.getElementById('cfgCompetitionMode')
+    competitionMode: document.getElementById('cfgCompetitionMode'),
+    teamResults: document.getElementById('cfgTeamResults')
   };
   let logoUploaded = false;
   if (cfgFields.logoFile && cfgFields.logoPreview) {
@@ -108,6 +109,9 @@ document.addEventListener('DOMContentLoaded', function () {
     if (cfgFields.competitionMode) {
       cfgFields.competitionMode.checked = !!data.competitionMode;
     }
+    if (cfgFields.teamResults) {
+      cfgFields.teamResults.checked = data.teamResults !== false;
+    }
   }
   renderCfg(cfgInitial);
   document.getElementById('cfgResetBtn').addEventListener('click', function (e) {
@@ -132,7 +136,8 @@ document.addEventListener('DOMContentLoaded', function () {
       CheckAnswerButton: cfgFields.checkAnswerButton.checked ? 'yes' : 'no',
       QRUser: cfgFields.qrUser.checked,
       QRRestrict: cfgFields.teamRestrict ? cfgFields.teamRestrict.checked : cfgInitial.QRRestrict,
-      competitionMode: cfgFields.competitionMode ? cfgFields.competitionMode.checked : cfgInitial.competitionMode
+      competitionMode: cfgFields.competitionMode ? cfgFields.competitionMode.checked : cfgInitial.competitionMode,
+      teamResults: cfgFields.teamResults ? cfgFields.teamResults.checked : cfgInitial.teamResults
     });
     fetch('/config.json', {
       method: 'POST',

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -26,5 +26,8 @@ window.quizConfig = {
   QRRestrict: false,
 
   // Wettkampfmodus aktivieren
-  competitionMode: false
+  competitionMode: false,
+
+  // Ergebnisübersicht für Teams anzeigen
+  teamResults: true
 };

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -200,7 +200,7 @@ function runQuiz(questions){
       sessionStorage.setItem('quizSolved', JSON.stringify(solved));
     }
 
-    if(cfg.competitionMode){
+    if(cfg.teamResults){
       let total = null;
       const dataEl = document.getElementById('catalogs-data');
       if(dataEl){

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -139,6 +139,13 @@
                 </label>
               </div>
             </div>
+            <div>
+              <div class="uk-margin">
+                <label><input class="uk-checkbox" type="checkbox" id="cfgTeamResults"> Ergebnisübersicht anzeigen
+                  <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Zeigt Teams nach Abschluss aller Kataloge eine Übersicht ihrer Ergebnisse.; pos: right"></span>
+                </label>
+              </div>
+            </div>
           </div>
         </form>
         <div class="uk-margin uk-flex uk-flex-between">


### PR DESCRIPTION
## Summary
- show results overview for any team that finished all catalogs
- allow admins to enable/disable results overview via new checkbox
- document `teamResults` in the configuration

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- ❌ `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f484aa928832ba17b58d9762c6432