### PR TITLE
Fix Docker build missing libwebp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.2-alpine
 
-RUN apk add --no-cache libpng libjpeg-turbo freetype \
-    && apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev \
+RUN apk add --no-cache libpng libjpeg-turbo freetype libwebp \
+    && apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install gd \
     && apk del .build-deps


### PR DESCRIPTION
## Summary
- install libwebp and libwebp-dev packages so gd builds with WebP support

## Testing
- `pytest -q`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685088a589e4832bb2f98840701101d4