### PR TITLE
Add intro page showing catalog info

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -92,8 +92,25 @@
     return [];
   }
 
-  async function loadQuestions(id, file, letter, uid){
+  async function loadQuestions(id, file, letter, uid, name, desc){
     sessionStorage.setItem('quizCatalog', uid || id);
+    sessionStorage.setItem('quizCatalogName', name || id);
+    if(desc !== undefined){
+      sessionStorage.setItem('quizCatalogDesc', desc);
+    } else {
+      sessionStorage.removeItem('quizCatalogDesc');
+    }
+    const headerEl = document.getElementById('quiz-header');
+    if(headerEl){
+      let title = headerEl.querySelector('h1');
+      if(!title){
+        title = document.createElement('h1');
+        title.className = 'uk-margin-remove-bottom';
+        headerEl.appendChild(title);
+      }
+      title.textContent = name || id;
+    }
+    setSubHeader(desc || '');
     if(letter){
       const cfg = window.quizConfig || {};
       if(cfg.puzzleWordEnabled && letter){
@@ -198,8 +215,7 @@
           return;
         }
         history.replaceState(null, '', '?katalog=' + cat.id);
-        setSubHeader(cat.description || '');
-        loadQuestions(cat.id, cat.file, cat.raetsel_buchstabe, cat.uid);
+        loadQuestions(cat.id, cat.file, cat.raetsel_buchstabe, cat.uid, cat.name || cat.id, cat.description || '');
       });
       const title = document.createElement('h3');
       title.textContent = cat.name || cat.id;
@@ -425,7 +441,7 @@
               return;
             }
           }
-        loadQuestions(selected.id, selected.file, selected.raetsel_buchstabe, selected.uid);
+        loadQuestions(selected.id, selected.file, selected.raetsel_buchstabe, selected.uid, selected.name || selected.id, selected.description || '');
       }else{
         showSelection(catalogs, solvedNow);
       }

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -111,7 +111,7 @@ function runQuiz(questions){
 
   let current = 0;
   // Zu jedem Eintrag im Array ein DOM-Element erzeugen
-  const elements = shuffled.map((q, idx) => createQuestion(q, idx));
+  const elements = [createStart()].concat(shuffled.map((q, idx) => createQuestion(q, idx)));
   // Speichert true/false für jede beantwortete Frage
   const results = new Array(questionCount).fill(false);
   const summaryEl = createSummary(); // Abschlussseite
@@ -129,12 +129,7 @@ function runQuiz(questions){
   styleEl.textContent = `\n    body { background-color: ${cfg.backgroundColor || '#ffffff'}; }\n    .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n  `;
   document.head.appendChild(styleEl);
 
-  // hide header once the quiz starts
   const headerEl = document.getElementById('quiz-header');
-  if (headerEl) {
-    headerEl.innerHTML = '';
-    headerEl.classList.add('uk-hidden');
-  }
 
   elements.forEach((el, i) => {
     if (i !== 0) el.classList.add('uk-hidden');
@@ -153,13 +148,13 @@ function runQuiz(questions){
       progress.classList.add('uk-hidden');
       progress.setAttribute('aria-valuenow', 0);
       if (announcer) announcer.textContent = '';
-    } else if(i < questionCount){
+    } else if(i <= questionCount && i > 0){
       // Fragen anzeigen und Fortschritt aktualisieren
       progress.classList.remove('uk-hidden');
       progress.value = i;
       progress.setAttribute('aria-valuenow', i);
       if (announcer) announcer.textContent = `Frage ${i} von ${questionCount}`;
-    } else if(i === questionCount){
+    } else if(i === questionCount + 1){
       // Nach der letzten Frage Zusammenfassung anzeigen
       progress.value = questionCount;
       progress.setAttribute('aria-valuenow', questionCount);
@@ -171,6 +166,10 @@ function runQuiz(questions){
 
   // Blendet die nächste Frage ein
   function next(){
+    if(current === 0 && headerEl){
+      headerEl.innerHTML = '';
+      headerEl.classList.add('uk-hidden');
+    }
     if(current < questionCount){
       current++;
       showQuestion(current);


### PR DESCRIPTION
## Summary
- store catalog name/description in sessionStorage when loading questions
- show catalog title and description in header before quiz starts
- add intro screen before first question

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685421d6765c832ba64b2a74b8eaacca