### PR TITLE
Update service tests for PDO-based storage

### DIFF
--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -5,64 +5,85 @@ declare(strict_types=1);
 namespace Tests\Service;
 
 use App\Service\CatalogService;
+use PDO;
 use Tests\TestCase;
 
 class CatalogServiceTest extends TestCase
 {
+    private function createPdo(): PDO
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id TEXT NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
+        return $pdo;
+    }
+
     public function testReadWrite(): void
     {
-        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
-        mkdir($dir);
-        $service = new CatalogService();
+        $pdo = $this->createPdo();
+        $service = new CatalogService($pdo);
         $file = 'test.json';
-        $data = ['a' => 1];
+        $catalog = [[
+            'uid' => 'uid1',
+            'id' => 'cat1',
+            'file' => $file,
+            'name' => 'Test',
+        ]];
+        $service->write('catalogs.json', $catalog);
+        $data = [['type' => 'text', 'prompt' => 'Hello']];
 
         $service->write($file, $data);
         $this->assertJsonStringEqualsJsonString(json_encode($data, JSON_PRETTY_PRINT), $service->read($file));
-
-        unlink($dir . '/' . $file);
-        rmdir($dir);
     }
 
     public function testReadReturnsNullIfMissing(): void
     {
-        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
-        mkdir($dir);
-        $service = new CatalogService();
+        $pdo = $this->createPdo();
+        $service = new CatalogService($pdo);
 
         $this->assertNull($service->read('missing.json'));
-
-        rmdir($dir);
     }
 
     public function testDelete(): void
     {
-        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
-        mkdir($dir);
-        $service = new CatalogService();
+        $pdo = $this->createPdo();
+        $service = new CatalogService($pdo);
         $file = 'del.json';
+        $service->write('catalogs.json', [[
+            'uid' => 'uid2',
+            'id' => 'del',
+            'file' => $file,
+            'name' => 'Del',
+        ]]);
         $service->write($file, []);
-        $this->assertFileExists($dir . '/' . $file);
+        $stmt = $pdo->query('SELECT COUNT(*) FROM questions');
+        $this->assertSame('0', $stmt->fetchColumn());
         $service->delete($file);
-        $this->assertFileDoesNotExist($dir . '/' . $file);
-        rmdir($dir);
+        $stmt = $pdo->query('SELECT COUNT(*) FROM catalogs');
+        $this->assertSame('0', $stmt->fetchColumn());
     }
 
     public function testDeleteQuestion(): void
     {
-        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
-        mkdir($dir);
-        $service = new CatalogService();
+        $pdo = $this->createPdo();
+        $service = new CatalogService($pdo);
         $file = 'q.json';
-        $data = [['a' => 1], ['b' => 2]];
+        $service->write('catalogs.json', [[
+            'uid' => 'uid3',
+            'id' => 'qid',
+            'file' => $file,
+            'name' => 'Q',
+        ]]);
+        $data = [
+            ['type' => 'text', 'prompt' => 'A'],
+            ['type' => 'text', 'prompt' => 'B'],
+        ];
         $service->write($file, $data);
 
         $service->deleteQuestion($file, 0);
         $remaining = json_decode($service->read($file), true);
         $this->assertCount(1, $remaining);
-        $this->assertSame(['b' => 2], $remaining[0]);
-
-        unlink($dir . '/' . $file);
-        rmdir($dir);
+        $this->assertSame('B', $remaining[0]['prompt']);
     }
 }

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -5,30 +5,31 @@ declare(strict_types=1);
 namespace Tests\Service;
 
 use App\Service\ConfigService;
+use PDO;
 use Tests\TestCase;
 
 class ConfigServiceTest extends TestCase
 {
     public function testReadWriteConfig(): void
     {
-        $tmp = tempnam(sys_get_temp_dir(), 'config');
-        $service = new ConfigService();
-        $data = ['foo' => 'bar'];
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT);');
+        $service = new ConfigService($pdo);
+        $data = ['pageTitle' => 'Demo'];
 
         $service->saveConfig($data);
-        $this->assertFileExists($tmp);
-        $expected = json_encode($data, JSON_PRETTY_PRINT) . "\n";
+        $expected = json_encode(['pageTitle' => 'Demo'], JSON_PRETTY_PRINT);
         $this->assertSame($expected, $service->getJson());
         $this->assertEquals($data, $service->getConfig());
-
-        unlink($tmp);
     }
 
     public function testGetJsonReturnsNullIfFileMissing(): void
     {
-        $tmp = tempnam(sys_get_temp_dir(), 'config');
-        unlink($tmp);
-        $service = new ConfigService();
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT);');
+        $service = new ConfigService($pdo);
 
         $this->assertNull($service->getJson());
         $this->assertEquals([], $service->getConfig());

--- a/tests/Service/PhotoConsentServiceTest.php
+++ b/tests/Service/PhotoConsentServiceTest.php
@@ -5,20 +5,23 @@ declare(strict_types=1);
 namespace Tests\Service;
 
 use App\Service\PhotoConsentService;
+use PDO;
 use Tests\TestCase;
 
 class PhotoConsentServiceTest extends TestCase
 {
     public function testAddConsentAppendsEntry(): void
     {
-        $tmp = tempnam(sys_get_temp_dir(), 'consent');
-        $svc = new PhotoConsentService();
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL);');
+        $svc = new PhotoConsentService($pdo);
         $svc->add('TeamA', 123);
         $svc->add('TeamB', 456);
-        $data = json_decode(file_get_contents($tmp), true);
+        $stmt = $pdo->query('SELECT team,time FROM photo_consents ORDER BY id');
+        $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
         $this->assertCount(2, $data);
         $this->assertSame('TeamA', $data[0]['team']);
-        $this->assertSame(456, $data[1]['time']);
-        unlink($tmp);
+        $this->assertSame(456, (int)$data[1]['time']);
     }
 }

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -5,64 +5,63 @@ declare(strict_types=1);
 namespace Tests\Service;
 
 use App\Service\ResultService;
+use PDO;
 use Tests\TestCase;
 
 class ResultServiceTest extends TestCase
 {
     public function testAddIncrementsAttemptForSameCatalog(): void
     {
-        $tmp = tempnam(sys_get_temp_dir(), 'results');
-        $service = new ResultService();
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $service = new ResultService($pdo);
 
         $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $this->assertSame(1, $first['attempt']);
 
         $second = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $this->assertSame(2, $second['attempt']);
-
-        unlink($tmp);
     }
 
     public function testAddDoesNotIncrementAcrossCatalogs(): void
     {
-        $tmp = tempnam(sys_get_temp_dir(), 'results');
-        $service = new ResultService();
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $service = new ResultService($pdo);
 
         $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $this->assertSame(1, $first['attempt']);
 
         $other = $service->add(['name' => 'TeamA', 'catalog' => 'cat2']);
         $this->assertSame(1, $other['attempt']);
-
-        unlink($tmp);
     }
 
     public function testMarkPuzzleUpdatesEntry(): void
     {
-        $tmp = tempnam(sys_get_temp_dir(), 'results');
-        $service = new ResultService();
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $service = new ResultService($pdo);
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $ts = time();
         $service->markPuzzle('TeamA', 'cat1', $ts);
-        $data = $service->getAll();
-
-        $this->assertSame($ts, $data[0]['puzzleTime']);
-
-        unlink($tmp);
+        $stmt = $pdo->query('SELECT puzzleTime FROM results');
+        $this->assertSame($ts, (int)$stmt->fetchColumn());
     }
 
     public function testSetPhotoUpdatesEntry(): void
     {
-        $tmp = tempnam(sys_get_temp_dir(), 'results');
-        $service = new ResultService();
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $service = new ResultService($pdo);
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $service->setPhoto('TeamA', 'cat1', '/photo/test.jpg');
-        $data = $service->getAll();
-
-        $this->assertSame('/photo/test.jpg', $data[0]['photo']);
-
-        unlink($tmp);
+        $stmt = $pdo->query('SELECT photo FROM results');
+        $this->assertSame('/photo/test.jpg', $stmt->fetchColumn());
     }
 }


### PR DESCRIPTION
## Summary
- update service tests to use in-memory SQLite databases
- create required schema and pass PDO to services
- adjust assertions for DB access

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68534289499c832b9bfa553fcf0f7bcd