### PR TITLE
Fix puzzle word on summary page

### DIFF
--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -28,5 +28,8 @@
 {% block scripts %}
   <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/custom-icons.js"></script>
+  <script>
+    window.quizConfig = {{ config|json_encode|raw }};
+  </script>
   <script src="/js/summary.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- include `window.quizConfig` in `summary.twig`

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68500e2fd3d8832ba4352f300a6fbce9