### PR TITLE
Fix puzzle word inputs alignment

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -280,3 +280,11 @@ body.dark-mode .sticky-actions {
   font-weight: bold;
 }
 
+/* Puzzle word input and feedback button */
+#cfgPuzzleWordWrap .uk-input,
+#cfgPuzzleWordWrap .uk-button {
+  height: 44px;
+  line-height: 44px;
+  box-sizing: border-box;
+}
+

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -150,7 +150,7 @@
                 <label><input class="uk-checkbox" type="checkbox" id="cfgPuzzleEnabled"> Rätselwort
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Blendet Buchstaben für das Rätselwort ein und speichert den vollständigen Begriff.; pos: right"></span>
                 </label>
-                <div id="cfgPuzzleWordWrap" class="uk-margin-small-top uk-grid uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small" uk-grid uk-height-match="target: > div > *">
+                <div id="cfgPuzzleWordWrap" class="uk-margin-small-top uk-grid uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small uk-flex-middle" uk-grid>
                   <div class="uk-flex uk-flex-middle">
                     <input class="uk-input" type="text" id="cfgPuzzleWord" placeholder="Rätselwort">
                   </div>


### PR DESCRIPTION
## Summary
- align puzzle word input and button by using `uk-flex-middle`
- set consistent height for puzzle word fields

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850389ce700832b98e29b91c79057d9