### PR TITLE
Fix catalog name display in results

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const tr = document.createElement('tr');
         const cells = [
           r.attempt,
-          r.catalog,
+          r.catalogName || r.catalog,
           `${r.correct}/${r.total}`,
           formatTime(r.time),
           r.puzzleTime ? formatTime(r.puzzleTime) : '',

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -17,7 +17,12 @@ class ResultService
 
     public function getAll(): array
     {
-        $stmt = $this->pdo->query('SELECT name,catalog,attempt,correct,total,time,puzzleTime,photo FROM results ORDER BY id');
+        $sql = 'SELECT r.name, r.catalog, r.attempt, r.correct, r.total, r.time, r.puzzleTime, r.photo, ' .
+            'c.name AS catalogName '
+            . 'FROM results r '
+            . 'LEFT JOIN catalogs c ON c.uid = r.catalog OR c.id = r.catalog '
+            . 'ORDER BY r.id';
+        $stmt = $this->pdo->query($sql);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -283,7 +283,7 @@
             <tr>
               <td>{{ r.name }}</td>
               <td>{{ r.attempt }}</td>
-              <td>{{ r.catalog }}</td>
+              <td>{{ r.catalogName ?? r.catalog }}</td>
               <td>{{ r.correct }}/{{ r.total }}</td>
               <td>{{ r.time | date('Y-m-d H:i') }}</td>
               <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -29,7 +29,7 @@
         <tr>
           <td>{{ r.name }}</td>
           <td>{{ r.attempt }}</td>
-          <td>{{ r.catalog }}</td>
+          <td>{{ r.catalogName ?? r.catalog }}</td>
           <td>{{ r.correct }}/{{ r.total }}</td>
           <td>{{ r.time | date('Y-m-d H:i') }}</td>
           <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>


### PR DESCRIPTION
## Summary
- fetch catalog names when reading results
- show catalog name in admin and results pages
- show catalog name when rendering table via JS

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685452fd3a94832bbb4e54f785e24315