### PR TITLE
Improve startup error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,17 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 ## Schnellstart
 
 1. Abhängigkeiten installieren:
-   ```bash
-   composer install
-   ```
-   Beim ersten Aufruf legt Composer eine `composer.lock` an und lädt alle
-   benötigten Pakete herunter. Die Datei wird bewusst nicht versioniert,
-   sodass stets die neuesten kompatiblen Abhängigkeiten installiert werden.
-   Das Docker-Setup installiert dabei automatisch die PHP-Erweiterung *gd*,
-   welche für die Bibliothek `setasign/fpdf` benötigt wird.
+  ```bash
+  composer install
+  ```
+  Beim ersten Aufruf legt Composer eine `composer.lock` an und lädt alle
+  benötigten Pakete herunter. Die Datei wird bewusst nicht versioniert,
+  sodass stets die neuesten kompatiblen Abhängigkeiten installiert werden.
+  Wer die Anwendung ohne Docker betreibt, muss diesen Schritt manuell
+  ausführen. Fehlt das Verzeichnis `vendor/`, zeigt die App eine
+  entsprechende Fehlermeldung an.
+  Das Docker-Setup installiert dabei automatisch die PHP-Erweiterung *gd*,
+  welche für die Bibliothek `setasign/fpdf` benötigt wird.
    Wurden neue Pakete in `composer.json` eingetragen, sollte anschließend
    `composer update --lock` ausgeführt werden, um die `composer.lock`
    zu aktualisieren. Andernfalls bricht der Docker-Build mit Hinweis auf
@@ -147,7 +150,8 @@ liegt im Verzeichnis `config/` bereits eine kleine `php.ini` bei, die in
 Die verwendete Domain wird aus der Datei `.env` gelesen (Variable `DOMAIN`).
 Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
 Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.
-Ein vorheriges `composer install` ist somit nicht mehr erforderlich.
+Ein vorheriges `composer install` ist somit nicht mehr erforderlich,
+solange die App innerhalb des Docker-Setups gestartet wird.
 
 Ist in der `.env` die Variable `POSTGRES_DSN` gesetzt, legt das Entrypoint-
 Skript beim Start automatisch die Datenbank anhand von `docs/schema.sql` an und

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,12 @@
 <?php
-require __DIR__ . '/../vendor/autoload.php';
+$autoloader = __DIR__ . '/../vendor/autoload.php';
+if (!is_readable($autoloader)) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo "Autoloader not found. Please run 'composer install'.\n";
+    exit(1);
+}
+require $autoloader;
 
 // Load environment variables from .env if available
 $envFile = __DIR__ . '/../.env';


### PR DESCRIPTION
## Summary
- add helpful error message if `vendor/autoload.php` is missing
- clarify composer usage in README

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_68533b5b9a14832ba3e4988e5516ea05