### PR TITLE
Adjust default admin credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Alle wesentlichen Einstellungen finden sich in `data/config.json`. Hier lassen s
   "buttonColor": "#1e87f0",
   "CheckAnswerButton": "no",
   "adminUser": "admin",
-  "adminPass": "password",
+  "adminPass": "admin",
   "QRRestrict": false,
   "competitionMode": false,
   "teamResults": true,

--- a/data-default/config.json
+++ b/data-default/config.json
@@ -9,7 +9,7 @@
   "buttonColor": "#1e87f0",
   "CheckAnswerButton": "no",
   "adminUser": "admin",
-  "adminPass": "password",
+  "adminPass": "admin",
   "QRRestrict": false,
   "competitionMode": false,
   "teamResults": true,

--- a/data/config.json
+++ b/data/config.json
@@ -9,7 +9,7 @@
   "buttonColor": "#1e87f0",
   "CheckAnswerButton": "no",
   "adminUser": "admin",
-  "adminPass": "password",
+  "adminPass": "admin",
   "QRRestrict": false,
   "competitionMode": false,
   "teamResults": true,

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -29,7 +29,7 @@ class LoginController
         $config = (new ConfigService($pdo))->getConfig();
 
         $user = $config['adminUser'] ?? 'admin';
-        $pass = $config['adminPass'] ?? 'password';
+        $pass = $config['adminPass'] ?? 'admin';
 
         if (($data['username'] ?? '') === $user && ($data['password'] ?? '') === $pass) {
             if (session_status() === PHP_SESSION_NONE) {


### PR DESCRIPTION
## Summary
- use `admin` as fallback admin password
- update example config data and README

## Testing
- `vendor/bin/phpcs` *(fails: No such file or directory)*
- `vendor/bin/phpstan` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685442def9a8832ba093fefba4e7f419