### PR TITLE
Fix PDO warning and clarify extension requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
   Wer die Anwendung ohne Docker betreibt, muss diesen Schritt manuell
   ausführen. Fehlt das Verzeichnis `vendor/`, zeigt die App eine
   entsprechende Fehlermeldung an.
-  Das Docker-Setup installiert dabei automatisch die PHP-Erweiterung *gd*,
-  welche für die Bibliothek `setasign/fpdf` benötigt wird.
+  Das Docker-Setup installiert dabei automatisch die PHP-Erweiterungen
+  *gd* und *pdo_pgsql*. Ersteres benötigt die Bibliothek
+  `setasign/fpdf`, letzteres stellt die Verbindung zu PostgreSQL her.
+  Wer die Anwendung ohne Docker betreibt, muss *pdo_pgsql* manuell
+  aktivieren, damit die Datenbankanbindung funktioniert.
    Wurden neue Pakete in `composer.json` eingetragen, sollte anschließend
    `composer update --lock` ausgeführt werden, um die `composer.lock`
    zu aktualisieren. Andernfalls bricht der Docker-Build mit Hinweis auf

--- a/src/routes.php
+++ b/src/routes.php
@@ -20,7 +20,6 @@ use App\Service\CatalogService;
 use App\Service\ResultService;
 use App\Service\TeamService;
 use App\Service\PhotoConsentService;
-use PDO;
 use App\Controller\ResultController;
 use App\Controller\TeamController;
 use App\Controller\PasswordController;


### PR DESCRIPTION
## Summary
- remove unused `PDO` import from `src/routes.php`
- document that the `pdo_pgsql` extension is required when running without Docker

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_685426f08a34832ba87208dcf9c85665