### PR TITLE
Fix ranking numbering in admin results

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -221,7 +221,7 @@ document.addEventListener('DOMContentLoaded', () => {
           teamDiv.className = 'uk-width-expand';
           teamDiv.setAttribute('uk-leader', '');
           teamDiv.style.setProperty('--uk-leader-fill-content', ' ');
-          teamDiv.textContent = item.name;
+          teamDiv.textContent = `${i + 1}. ${item.name}`;
 
           const timeDiv = document.createElement('div');
           timeDiv.textContent = item.value;


### PR DESCRIPTION
## Summary
- show place numbers inside top 3 lists on results page

## Testing
- `npm --version`
- `composer --version` *(fails: command not found)*
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a5f5fce0832b9f55dc4cb9892709