### PR TITLE
Add POSTGRES_PASSWORD variable and update scripts

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,5 @@ LETSENCRYPT_EMAIL=admin@example.com
 POSTGRES_DSN=pgsql:host=postgres;dbname=quiz
 POSTGRES_USER=quiz
 POSTGRES_PASS=quiz
+POSTGRES_PASSWORD=quiz
 POSTGRES_DB=quiz

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Ein vorheriges `composer install` ist somit nicht mehr erforderlich.
 Ist in der `.env` die Variable `POSTGRES_DSN` gesetzt, legt das Entrypoint-
 Skript beim Start automatisch die Datenbank anhand von `docs/schema.sql` an und
 importiert die vorhandenen JSON-Daten. Neben `POSTGRES_DSN` werden dafür auch
-`POSTGRES_USER`, `POSTGRES_PASS` und `POSTGRES_DB` ausgewertet.
+`POSTGRES_USER`, `POSTGRES_PASSWORD` und `POSTGRES_DB` ausgewertet (zur
+Kompatibilität wird auch `POSTGRES_PASS` noch unterstützt).
 
 ### Bildgrößen anpassen
 

--- a/config/settings.php
+++ b/config/settings.php
@@ -25,7 +25,7 @@ $settings += [
 
 $settings['postgres_dsn'] = getenv('POSTGRES_DSN') ?: ($settings['postgres_dsn'] ?? null);
 $settings['postgres_user'] = getenv('POSTGRES_USER') ?: ($settings['postgres_user'] ?? null);
-$settings['postgres_pass'] = getenv('POSTGRES_PASS') ?: ($settings['postgres_pass'] ?? null);
+$settings['postgres_pass'] = getenv('POSTGRES_PASSWORD') ?: getenv('POSTGRES_PASS') ?: ($settings['postgres_pass'] ?? null);
 
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,7 @@ if [ -n "$POSTGRES_DSN" ] && [ -f docs/schema.sql ]; then
     echo "Initializing PostgreSQL schema"
     host=$(echo "$POSTGRES_DSN" | sed -n 's/.*host=\([^;]*\).*/\1/p')
     db=${POSTGRES_DB:-$(echo "$POSTGRES_DSN" | sed -n 's/.*dbname=\([^;]*\).*/\1/p')}
-    export PGPASSWORD="$POSTGRES_PASS"
+    export PGPASSWORD="${POSTGRES_PASSWORD:-$POSTGRES_PASS}"
     psql -h "$host" -U "$POSTGRES_USER" -d "$db" -f docs/schema.sql >/dev/null
     unset PGPASSWORD
     if [ -f scripts/import_to_pgsql.php ]; then

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -11,7 +11,7 @@ if (is_readable($configFile)) {
 
 $dsn = getenv('POSTGRES_DSN') ?: ($config['postgres_dsn'] ?? null);
 $user = getenv('POSTGRES_USER') ?: ($config['postgres_user'] ?? null);
-$pass = getenv('POSTGRES_PASS') ?: ($config['postgres_pass'] ?? null);
+$pass = getenv('POSTGRES_PASSWORD') ?: getenv('POSTGRES_PASS') ?: ($config['postgres_pass'] ?? null);
 $db   = getenv('POSTGRES_DB') ?: ($config['postgres_db'] ?? null);
 
 if (!$dsn || !$user || !$db) {


### PR DESCRIPTION
## Summary
- add `POSTGRES_PASSWORD` to `.env`
- read `POSTGRES_PASSWORD` in docker-entrypoint and PHP config
- fallback to `POSTGRES_PASS` for backwards compatibility
- document the new variable in README

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fe3d4c64832b9310a02de89eeb43