### PR TITLE
Add catalog comment migration and auto-run

### DIFF
--- a/migrations/20240619_add_comment_to_catalogs.sql
+++ b/migrations/20240619_add_comment_to_catalogs.sql
@@ -1,0 +1,1 @@
+ALTER TABLE catalogs ADD COLUMN comment TEXT;

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -104,7 +104,7 @@ $catalogDir = "$base/data/kataloge";
 $catalogsFile = "$catalogDir/catalogs.json";
 if (is_readable($catalogsFile)) {
     $catalogs = json_decode(file_get_contents($catalogsFile), true) ?? [];
-    $catStmt = $pdo->prepare('INSERT INTO catalogs(uid,id,file,name,description,qrcode_url,raetsel_buchstabe) VALUES(?,?,?,?,?,?,?)');
+    $catStmt = $pdo->prepare('INSERT INTO catalogs(uid,id,file,name,description,qrcode_url,raetsel_buchstabe,comment) VALUES(?,?,?,?,?,?,?,?)');
     $qStmt = $pdo->prepare('INSERT INTO questions(catalog_id,type,prompt,options,answers,terms,items) VALUES(?,?,?,?,?,?,?)');
     foreach ($catalogs as $cat) {
         $catStmt->execute([
@@ -114,7 +114,8 @@ if (is_readable($catalogsFile)) {
             $cat['name'] ?? '',
             $cat['description'] ?? null,
             $cat['qrcode_url'] ?? null,
-            $cat['raetsel_buchstabe'] ?? null
+            $cat['raetsel_buchstabe'] ?? null,
+            $cat['comment'] ?? null
         ]);
         $file = $catalogDir . '/' . ($cat['file'] ?? '');
         if (is_readable($file)) {

--- a/src/Infrastructure/Migrations/Migrator.php
+++ b/src/Infrastructure/Migrations/Migrator.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Migrations;
+
+use PDO;
+
+class Migrator
+{
+    public static function migrate(PDO $pdo, string $dir): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS migrations (version TEXT PRIMARY KEY)');
+        $stmt = $pdo->query('SELECT version FROM migrations');
+        $applied = $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];
+        $files = glob(rtrim($dir, '/'). '/*.sql');
+        sort($files);
+        foreach ($files as $file) {
+            $version = basename($file);
+            if (in_array($version, $applied, true)) {
+                continue;
+            }
+            $sql = file_get_contents($file);
+            if ($sql === false) {
+                continue;
+            }
+            $pdo->exec($sql);
+            $ins = $pdo->prepare('INSERT INTO migrations(version) VALUES(?)');
+            $ins->execute([$version]);
+        }
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -49,9 +49,11 @@ require_once __DIR__ . '/Controller/SummaryController.php';
 require_once __DIR__ . '/Controller/EvidenceController.php';
 
 use App\Infrastructure\Database;
+use App\Infrastructure\Migrations\Migrator;
 
 return function (\Slim\App $app) {
     $pdo = Database::connectFromEnv();
+    Migrator::migrate($pdo, __DIR__ . '/../migrations');
     $configService = new ConfigService($pdo);
     $catalogService = new CatalogService($pdo);
     $resultService = new ResultService($pdo);


### PR DESCRIPTION
## Summary
- add simple migration runner
- run migrations when bootstrapping routes
- update Postgres import script for new comment column
- include SQL migration for comment

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546540b014832bb2dbc91bc286c3da