### PR TITLE
Add catalog comment modal for admin

### DIFF
--- a/data-default/kataloge/catalogs.json
+++ b/data-default/kataloge/catalogs.json
@@ -6,7 +6,8 @@
     "name": "Station-1",
     "description": "Speicher und Geraete",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_1",
-    "raetsel_buchstabe": "A"
+    "raetsel_buchstabe": "A",
+    "comment": ""
   },
   {
     "uid": "d0e42823-2da0-4858-a827-7d5d5d164d7d",
@@ -15,7 +16,8 @@
     "name": "Station-2",
     "description": "Bedienung und Symbole",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_2",
-    "raetsel_buchstabe": "B"
+    "raetsel_buchstabe": "B",
+    "comment": ""
   },
   {
     "uid": "14a904ff-cfbf-4ac5-85e0-b70222e9b31c",
@@ -24,7 +26,8 @@
     "name": "Station-3",
     "description": "WWW und Speicherarten",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_3",
-    "raetsel_buchstabe": "C"
+    "raetsel_buchstabe": "C",
+    "comment": ""
   },
   {
     "uid": "f1da5d20-c668-44ba-a1a6-7297fe9539c0",
@@ -33,7 +36,8 @@
     "name": "Station-4",
     "description": "Begriffe und Geraetegroessen",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_4",
-    "raetsel_buchstabe": "D"
+    "raetsel_buchstabe": "D",
+    "comment": ""
   },
   {
     "uid": "588eae96-0999-4124-a13a-e282e149c341",
@@ -42,7 +46,8 @@
     "name": "Station-5",
     "description": "Programme und Binaersystem",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_5",
-    "raetsel_buchstabe": "E"
+    "raetsel_buchstabe": "E",
+    "comment": ""
   },
   {
     "uid": "808487f9-eb09-4b41-b887-0baf82b2b92d",
@@ -51,7 +56,8 @@
     "name": "Station-6",
     "description": "Dateien und URLs",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_6",
-    "raetsel_buchstabe": "F"
+    "raetsel_buchstabe": "F",
+    "comment": ""
   },
   {
     "uid": "6dfc8316-45d3-4737-838c-811419709d9c",
@@ -60,7 +66,8 @@
     "name": "Station-7",
     "description": "Netzwerke und Kuerzel",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_7",
-    "raetsel_buchstabe": "G"
+    "raetsel_buchstabe": "G",
+    "comment": ""
   },
   {
     "uid": "0c0dc60a-6d20-4e16-9f71-d926f143c874",
@@ -69,6 +76,7 @@
     "name": "Station-8",
     "description": "Cloud und Steuerung",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_8",
-    "raetsel_buchstabe": "H"
+    "raetsel_buchstabe": "H",
+    "comment": ""
   }
 ]

--- a/data/kataloge/catalogs.json
+++ b/data/kataloge/catalogs.json
@@ -6,7 +6,8 @@
     "name": "Station-1",
     "description": "Speicher und Geraete",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_1",
-    "raetsel_buchstabe": "A"
+    "raetsel_buchstabe": "A",
+    "comment": ""
   },
   {
     "uid": "d0e42823-2da0-4858-a827-7d5d5d164d7d",
@@ -15,7 +16,8 @@
     "name": "Station-2",
     "description": "Bedienung und Symbole",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_2",
-    "raetsel_buchstabe": "B"
+    "raetsel_buchstabe": "B",
+    "comment": ""
   },
   {
     "uid": "14a904ff-cfbf-4ac5-85e0-b70222e9b31c",
@@ -24,7 +26,8 @@
     "name": "Station-3",
     "description": "WWW und Speicherarten",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_3",
-    "raetsel_buchstabe": "C"
+    "raetsel_buchstabe": "C",
+    "comment": ""
   },
   {
     "uid": "f1da5d20-c668-44ba-a1a6-7297fe9539c0",
@@ -33,7 +36,8 @@
     "name": "Station-4",
     "description": "Begriffe und Geraetegroessen",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_4",
-    "raetsel_buchstabe": "D"
+    "raetsel_buchstabe": "D",
+    "comment": ""
   },
   {
     "uid": "588eae96-0999-4124-a13a-e282e149c341",
@@ -42,7 +46,8 @@
     "name": "Station-5",
     "description": "Programme und Binaersystem",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_5",
-    "raetsel_buchstabe": "E"
+    "raetsel_buchstabe": "E",
+    "comment": ""
   },
   {
     "uid": "808487f9-eb09-4b41-b887-0baf82b2b92d",
@@ -51,7 +56,8 @@
     "name": "Station-6",
     "description": "Dateien und URLs",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_6",
-    "raetsel_buchstabe": "F"
+    "raetsel_buchstabe": "F",
+    "comment": ""
   },
   {
     "uid": "6dfc8316-45d3-4737-838c-811419709d9c",
@@ -60,7 +66,8 @@
     "name": "Station-7",
     "description": "Netzwerke und Kuerzel",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_7",
-    "raetsel_buchstabe": "G"
+    "raetsel_buchstabe": "G",
+    "comment": ""
   },
   {
     "uid": "0c0dc60a-6d20-4e16-9f71-d926f143c874",
@@ -69,6 +76,7 @@
     "name": "Station-8",
     "description": "Cloud und Steuerung",
     "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_8",
-    "raetsel_buchstabe": "H"
+    "raetsel_buchstabe": "H",
+    "comment": ""
   }
 ]

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -54,7 +54,8 @@ CREATE TABLE IF NOT EXISTS catalogs (
     name TEXT NOT NULL,
     description TEXT,
     qrcode_url TEXT,
-    raetsel_buchstabe TEXT
+    raetsel_buchstabe TEXT,
+    comment TEXT
 );
 
 -- Questions belonging to catalogs

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -78,9 +78,13 @@ document.addEventListener('DOMContentLoaded', function () {
   const puzzleTextarea = document.getElementById('puzzleFeedbackTextarea');
   const puzzleSaveBtn = document.getElementById('puzzleFeedbackSave');
   const puzzleModal = UIkit.modal('#puzzleFeedbackModal');
+  const commentTextarea = document.getElementById('catalogCommentTextarea');
+  const commentSaveBtn = document.getElementById('catalogCommentSave');
+  const commentModal = UIkit.modal('#catalogCommentModal');
   const resultsResetModal = UIkit.modal('#resultsResetModal');
   const resultsResetConfirm = document.getElementById('resultsResetConfirm');
   let puzzleFeedback = '';
+  let currentCommentInput = null;
   let logoUploaded = false;
   if (cfgFields.logoFile && cfgFields.logoPreview) {
     const bar = document.getElementById('cfgLogoProgress');
@@ -181,6 +185,17 @@ document.addEventListener('DOMContentLoaded', function () {
         notify('Feedbacktext gespeichert', 'success');
       }
     }).catch(() => {});
+  });
+
+  commentSaveBtn?.addEventListener('click', () => {
+    if(!currentCommentInput || !commentTextarea) return;
+    currentCommentInput.value = commentTextarea.value;
+    const btn = currentCommentInput.previousSibling;
+    if(btn && btn.textContent !== undefined){
+      btn.textContent = commentTextarea.value.trim() ? 'Kommentar bearbeiten' : 'Kommentar eingeben';
+    }
+    commentModal.hide();
+    currentCommentInput = null;
   });
   document.getElementById('cfgResetBtn').addEventListener('click', function (e) {
     e.preventDefault();
@@ -381,6 +396,25 @@ document.addEventListener('DOMContentLoaded', function () {
     letter.maxLength = 1;
     letterCell.appendChild(letter);
 
+    const commentCell = document.createElement('td');
+    const commentBtn = document.createElement('button');
+    commentBtn.className = 'uk-button uk-button-default';
+    const commentField = document.createElement('input');
+    commentField.type = 'hidden';
+    commentField.className = 'cat-comment';
+    commentField.value = cat.comment || '';
+    function updateCommentBtn(){
+      commentBtn.textContent = commentField.value.trim() ? 'Kommentar bearbeiten' : 'Kommentar eingeben';
+    }
+    updateCommentBtn();
+    commentBtn.addEventListener('click', () => {
+      currentCommentInput = commentField;
+      if(commentTextarea) commentTextarea.value = commentField.value;
+      commentModal.show();
+    });
+    commentCell.appendChild(commentBtn);
+    commentCell.appendChild(commentField);
+
     const delCell = document.createElement('td');
     const del = document.createElement('button');
     del.className = 'uk-button uk-button-danger';
@@ -402,6 +436,7 @@ document.addEventListener('DOMContentLoaded', function () {
     row.appendChild(nameCell);
     row.appendChild(descCell);
     row.appendChild(letterCell);
+    row.appendChild(commentCell);
     row.appendChild(delCell);
 
     return row;
@@ -427,7 +462,8 @@ document.addEventListener('DOMContentLoaded', function () {
           file,
           name: row.querySelector('.cat-name').value.trim(),
           description: row.querySelector('.cat-desc').value.trim(),
-          raetsel_buchstabe: row.querySelector('.cat-letter').value.trim()
+          raetsel_buchstabe: row.querySelector('.cat-letter').value.trim(),
+          comment: row.querySelector('.cat-comment').value.trim()
         };
       })
       .filter(c => c.id)

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -19,7 +19,7 @@ class CatalogService
     public function read(string $file): ?string
     {
         if ($file === 'catalogs.json') {
-            $stmt = $this->pdo->query('SELECT uid,id,file,name,description,qrcode_url,raetsel_buchstabe FROM catalogs ORDER BY id');
+            $stmt = $this->pdo->query('SELECT uid,id,file,name,description,qrcode_url,raetsel_buchstabe,comment FROM catalogs ORDER BY id');
             $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
             return json_encode($data, JSON_PRETTY_PRINT);
         }
@@ -63,7 +63,7 @@ class CatalogService
             }
             $this->pdo->beginTransaction();
             $this->pdo->exec('DELETE FROM catalogs');
-            $stmt = $this->pdo->prepare('INSERT INTO catalogs(uid,id,file,name,description,qrcode_url,raetsel_buchstabe) VALUES(?,?,?,?,?,?,?)');
+            $stmt = $this->pdo->prepare('INSERT INTO catalogs(uid,id,file,name,description,qrcode_url,raetsel_buchstabe,comment) VALUES(?,?,?,?,?,?,?,?)');
             foreach ($data as $cat) {
                 $stmt->execute([
                     $cat['uid'] ?? '',
@@ -73,6 +73,7 @@ class CatalogService
                     $cat['description'] ?? null,
                     $cat['qrcode_url'] ?? null,
                     $cat['raetsel_buchstabe'] ?? null,
+                    $cat['comment'] ?? null,
                 ]);
             }
             $this->pdo->commit();

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -190,6 +190,17 @@
           </div>
         </div>
 
+        <div id="catalogCommentModal" uk-modal>
+          <div class="uk-modal-dialog uk-modal-body">
+            <h2 class="uk-modal-title">Kommentar zum Katalog</h2>
+            <textarea id="catalogCommentTextarea" class="uk-textarea" rows="5" placeholder="Kommentar eingeben..."></textarea>
+            <div class="uk-flex uk-flex-right uk-margin-top">
+              <button id="catalogCommentSave" class="uk-button uk-button-primary" type="button">Speichern</button>
+              <button class="uk-button uk-button-default uk-modal-close" type="button">Abbrechen</button>
+            </div>
+          </div>
+        </div>
+
       </div>
     </li>
     <li>
@@ -205,6 +216,7 @@
                   <th>Name</th>
                   <th>Beschreibung</th>
                   <th>Buchstabe</th>
+                  <th>Kommentar</th>
                   <th></th>
                 </tr>
               </thead>

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -14,7 +14,7 @@ class CatalogServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
         $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id TEXT NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
         return $pdo;
     }
@@ -29,6 +29,7 @@ class CatalogServiceTest extends TestCase
             'id' => 'cat1',
             'file' => $file,
             'name' => 'Test',
+            'comment' => ''
         ]];
         $service->write('catalogs.json', $catalog);
         $data = [['type' => 'text', 'prompt' => 'Hello']];
@@ -55,6 +56,7 @@ class CatalogServiceTest extends TestCase
             'id' => 'del',
             'file' => $file,
             'name' => 'Del',
+            'comment' => ''
         ]]);
         $service->write($file, []);
         $stmt = $pdo->query('SELECT COUNT(*) FROM questions');
@@ -74,6 +76,7 @@ class CatalogServiceTest extends TestCase
             'id' => 'qid',
             'file' => $file,
             'name' => 'Q',
+            'comment' => ''
         ]]);
         $data = [
             ['type' => 'text', 'prompt' => 'A'],


### PR DESCRIPTION
## Summary
- add `comment` column to DB schema
- support comment field in `CatalogService`
- extend admin template with comment column and modal
- add comment handling in admin script
- update datasets and tests

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685462580764832b8928429026e66689