### PR TITLE
Update upload size instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ Um größere Uploads zu erlauben, kann die maximale
 Request-Größe des Reverse Proxys über die Umgebungsvariable
 `CLIENT_MAX_BODY_SIZE` angepasst werden. In der mitgelieferten
 `docker-compose.yml` ist dieser Wert auf `10m` gesetzt.
+Beim Einsatz von **jwilder/nginx-proxy** greift der Wert jedoch nur,
+solange keine eigene Vhost-Konfiguration für die Domain existiert.
+Soll ein höheres Limit dauerhaft gelten, empfiehlt es sich daher,
+eine Datei im Verzeichnis `vhost.d/` anzulegen. Der Dateiname muss
+exakt der bei `VIRTUAL_HOST` hinterlegten Domain entsprechen und kann
+zum Beispiel folgenden Inhalt haben:
+
+```nginx
+client_max_body_size 20m;
+```
+
+Nach dem Anlegen der Datei sollte der Proxy neu gestartet werden,
+damit die Einstellung aktiv wird. Zusätzlich können innerhalb des
+App-Containers die Werte `upload_max_filesize` und `post_max_size`
+angepasst werden, etwa über eine eigene `php.ini`.
 Die verwendete Domain wird aus der Datei `.env` gelesen (Variable `DOMAIN`).
 Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
 Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.


### PR DESCRIPTION
## Summary
- document how to override `client_max_body_size`
- hint about adjusting PHP limits

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685093f5abc0832b9aa0efb7670b2b0f