### PR TITLE
Fix Slim startup in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,8 @@ services:
       - VIRTUAL_HOST=${DOMAIN}
       - LETSENCRYPT_HOST=${DOMAIN}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
+    depends_on:
+      - postgres
     # Use router.php so that Slim handles routes for non-existent static files
     command: php -S 0.0.0.0:8080 -t public public/router.php
     expose:


### PR DESCRIPTION
## Summary
- add postgres dependency for slim container

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68531f9475a0832ba8162364c90e974c