### PR TITLE
Handle direct-link completion modal

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -416,7 +416,11 @@
       if(selected){
         if(cfg.competitionMode && solvedNow.has(selected.id)){
           const remaining = catalogs.filter(c => !solvedNow.has(c.id)).map(c => c.name || c.id).join(', ');
-          showCatalogSolvedModal(selected.name || selected.id, remaining);
+          if(catalogs.length && solvedNow.size === catalogs.length){
+            showAllSolvedModal();
+          } else {
+            showCatalogSolvedModal(selected.name || selected.id, remaining);
+          }
           showSelection(catalogs, solvedNow);
           return;
         }


### PR DESCRIPTION
## Summary
- show the "All catalogs solved" modal when a completed catalog is opened directly

## Testing
- `node tests/test_competition_mode.js`
- `python3 -m pytest -q tests/test_json_validity.py tests/test_html_validity.py`
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685008fe42f4832b8941e335cd887f89