### PR TITLE
Improve upload error feedback

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -85,8 +85,9 @@ document.addEventListener('DOMContentLoaded', function () {
       url: '/logo.png',
       name: 'file',
       multiple: false,
-      error: function () {
-        notify('Fehler beim Hochladen', 'danger');
+      error: function (e) {
+        const msg = (e && e.xhr && e.xhr.responseText) ? e.xhr.responseText : 'Fehler beim Hochladen';
+        notify(msg, 'danger');
       },
       loadStart: function (e) {
         bar.removeAttribute('hidden');

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -935,15 +935,20 @@ function runQuiz(questions){
       fd.append('name', name);
       fd.append('catalog', catalog);
       fetch('/photos', { method: 'POST', body: fd })
-        .then(r => r.ok ? r.json() : Promise.reject())
+        .then(async r => {
+          if (!r.ok) {
+            throw new Error(await r.text());
+          }
+          return r.json();
+        })
         .then(() => {
           feedback.textContent = 'Foto gespeichert';
           feedback.className = 'uk-margin-top uk-text-center uk-text-success';
           btn.disabled = true;
           input.disabled = true;
         })
-        .catch(() => {
-          feedback.textContent = 'Fehler beim Hochladen';
+        .catch(e => {
+          feedback.textContent = e.message || 'Fehler beim Hochladen';
           feedback.className = 'uk-margin-top uk-text-center uk-text-danger';
         });
     });

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -191,7 +191,12 @@ document.addEventListener('DOMContentLoaded', () => {
       fd.append('catalog', 'summary');
       fd.append('team', user);
       fetch('/photos', { method: 'POST', body: fd })
-        .then(r => r.ok ? r.json() : Promise.reject())
+        .then(async r => {
+          if (!r.ok) {
+            throw new Error(await r.text());
+          }
+          return r.json();
+        })
         .then(() => {
           feedback.textContent = 'Foto gespeichert';
           feedback.className = 'uk-margin-top uk-text-center uk-text-success';
@@ -199,8 +204,8 @@ document.addEventListener('DOMContentLoaded', () => {
           input.disabled = true;
           consent.disabled = true;
         })
-        .catch(() => {
-          feedback.textContent = 'Fehler beim Hochladen';
+        .catch(e => {
+          feedback.textContent = e.message || 'Fehler beim Hochladen';
           feedback.className = 'uk-margin-top uk-text-center uk-text-danger';
         });
     });

--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -26,22 +26,26 @@ class EvidenceController
     {
         $files = $request->getUploadedFiles();
         if (!isset($files['photo'])) {
-            return $response->withStatus(400);
+            $response->getBody()->write('missing file');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
         $file = $files['photo'];
         if ($file->getError() !== UPLOAD_ERR_OK) {
-            return $response->withStatus(400);
+            $response->getBody()->write('upload error');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
         $ext = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
         if (!in_array($ext, ['jpg', 'jpeg', 'png', 'webp'], true)) {
-            return $response->withStatus(400);
+            $response->getBody()->write('unsupported file type');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
         $parsed = $request->getParsedBody() ?? [];
         $user = isset($parsed['name']) ? (string)$parsed['name'] : '';
         $catalog = isset($parsed['catalog']) ? (string)$parsed['catalog'] : '';
         $team = isset($parsed['team']) ? (string)$parsed['team'] : '';
         if ($team === '') {
-            return $response->withStatus(400);
+            $response->getBody()->write('missing team');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
 
         $safeUser = preg_replace('/[^A-Za-z0-9_-]/', '_', $user);

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -37,17 +37,20 @@ class LogoController
     {
         $files = $request->getUploadedFiles();
         if (!isset($files['file'])) {
-            return $response->withStatus(400);
+            $response->getBody()->write('missing file');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
 
         $file = $files['file'];
         if ($file->getError() !== UPLOAD_ERR_OK) {
-            return $response->withStatus(400);
+            $response->getBody()->write('upload error');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
 
         $extension = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
         if (!in_array($extension, ['png', 'webp'], true)) {
-            return $response->withStatus(400);
+            $response->getBody()->write('unsupported file type');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
 
         $target = __DIR__ . "/../../data/logo.$extension";


### PR DESCRIPTION
## Summary
- show textual error when logo upload fails
- show textual error when photo upload fails
- display server-side error message in upload UIs

## Testing
- `vendor/bin/phpunit` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507d3717d4832ba3c752a5b82413d2