### PR TITLE
Add catalog id column migration

### DIFF
--- a/migrations/20240620_add_id_column_to_catalogs.sql
+++ b/migrations/20240620_add_id_column_to_catalogs.sql
@@ -1,0 +1,4 @@
+ALTER TABLE catalogs ADD COLUMN IF NOT EXISTS id TEXT;
+UPDATE catalogs SET id = regexp_replace(file, '\\.json$', '') WHERE id IS NULL OR id = '';
+ALTER TABLE catalogs ALTER COLUMN id SET NOT NULL;
+ALTER TABLE catalogs ADD CONSTRAINT catalogs_id_unique UNIQUE(id);


### PR DESCRIPTION
## Summary
- add migration for catalog id column to store display order

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685466eac140832bab1bf480e4eb8446