### PR TITLE
Fix PHPStan unused fields

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -18,11 +18,10 @@ class AdminController
     {
         $view = Twig::fromRequest($request);
         $cfg = (new ConfigService(
-            __DIR__ . '/../../data/config.json',
             __DIR__ . '/../../config/config.json'
         ))->getConfig();
-        $results = (new ResultService(__DIR__ . '/../../data/results.json'))->getAll();
-        $catalogSvc = new CatalogService(__DIR__ . '/../../data/kataloge');
+        $results = (new ResultService())->getAll();
+        $catalogSvc = new CatalogService();
         $catalogsJson = $catalogSvc->read('catalogs.json');
         $catalogs = [];
         if ($catalogsJson !== null) {
@@ -45,7 +44,7 @@ class AdminController
             }
         }
 
-        $teams = (new TeamService(__DIR__ . '/../../data/teams.json'))->getAll();
+        $teams = (new TeamService())->getAll();
 
         return $view->render($response, 'admin.twig', [
             'config' => $cfg,

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -15,7 +15,6 @@ class HelpController
     {
         $view = Twig::fromRequest($request);
         $cfg = (new ConfigService(
-            __DIR__ . '/../../data/config.json',
             __DIR__ . '/../../config/config.json'
         ))->getConfig();
 

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -16,11 +16,10 @@ class HomeController
     {
         $view = Twig::fromRequest($request);
         $cfg = (new ConfigService(
-            __DIR__ . '/../../data/config.json',
             __DIR__ . '/../../config/config.json'
         ))->getConfig();
 
-        $catalogService = new CatalogService(__DIR__ . '/../../data/kataloge');
+        $catalogService = new CatalogService();
         $catalogsJson = $catalogService->read('catalogs.json');
         $catalogs = [];
         if ($catalogsJson !== null) {

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -25,7 +25,6 @@ class LoginController
         }
 
         $config = (new ConfigService(
-            __DIR__ . '/../../data/config.json',
             __DIR__ . '/../../config/config.json'
         ))->getConfig();
         $user = $config['adminUser'] ?? 'admin';

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -9,18 +9,11 @@ use PDO;
 
 class CatalogService
 {
-    private string $basePath;
     private PDO $pdo;
 
-    public function __construct(string $basePath)
+    public function __construct()
     {
-        $this->basePath = rtrim($basePath, '/');
         $this->pdo = Database::connect();
-    }
-
-    private function path(string $file): string
-    {
-        return $this->basePath . '/' . basename($file);
     }
 
     public function read(string $file): ?string

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -9,13 +9,11 @@ use PDO;
 
 class ConfigService
 {
-    private string $path;
     private ?string $fallbackPath = null;
     private PDO $pdo;
 
-    public function __construct(string $path, ?string $fallbackPath = null)
+    public function __construct(?string $fallbackPath = null)
     {
-        $this->path = $path;
         $this->fallbackPath = $fallbackPath;
         $this->pdo = Database::connect();
     }

--- a/src/Service/PhotoConsentService.php
+++ b/src/Service/PhotoConsentService.php
@@ -9,12 +9,10 @@ use PDO;
 
 class PhotoConsentService
 {
-    private string $path;
     private PDO $pdo;
 
-    public function __construct(string $path)
+    public function __construct()
     {
-        $this->path = $path;
         $this->pdo = Database::connect();
     }
 

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -9,12 +9,10 @@ use PDO;
 
 class ResultService
 {
-    private string $path;
     private PDO $pdo;
 
-    public function __construct(string $path)
+    public function __construct()
     {
-        $this->path = $path;
         $this->pdo = Database::connect();
     }
 

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -9,12 +9,10 @@ use PDO;
 
 class TeamService
 {
-    private string $path;
     private PDO $pdo;
 
-    public function __construct(string $path)
+    public function __construct()
     {
-        $this->path = $path;
         $this->pdo = Database::connect();
     }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -49,13 +49,10 @@ require_once __DIR__ . '/Controller/SummaryController.php';
 require_once __DIR__ . '/Controller/EvidenceController.php';
 
 return function (\Slim\App $app) {
-    $configService = new ConfigService(
-        __DIR__ . '/../data/config.json',
-        __DIR__ . '/../config/config.json'
-    );
-    $catalogService = new CatalogService(__DIR__ . '/../data/kataloge');
-    $resultService = new ResultService(__DIR__ . '/../data/results.json');
-    $teamService = new TeamService(__DIR__ . '/../data/teams.json');
+    $configService = new ConfigService(__DIR__ . '/../config/config.json');
+    $catalogService = new CatalogService();
+    $resultService = new ResultService();
+    $teamService = new TeamService();
 
     $configController = new ConfigController($configService);
     $catalogController = new CatalogController($catalogService);
@@ -69,7 +66,7 @@ return function (\Slim\App $app) {
     $qrController = new QrController();
     $logoController = new LogoController($configService);
     $summaryController = new SummaryController($configService);
-    $consentService = new PhotoConsentService(__DIR__ . '/../data/photo_consents.json');
+    $consentService = new PhotoConsentService();
     $evidenceController = new EvidenceController(
         $resultService,
         $consentService,

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -15,7 +15,7 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $controller = new CatalogController(new CatalogService($dir));
+        $controller = new CatalogController(new CatalogService());
         $request = $this->createRequest('GET', '/kataloge/missing.json', ['HTTP_ACCEPT' => 'application/json']);
         $response = $controller->get($request, new Response(), ['file' => 'missing.json']);
         $this->assertEquals(404, $response->getStatusCode());
@@ -26,7 +26,7 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService($dir);
+        $service = new CatalogService();
         $controller = new CatalogController($service);
 
         $request = $this->createRequest('POST', '/kataloge/test.json');
@@ -50,7 +50,7 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService($dir);
+        $service = new CatalogService();
         $controller = new CatalogController($service);
 
         $createReq = $this->createRequest('PUT', '/kataloge/new.json');
@@ -73,7 +73,7 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService($dir);
+        $service = new CatalogService();
         $controller = new CatalogController($service);
 
         $service->write('cat.json', [['a' => 1], ['b' => 2]]);
@@ -94,7 +94,7 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $controller = new CatalogController(new CatalogService($dir));
+        $controller = new CatalogController(new CatalogService());
 
         $request = $this->createRequest('POST', '/kataloge/test.json', ['HTTP_CONTENT_TYPE' => 'application/json']);
         $stream = fopen('php://temp', 'r+');

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -15,7 +15,7 @@ class ConfigControllerTest extends TestCase
     {
         $tmp = tempnam(sys_get_temp_dir(), 'config');
         unlink($tmp);
-        $controller = new ConfigController(new ConfigService($tmp));
+        $controller = new ConfigController(new ConfigService());
         $request = $this->createRequest('GET', '/config.json');
         $response = $controller->get($request, new Response());
 
@@ -25,7 +25,7 @@ class ConfigControllerTest extends TestCase
     public function testPostAndGet(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'config');
-        $service = new ConfigService($tmp);
+        $service = new ConfigService();
         $controller = new ConfigController($service);
 
         $request = $this->createRequest('POST', '/config.json');
@@ -43,7 +43,7 @@ class ConfigControllerTest extends TestCase
     public function testPostInvalidJson(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'config');
-        $service = new ConfigService($tmp);
+        $service = new ConfigService();
         $controller = new ConfigController($service);
 
         $request = $this->createRequest('POST', '/config.json', ['HTTP_CONTENT_TYPE' => 'application/json']);

--- a/tests/Controller/LogoControllerTest.php
+++ b/tests/Controller/LogoControllerTest.php
@@ -14,7 +14,7 @@ class LogoControllerTest extends TestCase
 {
     public function testGetNotFound(): void
     {
-        $cfg = new ConfigService(sys_get_temp_dir() . '/cfg.json');
+        $cfg = new ConfigService();
         $controller = new LogoController($cfg);
         $request = $this->createRequest('GET', '/logo.png');
         $response = $controller->get($request, new Response());
@@ -25,7 +25,7 @@ class LogoControllerTest extends TestCase
     public function testPostAndGet(): void
     {
         $tmpConfig = tempnam(sys_get_temp_dir(), 'cfg');
-        $cfg = new ConfigService($tmpConfig);
+        $cfg = new ConfigService();
         $controller = new LogoController($cfg);
         $logoFile = tempnam(sys_get_temp_dir(), 'logo');
         imagepng(imagecreatetruecolor(10, 10), $logoFile);
@@ -48,7 +48,7 @@ class LogoControllerTest extends TestCase
     public function testPostAndGetWebp(): void
     {
         $tmpConfig = tempnam(sys_get_temp_dir(), 'cfg');
-        $cfg = new ConfigService($tmpConfig);
+        $cfg = new ConfigService();
         $controller = new LogoController($cfg);
         $logoFile = tempnam(sys_get_temp_dir(), 'logo');
         file_put_contents($logoFile, 'dummy');

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -13,7 +13,7 @@ class CatalogServiceTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService($dir);
+        $service = new CatalogService();
         $file = 'test.json';
         $data = ['a' => 1];
 
@@ -28,7 +28,7 @@ class CatalogServiceTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService($dir);
+        $service = new CatalogService();
 
         $this->assertNull($service->read('missing.json'));
 
@@ -39,7 +39,7 @@ class CatalogServiceTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService($dir);
+        $service = new CatalogService();
         $file = 'del.json';
         $service->write($file, []);
         $this->assertFileExists($dir . '/' . $file);
@@ -52,7 +52,7 @@ class CatalogServiceTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService($dir);
+        $service = new CatalogService();
         $file = 'q.json';
         $data = [['a' => 1], ['b' => 2]];
         $service->write($file, $data);

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -12,7 +12,7 @@ class ConfigServiceTest extends TestCase
     public function testReadWriteConfig(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'config');
-        $service = new ConfigService($tmp);
+        $service = new ConfigService();
         $data = ['foo' => 'bar'];
 
         $service->saveConfig($data);
@@ -28,7 +28,7 @@ class ConfigServiceTest extends TestCase
     {
         $tmp = tempnam(sys_get_temp_dir(), 'config');
         unlink($tmp);
-        $service = new ConfigService($tmp);
+        $service = new ConfigService();
 
         $this->assertNull($service->getJson());
         $this->assertEquals([], $service->getConfig());

--- a/tests/Service/PhotoConsentServiceTest.php
+++ b/tests/Service/PhotoConsentServiceTest.php
@@ -12,7 +12,7 @@ class PhotoConsentServiceTest extends TestCase
     public function testAddConsentAppendsEntry(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'consent');
-        $svc = new PhotoConsentService($tmp);
+        $svc = new PhotoConsentService();
         $svc->add('TeamA', 123);
         $svc->add('TeamB', 456);
         $data = json_decode(file_get_contents($tmp), true);

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -12,7 +12,7 @@ class ResultServiceTest extends TestCase
     public function testAddIncrementsAttemptForSameCatalog(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'results');
-        $service = new ResultService($tmp);
+        $service = new ResultService();
 
         $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $this->assertSame(1, $first['attempt']);
@@ -26,7 +26,7 @@ class ResultServiceTest extends TestCase
     public function testAddDoesNotIncrementAcrossCatalogs(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'results');
-        $service = new ResultService($tmp);
+        $service = new ResultService();
 
         $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $this->assertSame(1, $first['attempt']);
@@ -40,7 +40,7 @@ class ResultServiceTest extends TestCase
     public function testMarkPuzzleUpdatesEntry(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'results');
-        $service = new ResultService($tmp);
+        $service = new ResultService();
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $ts = time();
@@ -55,7 +55,7 @@ class ResultServiceTest extends TestCase
     public function testSetPhotoUpdatesEntry(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'results');
-        $service = new ResultService($tmp);
+        $service = new ResultService();
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $service->setPhoto('TeamA', 'cat1', '/photo/test.jpg');


### PR DESCRIPTION
## Summary
- remove unused service constructor arguments
- update routes and controllers for new service signatures
- adjust tests to match new constructors

## Testing
- `ls vendor 2>&1 | head`

------
https://chatgpt.com/codex/tasks/task_e_68531e92664c832b89b30d5c8331cf22