### PR TITLE
Simplify puzzle feedback UI

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -40,17 +40,11 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function updatePuzzleFeedbackUI() {
-    if (!puzzleBadge || !puzzleIcon || !puzzleLabel) return;
+    if (!puzzleIcon || !puzzleLabel) return;
     if (puzzleFeedback.trim().length > 0) {
-      puzzleBadge.textContent = 'Gesetzt';
-      puzzleBadge.classList.remove('uk-label-danger');
-      puzzleBadge.classList.add('uk-label-success');
       puzzleIcon.setAttribute('uk-icon', 'icon: check');
       puzzleLabel.textContent = 'Feedbacktext bearbeiten';
     } else {
-      puzzleBadge.textContent = 'Kein Text';
-      puzzleBadge.classList.remove('uk-label-success');
-      puzzleBadge.classList.add('uk-label-danger');
       puzzleIcon.setAttribute('uk-icon', 'icon: pencil');
       puzzleLabel.textContent = 'Feedbacktext eingeben';
     }
@@ -78,7 +72,6 @@ document.addEventListener('DOMContentLoaded', function () {
     puzzleWrap: document.getElementById('cfgPuzzleWordWrap')
   };
   const puzzleFeedbackBtn = document.getElementById('puzzleFeedbackBtn');
-  const puzzleBadge = document.getElementById('puzzleFeedbackBadge');
   const puzzleIcon = document.getElementById('puzzleFeedbackIcon');
   const puzzleLabel = document.getElementById('puzzleFeedbackLabel');
   const puzzleTextarea = document.getElementById('puzzleFeedbackTextarea');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -158,7 +158,6 @@
                     <button id="puzzleFeedbackBtn" class="uk-button uk-button-default uk-margin-small-top uk-margin-remove-top@m" type="button" uk-toggle="target: #puzzleFeedbackModal">
                       <span id="puzzleFeedbackIcon" uk-icon="icon: pencil"></span>
                       <span id="puzzleFeedbackLabel">Feedbacktext eingeben</span>
-                      <span id="puzzleFeedbackBadge" class="uk-label uk-label-danger uk-margin-small-left">Kein Text</span>
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- streamline puzzle feedback layout in admin
- remove badge for puzzle feedback status

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6850230c4958832bb79c57901a0d193e