### PR TITLE
Adjust puzzle input layout

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -150,13 +150,17 @@
                 <label><input class="uk-checkbox" type="checkbox" id="cfgPuzzleEnabled"> Rätselwort
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Blendet Buchstaben für das Rätselwort ein und speichert den vollständigen Begriff.; pos: right"></span>
                 </label>
-                <div id="cfgPuzzleWordWrap" class="uk-margin-small-top">
-                  <input class="uk-input" type="text" id="cfgPuzzleWord" placeholder="Rätselwort">
-                  <button id="puzzleFeedbackBtn" class="uk-button uk-button-default uk-margin-small-top" type="button" uk-toggle="target: #puzzleFeedbackModal">
-                    <span id="puzzleFeedbackIcon" uk-icon="icon: pencil"></span>
-                    <span id="puzzleFeedbackLabel">Feedbacktext eingeben</span>
-                    <span id="puzzleFeedbackBadge" class="uk-label uk-label-danger uk-margin-small-left">Kein Text</span>
-                  </button>
+                <div id="cfgPuzzleWordWrap" class="uk-margin-small-top uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small" uk-grid>
+                  <div>
+                    <input class="uk-input" type="text" id="cfgPuzzleWord" placeholder="Rätselwort">
+                  </div>
+                  <div>
+                    <button id="puzzleFeedbackBtn" class="uk-button uk-button-default uk-margin-small-top uk-margin-remove-top@m" type="button" uk-toggle="target: #puzzleFeedbackModal">
+                      <span id="puzzleFeedbackIcon" uk-icon="icon: pencil"></span>
+                      <span id="puzzleFeedbackLabel">Feedbacktext eingeben</span>
+                      <span id="puzzleFeedbackBadge" class="uk-label uk-label-danger uk-margin-small-left">Kein Text</span>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- display puzzle word input and feedback button side by side on large screens

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685016a04e78832b911119a875209b30