### PR TITLE
Improve ranking display

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -165,9 +165,10 @@ document.addEventListener('DOMContentLoaded', () => {
     grid.innerHTML = '';
     const cards = [
       { title: 'Rätselwort-Bestzeit', list: rankings.puzzleList },
-      { title: 'Katalog-Geschwindigkeitsmeister', list: rankings.catalogList },
+      { title: 'Katalogmeister', list: rankings.catalogList },
       { title: 'Highscore-Champions', list: rankings.pointsList }
     ];
+    const MAX_ITEMS = 3;
     cards.forEach(card => {
       const col = document.createElement('div');
       const c = document.createElement('div');
@@ -178,16 +179,11 @@ document.addEventListener('DOMContentLoaded', () => {
       c.appendChild(h);
       const ol = document.createElement('ol');
       ol.className = 'uk-list uk-list-decimal';
-      if (card.list.length === 0) {
+      for (let i = 0; i < MAX_ITEMS; i++) {
         const li = document.createElement('li');
-        li.textContent = 'Keine Daten';
+        const item = card.list[i];
+        li.textContent = item ? `${item.name} – ${item.value}` : '-';
         ol.appendChild(li);
-      } else {
-        card.list.forEach(item => {
-          const li = document.createElement('li');
-          li.textContent = `${item.name} – ${item.value}`;
-          ol.appendChild(li);
-        });
       }
       c.appendChild(ol);
       col.appendChild(c);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -265,7 +265,7 @@
           <h2 class="uk-heading-bullet">Ergebnisse</h2>
           <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="Aktualisieren" aria-label="Aktualisieren"></button>
         </div>
-        <div id="rankingGrid" class="uk-grid-small uk-child-width-1-1 uk-child-width-1-3@m uk-margin-bottom" uk-grid></div>
+        <div id="rankingGrid" class="uk-grid-small uk-child-width-1-1 uk-child-width-1-3@m uk-margin-bottom" uk-grid uk-height-match="target: > div > .uk-card"></div>
         <div style="overflow-x: auto">
         <table class="uk-table uk-table-divider uk-table-responsive">
           <thead>

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -19,7 +19,7 @@
       <h2 class="uk-heading-bullet">Ergebnisse</h2>
       <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="Aktualisieren" aria-label="Aktualisieren"></button>
     </div>
-    <div id="rankingGrid" class="uk-grid-small uk-child-width-1-1 uk-child-width-1-3@m uk-margin-bottom" uk-grid></div>
+    <div id="rankingGrid" class="uk-grid-small uk-child-width-1-1 uk-child-width-1-3@m uk-margin-bottom" uk-grid uk-height-match="target: > div > .uk-card"></div>
     <table class="uk-table uk-table-divider">
       <thead>
         <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th><th>Rätselwort gelöst</th><th>Beweisfoto</th></tr>


### PR DESCRIPTION
## Summary
- rename "Katalog-Geschwindigkeitsmeister" to "Katalogmeister"
- keep a fixed height for ranking cards
- show placeholders in the Top‑3 lists

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506500dc84832bb44806a1ce4a1ed9