### PR TITLE
Respect teamResults setting

### DIFF
--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -2,6 +2,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const resultsBtn = document.getElementById('show-results-btn');
   const puzzleBtn = document.getElementById('check-puzzle-btn');
   const photoBtn = document.getElementById('upload-photo-btn');
+  const resultsEnabled = !(window.quizConfig && window.quizConfig.teamResults === false);
+  if (resultsBtn && !resultsEnabled) {
+    resultsBtn.remove();
+  }
   const photoEnabled = !(window.quizConfig && window.quizConfig.photoUpload === false);
   if (photoBtn && !photoEnabled) {
     photoBtn.remove();

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -29,7 +29,9 @@
   {% endembed %}
   <div class="uk-container uk-container-small uk-text-center">
     <h2 class="uk-heading-bullet">Herzlichen Glückwunsch, du hast alle Kataloge gelöst!</h2>
+    {% if config.teamResults is not defined or config.teamResults %}
     <button id="show-results-btn" class="uk-button uk-button-primary uk-margin-top">Ergebnisse anzeigen</button>
+    {% endif %}
     {% if config.photoUpload is not defined or config.photoUpload %}
     <button id="upload-photo-btn" class="uk-button uk-button-primary uk-margin-top">Beweisfoto einreichen</button>
     {% endif %}


### PR DESCRIPTION
## Summary
- show results button only if teamResults option is enabled
- hide the results button in JS when teamResults is disabled

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507e0b2438832b99701f0def0321eb