### PR TITLE
Fix QR controller BlockSizeMode import

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -9,7 +9,7 @@ use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
-use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeMode;
+use Endroid\QrCode\BlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -44,7 +44,7 @@ class QrController
         }
 
         $result = $builder
-            ->roundBlockSizeMode(RoundBlockSizeMode::ENLARGE)
+            ->setBlockSizeMode(BlockSizeMode::ENLARGE)
             ->build();
 
         $data = $result->getString();

--- a/stubs/endroid_qr.stub
+++ b/stubs/endroid_qr.stub
@@ -1,7 +1,7 @@
 <?php
-namespace Endroid\QrCode\RoundBlockSizeMode;
+namespace Endroid\QrCode;
 
-final class RoundBlockSizeMode
+final class BlockSizeMode
 {
     public const MARGIN = 'margin';
     public const ENLARGE = 'enlarge';

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class QrControllerTest extends TestCase
+{
+    public function testQrImage(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/qr.png?t=Test');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('image/png', $response->getHeaderLine('Content-Type'));
+        $this->assertNotSame('', (string) $response->getBody());
+    }
+}


### PR DESCRIPTION
## Summary
- use `BlockSizeMode` from Endroid QR Code 5.1
- adjust stub for phpstan
- add regression test for `/qr.png`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*
- `./vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `./vendor/bin/phpcs` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684f4c407064832baf9566547147fba4