### PR TITLE
Add creative QR code demo variants

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -6,8 +6,11 @@ namespace App\Controller;
 
 use Endroid\QrCode\Builder\Builder;
 use Endroid\QrCode\Writer\PngWriter;
+use Endroid\QrCode\Writer\SvgWriter;
+use Endroid\QrCode\Writer\WebPWriter;
 use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
+use Endroid\QrCode\ErrorCorrectionLevel;
 use Endroid\QrCode\Label\Font\NotoSans;
 use Endroid\QrCode\RoundBlockSizeMode;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -27,9 +30,17 @@ class QrController
         $bg     = (string)($params['bg'] ?? 'ffffff');
         $size   = (int)($params['s'] ?? 300);
         $margin = (int)($params['m'] ?? 20);
+        $demo   = (string)($params['demo'] ?? '');
+
+        $writer  = new PngWriter();
+        if ($demo === 'svg' || $demo === 'svg-clean') {
+            $writer = new SvgWriter();
+        } elseif ($demo === 'webp') {
+            $writer = new WebPWriter();
+        }
 
         $builder = Builder::create()
-            ->writer(new PngWriter())
+            ->writer($writer)
             ->data($text)
             ->encoding(new Encoding('UTF-8'))
             ->size($size)
@@ -38,6 +49,32 @@ class QrController
             ->foregroundColor($this->parseColor($fg, new Color(35, 180, 90)))
             ->labelText($text)
             ->labelFont(new NotoSans(20));
+
+        if ($demo === 'logo') {
+            $builder = $builder
+                ->logoPath(__DIR__ . '/../../public/favicon.svg')
+                ->logoResizeToWidth(60)
+                ->logoPunchoutBackground(true);
+        } elseif ($demo === 'label') {
+            $builder = $builder
+                ->labelText('Jetzt scannen!')
+                ->labelFont(new NotoSans(22));
+        } elseif ($demo === 'colors') {
+            $builder = $builder
+                ->foregroundColor(new Color(0, 102, 204))
+                ->backgroundColor(new Color(240, 248, 255));
+        } elseif ($demo === 'svg') {
+            $builder = $builder->writerOptions(['svgRoundBlocks' => true]);
+        } elseif ($demo === 'high') {
+            $builder = $builder->errorCorrectionLevel(ErrorCorrectionLevel::High);
+        } elseif ($demo === 'webp') {
+            $builder = $builder->writerOptions(['quality' => 95]);
+        } elseif ($demo === 'svg-clean') {
+            $builder = $builder->writerOptions([
+                SvgWriter::WRITER_OPTION_EXCLUDE_XML_DECLARATION => true,
+                SvgWriter::WRITER_OPTION_BLOCK_ID => 'meinQRSVG',
+            ]);
+        }
 
         if (class_exists(\Endroid\QrCode\Label\Alignment\LabelAlignmentCenter::class)) {
             $builder = $builder->labelAlignment(new \Endroid\QrCode\Label\Alignment\LabelAlignmentCenter());
@@ -49,10 +86,17 @@ class QrController
 
         $data = $result->getString();
 
+        $extension = 'png';
+        if ($writer instanceof SvgWriter) {
+            $extension = 'svg';
+        } elseif ($writer instanceof WebPWriter) {
+            $extension = 'webp';
+        }
+
         $response->getBody()->write($data);
         return $response
-            ->withHeader('Content-Type', 'image/png')
-            ->withHeader('Content-Disposition', 'inline; filename="qr.png"');
+            ->withHeader('Content-Type', $result->getMimeType())
+            ->withHeader('Content-Disposition', 'inline; filename="qr.' . $extension . '"');
     }
 
     private function parseColor(string $hex, Color $default): Color

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -32,7 +32,7 @@
     <li data-help="Gespeicherte Ergebnisse mit richtigen Antworten und Zeit einsehen. 'Zurücksetzen' löscht alle Daten, 'Herunterladen' exportiert sie als CSV."><a href="#">Ergebnisse</a></li>
     <li data-help="QR-Codes für alle Kataloge und Teams anzeigen, um Quizlinks oder Anmeldungen weiterzugeben. 'Drucken' erstellt eine übersichtliche Liste."><a href="#">Zusammenfassung</a></li>
     <li data-help="Neues Administrationspasswort eingeben, wiederholen und speichern."><a href="#">Passwort ändern</a></li>
-    <li data-help="Farbige Beispiel-QR-Codes als Designvorlage."><a href="#">QR-Code Samples</a></li>
+    <li data-help="Kreative Beispiel-QR-Codes mit Logo, Label und speziellen Farben."><a href="#">QR-Code Samples</a></li>
   </ul>
   <ul class="uk-switcher uk-margin">
     <li>
@@ -339,15 +339,48 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">QR-Code Samples</h2>
         <div class="card-grid" uk-grid>
-          {% set colors = ['ff5733','33c3ff','a433ff','ff33a6','33ff57','ffd433','3380ff','ff3333','33ffd9','7f33ff'] %}
-          {% for i in 1..10 %}
           <div class="uk-width-1-1 uk-width-1-2@s">
             <div class="export-card uk-card uk-card-default uk-card-body">
-              <h4 class="uk-card-title">Sample {{ i }}</h4>
-              <img src="/qr.png?t={{ ('Sample ' ~ i)|url_encode }}&fg={{ colors[i-1] }}" alt="Sample {{ i }}" width="200" height="200">
+              <h4 class="uk-card-title">Logo</h4>
+              <img src="/qr.png?t=Logo&demo=logo" alt="QR mit Logo" width="200" height="200">
             </div>
           </div>
-          {% endfor %}
+          <div class="uk-width-1-1 uk-width-1-2@s">
+            <div class="export-card uk-card uk-card-default uk-card-body">
+              <h4 class="uk-card-title">Label-Font</h4>
+              <img src="/qr.png?t=Label&demo=label" alt="QR mit Label" width="200" height="200">
+            </div>
+          </div>
+          <div class="uk-width-1-1 uk-width-1-2@s">
+            <div class="export-card uk-card uk-card-default uk-card-body">
+              <h4 class="uk-card-title">Farben</h4>
+              <img src="/qr.png?t=Farben&demo=colors" alt="QR in Farbe" width="200" height="200">
+            </div>
+          </div>
+          <div class="uk-width-1-1 uk-width-1-2@s">
+            <div class="export-card uk-card uk-card-default uk-card-body">
+              <h4 class="uk-card-title">SVG-Rund</h4>
+              <img src="/qr.png?t=SVG&demo=svg" alt="Runde SVG-Pixel" width="200" height="200">
+            </div>
+          </div>
+          <div class="uk-width-1-1 uk-width-1-2@s">
+            <div class="export-card uk-card uk-card-default uk-card-body">
+              <h4 class="uk-card-title">Fehlerkorrektur</h4>
+              <img src="/qr.png?t=Fehler&demo=high" alt="QR mit hoher Fehlerkorrektur" width="200" height="200">
+            </div>
+          </div>
+          <div class="uk-width-1-1 uk-width-1-2@s">
+            <div class="export-card uk-card uk-card-default uk-card-body">
+              <h4 class="uk-card-title">WebP</h4>
+              <img src="/qr.png?t=WebP&demo=webp" alt="WebP-QR" width="200" height="200">
+            </div>
+          </div>
+          <div class="uk-width-1-1 uk-width-1-2@s">
+            <div class="export-card uk-card uk-card-default uk-card-body">
+              <h4 class="uk-card-title">SVG Clean</h4>
+              <img src="/qr.png?t=Clean&demo=svg-clean" alt="SVG ohne Header" width="200" height="200">
+            </div>
+          </div>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- show creative QR samples with logo, special font, colors and more
- extend `QrController` to support demo variants and different writers

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `vendor/bin/phpstan analyse` *(fails: command not found)*
- `vendor/bin/phpcs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f591eedac832baa238f51be5add7d