### PR TITLE
Increase allowed upload size

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,29 @@ Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `data/photos` und werden durch das Volume ebenfalls dauerhaft gespeichert. Die
 ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
 wird dadurch ebenfalls persistiert.
+Um größere Uploads zu erlauben, kann die maximale
+Request-Größe des Reverse Proxys über die Umgebungsvariable
+`CLIENT_MAX_BODY_SIZE` angepasst werden. In der mitgelieferten
+`docker-compose.yml` ist dieser Wert auf `10m` gesetzt.
 Die verwendete Domain wird aus der Datei `.env` gelesen (Variable `DOMAIN`).
 Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
 Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.
 Ein vorheriges `composer install` ist somit nicht mehr erforderlich.
+
+### Bildgrößen anpassen
+
+Damit die Uploads keine übermäßig großen Dateien erzeugen, kann optional die
+Bibliothek [Intervention Image](https://image.intervention.io/) genutzt
+werden.
+Sie lässt sich per
+
+```bash
+composer require intervention/image
+```
+
+einbinden. Die Controller verkleinern Bilder dann automatisch auf eine
+maximale Kantenlänge von 1500&nbsp;Pixeln (Beweisfotos) beziehungsweise
+512&nbsp;Pixeln (Logo) und speichern sie mit 70–80&nbsp;% Qualität.
 
 Die Anwendung lädt beim Start eine vorhandene `.env`-Datei ein, auch wenn sie
 ohne Docker betrieben wird. Ist `DOMAIN` dort gesetzt, wird für QR-Codes und

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: jwilder/nginx-proxy:alpine
     container_name: nginx-proxy
     restart: always
+    environment:
+      - CLIENT_MAX_BODY_SIZE=10m
     ports:
       - "80:80"
       - "443:443"

--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use App\Service\ResultService;
 use App\Service\PhotoConsentService;
+use Intervention\Image\ImageManagerStatic as Image;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -59,7 +60,16 @@ class EvidenceController
         }
 
         $target = $dir . '/' . $fileName;
-        $file->moveTo($target);
+        if (class_exists(Image::class)) {
+            $img = Image::make($file->getStream());
+            $img->resize(1500, 1500, function ($constraint) {
+                $constraint->aspectRatio();
+                $constraint->upsize();
+            });
+            $img->save($target, 70);
+        } else {
+            $file->moveTo($target);
+        }
 
         $this->consent->add($team, time());
 

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Service\ConfigService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Intervention\Image\ImageManagerStatic as Image;
 
 class LogoController
 {
@@ -54,7 +55,16 @@ class LogoController
         }
 
         $target = __DIR__ . "/../../data/logo.$extension";
-        $file->moveTo($target);
+        if (class_exists(Image::class)) {
+            $img = Image::make($file->getStream());
+            $img->resize(512, 512, function ($constraint) {
+                $constraint->aspectRatio();
+                $constraint->upsize();
+            });
+            $img->save($target, 80);
+        } else {
+            $file->moveTo($target);
+        }
 
         $cfg = $this->config->getConfig();
         $cfg['logoPath'] = '/logo.' . $extension;


### PR DESCRIPTION
## Summary
- bump nginx upload limit to 10MB
- document `CLIENT_MAX_BODY_SIZE` in README
- compress uploaded images using Intervention Image

## Testing
- `pytest tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

Codex couldn't run PHP tests due to missing `php` and `composer` in the environment.

------
https://chatgpt.com/codex/tasks/task_e_68507fa39b54832bb0ab892b01c3b027