### PR TITLE
Fix composer config line and add debugging steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,15 @@ jobs:
                   coverage: xdebug
 
             - name: Configure Composer allow-plugins
-              run: composer config --no-plugins allow-plugins.phpstan/extension-installer true
+              run: composer config allow-plugins.phpstan/extension-installer true
 
             - name: Install dependencies with Composer
               uses: ramsey/composer-install@v2
 
-            - name: Debug Composer installation
+            - name: Debug Composer
+              run: composer show --all
+
+            - name: Ensure vendor/bin Exists
               run: ls -la vendor/bin
 
             - name: Coding standards


### PR DESCRIPTION
## Summary
- fix the composer plugin configuration in `tests.yml`
- add extra Composer debugging steps to help diagnose install issues

## Testing
- `N/A` (composer and php unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_6852025b5024832bb118c3f619d0fca2