### PR TITLE
Track puzzle word completion time

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -831,6 +831,13 @@ function runQuiz(questions){
         feedback.textContent = custom || 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
         feedback.className = 'uk-margin-top uk-text-center uk-text-success';
         sessionStorage.setItem('puzzleSolved', 'true');
+        const user = sessionStorage.getItem('quizUser') || '';
+        const catalog = sessionStorage.getItem('quizCatalog') || 'unknown';
+        fetch('/results', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: user, catalog, puzzleTime: Math.floor(Date.now()/1000) })
+        }).catch(()=>{});
       }else{
         feedback.textContent = 'Das ist leider nicht korrekt. Versuch es erneut!';
         feedback.className = 'uk-margin-top uk-text-center uk-text-danger';

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!groups.length) {
       const tr = document.createElement('tr');
       const td = document.createElement('td');
-      td.colSpan = 5;
+      td.colSpan = 6;
       td.textContent = 'Keine Daten';
       tr.appendChild(td);
       tbody.appendChild(tr);
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
     groups.forEach(g => {
       const head = document.createElement('tr');
       const th = document.createElement('th');
-      th.colSpan = 5;
+      th.colSpan = 6;
       th.textContent = g.name;
       head.appendChild(th);
       tbody.appendChild(head);
@@ -34,7 +34,8 @@ document.addEventListener('DOMContentLoaded', () => {
           r.attempt,
           r.catalog,
           `${r.correct}/${r.total}`,
-          formatTime(r.time)
+          formatTime(r.time),
+          r.puzzleTime ? formatTime(r.puzzleTime) : ''
         ];
         const nameCell = document.createElement('td');
         nameCell.textContent = r.name;

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -91,6 +91,13 @@ document.addEventListener('DOMContentLoaded', () => {
           feedback.textContent = custom || 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
           feedback.className = 'uk-margin-top uk-text-center uk-text-success';
           sessionStorage.setItem('puzzleSolved', 'true');
+          const userName = sessionStorage.getItem('quizUser') || '';
+          const catalog = sessionStorage.getItem('quizCatalog') || 'unknown';
+          fetch('/results', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: userName, catalog, puzzleTime: Math.floor(Date.now()/1000) })
+          }).catch(()=>{});
           input.disabled = true;
           btn.textContent = 'Schließen';
         }else{

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -32,7 +32,7 @@ class ResultController
     {
         $data = $this->service->getAll();
         $rows = [];
-        $rows[] = ['Name', 'Versuch', 'Katalog', 'Richtige', 'Gesamt', 'Zeit'];
+        $rows[] = ['Name', 'Versuch', 'Katalog', 'Richtige', 'Gesamt', 'Zeit', 'Rätselwort'];
         foreach ($data as $r) {
             $rows[] = [
                 (string)($r['name'] ?? ''),
@@ -41,6 +41,7 @@ class ResultController
                 (int)($r['correct'] ?? 0),
                 (int)($r['total'] ?? 0),
                 date('Y-m-d H:i', (int)($r['time'] ?? 0)),
+                isset($r['puzzleTime']) ? date('Y-m-d H:i', (int)$r['puzzleTime']) : ''
             ];
         }
         // prepend UTF-8 BOM for better compatibility with spreadsheet tools
@@ -59,7 +60,14 @@ class ResultController
     {
         $data = json_decode((string) $request->getBody(), true);
         if (is_array($data)) {
-            $this->service->add($data);
+            if (isset($data['puzzleTime'])) {
+                $name = (string)($data['name'] ?? '');
+                $catalog = (string)($data['catalog'] ?? '');
+                $time = (int)$data['puzzleTime'];
+                $this->service->markPuzzle($name, $catalog, $time);
+            } else {
+                $this->service->add($data);
+            }
         }
         return $response->withStatus(204);
     }

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -43,6 +43,8 @@ class ResultService
             'correct' => (int)($data['correct'] ?? 0),
             'total' => (int)($data['total'] ?? 0),
             'time' => time(),
+            // optional timestamp when the puzzle word was solved
+            'puzzleTime' => isset($data['puzzleTime']) ? (int)$data['puzzleTime'] : null,
         ];
         $results[] = $entry;
         file_put_contents($this->path, json_encode($results, JSON_PRETTY_PRINT) . "\n");
@@ -52,5 +54,19 @@ class ResultService
     public function clear(): void
     {
         file_put_contents($this->path, "[]\n");
+    }
+
+    public function markPuzzle(string $name, string $catalog, int $time): void
+    {
+        $results = $this->getAll();
+        for ($i = count($results) - 1; $i >= 0; $i--) {
+            if (($results[$i]['name'] ?? '') === $name && ($results[$i]['catalog'] ?? '') === $catalog) {
+                if (!isset($results[$i]['puzzleTime'])) {
+                    $results[$i]['puzzleTime'] = $time;
+                    file_put_contents($this->path, json_encode($results, JSON_PRETTY_PRINT) . "\n");
+                }
+                break;
+            }
+        }
     }
 }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -269,7 +269,7 @@
         <div style="overflow-x: auto">
         <table class="uk-table uk-table-divider uk-table-responsive">
           <thead>
-            <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th></tr>
+            <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th><th>Rätselwort gelöst</th></tr>
           </thead>
           <tbody id="resultsTableBody">
             {% for r in results %}
@@ -279,9 +279,10 @@
               <td>{{ r.catalog }}</td>
               <td>{{ r.correct }}/{{ r.total }}</td>
               <td>{{ r.time | date('Y-m-d H:i') }}</td>
+              <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>
             </tr>
             {% else %}
-            <tr><td colspan="5">Keine Daten</td></tr>
+            <tr><td colspan="6">Keine Daten</td></tr>
             {% endfor %}
           </tbody>
         </table>

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -21,7 +21,7 @@
     </div>
     <table class="uk-table uk-table-divider">
       <thead>
-        <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th></tr>
+        <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th><th>Rätselwort gelöst</th></tr>
       </thead>
       <tbody id="resultsTableBody">
         {% for r in results %}
@@ -31,9 +31,10 @@
           <td>{{ r.catalog }}</td>
           <td>{{ r.correct }}/{{ r.total }}</td>
           <td>{{ r.time | date('Y-m-d H:i') }}</td>
+          <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>
         </tr>
         {% else %}
-        <tr><td colspan="5">Keine Daten</td></tr>
+        <tr><td colspan="6">Keine Daten</td></tr>
         {% endfor %}
       </tbody>
     </table>

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -36,4 +36,19 @@ class ResultServiceTest extends TestCase
 
         unlink($tmp);
     }
+
+    public function testMarkPuzzleUpdatesEntry(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'results');
+        $service = new ResultService($tmp);
+
+        $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
+        $ts = time();
+        $service->markPuzzle('TeamA', 'cat1', $ts);
+        $data = $service->getAll();
+
+        $this->assertSame($ts, $data[0]['puzzleTime']);
+
+        unlink($tmp);
+    }
 }


### PR DESCRIPTION
## Summary
- record optional `puzzleTime` for quiz results
- expose puzzle time in CSV export and results page templates
- update JS to display new column and send puzzle completion data
- add service method and unit tests for puzzle time updates

## Testing
- `vendor/bin/phpunit` *(fails: file not found)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68501bd3a564832ba3a506e41b7e492a