### PR TITLE
Persist puzzle feedback in config

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -164,6 +164,16 @@ document.addEventListener('DOMContentLoaded', function () {
     puzzleFeedback = puzzleTextarea.value;
     updatePuzzleFeedbackUI();
     puzzleModal.hide();
+    cfgInitial.puzzleFeedback = puzzleFeedback;
+    fetch('/config.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(cfgInitial)
+    }).then(r => {
+      if (r.ok) {
+        notify('Feedbacktext gespeichert', 'success');
+      }
+    }).catch(() => {});
   });
   document.getElementById('cfgResetBtn').addEventListener('click', function (e) {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- store puzzle feedback in cfgInitial
- persist puzzle feedback to `/config.json` when closing the modal
- notify the admin when the text is saved

## Testing
- `node tests/test_competition_mode.js`
- `pytest tests/test_json_validity.py`
- `pytest tests/test_html_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685028929930832ba705a64934c03676