### PR TITLE
Fix Intervention Image dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "slim/twig-view": "^3.3",
         "setasign/fpdf": "^1.8",
         "endroid/qr-code": "^5.0",
-        "intervention/image": "^2.8"
+        "intervention/image": "^2.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- set `intervention/image` requirement to `^2.7`

## Testing
- `pytest tests/test_html_validity.py -q`
- `pytest tests/test_json_validity.py -q`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68508db7fb60832ba827de1ac4e4885f