### PR TITLE
Fix boolean binding on data import

### DIFF
--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -38,7 +38,11 @@ if ($configData) {
     $sql = 'INSERT INTO config(' . implode(',', $cols) . ') VALUES(' . implode(',', $placeholders) . ')';
     $stmt = $pdo->prepare($sql);
     foreach ($configData as $k => $v) {
-        $stmt->bindValue(':' . $k, $v);
+        if (is_bool($v)) {
+            $stmt->bindValue(':' . $k, $v, PDO::PARAM_BOOL);
+        } else {
+            $stmt->bindValue(':' . $k, $v);
+        }
     }
     $stmt->execute();
     $pdo->exec("SELECT setval(pg_get_serial_sequence('config','id'), (SELECT COALESCE(MAX(id),0) FROM config))");


### PR DESCRIPTION
## Summary
- ensure booleans are bound correctly when importing config

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685432d41f6c832b9b6980b78e362dd9