### PR TITLE
Center topbar titles

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -115,6 +115,15 @@ body.uk-padding {
   display: flex;
   align-items: center;
 }
+.topbar .uk-navbar-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+.topbar .uk-navbar-center .uk-navbar-item {
+  width: 100%;
+  justify-content: center;
+}
 
 .nav-placeholder {
   height: 56px;

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -15,6 +15,9 @@
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
+    {% block center %}
+      <span class="uk-navbar-title uk-text-center">Datenschutz</span>
+    {% endblock %}
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -15,6 +15,9 @@
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
+    {% block center %}
+      <span class="uk-navbar-title uk-text-center">FAQ</span>
+    {% endblock %}
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -16,7 +16,7 @@
       <a href="/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
     {% block center %}
-      <span class="uk-navbar-title">Spielablauf <br>{{ config.header|default('Sommerfest 2025') }}</span>
+      <span class="uk-navbar-title uk-text-center">Spielablauf <br>{{ config.header|default('Sommerfest 2025') }}</span>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -15,6 +15,9 @@
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
+    {% block center %}
+      <span class="uk-navbar-title uk-text-center">Impressum</span>
+    {% endblock %}
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -16,7 +16,7 @@
       <a href="faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
     {% block center %}
-      <span id="topbar-title" class="uk-navbar-title" data-default-title="{{ config.header|default('Sommerfest 2025') }}">{{ config.header|default('Sommerfest 2025') }}</span>
+      <span id="topbar-title" class="uk-navbar-title uk-text-center" data-default-title="{{ config.header|default('Sommerfest 2025') }}">{{ config.header|default('Sommerfest 2025') }}</span>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -15,6 +15,9 @@
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
+    {% block center %}
+      <span class="uk-navbar-title uk-text-center">Lizenz</span>
+    {% endblock %}
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -16,7 +16,7 @@
       <a href="/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
     {% block center %}
-      <span class="uk-navbar-title">{{ config.header|default('Sommerfest 2025') }}</span>
+      <span class="uk-navbar-title uk-text-center">{{ config.header|default('Sommerfest 2025') }}</span>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">


### PR DESCRIPTION
## Summary
- show page name in topbar for Impressum, Datenschutz, Lizenz and FAQ
- center all topbar headings

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6851a09595a0832bbde31b9d6c4965e1