### PR TITLE
Fix mobile width for proof photo upload

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -927,8 +927,8 @@ function runQuiz(questions){
             '<label class="uk-form-label" for="photo-input">Beweisfoto auswählen</label>' +
             '<div uk-form-custom="target: true">' +
               '<input id="photo-input" type="file" accept="image/*" capture="environment" aria-label="Datei auswählen">' +
-              '<input class="uk-input uk-form-width-medium" type="text" placeholder="Keine Datei ausgewählt" disabled>' +
-              '<button class="uk-button uk-button-default" type="button" tabindex="-1">Durchsuchen</button>' +
+              '<input class="uk-input uk-width-1-1" type="text" placeholder="Keine Datei ausgewählt" disabled>' +
+              '<button class="uk-button uk-button-default uk-width-1-1 uk-margin-small-top" type="button" tabindex="-1">Durchsuchen</button>' +
             '</div>' +
           '</div>' +
           '<label class="uk-form-label uk-margin-small-bottom">' +

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -168,8 +168,8 @@ document.addEventListener('DOMContentLoaded', () => {
             '<label class="uk-form-label" for="photo-input">Beweisfoto auswählen</label>' +
             '<div uk-form-custom="target: true">' +
               '<input id="photo-input" type="file" accept="image/*" capture="environment" aria-label="Datei auswählen">' +
-              '<input class="uk-input uk-form-width-medium" type="text" placeholder="Keine Datei ausgewählt" disabled>' +
-              '<button class="uk-button uk-button-default" type="button" tabindex="-1">Durchsuchen</button>' +
+              '<input class="uk-input uk-width-1-1" type="text" placeholder="Keine Datei ausgewählt" disabled>' +
+              '<button class="uk-button uk-button-default uk-width-1-1 uk-margin-small-top" type="button" tabindex="-1">Durchsuchen</button>' +
             '</div>' +
           '</div>' +
           '<label class="uk-form-label uk-margin-small-bottom">' +


### PR DESCRIPTION
## Summary
- make photo upload text input and button full-width

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518b464d10832baf109164dc01acb7