### PR TITLE
Fix results table sorting

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -24,9 +24,26 @@ class AdminController
         $catalogSvc = new CatalogService($pdo);
         $catalogsJson = $catalogSvc->read('catalogs.json');
         $catalogs = [];
+        $catMap = [];
         if ($catalogsJson !== null) {
             $catalogs = json_decode($catalogsJson, true) ?? [];
+            foreach ($catalogs as $c) {
+                $name = $c['name'] ?? ($c['id'] ?? '');
+                if (isset($c['uid'])) {
+                    $catMap[$c['uid']] = $name;
+                }
+                if (isset($c['id'])) {
+                    $catMap[$c['id']] = $name;
+                }
+            }
         }
+        foreach ($results as &$row) {
+            $cat = $row['catalog'] ?? '';
+            if (isset($catMap[$cat])) {
+                $row['catalogName'] = $catMap[$cat];
+            }
+        }
+        unset($row);
 
         $uri    = $request->getUri();
         $domain = getenv('DOMAIN');


### PR DESCRIPTION
## Summary
- remove grouping from the results page script
- show all results ordered by last entry

## Testing
- `vendor/bin/phpcs` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545ebf14ec832b9babbb0c1185ca69