### PR TITLE
Fix photo upload directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 Das mitgelieferte `docker-compose.yml` startet das Quiz samt Reverse Proxy.
 Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `quizdata` gespeichert. So bleiben eingetragene Teams und Ergebnisse auch nach
-`docker-compose down` erhalten. Die ACME-Konfiguration des Let's-Encrypt-
-Begleiters landet im Ordner `acme/` und wird dadurch ebenfalls
-persistiert.
+`docker-compose down` erhalten. Hochgeladene Beweisfotos landen im Verzeichnis
+`data/photos` und werden durch das Volume ebenfalls dauerhaft gespeichert. Die
+ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
+wird dadurch ebenfalls persistiert.
 Die verwendete Domain wird aus der Datei `.env` gelesen (Variable `DOMAIN`).
 Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
 Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.

--- a/src/routes.php
+++ b/src/routes.php
@@ -64,7 +64,11 @@ return function (\Slim\App $app) {
     $logoController = new LogoController($configService);
     $summaryController = new SummaryController($configService);
     $consentService = new PhotoConsentService(__DIR__ . '/../data/photo_consents.json');
-    $evidenceController = new EvidenceController($resultService, $consentService, __DIR__ . '/../data/pics');
+    $evidenceController = new EvidenceController(
+        $resultService,
+        $consentService,
+        __DIR__ . '/../data/photos'
+    );
 
     $app->get('/', HomeController::class);
     $app->get('/favicon.ico', function (Request $request, Response $response) {


### PR DESCRIPTION
## Summary
- store uploaded photos under `data/photos`
- document that photos are kept in `quizdata` volume

## Testing
- `pytest -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68505f91db48832ba2662e2ce0868b1c