### PR TITLE
Add Mongo service for MongoDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,9 +55,19 @@ services:
     networks:
       - webproxy
 
+  mongo:
+    image: mongo:6
+    container_name: mongo
+    restart: always
+    volumes:
+      - mongodata:/data/db
+    networks:
+      - webproxy
+
 networks:
   webproxy:
     external: false
 
 volumes:
   quizdata:
+  mongodata:


### PR DESCRIPTION
## Summary
- support MongoDB by adding a new service

## Testing
- `vendor/bin/phpunit` *(fails: no such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6852aed45844832b9b5fa77cd6406b88