### PR TITLE
Enable photo upload toggle in admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,12 @@ Alle wesentlichen Einstellungen finden sich in `data/config.json`. Hier lassen s
   "adminPass": "password",
   "QRRestrict": false,
   "competitionMode": false,
-  "teamResults": true
+  "teamResults": true,
+  "photoUpload": true
 }
 ```
 
-Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus, verhindert Wiederholungen bereits abgeschlossener Kataloge und unterbindet die Anzeige der Katalogübersicht. Ein Fragenkatalog kann dann nur über einen direkten QR-Code-Link gestartet werden. Über `teamResults` lässt sich steuern, ob Teams nach Abschluss aller Kataloge ihre eigene Ergebnisübersicht angezeigt bekommen.
+Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus, verhindert Wiederholungen bereits abgeschlossener Kataloge und unterbindet die Anzeige der Katalogübersicht. Ein Fragenkatalog kann dann nur über einen direkten QR-Code-Link gestartet werden. Über `teamResults` lässt sich steuern, ob Teams nach Abschluss aller Kataloge ihre eigene Ergebnisübersicht angezeigt bekommen. `photoUpload` blendet die Buttons zum Hochladen von Beweisfotos ein oder aus.
 
 `ConfigService` liest und speichert diese Datei. Ein GET auf `/config.json` liefert den aktuellen Inhalt, ein POST auf dieselbe URL speichert geänderte Werte.
 

--- a/data/config.json
+++ b/data/config.json
@@ -13,6 +13,7 @@
   "QRRestrict": false,
   "competitionMode": false,
   "teamResults": true,
+  "photoUpload": true,
   "puzzleWordEnabled": true,
   "puzzleWord": "",
   "puzzleFeedback": ""

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -67,6 +67,7 @@ document.addEventListener('DOMContentLoaded', function () {
     teamRestrict: document.getElementById('cfgTeamRestrict'),
     competitionMode: document.getElementById('cfgCompetitionMode'),
     teamResults: document.getElementById('cfgTeamResults'),
+    photoUpload: document.getElementById('cfgPhotoUpload'),
     puzzleEnabled: document.getElementById('cfgPuzzleEnabled'),
     puzzleWord: document.getElementById('cfgPuzzleWord'),
     puzzleWrap: document.getElementById('cfgPuzzleWordWrap')
@@ -134,6 +135,9 @@ document.addEventListener('DOMContentLoaded', function () {
     if (cfgFields.teamResults) {
       cfgFields.teamResults.checked = data.teamResults !== false;
     }
+    if (cfgFields.photoUpload) {
+      cfgFields.photoUpload.checked = data.photoUpload !== false;
+    }
     if (cfgFields.puzzleEnabled) {
       cfgFields.puzzleEnabled.checked = data.puzzleWordEnabled !== false;
     }
@@ -199,6 +203,7 @@ document.addEventListener('DOMContentLoaded', function () {
       QRRestrict: cfgFields.teamRestrict ? cfgFields.teamRestrict.checked : cfgInitial.QRRestrict,
       competitionMode: cfgFields.competitionMode ? cfgFields.competitionMode.checked : cfgInitial.competitionMode,
       teamResults: cfgFields.teamResults ? cfgFields.teamResults.checked : cfgInitial.teamResults,
+      photoUpload: cfgFields.photoUpload ? cfgFields.photoUpload.checked : cfgInitial.photoUpload,
       puzzleWordEnabled: cfgFields.puzzleEnabled ? cfgFields.puzzleEnabled.checked : cfgInitial.puzzleWordEnabled,
       puzzleWord: cfgFields.puzzleWord ? cfgFields.puzzleWord.value.trim() : cfgInitial.puzzleWord,
       puzzleFeedback: puzzleFeedback

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -31,6 +31,9 @@ window.quizConfig = {
   // Ergebnisübersicht für Teams anzeigen
   teamResults: true,
 
+  // Beweisfotos aktivieren
+  photoUpload: true,
+
   // Rätselwort aktivieren und Begriff festlegen
   puzzleWordEnabled: true,
   puzzleWord: '',

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -274,16 +274,18 @@ function runQuiz(questions){
       }
     }
 
-    const photoBtn = document.createElement('button');
-    photoBtn.className = 'uk-button uk-button-primary uk-margin-top';
-    photoBtn.textContent = 'Beweisfoto einreichen';
-    styleButton(photoBtn);
-    photoBtn.addEventListener('click', () => {
-      const name = sessionStorage.getItem('quizUser') || '';
-      const catalogName = sessionStorage.getItem('quizCatalog') || 'unknown';
-      showPhotoModal(name, catalogName);
-    });
-    summaryEl.appendChild(photoBtn);
+    if(cfg.photoUpload !== false){
+      const photoBtn = document.createElement('button');
+      photoBtn.className = 'uk-button uk-button-primary uk-margin-top';
+      photoBtn.textContent = 'Beweisfoto einreichen';
+      styleButton(photoBtn);
+      photoBtn.addEventListener('click', () => {
+        const name = sessionStorage.getItem('quizUser') || '';
+        const catalogName = sessionStorage.getItem('quizCatalog') || 'unknown';
+        showPhotoModal(name, catalogName);
+      });
+      summaryEl.appendChild(photoBtn);
+    }
   }
 
   // Wählt basierend auf dem Fragetyp die passende Erzeugerfunktion aus

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -2,6 +2,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const resultsBtn = document.getElementById('show-results-btn');
   const puzzleBtn = document.getElementById('check-puzzle-btn');
   const photoBtn = document.getElementById('upload-photo-btn');
+  const photoEnabled = !(window.quizConfig && window.quizConfig.photoUpload === false);
+  if (photoBtn && !photoEnabled) {
+    photoBtn.remove();
+  }
   const puzzleInfo = document.getElementById('puzzle-solved-text');
   const user = sessionStorage.getItem('quizUser') || '';
 
@@ -206,7 +210,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (resultsBtn) { resultsBtn.addEventListener('click', showResults); }
   if (puzzleBtn) { puzzleBtn.addEventListener('click', showPuzzle); }
-  if (photoBtn) { photoBtn.addEventListener('click', showPhotoModal); }
+  if (photoBtn && photoEnabled) { photoBtn.addEventListener('click', showPhotoModal); }
 
   updatePuzzleInfo();
 });

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -147,6 +147,13 @@
             </div>
             <div>
               <div class="uk-margin">
+                <label><input class="uk-checkbox" type="checkbox" id="cfgPhotoUpload"> Beweisfotos aktivieren
+                  <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Blendet die Buttons zum Hochladen von Fotos ein oder aus.; pos: right"></span>
+                </label>
+              </div>
+            </div>
+            <div>
+              <div class="uk-margin">
                 <label><input class="uk-checkbox" type="checkbox" id="cfgPuzzleEnabled"> Rätselwort
                   <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Blendet Buchstaben für das Rätselwort ein und speichert den vollständigen Begriff.; pos: right"></span>
                 </label>

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -30,7 +30,9 @@
   <div class="uk-container uk-container-small uk-text-center">
     <h2 class="uk-heading-bullet">Herzlichen Glückwunsch, du hast alle Kataloge gelöst!</h2>
     <button id="show-results-btn" class="uk-button uk-button-primary uk-margin-top">Ergebnisse anzeigen</button>
+    {% if config.photoUpload is not defined or config.photoUpload %}
     <button id="upload-photo-btn" class="uk-button uk-button-primary uk-margin-top">Beweisfoto einreichen</button>
+    {% endif %}
     {% if config.puzzleWordEnabled %}
     <button id="check-puzzle-btn" class="uk-button uk-button-primary uk-margin-top">Rätselwort prüfen</button>
     <p id="puzzle-solved-text" class="uk-margin-top"></p>


### PR DESCRIPTION
## Summary
- add `photoUpload` option to configuration and README
- display new checkbox to toggle photo uploads
- hide photo upload buttons when disabled

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507c18e720832bb9e3830404dc44ca