### PR TITLE
Fix puzzle word container layout

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -150,7 +150,7 @@
                 <label><input class="uk-checkbox" type="checkbox" id="cfgPuzzleEnabled"> Rätselwort
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Blendet Buchstaben für das Rätselwort ein und speichert den vollständigen Begriff.; pos: right"></span>
                 </label>
-                <div id="cfgPuzzleWordWrap" class="uk-margin-small-top uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small" uk-grid>
+                <div id="cfgPuzzleWordWrap" class="uk-margin-small-top uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small uk-flex-top@m" uk-grid>
                   <div>
                     <input class="uk-input" type="text" id="cfgPuzzleWord" placeholder="Rätselwort">
                   </div>


### PR DESCRIPTION
## Summary
- keep puzzle word inputs aligned at the top on large screens

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685019efb994832bbadca853709b15d3