### PR TITLE
Fix file upload layout

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -310,3 +310,19 @@ body.dark-mode .sticky-actions {
   box-sizing: border-box;
 }
 
+/* Stacked layout for file upload fields */
+.stacked-upload {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.stacked-upload input[type="text"],
+.stacked-upload button {
+  width: 100%;
+}
+
+.stacked-upload button {
+  margin-top: 8px;
+}
+

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1118,7 +1118,7 @@ function runQuiz(questions){
           '</p>' +
           '<div class="uk-margin-small-bottom">' +
             '<label class="uk-form-label" for="photo-input">Beweisfoto auswählen</label>' +
-            '<div uk-form-custom="target: true">' +
+            '<div class="stacked-upload" uk-form-custom="target: true">' +
               '<input id="photo-input" type="file" accept="image/*" capture="environment" aria-label="Datei auswählen">' +
               '<input class="uk-input uk-width-1-1" type="text" placeholder="Keine Datei ausgewählt" disabled>' +
               '<button class="uk-button uk-button-default uk-width-1-1 uk-margin-small-top" type="button" tabindex="-1">Durchsuchen</button>' +

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -166,7 +166,7 @@ document.addEventListener('DOMContentLoaded', () => {
           '</p>' +
           '<div class="uk-margin-small-bottom">' +
             '<label class="uk-form-label" for="photo-input">Beweisfoto auswählen</label>' +
-            '<div uk-form-custom="target: true">' +
+            '<div class="stacked-upload" uk-form-custom="target: true">' +
               '<input id="photo-input" type="file" accept="image/*" capture="environment" aria-label="Datei auswählen">' +
               '<input class="uk-input uk-width-1-1" type="text" placeholder="Keine Datei ausgewählt" disabled>' +
               '<button class="uk-button uk-button-default uk-width-1-1 uk-margin-small-top" type="button" tabindex="-1">Durchsuchen</button>' +


### PR DESCRIPTION
## Summary
- keep file-upload controls stacked on all screens
- style stacked upload widget

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py` *(fails: no output)*
- `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852008325e0832bb46956c0c57394be