### PR TITLE
Fix puzzle feedback display

### DIFF
--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -79,15 +79,16 @@ document.addEventListener('DOMContentLoaded', () => {
     UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
     if(!solvedBefore) UIkit.util.on(modal, 'shown', () => { input.focus(); });
     const expected = (window.quizConfig && window.quizConfig.puzzleWord) ? window.quizConfig.puzzleWord : '';
+    const custom = (window.quizConfig && window.quizConfig.puzzleFeedback) ? window.quizConfig.puzzleFeedback.trim() : '';
     if(solvedBefore){
-      feedback.innerHTML = 'Du hast das Rätselwort bereits gelöst:<br><strong>' + expected + '</strong><br>Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
+      feedback.innerHTML = 'Du hast das Rätselwort bereits gelöst:<br><strong>' + expected + '</strong><br>' + (custom || 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!');
       feedback.className = 'uk-margin-top uk-text-center uk-text-success';
       btn.addEventListener('click', () => ui.hide());
     }else{
       btn.addEventListener('click', () => {
         const val = (input.value || '').trim().toLowerCase();
         if(val && val === expected.toLowerCase()){
-          feedback.textContent = 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
+          feedback.textContent = custom || 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
           feedback.className = 'uk-margin-top uk-text-center uk-text-success';
           sessionStorage.setItem('puzzleSolved', 'true');
           input.disabled = true;


### PR DESCRIPTION
## Summary
- show custom puzzle feedback when verifying the puzzle word in the summary view

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*
- `vendor/bin/phpcs` *(fails: command not found)*
- `vendor/bin/phpstan analyse` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685015fe66dc832b90f7caf730234b5a