### PR TITLE
Update puzzle modal to close after check

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -851,7 +851,7 @@ function runQuiz(questions){
     const ui = UIkit.modal(modal);
     UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
     UIkit.util.on(modal, 'shown', () => { input.focus(); });
-    btn.addEventListener('click', () => {
+    function handleCheck(){
       const expected = (window.quizConfig && window.quizConfig.puzzleWord) ? window.quizConfig.puzzleWord.toLowerCase() : '';
       const val = (input.value || '').trim().toLowerCase();
       if(val && val === expected){
@@ -870,14 +870,20 @@ function runQuiz(questions){
         feedback.textContent = 'Das ist leider nicht korrekt. Versuch es erneut!';
         feedback.className = 'uk-margin-top uk-text-center uk-text-danger';
       }
+
       input.disabled = true;
-      btn.disabled = true;
       if(attemptKey) sessionStorage.setItem(attemptKey, 'true');
       if(btnEl){
         btnEl.disabled = true;
         btnEl.style.display = 'none';
       }
-    });
+
+      btn.textContent = 'Schließen';
+      btn.removeEventListener('click', handleCheck);
+      btn.addEventListener('click', () => ui.hide());
+    }
+
+    btn.addEventListener('click', handleCheck);
     ui.show();
   }
 


### PR DESCRIPTION
## Summary
- adjust behaviour of the puzzle modal
- disable further editing after one try
- change button to close the modal

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68503326a974832b9ba518ac8845dcfa