### PR TITLE
Move disclaimer to help page

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -135,10 +135,6 @@ function runQuiz(questions){
     headerEl.innerHTML = '';
     headerEl.classList.add('uk-hidden');
   }
-  const disclaimerEl = document.getElementById('front-disclaimer');
-  if (disclaimerEl) {
-    disclaimerEl.classList.remove('uk-hidden');
-  }
 
   elements.forEach((el, i) => {
     if (i !== 0) el.classList.add('uk-hidden');
@@ -194,9 +190,6 @@ function runQuiz(questions){
   function updateSummary(){
     if(summaryShown) return;
     summaryShown = true;
-    if (disclaimerEl) {
-      disclaimerEl.classList.remove('uk-hidden');
-    }
     const score = results.filter(r => r).length;
     let user = sessionStorage.getItem('quizUser');
     if(!user && !cfg.QRRestrict){

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -38,12 +38,9 @@ class HomeController
             }
         }
 
-        $showDisclaimer = true;
-
         return $view->render($response, 'index.twig', [
             'config' => $cfg,
             'catalogs' => $catalogs,
-            'showDisclaimer' => $showDisclaimer,
         ]);
     }
 }

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -59,6 +59,15 @@
       </ul>
       <p class="uk-text-lead uk-margin-top">Viel Spaß bei der Rally, beim Raten, Punkte sammeln und natürlich beim gemeinsamen Mitfiebern!</p>
     </div>
+    <div class="uk-card uk-card-default uk-card-body uk-margin">
+      <h3 class="uk-heading-bullet">Disclaimer / Hinweis</h3>
+        <p>Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer spannenden Zusammenarbeit zwischen menschlicher Erfahrung und k&uuml;nstlicher Intelligenz. W&auml;hrend Ideen, Organisation und jede Menge Praxiswissen von Menschen stammen, wurden alle Codezeilen experimentell komplett von OpenAI Codex geschrieben. F&uuml;r die kreativen Konzepte und Inhalte kam ChatGPT 4.1 zum Einsatz, bei der Fehlersuche half Github Copilot und das Logo wurde von der KI Sora entworfen.</p>
+        <p>Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial moderner Codeassistenten in der Praxis zu erproben.</p>
+        <p>Im Mittelpunkt stand die Zug&auml;nglichkeit f&uuml;r alle Nutzergruppen &ndash; daher ist die Anwendung barrierefrei gestaltet und eignet sich auch f&uuml;r Menschen mit Einschr&auml;nkungen. Datenschutz und Sicherheit werden konsequent beachtet, sodass alle Daten gesch&uuml;tzt sind.</p>
+        <p>Die App zeichnet sich durch eine hohe Performance und Stabilit&auml;t auch bei vielen gleichzeitigen Teilnehmenden aus. Das Bedienkonzept ist selbsterkl&auml;rend, wodurch eine schnelle und intuitive Nutzung auf allen Endger&auml;ten &ndash; ob Smartphone, Tablet oder Desktop &ndash; gew&auml;hrleistet wird.</p>
+        <p>Zudem wurde auf eine ressourcenschonende Arbeitsweise und eine unkomplizierte Anbindung an andere Systeme Wert gelegt.</p>
+      <p>Mit dieser App zeigen wir, was heute schon m&ouml;glich ist, wenn Menschen und verschiedene KI-Tools wie ChatGPT, Codex, Copilot und Sora gemeinsam an neuen digitalen Ideen t&uuml;fteln.</p>
+    </div>
   </div>
 {% endblock %}
 

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -36,17 +36,6 @@
       <span id="question-announcer" class="uk-hidden-visually" aria-live="polite"></span>
       <div id="quiz"></div>
     </div>
-    {% if showDisclaimer %}
-    <div id="front-disclaimer" class="uk-card uk-card-default uk-card-body uk-margin">
-      <h3 class="uk-heading-bullet">Disclaimer / Hinweis</h3>
-        <p>Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer spannenden Zusammenarbeit zwischen menschlicher Erfahrung und k&uuml;nstlicher Intelligenz. W&auml;hrend Ideen, Organisation und jede Menge Praxiswissen von Menschen stammen, wurden alle Codezeilen experimentell komplett von OpenAI Codex geschrieben. F&uuml;r die kreativen Konzepte und Inhalte kam ChatGPT 4.1 zum Einsatz, bei der Fehlersuche half Github Copilot und das Logo wurde von der KI Sora entworfen.</p>
-        <p>Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial moderner Codeassistenten in der Praxis zu erproben.</p>
-        <p>Im Mittelpunkt stand die Zug&auml;nglichkeit f&uuml;r alle Nutzergruppen &ndash; daher ist die Anwendung barrierefrei gestaltet und eignet sich auch f&uuml;r Menschen mit Einschr&auml;nkungen. Datenschutz und Sicherheit werden konsequent beachtet, sodass alle Daten gesch&uuml;tzt sind.</p>
-        <p>Die App zeichnet sich durch eine hohe Performance und Stabilit&auml;t auch bei vielen gleichzeitigen Teilnehmenden aus. Das Bedienkonzept ist selbsterkl&auml;rend, wodurch eine schnelle und intuitive Nutzung auf allen Endger&auml;ten &ndash; ob Smartphone, Tablet oder Desktop &ndash; gew&auml;hrleistet wird.</p>
-        <p>Zudem wurde auf eine ressourcenschonende Arbeitsweise und eine unkomplizierte Anbindung an andere Systeme Wert gelegt.</p>
-      <p>Mit dieser App zeigen wir, was heute schon m&ouml;glich ist, wenn Menschen und verschiedene KI-Tools wie ChatGPT, Codex, Copilot und Sora gemeinsam an neuen digitalen Ideen t&uuml;fteln.</p>
-      </div>
-    {% endif %}
   </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add the disclaimer text to `help.twig`
- remove disclaimer from the index page template
- drop `showDisclaimer` handling in `HomeController`
- clean up JS references to the old disclaimer element

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6851dfc6eb20832bb4201fd441b20ae7