### PR TITLE
Implement competition mode redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Alle wesentlichen Einstellungen finden sich in `data/config.json`. Hier lassen s
 }
 ```
 
-Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus, verhindert Wiederholungen bereits abgeschlossener Kataloge und unterbindet die Anzeige der Katalogübersicht. Ein Fragenkatalog kann dann nur über einen direkten QR-Code-Link gestartet werden. Über `teamResults` lässt sich steuern, ob Teams nach Abschluss aller Kataloge ihre eigene Ergebnisübersicht angezeigt bekommen. `photoUpload` blendet die Buttons zum Hochladen von Beweisfotos ein oder aus.
+Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus, verhindert Wiederholungen bereits abgeschlossener Kataloge und unterbindet die Anzeige der Katalogübersicht. Ein Fragenkatalog kann dann nur über einen direkten QR-Code-Link gestartet werden. Im Wettkampfmodus führt ein Aufruf der Hauptseite ohne gültigen Katalog-Parameter automatisch zur Hilfe-Seite. Über `teamResults` lässt sich steuern, ob Teams nach Abschluss aller Kataloge ihre eigene Ergebnisübersicht angezeigt bekommen. `photoUpload` blendet die Buttons zum Hochladen von Beweisfotos ein oder aus.
 
 `ConfigService` liest und speichert diese Datei. Ein GET auf `/config.json` liefert den aktuellen Inhalt, ein POST auf dieselbe URL speichert geänderte Werte.
 

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -27,6 +27,17 @@ class HomeController
             $catalogs = json_decode($catalogsJson, true) ?? [];
         }
 
+        if (($cfg['competitionMode'] ?? false) === true) {
+            $params = $request->getQueryParams();
+            $id = $params['katalog'] ?? '';
+            $allowedIds = array_map(static fn($c) => $c['id'] ?? '', $catalogs);
+            if ($id === '' || !in_array($id, $allowedIds, true)) {
+                return $response
+                    ->withHeader('Location', '/help')
+                    ->withStatus(302);
+            }
+        }
+
         $showDisclaimer = true;
 
         return $view->render($response, 'index.twig', [

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -15,4 +15,39 @@ class HomeControllerTest extends TestCase
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
+
+    private function withCompetitionMode(callable $fn): void
+    {
+        $cfgPath = dirname(__DIR__, 2) . '/data/config.json';
+        $orig = file_get_contents($cfgPath);
+        $cfg = json_decode($orig, true);
+        $cfg['competitionMode'] = true;
+        file_put_contents($cfgPath, json_encode($cfg, JSON_PRETTY_PRINT) . "\n");
+        try {
+            $fn();
+        } finally {
+            file_put_contents($cfgPath, $orig);
+        }
+    }
+
+    public function testCompetitionRedirect(): void
+    {
+        $this->withCompetitionMode(function () {
+            $app = $this->getAppInstance();
+            $request = $this->createRequest('GET', '/');
+            $response = $app->handle($request);
+            $this->assertEquals(302, $response->getStatusCode());
+            $this->assertEquals(['/help'], $response->getHeader('Location'));
+        });
+    }
+
+    public function testCompetitionAllowsCatalog(): void
+    {
+        $this->withCompetitionMode(function () {
+            $app = $this->getAppInstance();
+            $request = $this->createRequest('GET', '/?katalog=station_1');
+            $response = $app->handle($request);
+            $this->assertEquals(200, $response->getStatusCode());
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- redirect invalid quiz starts to `/help` in competition mode
- clarify competition mode behaviour in README
- expand HomeController tests for competition mode

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_68519ca1f388832b9d07f1c5fc78050b