### PR TITLE
Update help topbar

### DIFF
--- a/templates/help.twig
+++ b/templates/help.twig
@@ -15,6 +15,9 @@
     {% block left %}
       <a href="/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
+    {% block center %}
+      <span class="uk-navbar-title">Spielablauf <br>{{ config.header|default('Sommerfest 2025') }}</span>
+    {% endblock %}
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
@@ -25,7 +28,6 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small">
-    <h1 class="uk-heading-divider">Spielerklärung</h1>
     <div class="uk-card uk-card-default uk-card-body uk-margin">
       <p>Es gibt verschiedene Stationen, die auf der Karte markiert sind. An jeder Station scannt ihr mit eurem Handy oder Tablet den dort angebrachten QR-Code und öffnet den Link – und schon kann's losgehen.</p>
       <h2 class="uk-heading-bullet">So funktioniert das Spiel</h2>


### PR DESCRIPTION
## Summary
- remove explicit heading from the help page
- display the configuration title in the help page topbar

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68519f162f88832ba8d2520666fdfd54