### PR TITLE
Add QR controller integration test

### DIFF
--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class QrControllerTest extends TestCase
+{
+    public function testQrImageIsGenerated(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/qr.png?t=Test');
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/png', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
+    }
+}


### PR DESCRIPTION
## Summary
- add test to ensure `/qr.png?t=Test` returns a PNG

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `pytest -q tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_684f51b9ba34832b8e836ddca6523390