### PR TITLE
Fix missing team on photo upload

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -936,6 +936,7 @@ function runQuiz(questions){
       fd.append('photo', file);
       fd.append('name', name);
       fd.append('catalog', catalog);
+      fd.append('team', name);
       fetch('/photos', { method: 'POST', body: fd })
         .then(async r => {
           if (!r.ok) {


### PR DESCRIPTION
## Summary
- include team name in quiz photo upload request

## Testing
- `pytest -q tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685089d16e40832b80008f774608e7a1