### PR TITLE
Fix PostgreSQL readiness check in entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,7 +30,7 @@ if [ -n "$POSTGRES_DSN" ] && [ -f docs/schema.sql ]; then
 
     echo "Waiting for PostgreSQL to become available..."
     timeout=30
-    until psql -h "$host" -p "$port" -U "$POSTGRES_USER" -d "$db" -c '\\q'; do
+    until psql -h "$host" -p "$port" -U "$POSTGRES_USER" -d "$db" -c 'SELECT 1;' >/dev/null 2>&1; do
         if [ $timeout -le 0 ]; then
             echo "PostgreSQL not reachable, aborting." >&2
             exit 1


### PR DESCRIPTION
## Summary
- fix the `psql` command in `docker-entrypoint.sh`

## Testing
- `pytest`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854297aa76c832bb06f3f02f622eb4b