### PR TITLE
Secure admin password

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Alle wesentlichen Einstellungen finden sich in `data/config.json`. Hier lassen s
   "buttonColor": "#1e87f0",
   "CheckAnswerButton": "no",
   "adminUser": "admin",
-  "adminPass": "password",
+  "adminPass": "$2b$12$RoNQr1KMGXROQTS1hhqfruEYsr27wiHPgc6hcI71BIpb6./zu6BM2",
   "QRRestrict": false,
   "competitionMode": false,
   "teamResults": true,

--- a/data-default/config.json
+++ b/data-default/config.json
@@ -9,7 +9,7 @@
   "buttonColor": "#1e87f0",
   "CheckAnswerButton": "no",
   "adminUser": "admin",
-  "adminPass": "password",
+  "adminPass": "$2b$12$RoNQr1KMGXROQTS1hhqfruEYsr27wiHPgc6hcI71BIpb6./zu6BM2",
   "QRRestrict": false,
   "competitionMode": false,
   "teamResults": true,

--- a/data/config.json
+++ b/data/config.json
@@ -9,7 +9,7 @@
   "buttonColor": "#1e87f0",
   "CheckAnswerButton": "no",
   "adminUser": "admin",
-  "adminPass": "password",
+  "adminPass": "$2b$12$RoNQr1KMGXROQTS1hhqfruEYsr27wiHPgc6hcI71BIpb6./zu6BM2",
   "QRRestrict": false,
   "competitionMode": false,
   "teamResults": true,

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -35,6 +35,12 @@ $pdo->exec('TRUNCATE config, teams, results, catalogs, questions, photo_consents
 $configData = array_intersect_key($config, array_flip([
     'displayErrorDetails','QRUser','logoPath','pageTitle','header','subheader','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback'
 ]));
+if (isset($configData['adminPass'])) {
+    $info = password_get_info($configData['adminPass']);
+    if ($info['algo'] === 0) {
+        $configData['adminPass'] = password_hash($configData['adminPass'], PASSWORD_DEFAULT);
+    }
+}
 if ($configData) {
     $cols = array_keys($configData);
     $placeholders = array_map(fn($c)=>":".$c, $cols);

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -29,9 +29,20 @@ class LoginController
         $config = (new ConfigService($pdo))->getConfig();
 
         $user = $config['adminUser'] ?? 'admin';
-        $pass = $config['adminPass'] ?? 'password';
+        $storedPass = $config['adminPass'] ?? 'password';
 
-        if (($data['username'] ?? '') === $user && ($data['password'] ?? '') === $pass) {
+        $valid = false;
+        if (($data['username'] ?? '') === $user) {
+            $pwd = $data['password'] ?? '';
+            $info = password_get_info($storedPass);
+            if ($info['algo'] !== 0) {
+                $valid = password_verify($pwd, $storedPass);
+            } else {
+                $valid = $pwd === $storedPass;
+            }
+        }
+
+        if ($valid) {
             if (session_status() === PHP_SESSION_NONE) {
                 session_start();
             }

--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -35,7 +35,7 @@ class PasswordController
         }
 
         $cfg = $this->service->getConfig();
-        $cfg['adminPass'] = $pass;
+        $cfg['adminPass'] = password_hash($pass, PASSWORD_DEFAULT);
         $this->service->saveConfig($cfg);
 
         return $response->withStatus(204);


### PR DESCRIPTION
## Summary
- hash admin password in config files
- verify hashed password during login
- store hashed password during password changes
- hash admin password when importing config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854675a5f58832b9ecccddada552673