### PR TITLE
Introduce stable catalog UID

### DIFF
--- a/data/kataloge/catalogs.json
+++ b/data/kataloge/catalogs.json
@@ -1,5 +1,6 @@
 [
   {
+    "uid": "340da4f1-d796-49c2-aeaf-932280de5167",
     "id": "station_1",
     "file": "station_1.json",
     "name": "Station-1",
@@ -8,6 +9,7 @@
     "raetsel_buchstabe": "A"
   },
   {
+    "uid": "d0e42823-2da0-4858-a827-7d5d5d164d7d",
     "id": "station_2",
     "file": "station_2.json",
     "name": "Station-2",
@@ -16,6 +18,7 @@
     "raetsel_buchstabe": "B"
   },
   {
+    "uid": "14a904ff-cfbf-4ac5-85e0-b70222e9b31c",
     "id": "station_3",
     "file": "station_3.json",
     "name": "Station-3",
@@ -24,6 +27,7 @@
     "raetsel_buchstabe": "C"
   },
   {
+    "uid": "f1da5d20-c668-44ba-a1a6-7297fe9539c0",
     "id": "station_4",
     "file": "station_4.json",
     "name": "Station-4",
@@ -32,6 +36,7 @@
     "raetsel_buchstabe": "D"
   },
   {
+    "uid": "588eae96-0999-4124-a13a-e282e149c341",
     "id": "station_5",
     "file": "station_5.json",
     "name": "Station-5",
@@ -40,6 +45,7 @@
     "raetsel_buchstabe": "E"
   },
   {
+    "uid": "808487f9-eb09-4b41-b887-0baf82b2b92d",
     "id": "station_6",
     "file": "station_6.json",
     "name": "Station-6",
@@ -48,6 +54,7 @@
     "raetsel_buchstabe": "F"
   },
   {
+    "uid": "6dfc8316-45d3-4737-838c-811419709d9c",
     "id": "station_7",
     "file": "station_7.json",
     "name": "Station-7",
@@ -56,6 +63,7 @@
     "raetsel_buchstabe": "G"
   },
   {
+    "uid": "0c0dc60a-6d20-4e16-9f71-d926f143c874",
     "id": "station_8",
     "file": "station_8.json",
     "name": "Station-8",

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -328,15 +328,16 @@ document.addEventListener('DOMContentLoaded', function () {
     row.dataset.id = cat.id || '';
     row.dataset.file = cat.file || '';
     row.dataset.initialFile = cat.file || '';
+    row.dataset.uid = cat.uid || crypto.randomUUID();
 
-    const uid = 'cat-' + catalogRowIndex++;
+    const rowId = 'cat-' + catalogRowIndex++;
 
     const idCell = document.createElement('td');
     const idInput = document.createElement('input');
     idInput.type = 'text';
     idInput.className = 'uk-input cat-id';
     idInput.placeholder = 'ID';
-    idInput.id = uid + '-id';
+    idInput.id = rowId + '-id';
     idInput.value = cat.id || '';
     idCell.appendChild(idInput);
 
@@ -345,7 +346,7 @@ document.addEventListener('DOMContentLoaded', function () {
     name.type = 'text';
     name.className = 'uk-input cat-name';
     name.placeholder = 'Name';
-    name.id = uid + '-name';
+    name.id = rowId + '-name';
     name.value = cat.name || '';
     name.addEventListener('input', () => {
       if (row.dataset.new === 'true' && idInput.value.trim() === '') {
@@ -360,7 +361,7 @@ document.addEventListener('DOMContentLoaded', function () {
     desc.type = 'text';
     desc.className = 'uk-input cat-desc';
     desc.placeholder = 'Beschreibung';
-    desc.id = uid + '-desc';
+    desc.id = rowId + '-desc';
     desc.value = cat.description || '';
     descCell.appendChild(desc);
 
@@ -369,7 +370,7 @@ document.addEventListener('DOMContentLoaded', function () {
     letter.type = 'text';
     letter.className = 'uk-input cat-letter';
     letter.placeholder = 'Buchstabe';
-    letter.id = uid + '-letter';
+    letter.id = rowId + '-letter';
     letter.value = cat.raetsel_buchstabe || '';
     letter.maxLength = 1;
     letterCell.appendChild(letter);
@@ -411,6 +412,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const id = row.querySelector('.cat-id').value.trim();
         const file = id ? id + '.json' : '';
         return {
+          uid: row.dataset.uid,
           id,
           file,
           name: row.querySelector('.cat-name').value.trim(),

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -92,8 +92,8 @@
     return [];
   }
 
-  async function loadQuestions(id, file, letter){
-    sessionStorage.setItem('quizCatalog', id);
+  async function loadQuestions(id, file, letter, uid){
+    sessionStorage.setItem('quizCatalog', uid || id);
     if(letter){
       const cfg = window.quizConfig || {};
       if(cfg.puzzleWordEnabled && letter){
@@ -192,14 +192,14 @@
       card.style.cursor = 'pointer';
       card.addEventListener('click', () => {
         const localSolved = new Set(JSON.parse(sessionStorage.getItem('quizSolved') || '[]'));
-        if((window.quizConfig || {}).competitionMode && localSolved.has(cat.id)){
-          const remaining = catalogs.filter(c => !localSolved.has(c.id)).map(c => c.name || c.id).join(', ');
+        if((window.quizConfig || {}).competitionMode && localSolved.has(cat.uid)){
+          const remaining = catalogs.filter(c => !localSolved.has(c.uid)).map(c => c.name || c.id).join(', ');
           showCatalogSolvedModal(cat.name || cat.id, remaining);
           return;
         }
         history.replaceState(null, '', '?katalog=' + cat.id);
         setSubHeader(cat.description || '');
-        loadQuestions(cat.id, cat.file, cat.raetsel_buchstabe);
+        loadQuestions(cat.id, cat.file, cat.raetsel_buchstabe, cat.uid);
       });
       const title = document.createElement('h3');
       title.textContent = cat.name || cat.id;
@@ -414,8 +414,8 @@
       const solvedNow = await buildSolvedSet(cfg);
       const selected = catalogs.find(c => c.id === id);
       if(selected){
-          if(cfg.competitionMode && solvedNow.has(selected.id)){
-            const remaining = catalogs.filter(c => !solvedNow.has(c.id)).map(c => c.name || c.id).join(', ');
+          if(cfg.competitionMode && solvedNow.has(selected.uid)){
+            const remaining = catalogs.filter(c => !solvedNow.has(c.uid)).map(c => c.name || c.id).join(', ');
             if(catalogs.length && solvedNow.size === catalogs.length){
               showAllSolvedModal();
               return;
@@ -425,7 +425,7 @@
               return;
             }
           }
-        loadQuestions(selected.id, selected.file, selected.raetsel_buchstabe);
+        loadQuestions(selected.id, selected.file, selected.raetsel_buchstabe, selected.uid);
       }else{
         showSelection(catalogs, solvedNow);
       }

--- a/tests/test_competition_mode.js
+++ b/tests/test_competition_mode.js
@@ -17,7 +17,7 @@ const context = {
   },
   fetch: async () => ({
     ok: true,
-    json: async () => [{ name: 'Team1', catalog: 'cat1' }]
+    json: async () => [{ name: 'Team1', catalog: 'uid1' }]
   }),
   console
 };
@@ -27,7 +27,7 @@ context.sessionStorage.setItem('quizUser', 'Team1');
 
 (async () => {
   const res = await buildSolvedSet({ competitionMode: true });
-  assert(res.has('cat1'));
-  assert.deepStrictEqual(JSON.parse(context.sessionStorage.getItem('quizSolved')), ['cat1']);
+  assert(res.has('uid1'));
+  assert.deepStrictEqual(JSON.parse(context.sessionStorage.getItem('quizSolved')), ['uid1']);
   console.log('ok');
 })().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- track catalogs via a persistent `uid`
- generate a UUID for new catalogs and preserve it on edit
- store and check solved catalogs using this `uid`
- adjust competition-mode test for new behaviour

## Testing
- `node tests/test_competition_mode.js`
- `pytest -q tests/test_json_validity.py`
- `pytest -q tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_685285dd3ab8832b96828c735eb5d187