### PR TITLE
Improve QR code colors for catalog/team summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier 
 
 QR-Codes können pro Eintrag über `qr_image` oder `qrcode_url` hinterlegt werden. Neben Data-URIs und lokalen Pfaden werden dabei nun auch HTTP- oder HTTPS-URLs unterstützt.
 
-In der Zusammenfassung erscheint weiterhin der einfache QR-Code. Ein farbig gestaltetes Beispiel mit dem PHP-Paket *Endroid\\QrCode* ist im Template hinterlegt, aber auskommentiert.
+Die Übersichtsseiten erzeugen ihre QR-Codes jetzt lokal mit der Bibliothek *Endroid\\QrCode*. Katalog-Links erscheinen rot, Team-Links blau.
 
 ## Tests
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -275,8 +275,7 @@
               <h4 class="uk-card-title">{{ c.name }}</h4>
               <p>{{ c.description }}</p>
               {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ c.id : '?katalog=' ~ c.id %}
-              <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ link|url_encode }}" alt="QR" width="96" height="96">
-              <!--<img src="/qr.png?t={{ link|url_encode }}" alt="QR Design" width="96" height="96">-->
+              <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}
@@ -292,8 +291,7 @@
           <div class="uk-width-1-1 uk-width-1-2@s">
             <div class="export-card uk-card uk-card-default uk-card-body">
               <h4 class="uk-card-title">{{ t }}</h4>
-              <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ t|url_encode }}" alt="QR" width="96" height="96">
-              <!--<img src="/qr.png?t={{ t|url_encode }}" alt="QR Design" width="96" height="96">-->
+              <img src="/qr.png?t={{ t|url_encode }}&fg=004bc8" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -22,7 +22,7 @@
                         </div>
                         <div class="uk-width-auto@s uk-width-1-1">
                             {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ katalog.id : '?katalog=' ~ katalog.id %}
-                            <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data={{ link|url_encode }}" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
+                            <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
                             <button class="uk-button uk-button-danger uk-button-small uk-width-1-1">Löschen</button>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- generate QR codes in the admin views with `/qr.png`
- apply red color for catalog links and blue for team links
- clarify README about local QR code generation

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5df9098c832b87a6cd2af3a423fb