### PR TITLE
Fix swipe card visibility in dark mode

### DIFF
--- a/templates/vuequiz/index.html
+++ b/templates/vuequiz/index.html
@@ -223,17 +223,17 @@ createApp({
           {{ question.rightLabel || 'Richtig' }}
         </div>
         <div class="absolute inset-y-0 left-0 w-1/3 overflow-hidden cursor-pointer" @click="swipe('left')">
-          <div class="absolute inset-0 bg-white rounded-lg shadow-md flex items-center justify-center" style="transform: translateX(-66%);">
+          <div class="absolute inset-0 bg-white text-black rounded-lg shadow-md flex items-center justify-center" style="transform: translateX(-66%);">
             <span class="text-2xl">&larr;</span>
           </div>
         </div>
         <div class="absolute inset-y-0 right-0 w-1/3 overflow-hidden cursor-pointer" @click="swipe('right')">
-          <div class="absolute inset-0 bg-white rounded-lg shadow-md flex items-center justify-center" style="transform: translateX(66%);">
+          <div class="absolute inset-0 bg-white text-black rounded-lg shadow-md flex items-center justify-center" style="transform: translateX(66%);">
             <span class="text-2xl">&rarr;</span>
           </div>
         </div>
         <div v-for="(c, idx) in cards" :key="idx" class="absolute inset-0 bg-white rounded-lg shadow-md flex items-center justify-center transition-transform duration-300" :style="styleCard(idx)" @pointerdown="idx === cards.length-1 && start($event)" @pointermove="idx === cards.length-1 && move($event)" @pointerup="idx === cards.length-1 && end()" @pointercancel="idx === cards.length-1 && end()">
-          <span class="p-4 text-center">{{ c.text }}</span>
+          <span class="p-4 text-center text-black">{{ c.text }}</span>
         </div>
         <div v-if="dragging" class="absolute top-4 left-4 text-2xl font-bold pointer-events-none" :class="offsetX >= 0 ? 'text-green-600' : 'text-red-600'">{{ label }}</div>
       </div>


### PR DESCRIPTION
## Summary
- ensure swipe card overlay text is dark
- fix swipe cards text color

## Testing
- `python3 -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6851ff0d0ea4832b86504569dd11a4ad