### PR TITLE
Fix builder method for QR block size

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -44,7 +44,7 @@ class QrController
         }
 
         $result = $builder
-            ->setBlockSizeMode(BlockSizeMode::ENLARGE)
+            ->withBlockSizeMode(BlockSizeMode::ENLARGE)
             ->build();
 
         $data = $result->getString();


### PR DESCRIPTION
## Summary
- fix block size mode method call in QR controller

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684f556d7954832ba83e91c0514ee3c9