### PR TITLE
Improve swipe card clarity with vertical labels

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -660,6 +660,26 @@ function runQuiz(questions){
     container.style.touchAction = 'none';
     div.appendChild(container);
 
+    const leftStatic = document.createElement('div');
+    leftStatic.textContent = q.leftLabel || 'Falsch';
+    leftStatic.style.position = 'absolute';
+    leftStatic.style.left = '0';
+    leftStatic.style.top = '50%';
+    leftStatic.style.transform = 'translate(-50%, -50%) rotate(180deg)';
+    leftStatic.style.writingMode = 'vertical-rl';
+    leftStatic.style.pointerEvents = 'none';
+    container.appendChild(leftStatic);
+
+    const rightStatic = document.createElement('div');
+    rightStatic.textContent = q.rightLabel || 'Richtig';
+    rightStatic.style.position = 'absolute';
+    rightStatic.style.right = '0';
+    rightStatic.style.top = '50%';
+    rightStatic.style.transform = 'translate(50%, -50%)';
+    rightStatic.style.writingMode = 'vertical-rl';
+    rightStatic.style.pointerEvents = 'none';
+    container.appendChild(rightStatic);
+
     const label = document.createElement('div');
     label.style.position = 'absolute';
     label.style.top = '8px';
@@ -736,7 +756,7 @@ function runQuiz(questions){
         const dir = offsetX > 0 ? 'right' : 'left';
         const labelText = offsetX > 0 ? (q.rightLabel || 'Ja') : (q.leftLabel || 'Nein');
         const correct = (dir === 'right') === !!card.correct;
-        resultsLocal.push({label: labelText, correct});
+        resultsLocal.push({text: card.text, label: labelText, correct});
         if(cardEl){
           cardEl.style.transform = `translate(${offsetX > 0 ? 1000 : -1000}px,${offsetY}px)`;
         }

--- a/templates/vuequiz/index.html
+++ b/templates/vuequiz/index.html
@@ -74,7 +74,12 @@ createApp({
     }
 
     function formatAnswer(ans) {
-      if (Array.isArray(ans)) return ans.join(', ');
+      if (Array.isArray(ans)) {
+        if (ans.length && typeof ans[0] === 'object' && ans[0] !== null && 'text' in ans[0] && 'label' in ans[0]) {
+          return ans.map(a => `${a.text}: ${a.label}`).join('; ');
+        }
+        return ans.join(', ');
+      }
       return ans;
     }
 
@@ -162,7 +167,7 @@ createApp({
           offsetY.value = 0;
           if (!cards.value.length) {
             const allCorrect = results.value.every(r => r.correct);
-            emit('answered', { correct: allCorrect, answer: results.value.map(r => r.label) });
+            emit('answered', { correct: allCorrect, answer: results.value.map(r => ({ text: r.text, label: r.label })) });
           }
         }, 300);
       } else {
@@ -190,6 +195,12 @@ createApp({
     <div>
       <p class="mb-4">{{ question.question }}</p>
       <div class="relative w-full h-64 select-none">
+        <div class="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-full pointer-events-none text-red-600" style="writing-mode: vertical-rl; transform: translate(-50%, -50%) rotate(180deg);">
+          {{ question.leftLabel || 'Falsch' }}
+        </div>
+        <div class="absolute right-0 top-1/2 -translate-y-1/2 translate-x-full pointer-events-none text-green-600" style="writing-mode: vertical-rl;">
+          {{ question.rightLabel || 'Richtig' }}
+        </div>
         <div v-for="(c, idx) in cards" :key="idx" class="absolute inset-0 bg-white rounded-lg shadow-md flex items-center justify-center transition-transform duration-300" :style="styleCard(idx)" @pointerdown="idx === cards.length-1 && start($event)" @pointermove="idx === cards.length-1 && move($event)" @pointerup="idx === cards.length-1 && end()" @pointercancel="idx === cards.length-1 && end()">
           <span class="p-4 text-center">{{ c.text }}</span>
         </div>


### PR DESCRIPTION
## Summary
- show static vertical labels "Richtig" and "Falsch" on swipe cards
- keep mapping of swipe answers in the Vue quiz
- extend answer formatting to show which card got which answer

## Testing
- `pytest -q tests/test_json_validity.py`
- `pytest -q tests/test_html_validity.py`
- ⚠️ `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6851f0a4fc28832ba259af4d3517a349