### PR TITLE
Fix summary print tooltip

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -255,7 +255,8 @@ body.dark-mode .sticky-actions {
   .uk-navbar,
   button,
   .uk-button,
-  .uk-icon-button {
+  .uk-icon-button,
+  .uk-tooltip {
     display: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- hide UIkit tooltip in print view

## Testing
- `python3 -m pytest -q tests/test_json_validity.py`
- `python3 -m pytest -q tests/test_html_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68527d78dff0832ba9859ce9571819a3