### PR TITLE
Add rankings to results page

### DIFF
--- a/templates/results.twig
+++ b/templates/results.twig
@@ -19,6 +19,7 @@
       <h2 class="uk-heading-bullet">Ergebnisse</h2>
       <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="Aktualisieren" aria-label="Aktualisieren"></button>
     </div>
+    <div id="rankingGrid" class="uk-grid-small uk-child-width-1-1 uk-child-width-1-3@m uk-margin-bottom" uk-grid></div>
     <table class="uk-table uk-table-divider">
       <thead>
         <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th><th>Rätselwort gelöst</th><th>Beweisfoto</th></tr>


### PR DESCRIPTION
## Summary
- add ranking grid container
- compute and render ranking cards on results page
- show fastest puzzle word, fastest all catalogs, and high score rankings

## Testing
- `node tests/test_competition_mode.js`
- `python3 -m pytest -q`
- ❌ `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503cc97434832b944db4976e48c7f4