### PR TITLE
Build MongoDB via pecl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM php:8.2-alpine
 
 RUN apk add --no-cache libpng libjpeg-turbo freetype libwebp \
-    && apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev \
+    && apk add --no-cache --virtual .build-deps $PHPIZE_DEPS libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install gd \
-    && apk del .build-deps \
-    && apk add --no-cache php8-pecl-mongodb \
-    && docker-php-ext-enable mongodb
+    && pecl install mongodb \
+    && docker-php-ext-enable mongodb \
+    && apk del .build-deps
 
 # install composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
## Summary
- build MongoDB extension from pecl in Dockerfile
- add `$PHPIZE_DEPS` to build deps

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6852d099896c832b9ddb7a748b620828