### PR TITLE
Add DB envs to compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM php:8.2-alpine
 
+# allow Composer to run as root inside the container
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
 RUN apk add --no-cache libpng libjpeg-turbo freetype libwebp postgresql-client && \
     apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev postgresql-dev $PHPIZE_DEPS && \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp && \

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `data/photos` und werden durch das Volume ebenfalls dauerhaft gespeichert. Die
 ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
 wird dadurch ebenfalls persistiert. Zusätzlich läuft ein Adminer-Container,
-der die PostgreSQL-Datenbank über die Subdomain `https://adminer.<domain>` bereitstellt. Er
+der die PostgreSQL-Datenbank über die Subdomain `https://adminer.${DOMAIN}` bereitstellt. Er
 nutzt intern den Hostnamen `postgres` und erfordert keine weiteren Einstellungen.
 Um größere Uploads zu erlauben, kann die maximale
 Request-Größe des Reverse Proxys über die Umgebungsvariable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,10 @@ services:
       - VIRTUAL_HOST=${DOMAIN}
       - LETSENCRYPT_HOST=${DOMAIN}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
+      - POSTGRES_DSN=${POSTGRES_DSN}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
     depends_on:
       - postgres
     # Use router.php so that Slim handles routes for non-existent static files


### PR DESCRIPTION
## Summary
- add COMPOSER_ALLOW_SUPERUSER env var in Dockerfile
- pass database environment variables to the slim container via docker-compose

## Testing
- `docker-compose up -d` *(fails: command not found)*
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6854227b03d0832ba3adee1f0bce76a6