### PR TITLE
Update RoundBlockSizeMode usage

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -9,7 +9,7 @@ use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
-use Endroid\QrCode\BlockSizeMode\BlockSizeMode;
+use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -44,7 +44,7 @@ class QrController
         }
 
         $result = $builder
-            ->roundBlockSizeMode(BlockSizeMode::ENLARGE)
+            ->roundBlockSizeMode(RoundBlockSizeMode::ENLARGE)
             ->build();
 
         $data = $result->getString();

--- a/stubs/endroid_qr.stub
+++ b/stubs/endroid_qr.stub
@@ -1,7 +1,7 @@
 <?php
-namespace Endroid\QrCode\BlockSizeMode;
+namespace Endroid\QrCode\RoundBlockSizeMode;
 
-final class BlockSizeMode
+final class RoundBlockSizeMode
 {
     public const MARGIN = 'margin';
     public const ENLARGE = 'enlarge';


### PR DESCRIPTION
## Summary
- swap to new `RoundBlockSizeMode` namespace in QrController
- update the stub so phpstan knows about `RoundBlockSizeMode`

## Testing
- `./vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `./vendor/bin/phpcs` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f51154150832b81b13920eb2b52c3