### PR TITLE
Remove login labels

### DIFF
--- a/templates/login.twig
+++ b/templates/login.twig
@@ -35,14 +35,12 @@
           {% endif %}
           <form method="post" action="/login">
             <div class="uk-margin">
-              <label class="uk-form-label" for="username">Benutzername</label>
               <div class="uk-inline uk-width-1-1">
                 <span class="uk-form-icon" uk-icon="icon: user"></span>
                 <input class="uk-input uk-form-large" type="text" name="username" id="username" placeholder="Benutzername" required>
               </div>
             </div>
             <div class="uk-margin">
-              <label class="uk-form-label" for="password">Passwort</label>
               <div class="uk-inline uk-width-1-1">
                 <span class="uk-form-icon" uk-icon="icon: lock"></span>
                 <input class="uk-input uk-form-large" type="password" name="password" id="password" placeholder="Passwort" required>


### PR DESCRIPTION
## Summary
- remove labels for username and password on the admin login form

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_6851e11a4784832bb9e1f81df2154a47