### PR TITLE
Display puzzle solution timestamp

### DIFF
--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -2,11 +2,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const resultsBtn = document.getElementById('show-results-btn');
   const puzzleBtn = document.getElementById('check-puzzle-btn');
   const photoBtn = document.getElementById('upload-photo-btn');
+  const puzzleInfo = document.getElementById('puzzle-solved-text');
   const user = sessionStorage.getItem('quizUser') || '';
-  const puzzleInfo = document.createElement('p');
-  puzzleInfo.id = 'puzzle-info';
-  puzzleInfo.className = 'uk-margin-top';
-  puzzleBtn?.parentNode?.appendChild(puzzleInfo);
 
   const formatTs = window.formatPuzzleTime || function(ts){
     const d = new Date(ts * 1000);
@@ -24,13 +21,18 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   function updatePuzzleInfo(){
-    if(sessionStorage.getItem('puzzleSolved') !== 'true') return;
+    const solved = sessionStorage.getItem('puzzleSolved') === 'true';
     const catalog = sessionStorage.getItem('quizCatalog') || 'unknown';
-    fetchEntry(user, catalog).then(entry => {
-      if(entry && entry.puzzleTime){
-        puzzleInfo.textContent = `Rätselwort gelöst: ${formatTs(entry.puzzleTime)}`;
-      }
-    }).catch(()=>{});
+    if(solved){
+      puzzleBtn?.remove();
+      fetchEntry(user, catalog).then(entry => {
+        if(entry && entry.puzzleTime){
+          puzzleInfo.textContent = `Rätselwort gelöst: ${formatTs(entry.puzzleTime)}`;
+        }
+      }).catch(()=>{});
+    }else{
+      if(puzzleInfo) puzzleInfo.textContent = '';
+    }
   }
 
   function showResults(){
@@ -128,11 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ name: userName, catalog, puzzleTime: Math.floor(Date.now()/1000) })
           }).catch(()=>{});
-          fetchEntry(userName, catalog).then(entry => {
-            if(entry && entry.puzzleTime){
-              puzzleInfo.textContent = `Rätselwort gelöst: ${formatTs(entry.puzzleTime)}`;
-            }
-          }).catch(()=>{});
+          updatePuzzleInfo();
           input.disabled = true;
           btn.textContent = 'Schließen';
         }else{

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -33,6 +33,7 @@
     <button id="upload-photo-btn" class="uk-button uk-button-primary uk-margin-top">Beweisfoto einreichen</button>
     {% if config.puzzleWordEnabled %}
     <button id="check-puzzle-btn" class="uk-button uk-button-primary uk-margin-top">Rätselwort prüfen</button>
+    <p id="puzzle-solved-text" class="uk-margin-top"></p>
     {% endif %}
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show puzzle solved status element on summary page
- load timestamp from results and hide the puzzle button when solved

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850363f8874832b873714b7c3575584