### PR TITLE
Fix freeze in competition mode modal

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -414,16 +414,17 @@
       const solvedNow = await buildSolvedSet(cfg);
       const selected = catalogs.find(c => c.id === id);
       if(selected){
-        if(cfg.competitionMode && solvedNow.has(selected.id)){
-          const remaining = catalogs.filter(c => !solvedNow.has(c.id)).map(c => c.name || c.id).join(', ');
-          if(catalogs.length && solvedNow.size === catalogs.length){
-            showAllSolvedModal();
-          } else {
-            showCatalogSolvedModal(selected.name || selected.id, remaining);
+          if(cfg.competitionMode && solvedNow.has(selected.id)){
+            const remaining = catalogs.filter(c => !solvedNow.has(c.id)).map(c => c.name || c.id).join(', ');
+            if(catalogs.length && solvedNow.size === catalogs.length){
+              showAllSolvedModal();
+              return;
+            } else {
+              showCatalogSolvedModal(selected.name || selected.id, remaining);
+              showSelection(catalogs, solvedNow);
+              return;
+            }
           }
-          showSelection(catalogs, solvedNow);
-          return;
-        }
         loadQuestions(selected.id, selected.file, selected.raetsel_buchstabe);
       }else{
         showSelection(catalogs, solvedNow);


### PR DESCRIPTION
## Summary
- skip selection re-render in competition mode when all catalogs are solved

## Testing
- `npm --version`
- `node tests/test_competition_mode.js`
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500bee646c832bac6b571f6a682bb7