### PR TITLE
Fix summary buttons

### DIFF
--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -150,36 +150,41 @@ document.addEventListener('DOMContentLoaded', () => {
     const modal = document.createElement('div');
     modal.setAttribute('uk-modal', '');
     modal.setAttribute('aria-modal', 'true');
-    modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">' +
-      <h3 class="uk-modal-title uk-text-center">Beweisfoto einreichen</h3>
-      <p class="uk-text-small">Hinweis zum Hochladen von Gruppenfotos:<br>
-         Mit dem Upload eines Gruppenfotos bestätigen Sie, dass alle abgebildeten Teammitglieder der Verwendung des Fotos im Rahmen des Teamtages zustimmen. Das Hochladen ist freiwillig. Die Fotos werden ausschließlich für die Dokumentation des Teamtages verwendet und nach der Veranstaltung von der Onlineplattform gelöscht.
-      </p>
-      <input id="team-select" class="uk-input uk-margin-small-top" list="team-list" placeholder="Team wählen">
-      <datalist id="team-list"></datalist>
-      <label class="uk-form-label uk-margin-small-top">
-      <input type="checkbox" id="consent-checkbox" class="uk-checkbox">
-      Einverständnis aller Personen
-    </label>
-    <input id="photo-input" class="uk-input" type="file" accept="image/*" capture="environment">
-    <div id="photo-feedback" class="uk-margin-top uk-text-center"></div>
-    <button class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" disabled>Hochladen</button>   
+    modal.innerHTML =
+      '<div class="uk-modal-dialog uk-modal-body">' +
+        '<div class="uk-card uk-card-default uk-card-body uk-padding-small uk-width-1-1">' +
+          '<p class="uk-text-small">Hinweis zum Hochladen von Gruppenfotos:<br>' +
+            'Mit dem Upload eines Fotos bestätigen Sie, dass alle abgebildeten Personen der Verwendung des Fotos im Rahmen der Veranstaltung zustimmen. Das Hochladen ist freiwillig. Die Fotos werden ausschließlich für die Dokumentation der Veranstaltung verwendet und nach der Veranstaltung von der Onlineplattform gelöscht.' +
+          '</p>' +
+          '<div class="uk-margin-small-bottom">' +
+            '<label class="uk-form-label" for="photo-input">Beweisfoto auswählen</label>' +
+            '<input id="photo-input" class="uk-input" type="file" accept="image/*" capture="environment">' +
+          '</div>' +
+          '<label class="uk-form-label uk-margin-small-bottom">' +
+            '<input type="checkbox" id="consent-checkbox" class="uk-checkbox uk-margin-small-right">' +
+            'Einverständnis aller abgebildeten Personen wurde eingeholt ' +
+          '</label>' +
+          '<div id="photo-feedback" class="uk-margin-small uk-text-center"></div>' +
+          '<button class="uk-button uk-button-primary uk-width-1-1" disabled>Hochladen</button>' +
+        '</div>' +
+      '</div>';
+
     const input = modal.querySelector('#photo-input');
     const feedback = modal.querySelector('#photo-feedback');
-    const consent = modal.querySelector('#consent-select');
+    const consent = modal.querySelector('#consent-checkbox');
     const btn = modal.querySelector('button');
     document.body.appendChild(modal);
     const ui = UIkit.modal(modal);
     UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
 
     function toggleBtn(){
-      btn.disabled = !input.files.length || consent.value !== 'yes';
+      btn.disabled = !input.files.length || !consent.checked;
     }
     input.addEventListener('change', toggleBtn);
     consent.addEventListener('change', toggleBtn);
     btn.addEventListener('click', () => {
       const file = input.files && input.files[0];
-      if(!file || consent.value !== 'yes') return;
+      if(!file || !consent.checked) return;
       const fd = new FormData();
       fd.append('photo', file);
       fd.append('name', user);


### PR DESCRIPTION
## Summary
- fix HTML quoting issue in `summary.js`
- update consent checkbox handling for photo upload
- simplify the photo upload modal and remove team selection box
- add group photo upload notice

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685070e19250832bb69c2609c9d8cc07