### PR TITLE
Fix broken summary page buttons

### DIFF
--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -150,7 +150,8 @@ document.addEventListener('DOMContentLoaded', () => {
     modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">' +
       '<h3 class="uk-modal-title uk-text-center">Beweisfoto einreichen</h3>' +
       '<p class="uk-text-small">Hinweis zum Hochladen von Gruppenfotos:<br>' +
-      'Mit dem Upload eines Gruppenfotos bestätigen Sie, dass alle abgebildeten Teammitglieder der Verwendung des Fotos im Rahmen des Teamtages zustimmen. Das Hochladen ist freiwillig. Die Fotos werden ausschließlich für die Dokumentation des Teamtages verwendet und nach der Veranstaltung von der Onlineplattform gelöscht.'</p>' +
+      'Mit dem Upload eines Gruppenfotos bestätigen Sie, dass alle abgebildeten Teammitglieder der Verwendung des Fotos im Rahmen des Teamtages zustimmen. Das Hochladen ist freiwillig. Die Fotos werden ausschließlich für die Dokumentation des Teamtages verwendet und nach der Veranstaltung von der Onlineplattform gelöscht.' +
+      '</p>' +
       '<select id="team-select" class="uk-select uk-margin-small-top">' +
       '<option value="">Team wählen</option>' +
       '</select>' +


### PR DESCRIPTION
## Summary
- fix summary modal HTML string concatenation

## Testing
- `vendor/bin/phpunit` *(fails: file not found)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_68505baaef40832b92b5a0fdad44710b