### PR TITLE
Fix Dockerfile extension install order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.2-alpine
 
 RUN apk add --no-cache libpng libjpeg-turbo freetype libwebp \
-    && apk add --no-cache --virtual .build-deps $PHPIZE_DEPS libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev \
+    && apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev $PHPIZE_DEPS \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install gd \
     && pecl install mongodb \


### PR DESCRIPTION
## Summary
- reorder build dependencies for GD and MongoDB before running Composer

## Testing
- `composer install --no-interaction --prefer-dist --no-progress` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6852d4d9bad0832baa89fb6df64d8427