### PR TITLE
Fix QR builder block size mode

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -9,7 +9,7 @@ use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\Label\Font\NotoSans;
-use Endroid\QrCode\BlockSizeMode;
+use Endroid\QrCode\RoundBlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -44,7 +44,7 @@ class QrController
         }
 
         $result = $builder
-            ->withBlockSizeMode(BlockSizeMode::ENLARGE)
+            ->roundBlockSizeMode(RoundBlockSizeMode::Margin)
             ->build();
 
         $data = $result->getString();

--- a/stubs/endroid_qr.stub
+++ b/stubs/endroid_qr.stub
@@ -1,7 +1,7 @@
 <?php
 namespace Endroid\QrCode;
 
-final class BlockSizeMode
+final class RoundBlockSizeMode
 {
     public const MARGIN = 'margin';
     public const ENLARGE = 'enlarge';


### PR DESCRIPTION
## Summary
- use `roundBlockSizeMode` instead of deprecated methods in `QrController`
- update stub for the new `RoundBlockSizeMode` class

## Testing
- `python3 -m pytest tests/test_html_validity.py -q`
- `python3 -m pytest tests/test_json_validity.py -q`
- `vendor/bin/phpunit --version` *(fails: file not found)*


------
https://chatgpt.com/codex/tasks/task_e_684f56e59678832b935aa6008034bd61