### PR TITLE
Sort catalog cards by id

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -198,6 +198,10 @@
       container.appendChild(p);
       return;
     }
+    catalogs = catalogs.slice().sort((a,b) => {
+      if(a.id === undefined || b.id === undefined) return 0;
+      return a.id.localeCompare(b.id);
+    });
 
     const grid = document.createElement('div');
     grid.className = 'uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-4@m uk-grid-small uk-text-center';


### PR DESCRIPTION
## Summary
- sort catalog cards by `id` before rendering the grid

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68545dc57b10832bb46129de166fe21d