### PR TITLE
Add puzzle letter display

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Unter `/admin` stehen folgende Tabs zur Verfügung:
 6. **Passwort ändern** – Administrationspasswort setzen.
 
 ### Fragenkataloge
-`data/kataloge/catalogs.json` listet verfügbare Kataloge mit `id`, Name und optionaler QR-Code-Adresse. Die API bietet hierzu folgende Endpunkte:
+`data/kataloge/catalogs.json` listet verfügbare Kataloge mit `id`, Name und optionaler QR-Code-Adresse. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:
 - `GET /kataloge/{file}` liefert den JSON-Katalog oder leitet im Browser auf `/?katalog=id` um.
 - `PUT /kataloge/{file}` legt eine neue Datei an.
 - `POST /kataloge/{file}` überschreibt einen Katalog mit gesendeten Daten.

--- a/data/kataloge/catalogs.json
+++ b/data/kataloge/catalogs.json
@@ -4,55 +4,63 @@
     "file": "station_1.json",
     "name": "Station-1",
     "description": "Speicher und Geraete",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_1"
+    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_1",
+    "raetsel_buchstabe": "A"
   },
   {
     "id": "station_2",
     "file": "station_2.json",
     "name": "Station-2",
     "description": "Bedienung und Symbole",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_2"
+    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_2",
+    "raetsel_buchstabe": "B"
   },
   {
     "id": "station_3",
     "file": "station_3.json",
     "name": "Station-3",
     "description": "WWW und Speicherarten",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_3"
+    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_3",
+    "raetsel_buchstabe": "C"
   },
   {
     "id": "station_4",
     "file": "station_4.json",
     "name": "Station-4",
     "description": "Begriffe und Geraetegroessen",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_4"
+    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_4",
+    "raetsel_buchstabe": "D"
   },
   {
     "id": "station_5",
     "file": "station_5.json",
     "name": "Station-5",
     "description": "Programme und Binaersystem",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_5"
+    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_5",
+    "raetsel_buchstabe": "E"
   },
   {
     "id": "station_6",
     "file": "station_6.json",
     "name": "Station-6",
     "description": "Dateien und URLs",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_6"
+    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_6",
+    "raetsel_buchstabe": "F"
   },
   {
     "id": "station_7",
     "file": "station_7.json",
     "name": "Station-7",
     "description": "Netzwerke und Kuerzel",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_7"
+    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_7",
+    "raetsel_buchstabe": "G"
   },
   {
     "id": "station_8",
     "file": "station_8.json",
     "name": "Station-8",
     "description": "Cloud und Steuerung",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_8"
+    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_8",
+    "raetsel_buchstabe": "H"
   }
 ]

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -269,3 +269,8 @@ body.dark-mode .sticky-actions {
   justify-content: center;
 }
 
+.quiz-letter {
+  font-size: 6rem;
+  font-weight: bold;
+}
+

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -92,8 +92,13 @@
     return [];
   }
 
-  async function loadQuestions(id, file){
+  async function loadQuestions(id, file, letter){
     sessionStorage.setItem('quizCatalog', id);
+    if(letter){
+      sessionStorage.setItem('quizLetter', letter);
+    }else{
+      sessionStorage.removeItem('quizLetter');
+    }
     try{
       const res = await fetch('/kataloge/' + file, { headers: { 'Accept': 'application/json' } });
       const data = await res.json();
@@ -170,7 +175,7 @@
         }
         history.replaceState(null, '', '?katalog=' + cat.id);
         setSubHeader(cat.description || '');
-        loadQuestions(cat.id, cat.file);
+        loadQuestions(cat.id, cat.file, cat.raetsel_buchstabe);
       });
       const title = document.createElement('h3');
       title.textContent = cat.name || cat.id;
@@ -391,7 +396,7 @@
           showSelection(catalogs, solvedNow);
           return;
         }
-        loadQuestions(selected.id, selected.file);
+        loadQuestions(selected.id, selected.file, selected.raetsel_buchstabe);
       }else{
         showSelection(catalogs, solvedNow);
       }

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -185,6 +185,16 @@ function runQuiz(questions){
     if(p) p.textContent = `${user} hat ${score} von ${questionCount} Punkten erreicht.`;
     const heading = summaryEl.querySelector('h3');
     if(heading) heading.textContent = `🎉 Danke für die Teilnahme ${user}!`;
+    const letter = sessionStorage.getItem('quizLetter');
+    const letterEl = summaryEl.querySelector('#quiz-letter');
+    if(letterEl){
+      if(letter){
+        letterEl.textContent = letter;
+        letterEl.style.display = 'block';
+      }else{
+        letterEl.style.display = 'none';
+      }
+    }
     if(score === questionCount && typeof window.startConfetti === 'function'){
       window.startConfetti();
     }
@@ -701,8 +711,13 @@ function runQuiz(questions){
     const h = document.createElement('h3');
     h.textContent = '🎉 Danke für die Teilnahme!';
     const p = document.createElement('p');
+    const letter = document.createElement('div');
+    letter.id = 'quiz-letter';
+    letter.className = 'quiz-letter uk-margin-top';
+    letter.style.display = 'none';
     div.appendChild(h);
     div.appendChild(p);
+    div.appendChild(letter);
     if(!cfg.competitionMode){
       const restart = document.createElement('a');
       restart.href = '/';


### PR DESCRIPTION
## Summary
- store optional `raetsel_buchstabe` value for each catalog
- remember the catalog letter during quiz loading
- show big puzzle letter on the summary screen
- style `.quiz-letter` in CSS
- document the new field in README

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_684fcba2d9ac832bb088586dae7c2384