### PR TITLE
Add mongo configuration support

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 DOMAIN=example.com
 LETSENCRYPT_EMAIL=admin@example.com
+MONGO_DSN=mongodb://mongo:27017
+MONGO_DB=quiz

--- a/config/settings.php
+++ b/config/settings.php
@@ -4,7 +4,26 @@ $settings = [];
 if (file_exists($path)) {
     $settings = json_decode(file_get_contents($path), true) ?? [];
 }
+
+// Load environment variables from .env if available
+$envFile = __DIR__ . '/../.env';
+if (is_readable($envFile)) {
+    $vars = parse_ini_file($envFile, false, INI_SCANNER_RAW);
+    if (is_array($vars)) {
+        foreach ($vars as $key => $value) {
+            if (getenv($key) === false) {
+                putenv($key . '=' . $value);
+                $_ENV[$key] = $value;
+            }
+        }
+    }
+}
+
 $settings += [
     'displayErrorDetails' => false,
 ];
+
+$settings['mongo_dsn'] = getenv('MONGO_DSN') ?: ($settings['mongo_dsn'] ?? null);
+$settings['mongo_db']  = getenv('MONGO_DB') ?: ($settings['mongo_db'] ?? null);
+
 return $settings;

--- a/data/config.json
+++ b/data/config.json
@@ -16,5 +16,7 @@
   "photoUpload": true,
   "puzzleWordEnabled": true,
   "puzzleWord": "",
-  "puzzleFeedback": ""
+  "puzzleFeedback": "",
+  "mongo_dsn": "mongodb://mongo:27017",
+  "mongo_db": "quiz"
 }


### PR DESCRIPTION
## Summary
- add Mongo credentials to `.env`
- define `mongo_dsn` and `mongo_db` in `data/config.json`
- load `.env` from `config/settings.php` and expose new config values

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6852b1ab64a8832ba3355e6b335b0f28