### PR TITLE
Add puzzle word settings

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -12,5 +12,7 @@
   "adminPass": "password",
   "QRRestrict": false,
   "competitionMode": false,
-  "teamResults": true
+  "teamResults": true,
+  "puzzleWordEnabled": true,
+  "puzzleWord": ""
 }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -54,7 +54,10 @@ document.addEventListener('DOMContentLoaded', function () {
     qrUser: document.getElementById('cfgQRUser'),
     teamRestrict: document.getElementById('cfgTeamRestrict'),
     competitionMode: document.getElementById('cfgCompetitionMode'),
-    teamResults: document.getElementById('cfgTeamResults')
+    teamResults: document.getElementById('cfgTeamResults'),
+    puzzleEnabled: document.getElementById('cfgPuzzleEnabled'),
+    puzzleWord: document.getElementById('cfgPuzzleWord'),
+    puzzleWrap: document.getElementById('cfgPuzzleWordWrap')
   };
   let logoUploaded = false;
   if (cfgFields.logoFile && cfgFields.logoPreview) {
@@ -112,8 +115,24 @@ document.addEventListener('DOMContentLoaded', function () {
     if (cfgFields.teamResults) {
       cfgFields.teamResults.checked = data.teamResults !== false;
     }
+    if (cfgFields.puzzleEnabled) {
+      cfgFields.puzzleEnabled.checked = data.puzzleWordEnabled !== false;
+    }
+    if (cfgFields.puzzleWord) {
+      cfgFields.puzzleWord.value = data.puzzleWord || '';
+    }
+    if (cfgFields.puzzleWrap) {
+      cfgFields.puzzleWrap.style.display = cfgFields.puzzleEnabled.checked ? '' : 'none';
+    }
   }
   renderCfg(cfgInitial);
+  if (cfgFields.puzzleEnabled) {
+    cfgFields.puzzleEnabled.addEventListener('change', () => {
+      if (cfgFields.puzzleWrap) {
+        cfgFields.puzzleWrap.style.display = cfgFields.puzzleEnabled.checked ? '' : 'none';
+      }
+    });
+  }
   document.getElementById('cfgResetBtn').addEventListener('click', function (e) {
     e.preventDefault();
     renderCfg(cfgInitial);
@@ -137,7 +156,9 @@ document.addEventListener('DOMContentLoaded', function () {
       QRUser: cfgFields.qrUser.checked,
       QRRestrict: cfgFields.teamRestrict ? cfgFields.teamRestrict.checked : cfgInitial.QRRestrict,
       competitionMode: cfgFields.competitionMode ? cfgFields.competitionMode.checked : cfgInitial.competitionMode,
-      teamResults: cfgFields.teamResults ? cfgFields.teamResults.checked : cfgInitial.teamResults
+      teamResults: cfgFields.teamResults ? cfgFields.teamResults.checked : cfgInitial.teamResults,
+      puzzleWordEnabled: cfgFields.puzzleEnabled ? cfgFields.puzzleEnabled.checked : cfgInitial.puzzleWordEnabled,
+      puzzleWord: cfgFields.puzzleWord ? cfgFields.puzzleWord.value.trim() : cfgInitial.puzzleWord
     });
     fetch('/config.json', {
       method: 'POST',

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -94,7 +94,8 @@
 
   async function loadQuestions(id, file, letter){
     sessionStorage.setItem('quizCatalog', id);
-    if(letter){
+    const cfg = window.quizConfig || {};
+    if(cfg.puzzleWordEnabled && letter){
       sessionStorage.setItem('quizLetter', letter);
     }else{
       sessionStorage.removeItem('quizLetter');

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -29,5 +29,9 @@ window.quizConfig = {
   competitionMode: false,
 
   // Ergebnisübersicht für Teams anzeigen
-  teamResults: true
+  teamResults: true,
+
+  // Rätselwort aktivieren und Begriff festlegen
+  puzzleWordEnabled: true,
+  puzzleWord: ''
 };

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -185,7 +185,7 @@ function runQuiz(questions){
     if(p) p.textContent = `${user} hat ${score} von ${questionCount} Punkten erreicht.`;
     const heading = summaryEl.querySelector('h3');
     if(heading) heading.textContent = `🎉 Danke für die Teilnahme ${user}!`;
-    const letter = sessionStorage.getItem('quizLetter');
+    const letter = cfg.puzzleWordEnabled ? sessionStorage.getItem('quizLetter') : null;
     const letterEl = summaryEl.querySelector('#quiz-letter');
     if(letterEl){
       if(letter){

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -145,6 +145,16 @@
                 </label>
               </div>
             </div>
+            <div>
+              <div class="uk-margin">
+                <label><input class="uk-checkbox" type="checkbox" id="cfgPuzzleEnabled"> Rätselwort
+                  <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Blendet Buchstaben für das Rätselwort ein und speichert den vollständigen Begriff.; pos: right"></span>
+                </label>
+                <div id="cfgPuzzleWordWrap" class="uk-margin-small-top">
+                  <input class="uk-input" type="text" id="cfgPuzzleWord" placeholder="Rätselwort">
+                </div>
+              </div>
+            </div>
           </div>
         </form>
         <div class="uk-margin uk-flex uk-flex-between">


### PR DESCRIPTION
## Summary
- add configuration option for Rätselwort
- update admin UI to manage puzzle word
- respect option in catalog and quiz scripts

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcd4fbc84832b816cac77b28971ee