### PR TITLE
Hide QR samples and shorten summary QR codes

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -31,6 +31,8 @@ class QrController
         $size   = (int)($params['s'] ?? 300);
         $margin = (int)($params['m'] ?? 20);
         $demo   = (string)($params['demo'] ?? '');
+        $label  = (string)($params['label'] ?? '1');
+        $useLabel = !in_array(strtolower($label), ['0', 'false', 'no'], true);
 
         $writer  = new PngWriter();
         if ($demo === 'svg' || $demo === 'svg-clean') {
@@ -46,16 +48,20 @@ class QrController
             ->size($size)
             ->margin($margin)
             ->backgroundColor($this->parseColor($bg, new Color(255, 255, 255)))
-            ->foregroundColor($this->parseColor($fg, new Color(35, 180, 90)))
-            ->labelText($text)
-            ->labelFont(new NotoSans(20));
+            ->foregroundColor($this->parseColor($fg, new Color(35, 180, 90)));
+
+        if ($useLabel) {
+            $builder = $builder
+                ->labelText($text)
+                ->labelFont(new NotoSans(20));
+        }
 
         if ($demo === 'logo') {
             $builder = $builder
                 ->logoPath(__DIR__ . '/../../public/favicon.svg')
                 ->logoResizeToWidth(60)
                 ->logoPunchoutBackground(true);
-        } elseif ($demo === 'label') {
+        } elseif ($demo === 'label' && $useLabel) {
             $builder = $builder
                 ->labelText('Jetzt scannen!')
                 ->labelFont(new NotoSans(22));
@@ -76,7 +82,7 @@ class QrController
             ]);
         }
 
-        if (class_exists(\Endroid\QrCode\Label\Alignment\LabelAlignmentCenter::class)) {
+        if ($useLabel && class_exists(\Endroid\QrCode\Label\Alignment\LabelAlignmentCenter::class)) {
             $builder = $builder->labelAlignment(new \Endroid\QrCode\Label\Alignment\LabelAlignmentCenter());
         }
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -32,7 +32,6 @@
     <li data-help="Gespeicherte Ergebnisse mit richtigen Antworten und Zeit einsehen. 'Zurücksetzen' löscht alle Daten, 'Herunterladen' exportiert sie als CSV."><a href="#">Ergebnisse</a></li>
     <li data-help="QR-Codes für alle Kataloge und Teams anzeigen, um Quizlinks oder Anmeldungen weiterzugeben. 'Drucken' erstellt eine übersichtliche Liste."><a href="#">Zusammenfassung</a></li>
     <li data-help="Neues Administrationspasswort eingeben, wiederholen und speichern."><a href="#">Passwort ändern</a></li>
-    <li data-help="Kreative Beispiel-QR-Codes mit Logo, Label und speziellen Farben."><a href="#">QR-Code Samples</a></li>
   </ul>
   <ul class="uk-switcher uk-margin">
     <li>
@@ -275,7 +274,7 @@
               <h4 class="uk-card-title">{{ c.name }}</h4>
               <p>{{ c.description }}</p>
               {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ c.id : '?katalog=' ~ c.id %}
-              <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000" alt="QR" width="96" height="96">
+              <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000&label=0" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}
@@ -331,55 +330,6 @@
             <button id="passSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Neues Passwort speichern; pos: right">Speichern</button>
           </div>
         </form>
-      </div>
-    </li>
-    <li>
-      <div class="uk-container uk-container-large">
-        <h2 class="uk-heading-bullet">QR-Code Samples</h2>
-        <div class="card-grid" uk-grid>
-          <div class="uk-width-1-1 uk-width-1-2@s">
-            <div class="export-card uk-card uk-card-default uk-card-body">
-              <h4 class="uk-card-title">Logo</h4>
-              <img src="/qr.png?t=Logo&demo=logo" alt="QR mit Logo" width="200" height="200">
-            </div>
-          </div>
-          <div class="uk-width-1-1 uk-width-1-2@s">
-            <div class="export-card uk-card uk-card-default uk-card-body">
-              <h4 class="uk-card-title">Label-Font</h4>
-              <img src="/qr.png?t=Label&demo=label" alt="QR mit Label" width="200" height="200">
-            </div>
-          </div>
-          <div class="uk-width-1-1 uk-width-1-2@s">
-            <div class="export-card uk-card uk-card-default uk-card-body">
-              <h4 class="uk-card-title">Farben</h4>
-              <img src="/qr.png?t=Farben&demo=colors" alt="QR in Farbe" width="200" height="200">
-            </div>
-          </div>
-          <div class="uk-width-1-1 uk-width-1-2@s">
-            <div class="export-card uk-card uk-card-default uk-card-body">
-              <h4 class="uk-card-title">SVG-Rund</h4>
-              <img src="/qr.png?t=SVG&demo=svg" alt="Runde SVG-Pixel" width="200" height="200">
-            </div>
-          </div>
-          <div class="uk-width-1-1 uk-width-1-2@s">
-            <div class="export-card uk-card uk-card-default uk-card-body">
-              <h4 class="uk-card-title">Fehlerkorrektur</h4>
-              <img src="/qr.png?t=Fehler&demo=high" alt="QR mit hoher Fehlerkorrektur" width="200" height="200">
-            </div>
-          </div>
-          <div class="uk-width-1-1 uk-width-1-2@s">
-            <div class="export-card uk-card uk-card-default uk-card-body">
-              <h4 class="uk-card-title">WebP</h4>
-              <img src="/qr.png?t=WebP&demo=webp" alt="WebP-QR" width="200" height="200">
-            </div>
-          </div>
-          <div class="uk-width-1-1 uk-width-1-2@s">
-            <div class="export-card uk-card uk-card-default uk-card-body">
-              <h4 class="uk-card-title">SVG Clean</h4>
-              <img src="/qr.png?t=Clean&demo=svg-clean" alt="SVG ohne Header" width="200" height="200">
-            </div>
-          </div>
-        </div>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
## Summary
- hide QR samples tab and its content
- add optional `label` query param for generated QR codes
- disable QR label for catalog QR codes in admin summary

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: `bash: vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684f5fa2a86c832bb68971b329a7db8c