### PR TITLE
Display puzzle solution time

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -233,7 +233,24 @@ function runQuiz(questions){
 
     if(cfg.puzzleWordEnabled){
       const attemptKey = 'puzzleAttempt-' + catalog;
-      if(!sessionStorage.getItem(attemptKey)){
+      const puzzleSolved = sessionStorage.getItem('puzzleSolved') === 'true';
+      if(puzzleSolved){
+        fetch('/results.json').then(r => r.json()).then(list => {
+          if(Array.isArray(list)){
+            const name = sessionStorage.getItem('quizUser') || '';
+            const entry = list.slice().reverse().find(e => e.name === name && e.catalog === catalog && e.puzzleTime);
+            if(entry && entry.puzzleTime){
+              const d = new Date(entry.puzzleTime * 1000);
+              const pad = n => n.toString().padStart(2, '0');
+              const ts = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+              const info = document.createElement('p');
+              info.textContent = `Rätselwort gelöst: ${ts}`;
+              summaryEl.appendChild(info);
+            }
+          }
+        }).catch(()=>{});
+      }
+      if(!puzzleSolved && !sessionStorage.getItem(attemptKey)){
         const puzzleBtn = document.createElement('button');
         puzzleBtn.className = 'uk-button uk-button-primary uk-margin-top';
         puzzleBtn.textContent = 'Rätselwort überprüfen';


### PR DESCRIPTION
## Summary
- add logic to show when the puzzle word was solved
- only display puzzle check button when not solved yet

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_685031f0242c832b921579a7697916c8