### PR TITLE
Add Adminer for Postgres

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ LETSENCRYPT_EMAIL=admin@example.com
 POSTGRES_DSN=pgsql:host=postgres;dbname=quiz
 POSTGRES_USER=quiz
 POSTGRES_PASS=quiz
+POSTGRES_DB=quiz

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `docker-compose down` erhalten. Hochgeladene Beweisfotos landen im Verzeichnis
 `data/photos` und werden durch das Volume ebenfalls dauerhaft gespeichert. Die
 ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
-wird dadurch ebenfalls persistiert.
+wird dadurch ebenfalls persistiert. Zusätzlich läuft ein Adminer-Container,
+der die PostgreSQL-Datenbank unter `http://<domain>:8081` bereitstellt. Er
+nutzt intern den Hostnamen `postgres` und erfordert keine weiteren Einstellungen.
 Um größere Uploads zu erlauben, kann die maximale
 Request-Größe des Reverse Proxys über die Umgebungsvariable
 `CLIENT_MAX_BODY_SIZE` angepasst werden. In der mitgelieferten

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,18 @@ services:
     networks:
       - webproxy
 
+  adminer:
+    image: adminer
+    restart: always
+    environment:
+      - ADMINER_DEFAULT_SERVER=postgres
+    ports:
+      - "8081:8080"
+    depends_on:
+      - postgres
+    networks:
+      - webproxy
+
   letsencrypt:
     image: nginxproxy/acme-companion
     container_name: nginx-proxy-letsencrypt


### PR DESCRIPTION
## Summary
- run Adminer container at port 8081
- add default Postgres DB variable
- mention Adminer in README

## Testing
- `pytest -q`
- `python3 tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6852df2eff8c832bbbbacc381db7221e