### PR TITLE
Add display id field for catalogs

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -48,8 +48,9 @@ CREATE INDEX idx_results_name ON results(name);
 
 -- Catalog definitions
 CREATE TABLE IF NOT EXISTS catalogs (
-    uid TEXT PRIMARY KEY,
-    id TEXT UNIQUE NOT NULL,
+    id SERIAL PRIMARY KEY,
+    slug TEXT UNIQUE NOT NULL,
+    uid TEXT UNIQUE NOT NULL,
     file TEXT NOT NULL,
     name TEXT NOT NULL,
     description TEXT,
@@ -60,7 +61,7 @@ CREATE TABLE IF NOT EXISTS catalogs (
 -- Questions belonging to catalogs
 CREATE TABLE IF NOT EXISTS questions (
     id SERIAL PRIMARY KEY,
-    catalog_id TEXT NOT NULL,
+    catalog_id INTEGER NOT NULL,
     type TEXT NOT NULL,
     prompt TEXT NOT NULL,
     options JSONB,

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -104,12 +104,14 @@ $catalogDir = "$base/data/kataloge";
 $catalogsFile = "$catalogDir/catalogs.json";
 if (is_readable($catalogsFile)) {
     $catalogs = json_decode(file_get_contents($catalogsFile), true) ?? [];
-    $catStmt = $pdo->prepare('INSERT INTO catalogs(uid,id,file,name,description,qrcode_url,raetsel_buchstabe) VALUES(?,?,?,?,?,?,?)');
+    $catStmt = $pdo->prepare('INSERT INTO catalogs(id,slug,uid,file,name,description,qrcode_url,raetsel_buchstabe) VALUES(?,?,?,?,?,?,?,?)');
     $qStmt = $pdo->prepare('INSERT INTO questions(catalog_id,type,prompt,options,answers,terms,items) VALUES(?,?,?,?,?,?,?)');
+    $idx = 1;
     foreach ($catalogs as $cat) {
         $catStmt->execute([
-            $cat['uid'] ?? '',
+            $idx++,
             $cat['id'] ?? '',
+            $cat['uid'] ?? '',
             $cat['file'] ?? '',
             $cat['name'] ?? '',
             $cat['description'] ?? null,
@@ -121,7 +123,7 @@ if (is_readable($catalogsFile)) {
             $questions = json_decode(file_get_contents($file), true) ?? [];
             foreach ($questions as $q) {
                 $qStmt->execute([
-                    $cat['id'] ?? '',
+                    $idx - 1,
                     $q['type'] ?? '',
                     $q['prompt'] ?? '',
                     isset($q['options']) ? json_encode($q['options']) : null,

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -15,7 +15,11 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $controller = new CatalogController(new CatalogService());
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE catalogs(id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE NOT NULL, uid TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id INTEGER NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
+        $controller = new CatalogController(new CatalogService($pdo));
         $request = $this->createRequest('GET', '/kataloge/missing.json', ['HTTP_ACCEPT' => 'application/json']);
         $response = $controller->get($request, new Response(), ['file' => 'missing.json']);
         $this->assertEquals(404, $response->getStatusCode());
@@ -26,7 +30,11 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService();
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE catalogs(id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE NOT NULL, uid TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id INTEGER NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
+        $service = new CatalogService($pdo);
         $controller = new CatalogController($service);
 
         $request = $this->createRequest('POST', '/kataloge/test.json');
@@ -50,7 +58,11 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService();
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE catalogs(id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE NOT NULL, uid TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id INTEGER NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
+        $service = new CatalogService($pdo);
         $controller = new CatalogController($service);
 
         $createReq = $this->createRequest('PUT', '/kataloge/new.json');
@@ -73,7 +85,11 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $service = new CatalogService();
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE catalogs(id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE NOT NULL, uid TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id INTEGER NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
+        $service = new CatalogService($pdo);
         $controller = new CatalogController($service);
 
         $service->write('cat.json', [['a' => 1], ['b' => 2]]);
@@ -94,7 +110,11 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $controller = new CatalogController(new CatalogService());
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE catalogs(id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE NOT NULL, uid TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id INTEGER NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
+        $controller = new CatalogController(new CatalogService($pdo));
 
         $request = $this->createRequest('POST', '/kataloge/test.json', ['HTTP_CONTENT_TYPE' => 'application/json']);
         $stream = fopen('php://temp', 'r+');

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -14,8 +14,8 @@ class CatalogServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
-        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id TEXT NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
+        $pdo->exec('CREATE TABLE catalogs(id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE NOT NULL, uid TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id INTEGER NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
         return $pdo;
     }
 


### PR DESCRIPTION
## Summary
- introduce numeric `id` column for `catalogs`
- use `slug` for catalog identifier in CatalogService
- update import script and tests for new schema

## Testing
- `php -v` *(fails: command not found)*
- `vendor/bin/phpunit -c phpunit.xml --stop-on-failure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685462aa3768832bb6b88d107733d444