### PR TITLE
Add puzzle feedback editor

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -14,5 +14,6 @@
   "competitionMode": false,
   "teamResults": true,
   "puzzleWordEnabled": true,
-  "puzzleWord": ""
+  "puzzleWord": "",
+  "puzzleFeedback": ""
 }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -38,6 +38,24 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     return id;
   }
+
+  function updatePuzzleFeedbackUI() {
+    if (!puzzleBadge || !puzzleIcon || !puzzleLabel) return;
+    if (puzzleFeedback.trim().length > 0) {
+      puzzleBadge.textContent = 'Gesetzt';
+      puzzleBadge.classList.remove('uk-label-danger');
+      puzzleBadge.classList.add('uk-label-success');
+      puzzleIcon.setAttribute('uk-icon', 'icon: check');
+      puzzleLabel.textContent = 'Feedbacktext bearbeiten';
+    } else {
+      puzzleBadge.textContent = 'Kein Text';
+      puzzleBadge.classList.remove('uk-label-success');
+      puzzleBadge.classList.add('uk-label-danger');
+      puzzleIcon.setAttribute('uk-icon', 'icon: pencil');
+      puzzleLabel.textContent = 'Feedbacktext eingeben';
+    }
+    UIkit.icon(puzzleIcon, { icon: puzzleIcon.getAttribute('uk-icon').split(': ')[1] });
+  }
   // --------- Konfiguration bearbeiten ---------
   // Ausgangswerte aus der bestehenden Konfiguration
   const cfgInitial = window.quizConfig || {};
@@ -59,6 +77,14 @@ document.addEventListener('DOMContentLoaded', function () {
     puzzleWord: document.getElementById('cfgPuzzleWord'),
     puzzleWrap: document.getElementById('cfgPuzzleWordWrap')
   };
+  const puzzleFeedbackBtn = document.getElementById('puzzleFeedbackBtn');
+  const puzzleBadge = document.getElementById('puzzleFeedbackBadge');
+  const puzzleIcon = document.getElementById('puzzleFeedbackIcon');
+  const puzzleLabel = document.getElementById('puzzleFeedbackLabel');
+  const puzzleTextarea = document.getElementById('puzzleFeedbackTextarea');
+  const puzzleSaveBtn = document.getElementById('puzzleFeedbackSave');
+  const puzzleModal = UIkit.modal('#puzzleFeedbackModal');
+  let puzzleFeedback = '';
   let logoUploaded = false;
   if (cfgFields.logoFile && cfgFields.logoPreview) {
     const bar = document.getElementById('cfgLogoProgress');
@@ -121,6 +147,8 @@ document.addEventListener('DOMContentLoaded', function () {
     if (cfgFields.puzzleWord) {
       cfgFields.puzzleWord.value = data.puzzleWord || '';
     }
+    puzzleFeedback = data.puzzleFeedback || '';
+    updatePuzzleFeedbackUI();
     if (cfgFields.puzzleWrap) {
       cfgFields.puzzleWrap.style.display = cfgFields.puzzleEnabled.checked ? '' : 'none';
     }
@@ -133,6 +161,17 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
   }
+  puzzleFeedbackBtn?.addEventListener('click', () => {
+    if (puzzleTextarea) {
+      puzzleTextarea.value = puzzleFeedback;
+    }
+  });
+  puzzleSaveBtn?.addEventListener('click', () => {
+    if (!puzzleTextarea) return;
+    puzzleFeedback = puzzleTextarea.value;
+    updatePuzzleFeedbackUI();
+    puzzleModal.hide();
+  });
   document.getElementById('cfgResetBtn').addEventListener('click', function (e) {
     e.preventDefault();
     renderCfg(cfgInitial);
@@ -158,7 +197,8 @@ document.addEventListener('DOMContentLoaded', function () {
       competitionMode: cfgFields.competitionMode ? cfgFields.competitionMode.checked : cfgInitial.competitionMode,
       teamResults: cfgFields.teamResults ? cfgFields.teamResults.checked : cfgInitial.teamResults,
       puzzleWordEnabled: cfgFields.puzzleEnabled ? cfgFields.puzzleEnabled.checked : cfgInitial.puzzleWordEnabled,
-      puzzleWord: cfgFields.puzzleWord ? cfgFields.puzzleWord.value.trim() : cfgInitial.puzzleWord
+      puzzleWord: cfgFields.puzzleWord ? cfgFields.puzzleWord.value.trim() : cfgInitial.puzzleWord,
+      puzzleFeedback: puzzleFeedback
     });
     fetch('/config.json', {
       method: 'POST',

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -33,5 +33,6 @@ window.quizConfig = {
 
   // Rätselwort aktivieren und Begriff festlegen
   puzzleWordEnabled: true,
-  puzzleWord: ''
+  puzzleWord: '',
+  puzzleFeedback: ''
 };

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -824,7 +824,8 @@ function runQuiz(questions){
       const expected = (window.quizConfig && window.quizConfig.puzzleWord) ? window.quizConfig.puzzleWord.toLowerCase() : '';
       const val = (input.value || '').trim().toLowerCase();
       if(val && val === expected){
-        feedback.textContent = 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
+        const custom = (window.quizConfig && window.quizConfig.puzzleFeedback) ? window.quizConfig.puzzleFeedback.trim() : '';
+        feedback.textContent = custom || 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
         feedback.className = 'uk-margin-top uk-text-center uk-text-success';
       }else{
         feedback.textContent = 'Das ist leider nicht korrekt. Versuch es noch einmal!';

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -81,7 +81,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const expected = (window.quizConfig && window.quizConfig.puzzleWord) ? window.quizConfig.puzzleWord.toLowerCase() : '';
       const val = (input.value || '').trim().toLowerCase();
       if(val && val === expected){
-        feedback.textContent = 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
+        const custom = (window.quizConfig && window.quizConfig.puzzleFeedback) ? window.quizConfig.puzzleFeedback.trim() : '';
+        feedback.textContent = custom || 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
         feedback.className = 'uk-margin-top uk-text-center uk-text-success';
       }else{
         feedback.textContent = 'Das ist leider nicht korrekt. Versuch es noch einmal!';

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -152,6 +152,11 @@
                 </label>
                 <div id="cfgPuzzleWordWrap" class="uk-margin-small-top">
                   <input class="uk-input" type="text" id="cfgPuzzleWord" placeholder="Rätselwort">
+                  <button id="puzzleFeedbackBtn" class="uk-button uk-button-default uk-margin-small-top" type="button" uk-toggle="target: #puzzleFeedbackModal">
+                    <span id="puzzleFeedbackIcon" uk-icon="icon: pencil"></span>
+                    <span id="puzzleFeedbackLabel">Feedbacktext eingeben</span>
+                    <span id="puzzleFeedbackBadge" class="uk-label uk-label-danger uk-margin-small-left">Kein Text</span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -161,6 +166,17 @@
           <button id="cfgResetBtn" class="uk-button uk-button-default" uk-tooltip="title: Setzt alle Felder auf gespeicherte Werte zurück; pos: right">Zurücksetzen</button>
           <div>
             <button id="cfgSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Einstellungen speichern; pos: right">Speichern</button>
+          </div>
+        </div>
+
+        <div id="puzzleFeedbackModal" uk-modal>
+          <div class="uk-modal-dialog uk-modal-body">
+            <h2 class="uk-modal-title">Feedbacktext für das Rätselwort</h2>
+            <textarea id="puzzleFeedbackTextarea" class="uk-textarea" rows="5" placeholder="Feedbacktext eingeben..."></textarea>
+            <div class="uk-flex uk-flex-right uk-margin-top">
+              <button id="puzzleFeedbackSave" class="uk-button uk-button-primary" type="button">Speichern</button>
+              <button class="uk-button uk-button-default uk-modal-close" type="button">Abbrechen</button>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- allow admins to edit puzzle feedback through a modal dialog
- save the feedback text to config
- display custom feedback after correct riddle word entry

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850084d20d8832b8c3f01a42d84b6ca