### PR TITLE
Integrate Mongo Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `data/photos` und werden durch das Volume ebenfalls dauerhaft gespeichert. Die
 ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
 wird dadurch ebenfalls persistiert.
+Zusätzlich läuft ein Mongo-Express-Container mit, der die Datenbank unter
+`http://<domain>:8081` bereitstellt. Er nutzt die interne MongoDB-Verbindung
+`mongodb://mongo:27017/quiz` und erfordert keine weiteren Einstellungen.
 Um größere Uploads zu erlauben, kann die maximale
 Request-Größe des Reverse Proxys über die Umgebungsvariable
 `CLIENT_MAX_BODY_SIZE` angepasst werden. In der mitgelieferten

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,19 @@ services:
     networks:
       - webproxy
 
+  mongo-express:
+    image: mongo-express:latest
+    container_name: mongo-express
+    restart: always
+    depends_on:
+      - mongo
+    environment:
+      ME_CONFIG_MONGODB_URL: "${MONGO_DSN}/${MONGO_DB}"
+    ports:
+      - "8081:8081"
+    networks:
+      - webproxy
+
 networks:
   webproxy:
     external: false

--- a/src/routes.php
+++ b/src/routes.php
@@ -119,4 +119,10 @@ return function (\Slim\App $app) {
     $app->post('/photos', [$evidenceController, 'post']);
     $app->get('/photo/{team}/{file}', [$evidenceController, 'get']);
     $app->get('/summary', $summaryController);
+
+    $app->get('/database', function (Request $request, Response $response) {
+        $host = $request->getUri()->getHost();
+        $location = 'http://' . $host . ':8081';
+        return $response->withHeader('Location', $location)->withStatus(302);
+    });
 };

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -27,6 +27,7 @@
                 <li {% if tab == 'fragen' %}class="uk-active"{% endif %}><a href="/admin/fragen">Fragen anpassen</a></li>
                 <li {% if tab == 'teams' %}class="uk-active"{% endif %}><a href="/admin/teams">Teams/Personen</a></li>
                 <li {% if tab == 'ergebnisse' %}class="uk-active"{% endif %}><a href="/admin/ergebnisse">Ergebnisse</a></li>
+                <li><a href="/database" target="_blank">Datenbank</a></li>
                 <li {% if tab == 'pw' %}class="uk-active"{% endif %}><a href="/admin/pw">Passwort ändern</a></li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- add mongo-express container to docker-compose and use internal DSN
- provide DB access link in admin navbar
- route `/database` redirects to mongo-express
- document mongo-express in README

## Testing
- `pytest tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6852b477ad0c832ba0fa9f7ae2ae30a1