### PR TITLE
Apply custom colors on help page

### DIFF
--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -7,12 +7,18 @@ namespace App\Controller;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use App\Service\ConfigService;
 
 class HelpController
 {
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'help.twig');
+        $cfg = (new ConfigService(
+            __DIR__ . '/../../data/config.json',
+            __DIR__ . '/../../config/config.json'
+        ))->getConfig();
+
+        return $view->render($response, 'help.twig', ['config' => $cfg]);
     }
 }

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/css/highcontrast.css">
 {% endblock %}
 
-{% block body_class %}uk-background-muted uk-padding{% endblock %}
+{% block body_class %}uk-padding{% endblock %}
 
 {% block body %}
   {% embed 'topbar.twig' %}
@@ -64,4 +64,13 @@
   <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/custom-icons.js"></script>
+  <script>
+    window.quizConfig = {{ config|json_encode|raw }};
+    (function(){
+      const cfg = window.quizConfig || {};
+      const styleEl = document.createElement('style');
+      styleEl.textContent = `\n        body { background-color: ${cfg.backgroundColor || '#ffffff'}; }\n        .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n      `;
+      document.head.appendChild(styleEl);
+    })();
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- include config in HelpController
- style help page with configured colors

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68519d0e554c832b9d630044dc56c43f