### PR TITLE
Fix entrypoint command execution

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -58,5 +58,5 @@ if [ -n "$POSTGRES_DSN" ] && [ -f docs/schema.sql ]; then
     unset PGPASSWORD
 fi
 
-exec "$@"
+exec $@
 


### PR DESCRIPTION
## Summary
- ensure entrypoint properly executes command strings

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685429400a5c832ba987900a7cafb917