### PR TITLE
Show success notification on photo upload

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -971,6 +971,19 @@ function runQuiz(questions){
           btn.disabled = true;
           input.disabled = true;
           consent.disabled = true;
+          setTimeout(() => {
+            ui.hide();
+            if (typeof UIkit !== 'undefined' && UIkit.notification) {
+              UIkit.notification({
+                message: 'Bild erfolgreich gespeichert',
+                status: 'success',
+                pos: 'top-center',
+                timeout: 2000
+              });
+            } else {
+              alert('Bild erfolgreich gespeichert');
+            }
+          }, 1000);
         })
         .catch(e => {
           feedback.textContent = e.message || 'Fehler beim Hochladen';

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -211,6 +211,19 @@ document.addEventListener('DOMContentLoaded', () => {
           btn.disabled = true;
           input.disabled = true;
           consent.disabled = true;
+          setTimeout(() => {
+            ui.hide();
+            if (typeof UIkit !== 'undefined' && UIkit.notification) {
+              UIkit.notification({
+                message: 'Bild erfolgreich gespeichert',
+                status: 'success',
+                pos: 'top-center',
+                timeout: 2000
+              });
+            } else {
+              alert('Bild erfolgreich gespeichert');
+            }
+          }, 1000);
         })
         .catch(e => {
           feedback.textContent = e.message || 'Fehler beim Hochladen';


### PR DESCRIPTION
## Summary
- notify the user once a photo was saved

## Testing
- `python3 -m pytest tests/test_json_validity.py tests/test_html_validity.py`
- `node tests/test_competition_mode.js`
- ❌ `composer install && vendor/bin/phpunit` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685098372824832ba40312774851974d