### PR TITLE
Add pdo_pgsql extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:8.2-alpine
 
 RUN apk add --no-cache libpng libjpeg-turbo freetype libwebp \
-    && apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev $PHPIZE_DEPS \
+    && apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev postgresql-dev $PHPIZE_DEPS \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
-    && docker-php-ext-install gd \
+    && docker-php-ext-install gd pdo_pgsql \
     && apk del .build-deps
 
 # install composer


### PR DESCRIPTION
## Summary
- add `postgresql-dev` build dependency
- install PHP pdo_pgsql extension

## Testing
- `docker compose build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852dcdfe568832bb8c6aaf8427ea51f