### PR TITLE
Add evidence photo upload

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -262,6 +262,12 @@ body.dark-mode .sticky-actions {
   background-color: #fff;
 }
 
+.proof-thumb {
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+}
+
 .js-upload {
   min-height: 240px;
   display: flex;

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -242,6 +242,17 @@ function runQuiz(questions){
         summaryEl.appendChild(puzzleBtn);
       }
     }
+
+    const photoBtn = document.createElement('button');
+    photoBtn.className = 'uk-button uk-button-primary uk-margin-top';
+    photoBtn.textContent = 'Beweisfoto einreichen';
+    styleButton(photoBtn);
+    photoBtn.addEventListener('click', () => {
+      const name = sessionStorage.getItem('quizUser') || '';
+      const catalogName = sessionStorage.getItem('quizCatalog') || 'unknown';
+      showPhotoModal(name, catalogName);
+    });
+    summaryEl.appendChild(photoBtn);
   }
 
   // Wählt basierend auf dem Fragetyp die passende Erzeugerfunktion aus
@@ -849,6 +860,45 @@ function runQuiz(questions){
         btnEl.disabled = true;
         btnEl.style.display = 'none';
       }
+    });
+    ui.show();
+  }
+
+  function showPhotoModal(name, catalog){
+    const modal = document.createElement('div');
+    modal.setAttribute('uk-modal', '');
+    modal.setAttribute('aria-modal', 'true');
+    modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">' +
+      '<h3 class="uk-modal-title uk-text-center">Beweisfoto einreichen</h3>' +
+      '<input id="photo-input" class="uk-input" type="file" accept="image/*" capture="environment">' +
+      '<div id="photo-feedback" class="uk-margin-top uk-text-center"></div>' +
+      '<button class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Hochladen</button>' +
+      '</div>';
+    const input = modal.querySelector('#photo-input');
+    const feedback = modal.querySelector('#photo-feedback');
+    const btn = modal.querySelector('button');
+    document.body.appendChild(modal);
+    const ui = UIkit.modal(modal);
+    UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
+    btn.addEventListener('click', () => {
+      const file = input.files && input.files[0];
+      if(!file) return;
+      const fd = new FormData();
+      fd.append('photo', file);
+      fd.append('name', name);
+      fd.append('catalog', catalog);
+      fetch('/photos', { method: 'POST', body: fd })
+        .then(r => r.ok ? r.json() : Promise.reject())
+        .then(() => {
+          feedback.textContent = 'Foto gespeichert';
+          feedback.className = 'uk-margin-top uk-text-center uk-text-success';
+          btn.disabled = true;
+          input.disabled = true;
+        })
+        .catch(() => {
+          feedback.textContent = 'Fehler beim Hochladen';
+          feedback.className = 'uk-margin-top uk-text-center uk-text-danger';
+        });
     });
     ui.show();
   }

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!groups.length) {
       const tr = document.createElement('tr');
       const td = document.createElement('td');
-      td.colSpan = 6;
+      td.colSpan = 7;
       td.textContent = 'Keine Daten';
       tr.appendChild(td);
       tbody.appendChild(tr);
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
     groups.forEach(g => {
       const head = document.createElement('tr');
       const th = document.createElement('th');
-      th.colSpan = 6;
+      th.colSpan = 7;
       th.textContent = g.name;
       head.appendChild(th);
       tbody.appendChild(head);
@@ -35,14 +35,25 @@ document.addEventListener('DOMContentLoaded', () => {
           r.catalog,
           `${r.correct}/${r.total}`,
           formatTime(r.time),
-          r.puzzleTime ? formatTime(r.puzzleTime) : ''
+          r.puzzleTime ? formatTime(r.puzzleTime) : '',
+          null
         ];
         const nameCell = document.createElement('td');
         nameCell.textContent = r.name;
         tr.appendChild(nameCell);
-        cells.forEach(c => {
+        cells.forEach((c, idx) => {
           const td = document.createElement('td');
-          td.textContent = c;
+          if (idx === cells.length - 1) {
+            if (r.photo) {
+              const img = document.createElement('img');
+              img.src = r.photo;
+              img.alt = 'Beweisfoto';
+              img.className = 'proof-thumb';
+              td.appendChild(img);
+            }
+          } else {
+            td.textContent = c;
+          }
           tr.appendChild(td);
         });
         tbody.appendChild(tr);

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const resultsBtn = document.getElementById('show-results-btn');
   const puzzleBtn = document.getElementById('check-puzzle-btn');
+  const photoBtn = document.getElementById('upload-photo-btn');
   const user = sessionStorage.getItem('quizUser') || '';
 
   function showResults(){
@@ -110,6 +111,46 @@ document.addEventListener('DOMContentLoaded', () => {
     ui.show();
   }
 
+  function showPhotoModal(){
+    const modal = document.createElement('div');
+    modal.setAttribute('uk-modal', '');
+    modal.setAttribute('aria-modal', 'true');
+    modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">' +
+      '<h3 class="uk-modal-title uk-text-center">Beweisfoto einreichen</h3>' +
+      '<input id="photo-input" class="uk-input" type="file" accept="image/*" capture="environment">' +
+      '<div id="photo-feedback" class="uk-margin-top uk-text-center"></div>' +
+      '<button class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Hochladen</button>' +
+      '</div>';
+    const input = modal.querySelector('#photo-input');
+    const feedback = modal.querySelector('#photo-feedback');
+    const btn = modal.querySelector('button');
+    document.body.appendChild(modal);
+    const ui = UIkit.modal(modal);
+    UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
+    btn.addEventListener('click', () => {
+      const file = input.files && input.files[0];
+      if(!file) return;
+      const fd = new FormData();
+      fd.append('photo', file);
+      fd.append('name', user);
+      fd.append('catalog', 'summary');
+      fetch('/photos', { method: 'POST', body: fd })
+        .then(r => r.ok ? r.json() : Promise.reject())
+        .then(() => {
+          feedback.textContent = 'Foto gespeichert';
+          feedback.className = 'uk-margin-top uk-text-center uk-text-success';
+          btn.disabled = true;
+          input.disabled = true;
+        })
+        .catch(() => {
+          feedback.textContent = 'Fehler beim Hochladen';
+          feedback.className = 'uk-margin-top uk-text-center uk-text-danger';
+        });
+    });
+    ui.show();
+  }
+
   resultsBtn?.addEventListener('click', showResults);
   puzzleBtn?.addEventListener('click', showPuzzle);
+  photoBtn?.addEventListener('click', showPhotoModal);
 });

--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\ResultService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class EvidenceController
+{
+    private ResultService $results;
+    private string $dir;
+
+    public function __construct(ResultService $results, string $dir)
+    {
+        $this->results = $results;
+        $this->dir = rtrim($dir, '/');
+    }
+
+    public function post(Request $request, Response $response): Response
+    {
+        $files = $request->getUploadedFiles();
+        if (!isset($files['photo'])) {
+            return $response->withStatus(400);
+        }
+        $file = $files['photo'];
+        if ($file->getError() !== UPLOAD_ERR_OK) {
+            return $response->withStatus(400);
+        }
+        $ext = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
+        if (!in_array($ext, ['jpg', 'jpeg', 'png', 'webp'], true)) {
+            return $response->withStatus(400);
+        }
+        if (!is_dir($this->dir)) {
+            mkdir($this->dir, 0777, true);
+        }
+        $name = 'photo_' . time() . '_' . bin2hex(random_bytes(4)) . '.' . $ext;
+        $target = $this->dir . '/' . $name;
+        $file->moveTo($target);
+
+        $parsed = $request->getParsedBody() ?? [];
+        $user = isset($parsed['name']) ? (string)$parsed['name'] : '';
+        $catalog = isset($parsed['catalog']) ? (string)$parsed['catalog'] : '';
+        $path = '/photo/' . $name;
+        if ($user !== '' && $catalog !== '') {
+            $this->results->setPhoto($user, $catalog, $path);
+        }
+
+        $response->getBody()->write(json_encode(['path' => $path]));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    public function get(Request $request, Response $response, array $args = []): Response
+    {
+        $file = basename((string)($args['name'] ?? ''));
+        $path = $this->dir . '/' . $file;
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+        $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        $type = match ($ext) {
+            'jpg', 'jpeg' => 'image/jpeg',
+            'png' => 'image/png',
+            'webp' => 'image/webp',
+            default => 'application/octet-stream'
+        };
+        $response->getBody()->write((string)file_get_contents($path));
+        return $response->withHeader('Content-Type', $type);
+    }
+}

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -32,7 +32,7 @@ class ResultController
     {
         $data = $this->service->getAll();
         $rows = [];
-        $rows[] = ['Name', 'Versuch', 'Katalog', 'Richtige', 'Gesamt', 'Zeit', 'Rätselwort'];
+        $rows[] = ['Name', 'Versuch', 'Katalog', 'Richtige', 'Gesamt', 'Zeit', 'Rätselwort', 'Beweisfoto'];
         foreach ($data as $r) {
             $rows[] = [
                 (string)($r['name'] ?? ''),
@@ -41,7 +41,8 @@ class ResultController
                 (int)($r['correct'] ?? 0),
                 (int)($r['total'] ?? 0),
                 date('Y-m-d H:i', (int)($r['time'] ?? 0)),
-                isset($r['puzzleTime']) ? date('Y-m-d H:i', (int)$r['puzzleTime']) : ''
+                isset($r['puzzleTime']) ? date('Y-m-d H:i', (int)$r['puzzleTime']) : '',
+                (string)($r['photo'] ?? '')
             ];
         }
         // prepend UTF-8 BOM for better compatibility with spreadsheet tools

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -45,6 +45,7 @@ class ResultService
             'time' => time(),
             // optional timestamp when the puzzle word was solved
             'puzzleTime' => isset($data['puzzleTime']) ? (int)$data['puzzleTime'] : null,
+            'photo' => isset($data['photo']) ? (string)$data['photo'] : null,
         ];
         $results[] = $entry;
         file_put_contents($this->path, json_encode($results, JSON_PRETTY_PRINT) . "\n");
@@ -65,6 +66,18 @@ class ResultService
                     $results[$i]['puzzleTime'] = $time;
                     file_put_contents($this->path, json_encode($results, JSON_PRETTY_PRINT) . "\n");
                 }
+                break;
+            }
+        }
+    }
+
+    public function setPhoto(string $name, string $catalog, string $path): void
+    {
+        $results = $this->getAll();
+        for ($i = count($results) - 1; $i >= 0; $i--) {
+            if (($results[$i]['name'] ?? '') === $name && ($results[$i]['catalog'] ?? '') === $catalog) {
+                $results[$i]['photo'] = $path;
+                file_put_contents($this->path, json_encode($results, JSON_PRETTY_PRINT) . "\n");
                 break;
             }
         }

--- a/src/routes.php
+++ b/src/routes.php
@@ -24,6 +24,7 @@ use App\Controller\PasswordController;
 use App\Controller\QrController;
 use App\Controller\LogoController;
 use App\Controller\SummaryController;
+use App\Controller\EvidenceController;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
@@ -42,6 +43,7 @@ require_once __DIR__ . '/Controller/AdminCatalogController.php';
 require_once __DIR__ . '/Controller/QrController.php';
 require_once __DIR__ . '/Controller/LogoController.php';
 require_once __DIR__ . '/Controller/SummaryController.php';
+require_once __DIR__ . '/Controller/EvidenceController.php';
 
 return function (\Slim\App $app) {
     $configService = new ConfigService(
@@ -60,6 +62,7 @@ return function (\Slim\App $app) {
     $qrController = new QrController();
     $logoController = new LogoController($configService);
     $summaryController = new SummaryController($configService);
+    $evidenceController = new EvidenceController($resultService, __DIR__ . '/../data/photos');
 
     $app->get('/', HomeController::class);
     $app->get('/favicon.ico', function (Request $request, Response $response) {
@@ -100,5 +103,7 @@ return function (\Slim\App $app) {
     $app->post('/logo.png', [$logoController, 'post']);
     $app->get('/logo.webp', [$logoController, 'get'])->setArgument('ext', 'webp');
     $app->post('/logo.webp', [$logoController, 'post']);
+    $app->post('/photos', [$evidenceController, 'post']);
+    $app->get('/photo/{name}', [$evidenceController, 'get']);
     $app->get('/summary', $summaryController);
 };

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -21,7 +21,7 @@
     </div>
     <table class="uk-table uk-table-divider">
       <thead>
-        <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th><th>Rätselwort gelöst</th></tr>
+        <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th><th>Rätselwort gelöst</th><th>Beweisfoto</th></tr>
       </thead>
       <tbody id="resultsTableBody">
         {% for r in results %}
@@ -32,9 +32,10 @@
           <td>{{ r.correct }}/{{ r.total }}</td>
           <td>{{ r.time | date('Y-m-d H:i') }}</td>
           <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>
+          <td>{% if r.photo is defined and r.photo %}<img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb">{% endif %}</td>
         </tr>
         {% else %}
-        <tr><td colspan="6">Keine Daten</td></tr>
+        <tr><td colspan="7">Keine Daten</td></tr>
         {% endfor %}
       </tbody>
     </table>

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -30,6 +30,7 @@
   <div class="uk-container uk-container-small uk-text-center">
     <h2 class="uk-heading-bullet">Herzlichen Glückwunsch, du hast alle Kataloge gelöst!</h2>
     <button id="show-results-btn" class="uk-button uk-button-primary uk-margin-top">Ergebnisse anzeigen</button>
+    <button id="upload-photo-btn" class="uk-button uk-button-primary uk-margin-top">Beweisfoto einreichen</button>
     {% if config.puzzleWordEnabled %}
     <button id="check-puzzle-btn" class="uk-button uk-button-primary uk-margin-top">Rätselwort prüfen</button>
     {% endif %}

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -51,4 +51,18 @@ class ResultServiceTest extends TestCase
 
         unlink($tmp);
     }
+
+    public function testSetPhotoUpdatesEntry(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'results');
+        $service = new ResultService($tmp);
+
+        $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
+        $service->setPhoto('TeamA', 'cat1', '/photo/test.jpg');
+        $data = $service->getAll();
+
+        $this->assertSame('/photo/test.jpg', $data[0]['photo']);
+
+        unlink($tmp);
+    }
 }


### PR DESCRIPTION
## Summary
- allow results to have an optional photo
- add upload API and button for providing proof photos
- show miniature photo previews in results table
- style proof thumbnail images
- tests for new ResultService `setPhoto`

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685021f42a88832b87c5d54764a96dc4