### PR TITLE
Adjust help text placement

### DIFF
--- a/templates/help.twig
+++ b/templates/help.twig
@@ -27,8 +27,8 @@
   <div class="uk-container uk-container-small">
     <h1 class="uk-heading-divider">Spielerklärung</h1>
     <div class="uk-card uk-card-default uk-card-body uk-margin">
-      <p>Es gibt verschiedene Stationen, die auf der Karte markiert sind. An jeder Station scannt ihr mit eurem Handy oder Tablet den dort angebrachten QR-Code und öffnet den Link – und schon kann's losgehen.</p>
       <h2 class="uk-heading-bullet">So funktioniert das Spiel</h2>
+      <p>Es gibt verschiedene Stationen, die auf der Karte markiert sind. An jeder Station scannt ihr mit eurem Handy oder Tablet den dort angebrachten QR-Code und öffnet den Link – und schon kann's losgehen.</p>
       <ul class="uk-list uk-list-divider">
         <li>
           <h3 class="uk-heading-bullet">QR-Code scannen</h3>


### PR DESCRIPTION
## Summary
- move the explanation of the QR-code stations directly under the heading "So funktioniert das Spiel"

## Testing
- `vendor/bin/phpcs` *(fails: command not found)*
- `vendor/bin/phpstan` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519f4cacf4832bb5e79f8dcf0ca63f