### PR TITLE
Support POSTGRES_PASSWORD fallback

### DIFF
--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -11,7 +11,7 @@ class Database
     {
         $dsn  = getenv('POSTGRES_DSN') ?: '';
         $user = getenv('POSTGRES_USER') ?: '';
-        $pass = getenv('POSTGRES_PASS') ?: '';
+        $pass = getenv('POSTGRES_PASSWORD') ?: getenv('POSTGRES_PASS') ?: '';
         return new PDO($dsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
     }


### PR DESCRIPTION
## Summary
- prefer `POSTGRES_PASSWORD` over `POSTGRES_PASS` when connecting to the DB

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68534163780c832ba9d80ffffe33474a