### PR TITLE
Update German label in admin options

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -113,7 +113,7 @@
             </div>
             <div>
               <div class="uk-margin">
-                <label><input class="uk-checkbox" type="checkbox" id="cfgCheckAnswerButton"> Antwort-Prüfen-Button anzeigen
+                <label><input class="uk-checkbox" type="checkbox" id="cfgCheckAnswerButton"> Antwort prüfen Schaltfläche anzeigen
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Zeigt beim Quiz einen Button zum Prüfen der Antwort.; pos: right"></span>
                 </label>
               </div>


### PR DESCRIPTION
## Summary
- fix label text in admin template from `Antwort-Prüfen-Button anzeigen` to `Antwort prüfen Schaltfläche anzeigen`

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: `composer` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f4a959b1c832bad55a4696bb49735