### PR TITLE
Expose Adminer via subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `data/photos` und werden durch das Volume ebenfalls dauerhaft gespeichert. Die
 ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
 wird dadurch ebenfalls persistiert. Zusätzlich läuft ein Adminer-Container,
-der die PostgreSQL-Datenbank unter `http://<domain>:8081` bereitstellt. Er
+der die PostgreSQL-Datenbank über die Subdomain `https://adminer.<domain>` bereitstellt. Er
 nutzt intern den Hostnamen `postgres` und erfordert keine weiteren Einstellungen.
 Um größere Uploads zu erlauben, kann die maximale
 Request-Größe des Reverse Proxys über die Umgebungsvariable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,9 +34,10 @@ services:
     image: adminer
     restart: always
     environment:
+      - VIRTUAL_HOST=adminer.${DOMAIN}
+      - LETSENCRYPT_HOST=adminer.${DOMAIN}
+      - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
       - ADMINER_DEFAULT_SERVER=postgres
-    ports:
-      - "8081:8080"
     depends_on:
       - postgres
     networks:

--- a/src/routes.php
+++ b/src/routes.php
@@ -122,7 +122,7 @@ return function (\Slim\App $app) {
 
     $app->get('/database', function (Request $request, Response $response) {
         $uri = $request->getUri();
-        $location = 'http://' . $uri->getHost() . ':8081';
+        $location = 'https://adminer.' . $uri->getHost();
         return $response->withHeader('Location', $location)->withStatus(302);
     });
 };


### PR DESCRIPTION
## Summary
- expose Adminer through nginx-proxy with letsencrypt
- document new Adminer URL
- update `/database` redirect

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6852e49f2b24832ba091413bdc57e21e