### PR TITLE
Fix missing brace in catalog.js

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -95,11 +95,12 @@
   async function loadQuestions(id, file, letter){
     sessionStorage.setItem('quizCatalog', id);
     if(letter){
-    const cfg = window.quizConfig || {};
-    if(cfg.puzzleWordEnabled && letter){
-      sessionStorage.setItem('quizLetter', letter);
-    }else{
-      sessionStorage.removeItem('quizLetter');
+      const cfg = window.quizConfig || {};
+      if(cfg.puzzleWordEnabled && letter){
+        sessionStorage.setItem('quizLetter', letter);
+      }else{
+        sessionStorage.removeItem('quizLetter');
+      }
     }
     try{
       const res = await fetch('/kataloge/' + file, { headers: { 'Accept': 'application/json' } });


### PR DESCRIPTION
## Summary
- fix missing curly brace in `loadQuestions`

## Testing
- `node tests/test_competition_mode.js`
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(failed: php/phpunit not available)*

------
https://chatgpt.com/codex/tasks/task_e_684fd84c0520832b915cdefe446999d3