### PR TITLE
Use request scheme in /database redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
 wird dadurch ebenfalls persistiert.
 Zusätzlich läuft ein Mongo-Express-Container mit, der die Datenbank unter
-`http://<domain>:8081` bereitstellt. Er nutzt die interne MongoDB-Verbindung
-`mongodb://mongo:27017/quiz` und erfordert keine weiteren Einstellungen.
+`http://<domain>:8081` bereitstellt. Mongo Express ist dabei ausschließlich
+über HTTP erreichbar und nutzt die interne MongoDB-Verbindung
+`mongodb://mongo:27017/quiz`. Er erfordert keine weiteren Einstellungen.
 Um größere Uploads zu erlauben, kann die maximale
 Request-Größe des Reverse Proxys über die Umgebungsvariable
 `CLIENT_MAX_BODY_SIZE` angepasst werden. In der mitgelieferten

--- a/src/routes.php
+++ b/src/routes.php
@@ -121,8 +121,8 @@ return function (\Slim\App $app) {
     $app->get('/summary', $summaryController);
 
     $app->get('/database', function (Request $request, Response $response) {
-        $host = $request->getUri()->getHost();
-        $location = 'http://' . $host . ':8081';
+        $uri = $request->getUri();
+        $location = $uri->getScheme() . '://' . $uri->getHost() . ':8081';
         return $response->withHeader('Location', $location)->withStatus(302);
     });
 };


### PR DESCRIPTION
## Summary
- tweak `/database` route to use request URI scheme
- clarify in README that Mongo Express only runs via HTTP

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6852c9b519a0832ba3771c0434316abd