### PR TITLE
Fix team order persistence

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1036,10 +1036,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function renderTeams(list){
     teamListEl.innerHTML = '';
-    list
-      .slice()
-      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-      .forEach(n => teamListEl.appendChild(createTeamRow(n)));
+    list.forEach(n => teamListEl.appendChild(createTeamRow(n)));
   }
 
   if(teamListEl){
@@ -1061,8 +1058,7 @@ document.addEventListener('DOMContentLoaded', function () {
     e.preventDefault();
     const names = Array.from(teamListEl.querySelectorAll('input.uk-input'))
       .map(i => i.value.trim())
-      .filter(Boolean)
-      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+      .filter(Boolean);
     fetch('/teams.json', {
       method: 'POST',
       headers: { 'Content-Type':'application/json' },


### PR DESCRIPTION
## Summary
- keep manual ordering of teams in admin
- send team list in current order when saving

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6854690bd044832b8b6bec5bfeaad7e8