### PR TITLE
Fix automatic Postgres setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
 Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.
 Ein vorheriges `composer install` ist somit nicht mehr erforderlich.
 
+Ist in der `.env` die Variable `POSTGRES_DSN` gesetzt, legt das Entrypoint-
+Skript beim Start automatisch die Datenbank anhand von `docs/schema.sql` an und
+importiert die vorhandenen JSON-Daten. Neben `POSTGRES_DSN` werden dafür auch
+`POSTGRES_USER`, `POSTGRES_PASS` und `POSTGRES_DB` ausgewertet.
+
 ### Bildgrößen anpassen
 
 Damit hochgeladene Dateien nicht unnötig groß werden, ist die Bibliothek [Intervention Image](https://image.intervention.io/) nun fest eingebunden.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+# Load variables from .env if available and not already set
+if [ -r .env ]; then
+    while IFS='=' read -r key value; do
+        case "$key" in ''|\#*) continue ;; esac
+        if [ -z "$(printenv "$key")" ]; then
+            export "$key=$value"
+        fi
+    done < .env
+fi
+
 # Install composer dependencies if vendor directory is missing
 if [ ! -d vendor ]; then
     composer install --no-interaction --prefer-dist --no-progress


### PR DESCRIPTION
## Summary
- read `.env` in `docker-entrypoint.sh` so the DB init uses env vars
- document automatic database creation in README

## Testing
- `pytest tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6852fb247b14832b9e982538900e57eb