### PR TITLE
Fix composer MongoDB extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ RUN apk add --no-cache libpng libjpeg-turbo freetype libwebp \
     && apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install gd \
-    && apk del .build-deps
+    && apk del .build-deps \
+    && apk add --no-cache php8-pecl-mongodb \
+    && docker-php-ext-enable mongodb
 
 # install composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
## Summary
- install php8-pecl-mongodb for Slim app

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6852ce69e364832b813f8d96a95cbddb