### PR TITLE
Add summary page when all catalogs solved

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -146,12 +146,33 @@
     ui.show();
   }
 
+  function showAllSolvedModal(){
+    const modal = document.createElement('div');
+    modal.setAttribute('uk-modal', '');
+    modal.setAttribute('aria-modal', 'true');
+    modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">' +
+      '<h3 class="uk-modal-title uk-text-center">Alle Kataloge gespielt</h3>' +
+      '<p class="uk-text-center">Herzlichen Glückwunsch, alle Kataloge wurden erfolgreich gespielt!</p>' +
+      '<button class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Zur Auswertung wechseln</button>' +
+      '</div>';
+    const btn = modal.querySelector('button');
+    document.body.appendChild(modal);
+    const ui = UIkit.modal(modal);
+    UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
+    btn.addEventListener('click', () => { ui.hide(); window.location.href = "/summary"; });
+    ui.show();
+  }
+
   function showSelection(catalogs, solved){
     solved = solved || new Set();
     const container = document.getElementById('quiz');
     if(!container) return;
     container.innerHTML = '';
     const cfg = window.quizConfig || {};
+    if(catalogs.length && solved.size === catalogs.length){
+      showAllSolvedModal();
+      return;
+    }
     const params = new URLSearchParams(window.location.search);
     if(cfg.competitionMode && !params.get('katalog')){
       const p = document.createElement('p');

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -1,0 +1,96 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const resultsBtn = document.getElementById('show-results-btn');
+  const puzzleBtn = document.getElementById('check-puzzle-btn');
+  const user = sessionStorage.getItem('quizUser') || '';
+
+  function showResults(){
+    const modal = document.createElement('div');
+    modal.setAttribute('uk-modal', '');
+    modal.setAttribute('aria-modal', 'true');
+    modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">' +
+      '<h3 class="uk-modal-title uk-text-center">Ergebnisübersicht</h3>' +
+      '<div id="team-results" class="uk-overflow-auto"></div>' +
+      '<button class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Schließen</button>' +
+      '</div>';
+    const tbodyContainer = modal.querySelector('#team-results');
+    const closeBtn = modal.querySelector('button');
+    document.body.appendChild(modal);
+    const ui = UIkit.modal(modal);
+    UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
+    closeBtn.addEventListener('click', () => ui.hide());
+
+    fetch('/results.json')
+      .then(r => r.json())
+      .then(rows => {
+        const filtered = rows.filter(row => row.name === user);
+        const map = new Map();
+        filtered.forEach(r => {
+          map.set(r.catalog, `${r.correct}/${r.total}`);
+        });
+        const table = document.createElement('table');
+        table.className = 'uk-table uk-table-divider';
+        table.innerHTML = '<thead><tr><th>Katalog</th><th>Ergebnis</th></tr></thead>';
+        const tb = document.createElement('tbody');
+        if(map.size === 0){
+          const tr = document.createElement('tr');
+          const td = document.createElement('td');
+          td.colSpan = 2;
+          td.textContent = 'Keine Daten';
+          tr.appendChild(td);
+          tb.appendChild(tr);
+        }else{
+          map.forEach((res, cat) => {
+            const tr = document.createElement('tr');
+            const td1 = document.createElement('td');
+            td1.textContent = cat;
+            const td2 = document.createElement('td');
+            td2.textContent = res;
+            tr.appendChild(td1);
+            tr.appendChild(td2);
+            tb.appendChild(tr);
+          });
+        }
+        table.appendChild(tb);
+        if(tbodyContainer) tbodyContainer.appendChild(table);
+      })
+      .catch(() => {
+        if(tbodyContainer) tbodyContainer.textContent = 'Fehler beim Laden';
+      });
+
+    ui.show();
+  }
+
+  function showPuzzle(){
+    const modal = document.createElement('div');
+    modal.setAttribute('uk-modal', '');
+    modal.setAttribute('aria-modal', 'true');
+    modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">' +
+      '<h3 class="uk-modal-title uk-text-center">Rätselwort überprüfen</h3>' +
+      '<input id="puzzle-input" class="uk-input" type="text" placeholder="Rätselwort eingeben">' +
+      '<div id="puzzle-feedback" class="uk-margin-top uk-text-center"></div>' +
+      '<button class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Überprüfen</button>' +
+      '</div>';
+    const input = modal.querySelector('#puzzle-input');
+    const feedback = modal.querySelector('#puzzle-feedback');
+    const btn = modal.querySelector('button');
+    document.body.appendChild(modal);
+    const ui = UIkit.modal(modal);
+    UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
+    UIkit.util.on(modal, 'shown', () => { input.focus(); });
+    btn.addEventListener('click', () => {
+      const expected = (window.quizConfig && window.quizConfig.puzzleWord) ? window.quizConfig.puzzleWord.toLowerCase() : '';
+      const val = (input.value || '').trim().toLowerCase();
+      if(val && val === expected){
+        feedback.textContent = 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
+        feedback.className = 'uk-margin-top uk-text-center uk-text-success';
+      }else{
+        feedback.textContent = 'Das ist leider nicht korrekt. Versuch es noch einmal!';
+        feedback.className = 'uk-margin-top uk-text-center uk-text-danger';
+      }
+    });
+    ui.show();
+  }
+
+  resultsBtn?.addEventListener('click', showResults);
+  puzzleBtn?.addEventListener('click', showPuzzle);
+});

--- a/src/Controller/SummaryController.php
+++ b/src/Controller/SummaryController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use App\Service\ConfigService;
+use Slim\Views\Twig;
+
+class SummaryController
+{
+    private ConfigService $config;
+
+    public function __construct(ConfigService $config)
+    {
+        $this->config = $config;
+    }
+
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $view = Twig::fromRequest($request);
+        $cfg = $this->config->getConfig();
+        return $view->render($response, 'summary.twig', ['config' => $cfg]);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -23,6 +23,7 @@ use App\Controller\TeamController;
 use App\Controller\PasswordController;
 use App\Controller\QrController;
 use App\Controller\LogoController;
+use App\Controller\SummaryController;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
@@ -40,6 +41,7 @@ require_once __DIR__ . '/Controller/PasswordController.php';
 require_once __DIR__ . '/Controller/AdminCatalogController.php';
 require_once __DIR__ . '/Controller/QrController.php';
 require_once __DIR__ . '/Controller/LogoController.php';
+require_once __DIR__ . '/Controller/SummaryController.php';
 
 return function (\Slim\App $app) {
     $configService = new ConfigService(
@@ -57,6 +59,7 @@ return function (\Slim\App $app) {
     $passwordController = new PasswordController($configService);
     $qrController = new QrController();
     $logoController = new LogoController($configService);
+    $summaryController = new SummaryController($configService);
 
     $app->get('/', HomeController::class);
     $app->get('/favicon.ico', function (Request $request, Response $response) {
@@ -97,4 +100,5 @@ return function (\Slim\App $app) {
     $app->post('/logo.png', [$logoController, 'post']);
     $app->get('/logo.webp', [$logoController, 'get'])->setArgument('ext', 'webp');
     $app->post('/logo.webp', [$logoController, 'post']);
+    $app->get('/summary', $summaryController);
 };

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -1,0 +1,32 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Auswertung{% endblock %}
+
+{% block head %}
+  <link rel="stylesheet" href="/css/dark.css">
+  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/highcontrast.css">
+{% endblock %}
+
+{% block body_class %}uk-padding{% endblock %}
+
+{% block body %}
+  {% embed 'topbar.twig' %}
+    {% block left %}
+      <a href="/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+    {% endblock %}
+  {% endembed %}
+  <div class="uk-container uk-container-small uk-text-center">
+    <h2 class="uk-heading-bullet">Herzlichen Glückwunsch, du hast alle Kataloge gelöst!</h2>
+    <button id="show-results-btn" class="uk-button uk-button-primary uk-margin-top">Ergebnisse anzeigen</button>
+    {% if config.puzzleWordEnabled %}
+    <button id="check-puzzle-btn" class="uk-button uk-button-primary uk-margin-top">Rätselwort prüfen</button>
+    {% endif %}
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="/js/uikit-icons.min.js"></script>
+  <script src="/js/custom-icons.js"></script>
+  <script src="/js/summary.js"></script>
+{% endblock %}

--- a/tests/Controller/SummaryControllerTest.php
+++ b/tests/Controller/SummaryControllerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class SummaryControllerTest extends TestCase
+{
+    public function testSummaryPage(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/summary');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary
- add SummaryController and route
- create summary.twig with results and puzzle buttons
- implement summary.js for modal actions
- show final modal when all catalogs solved
- add tests for new controller

## Testing
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `npx jest tests/test_competition_mode.js` *(fails: 403 Forbidden)*
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685005035aac832b9ea1c59edeea1f2a