### PR TITLE
Add summary link when quiz finished

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -222,12 +222,12 @@ function runQuiz(questions){
         }
       }
       if(total !== null && solved.length === total){
-        const btn = document.createElement('button');
-        btn.className = 'uk-button uk-button-primary uk-margin-top';
-        btn.textContent = 'Ergebnisübersicht';
-        styleButton(btn);
-        btn.addEventListener('click', () => showResultsOverview(user));
-        summaryEl.appendChild(btn);
+        const link = document.createElement('a');
+        link.href = '/summary';
+        link.className = 'uk-button uk-button-primary uk-margin-top';
+        link.textContent = 'Ergebnisübersicht';
+        styleButton(link);
+        summaryEl.appendChild(link);
       }
     }
 


### PR DESCRIPTION
## Summary
- link to `/summary` page when all catalogs are solved

## Testing
- `vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501ff0b078832bba9c64b870ba18a4