### PR TITLE
Add check for Intervention Image

### DIFF
--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -60,16 +60,17 @@ class EvidenceController
         }
 
         $target = $dir . '/' . $fileName;
-        if (class_exists(Image::class)) {
-            $img = Image::make($file->getStream());
-            $img->resize(1500, 1500, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            });
-            $img->save($target, 70);
-        } else {
-            $file->moveTo($target);
+        if (!class_exists('\\Intervention\\Image\\ImageManager')) {
+            $response->getBody()->write('Intervention Image NICHT installiert');
+            return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
         }
+
+        $img = Image::make($file->getStream());
+        $img->resize(1500, 1500, function ($constraint) {
+            $constraint->aspectRatio();
+            $constraint->upsize();
+        });
+        $img->save($target, 70);
 
         $this->consent->add($team, time());
 

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -55,16 +55,17 @@ class LogoController
         }
 
         $target = __DIR__ . "/../../data/logo.$extension";
-        if (class_exists(Image::class)) {
-            $img = Image::make($file->getStream());
-            $img->resize(512, 512, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            });
-            $img->save($target, 80);
-        } else {
-            $file->moveTo($target);
+        if (!class_exists('\\Intervention\\Image\\ImageManager')) {
+            $response->getBody()->write('Intervention Image NICHT installiert');
+            return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
         }
+
+        $img = Image::make($file->getStream());
+        $img->resize(512, 512, function ($constraint) {
+            $constraint->aspectRatio();
+            $constraint->upsize();
+        });
+        $img->save($target, 80);
 
         $cfg = $this->config->getConfig();
         $cfg['logoPath'] = '/logo.' . $extension;


### PR DESCRIPTION
## Summary
- ensure Intervention Image is installed before resizing images
- report a plain text error if the library is missing

## Testing
- `python3 -m pytest -q tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685087c7150c832bbb1916b4d3e57818