### PR TITLE
Fix adminer redirect scheme

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -122,7 +122,7 @@ return function (\Slim\App $app) {
 
     $app->get('/database', function (Request $request, Response $response) {
         $uri = $request->getUri();
-        $location = $uri->getScheme() . '://' . $uri->getHost() . ':8081';
+        $location = 'http://' . $uri->getHost() . ':8081';
         return $response->withHeader('Location', $location)->withStatus(302);
     });
 };


### PR DESCRIPTION
## Summary
- fix http redirect to adminer container so the scheme isn't forced to HTTPS

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e2b4a964832b92855314535bc7bc