### PR TITLE
Enable lightbox preview for proof photos

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -59,11 +59,19 @@ document.addEventListener('DOMContentLoaded', () => {
           const td = document.createElement('td');
           if (idx === cells.length - 1) {
             if (r.photo) {
+              const a = document.createElement('a');
+              a.className = 'uk-inline';
+              a.href = r.photo;
+              a.dataset.caption = 'Beweisfoto';
+              a.dataset.attrs = 'class: uk-inverse-light';
+
               const img = document.createElement('img');
               img.src = r.photo;
               img.alt = 'Beweisfoto';
               img.className = 'proof-thumb';
-              td.appendChild(img);
+
+              a.appendChild(img);
+              td.appendChild(a);
             }
           } else {
             td.textContent = c;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -278,7 +278,7 @@
           <thead>
             <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th><th>Rätselwort gelöst</th><th>Beweisfoto</th></tr>
           </thead>
-          <tbody id="resultsTableBody">
+          <tbody id="resultsTableBody" uk-lightbox="nav: thumbnav; slidenav: false">
             {% for r in results %}
             <tr>
               <td>{{ r.name }}</td>
@@ -287,7 +287,7 @@
               <td>{{ r.correct }}/{{ r.total }}</td>
               <td>{{ r.time | date('Y-m-d H:i') }}</td>
               <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>
-              <td>{% if r.photo is defined and r.photo %}<img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb">{% endif %}</td>
+              <td>{% if r.photo is defined and r.photo %}<a class="uk-inline" href="{{ r.photo }}" data-caption="Beweisfoto" data-attrs="class: uk-inverse-light"><img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb"></a>{% endif %}</td>
             </tr>
             {% else %}
             <tr><td colspan="7">Keine Daten</td></tr>

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -24,7 +24,7 @@
       <thead>
         <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th><th>Rätselwort gelöst</th><th>Beweisfoto</th></tr>
       </thead>
-      <tbody id="resultsTableBody">
+      <tbody id="resultsTableBody" uk-lightbox="nav: thumbnav; slidenav: false">
         {% for r in results %}
         <tr>
           <td>{{ r.name }}</td>
@@ -33,7 +33,7 @@
           <td>{{ r.correct }}/{{ r.total }}</td>
           <td>{{ r.time | date('Y-m-d H:i') }}</td>
           <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>
-          <td>{% if r.photo is defined and r.photo %}<img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb">{% endif %}</td>
+          <td>{% if r.photo is defined and r.photo %}<a class="uk-inline" href="{{ r.photo }}" data-caption="Beweisfoto" data-attrs="class: uk-inverse-light"><img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb"></a>{% endif %}</td>
         </tr>
         {% else %}
         <tr><td colspan="7">Keine Daten</td></tr>


### PR DESCRIPTION
## Summary
- show proof photos using UIkit lightbox in admin and results pages
- wrap generated preview images in lightbox links

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_685090a85e08832bb0fe7b9809fa38d2