### PR TITLE
Reset tables before importing and handle boolean config

### DIFF
--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -28,6 +28,9 @@ try {
 
 $pdo->beginTransaction();
 
+// Clear existing tables to allow re-import without duplicates
+$pdo->exec('TRUNCATE config, teams, results, catalogs, questions, photo_consents RESTART IDENTITY CASCADE');
+
 // Import config
 $configData = array_intersect_key($config, array_flip([
     'displayErrorDetails','QRUser','logoPath','pageTitle','header','subheader','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback'
@@ -38,7 +41,11 @@ if ($configData) {
     $sql = 'INSERT INTO config(' . implode(',', $cols) . ') VALUES(' . implode(',', $placeholders) . ')';
     $stmt = $pdo->prepare($sql);
     foreach ($configData as $k => $v) {
-        $stmt->bindValue(':' . $k, $v);
+        if (is_bool($v)) {
+            $stmt->bindValue(':' . $k, $v, PDO::PARAM_BOOL);
+        } else {
+            $stmt->bindValue(':' . $k, $v);
+        }
     }
     $stmt->execute();
     $pdo->exec("SELECT setval(pg_get_serial_sequence('config','id'), (SELECT COALESCE(MAX(id),0) FROM config))");

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -45,7 +45,11 @@ class ConfigService
             $sql = 'INSERT INTO config(' . implode(',', $cols) . ') VALUES(' . $params . ')';
             $stmt = $this->pdo->prepare($sql);
             foreach ($filtered as $k => $v) {
-                $stmt->bindValue(':' . $k, $v);
+                if (is_bool($v)) {
+                    $stmt->bindValue(':' . $k, $v, PDO::PARAM_BOOL);
+                } else {
+                    $stmt->bindValue(':' . $k, $v);
+                }
             }
             $stmt->execute();
         }


### PR DESCRIPTION
## Summary
- reset database tables before importing JSON data to avoid duplicates
- bind boolean values properly when saving config

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685432d41f6c832b9b6980b78e362dd9