### PR TITLE
Add JSON import script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
    ```bash
    psql -f docs/schema.sql
    ```
+4. Anschließend einmalig die vorhandenen JSON-Daten importieren:
+   ```bash
+   php scripts/import_to_pgsql.php
+   ```
 
 ## Docker Compose
 

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -41,26 +41,40 @@ if ($configData) {
         $stmt->bindValue(':' . $k, $v);
     }
     $stmt->execute();
+    $pdo->exec("SELECT setval(pg_get_serial_sequence('config','id'), (SELECT COALESCE(MAX(id),0) FROM config))");
 }
 
 // Import teams
 $teamsFile = "$base/data/teams.json";
 if (is_readable($teamsFile)) {
     $teams = json_decode(file_get_contents($teamsFile), true) ?? [];
-    $stmt = $pdo->prepare('INSERT INTO teams(name) VALUES(?)');
-    foreach ($teams as $name) {
-        $stmt->execute([$name]);
+    $withId = isset($teams[0]['id']);
+    $sql = $withId ?
+        'INSERT INTO teams(id,name) VALUES(?,?)' :
+        'INSERT INTO teams(name) VALUES(?)';
+    $stmt = $pdo->prepare($sql);
+    foreach ($teams as $t) {
+        if ($withId) {
+            $stmt->execute([$t['id'], $t['name']]);
+        } else {
+            $name = is_array($t) ? ($t['name'] ?? '') : $t;
+            $stmt->execute([$name]);
+        }
     }
+    $pdo->exec("SELECT setval(pg_get_serial_sequence('teams','id'), (SELECT COALESCE(MAX(id),0) FROM teams))");
 }
 
 // Import results
 $resultsFile = "$base/data/results.json";
 if (is_readable($resultsFile)) {
     $results = json_decode(file_get_contents($resultsFile), true) ?? [];
-    $sql = 'INSERT INTO results(name,catalog,attempt,correct,total,time,puzzleTime,photo) VALUES(?,?,?,?,?,?,?,?)';
+    $withId = isset($results[0]['id']);
+    $sql = $withId
+        ? 'INSERT INTO results(id,name,catalog,attempt,correct,total,time,puzzleTime,photo) VALUES(?,?,?,?,?,?,?,?,?)'
+        : 'INSERT INTO results(name,catalog,attempt,correct,total,time,puzzleTime,photo) VALUES(?,?,?,?,?,?,?,?)';
     $stmt = $pdo->prepare($sql);
     foreach ($results as $r) {
-        $stmt->execute([
+        $params = [
             $r['name'] ?? '',
             $r['catalog'] ?? '',
             $r['attempt'] ?? 1,
@@ -69,8 +83,13 @@ if (is_readable($resultsFile)) {
             $r['time'] ?? time(),
             $r['puzzleTime'] ?? null,
             $r['photo'] ?? null,
-        ]);
+        ];
+        if ($withId) {
+            array_unshift($params, $r['id']);
+        }
+        $stmt->execute($params);
     }
+    $pdo->exec("SELECT setval(pg_get_serial_sequence('results','id'), (SELECT COALESCE(MAX(id),0) FROM results))");
 }
 
 // Import catalogs and questions
@@ -106,6 +125,7 @@ if (is_readable($catalogsFile)) {
             }
         }
     }
+    $pdo->exec("SELECT setval(pg_get_serial_sequence('questions','id'), (SELECT COALESCE(MAX(id),0) FROM questions))");
 }
 
 // Import photo consents
@@ -116,6 +136,7 @@ if (is_readable($consentFile)) {
     foreach ($consents as $c) {
         $stmt->execute([ $c['team'] ?? '', $c['time'] ?? 0 ]);
     }
+    $pdo->exec("SELECT setval(pg_get_serial_sequence('photo_consents','id'), (SELECT COALESCE(MAX(id),0) FROM photo_consents))");
 }
 
 $pdo->commit();


### PR DESCRIPTION
## Summary
- enhance import_to_pgsql.php to preserve IDs and update sequences
- document running the import script after creating database tables

## Testing
- `pytest -q`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py` *(fails: pytest not run earlier? but executed above maybe)*

------
https://chatgpt.com/codex/tasks/task_e_68531bd8b26c832bb34a667807e977b1