### PR TITLE
Fix back button in help page topbar

### DIFF
--- a/templates/help.twig
+++ b/templates/help.twig
@@ -13,7 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück" id="back-button"></a>
+      <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -13,7 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+      <a href="/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -13,7 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="/" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+      <a href="/" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück" id="back-button"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -13,7 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="/" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück" id="back-button"></a>
+      <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück" id="back-button"></a>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">


### PR DESCRIPTION
## Summary
- ensure the help page provides a dedicated back button

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_6851981c7964832bbfaf1db1a673b866