### PR TITLE
Implement confirmation modal for results reset

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -78,6 +78,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const puzzleTextarea = document.getElementById('puzzleFeedbackTextarea');
   const puzzleSaveBtn = document.getElementById('puzzleFeedbackSave');
   const puzzleModal = UIkit.modal('#puzzleFeedbackModal');
+  const resultsResetModal = UIkit.modal('#resultsResetModal');
+  const resultsResetConfirm = document.getElementById('resultsResetConfirm');
   let puzzleFeedback = '';
   let logoUploaded = false;
   if (cfgFields.logoFile && cfgFields.logoPreview) {
@@ -905,11 +907,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
   resultsResetBtn?.addEventListener('click', function (e) {
     e.preventDefault();
-    if (!confirm('Alle Ergebnisse löschen?')) return;
+    resultsResetModal.show();
+  });
+
+  resultsResetConfirm?.addEventListener('click', function () {
     fetch('/results', { method: 'DELETE' })
       .then(r => {
         if (!r.ok) throw new Error(r.statusText);
         notify('Ergebnisse gelöscht', 'success');
+        resultsResetModal.hide();
         window.location.reload();
       })
       .catch(err => {

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -14,11 +14,13 @@ class ResultController
 {
     private ResultService $service;
     private ConfigService $config;
+    private string $photoDir;
 
-    public function __construct(ResultService $service, ConfigService $config)
+    public function __construct(ResultService $service, ConfigService $config, string $photoDir)
     {
         $this->service = $service;
         $this->config = $config;
+        $this->photoDir = rtrim($photoDir, '/');
     }
 
     public function get(Request $request, Response $response): Response
@@ -83,6 +85,19 @@ class ResultController
     public function delete(Request $request, Response $response): Response
     {
         $this->service->clear();
+        if (is_dir($this->photoDir)) {
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->photoDir, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($files as $file) {
+                if ($file->isDir()) {
+                    @rmdir($file->getPathname());
+                } else {
+                    @unlink($file->getPathname());
+                }
+            }
+        }
         return $response->withStatus(204);
     }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -59,7 +59,11 @@ return function (\Slim\App $app) {
 
     $configController = new ConfigController($configService);
     $catalogController = new CatalogController($catalogService);
-    $resultController = new ResultController($resultService, $configService);
+    $resultController = new ResultController(
+        $resultService,
+        $configService,
+        __DIR__ . '/../data/photos'
+    );
     $teamController = new TeamController($teamService);
     $passwordController = new PasswordController($configService);
     $qrController = new QrController();

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -300,6 +300,16 @@
           <button id="resultsResetBtn" class="uk-button uk-button-default" uk-tooltip="title: Löscht alle gespeicherten Ergebnisse; pos: right">Zurücksetzen</button>
           <button id="resultsDownloadBtn" class="uk-button uk-button-primary" uk-tooltip="title: Ergebnisse herunterladen; pos: right">Herunterladen</button>
         </div>
+
+        <div id="resultsResetModal" uk-modal>
+          <div class="uk-modal-dialog uk-modal-body">
+            <p>Beim Zurücksetzen der Statistik werden auch alle hochgeladenen Beweisfotos unwiderruflich gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.<br>Soll die Statistik nun zurückgesetzt werden?</p>
+            <div class="uk-flex uk-flex-right uk-margin-top">
+              <button id="resultsResetConfirm" class="uk-button uk-button-danger" type="button">Löschen</button>
+              <button class="uk-button uk-button-default uk-modal-close" type="button">Abbrechen</button>
+            </div>
+          </div>
+        </div>
       </div>
     </li>
     <li>


### PR DESCRIPTION
## Summary
- add UIkit modal to confirm deletion of quiz results and photos
- trigger results reset via modal in admin interface
- remove all stored photos when clearing results
- pass photo directory to controller via routes

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py -q`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68527f12d468832b9d02012c07d17d26