### PR TITLE
Increase swipe card font size

### DIFF
--- a/templates/vuequiz/index.html
+++ b/templates/vuequiz/index.html
@@ -233,7 +233,7 @@ createApp({
           </div>
         </div>
         <div v-for="(c, idx) in cards" :key="idx" class="absolute inset-0 bg-white rounded-lg shadow-md flex items-center justify-center transition-transform duration-300" :style="styleCard(idx)" @pointerdown="idx === cards.length-1 && start($event)" @pointermove="idx === cards.length-1 && move($event)" @pointerup="idx === cards.length-1 && end()" @pointercancel="idx === cards.length-1 && end()">
-          <span class="p-4 text-center text-black">{{ c.text }}</span>
+          <span class="p-4 text-center text-black text-xl">{{ c.text }}</span>
         </div>
         <div v-if="dragging" class="absolute top-4 left-4 text-2xl font-bold pointer-events-none" :class="offsetX >= 0 ? 'text-green-600' : 'text-red-600'">{{ label }}</div>
       </div>


### PR DESCRIPTION
## Summary
- increase font size for swipe card text

## Testing
- `pytest tests/test_json_validity.py -q`
- `python3 tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_685200de9eac832bad00d45f76b1a740