### PR TITLE
Add slug column to catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ standardmäßig `https://` vorangestellt.
 
 ## Anpassung
 
-Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition enthält ein `id`, das dem Dateinamen ohne Endung entspricht. Bei neuen Katalogen generiert die Verwaltung dieses `id` automatisch aus dem eingegebenen Namen. Das `id` lässt sich später im Tab „Kataloge“ bei Bedarf ändern.
+Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition besitzt nun ein `slug`, über das der Katalog im Frontend aufgerufen wird. Das bisherige `id` dient nur noch der Sortierung und kann bei Bedarf angepasst werden.
 
 QR-Codes können pro Eintrag über `qr_image` oder `qrcode_url` hinterlegt werden. Neben Data-URIs und lokalen Pfaden werden dabei nun auch HTTP- oder HTTPS-URLs unterstützt.
 
@@ -283,8 +283,8 @@ Unter `/admin` stehen folgende Tabs zur Verfügung:
 6. **Passwort ändern** – Administrationspasswort setzen.
 
 ### Fragenkataloge
-`data/kataloge/catalogs.json` listet verfügbare Kataloge mit `id`, Name und optionaler QR-Code-Adresse. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:
-- `GET /kataloge/{file}` liefert den JSON-Katalog oder leitet im Browser auf `/?katalog=id` um.
+`data/kataloge/catalogs.json` listet verfügbare Kataloge mit `slug`, Name und optionaler QR-Code-Adresse. Das Feld `id` dient nur noch der internen Sortierung. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:
+- `GET /kataloge/{file}` liefert den JSON-Katalog oder leitet im Browser auf `/?katalog=slug` um.
 - `PUT /kataloge/{file}` legt eine neue Datei an.
 - `POST /kataloge/{file}` überschreibt einen Katalog mit gesendeten Daten.
 - `DELETE /kataloge/{file}` entfernt die Datei.

--- a/data-default/kataloge/catalogs.json
+++ b/data-default/kataloge/catalogs.json
@@ -2,6 +2,7 @@
   {
     "uid": "340da4f1-d796-49c2-aeaf-932280de5167",
     "id": "station_1",
+    "slug": "station_1",
     "file": "station_1.json",
     "name": "Station-1",
     "description": "Speicher und Geraete",
@@ -12,6 +13,7 @@
   {
     "uid": "d0e42823-2da0-4858-a827-7d5d5d164d7d",
     "id": "station_2",
+    "slug": "station_2",
     "file": "station_2.json",
     "name": "Station-2",
     "description": "Bedienung und Symbole",
@@ -22,6 +24,7 @@
   {
     "uid": "14a904ff-cfbf-4ac5-85e0-b70222e9b31c",
     "id": "station_3",
+    "slug": "station_3",
     "file": "station_3.json",
     "name": "Station-3",
     "description": "WWW und Speicherarten",
@@ -32,6 +35,7 @@
   {
     "uid": "f1da5d20-c668-44ba-a1a6-7297fe9539c0",
     "id": "station_4",
+    "slug": "station_4",
     "file": "station_4.json",
     "name": "Station-4",
     "description": "Begriffe und Geraetegroessen",
@@ -42,6 +46,7 @@
   {
     "uid": "588eae96-0999-4124-a13a-e282e149c341",
     "id": "station_5",
+    "slug": "station_5",
     "file": "station_5.json",
     "name": "Station-5",
     "description": "Programme und Binaersystem",
@@ -52,6 +57,7 @@
   {
     "uid": "808487f9-eb09-4b41-b887-0baf82b2b92d",
     "id": "station_6",
+    "slug": "station_6",
     "file": "station_6.json",
     "name": "Station-6",
     "description": "Dateien und URLs",
@@ -62,6 +68,7 @@
   {
     "uid": "6dfc8316-45d3-4737-838c-811419709d9c",
     "id": "station_7",
+    "slug": "station_7",
     "file": "station_7.json",
     "name": "Station-7",
     "description": "Netzwerke und Kuerzel",
@@ -72,6 +79,7 @@
   {
     "uid": "0c0dc60a-6d20-4e16-9f71-d926f143c874",
     "id": "station_8",
+    "slug": "station_8",
     "file": "station_8.json",
     "name": "Station-8",
     "description": "Cloud und Steuerung",

--- a/data/kataloge/catalogs.json
+++ b/data/kataloge/catalogs.json
@@ -2,6 +2,7 @@
   {
     "uid": "340da4f1-d796-49c2-aeaf-932280de5167",
     "id": "station_1",
+    "slug": "station_1",
     "file": "station_1.json",
     "name": "Station-1",
     "description": "Speicher und Geraete",
@@ -12,6 +13,7 @@
   {
     "uid": "d0e42823-2da0-4858-a827-7d5d5d164d7d",
     "id": "station_2",
+    "slug": "station_2",
     "file": "station_2.json",
     "name": "Station-2",
     "description": "Bedienung und Symbole",
@@ -22,6 +24,7 @@
   {
     "uid": "14a904ff-cfbf-4ac5-85e0-b70222e9b31c",
     "id": "station_3",
+    "slug": "station_3",
     "file": "station_3.json",
     "name": "Station-3",
     "description": "WWW und Speicherarten",
@@ -32,6 +35,7 @@
   {
     "uid": "f1da5d20-c668-44ba-a1a6-7297fe9539c0",
     "id": "station_4",
+    "slug": "station_4",
     "file": "station_4.json",
     "name": "Station-4",
     "description": "Begriffe und Geraetegroessen",
@@ -42,6 +46,7 @@
   {
     "uid": "588eae96-0999-4124-a13a-e282e149c341",
     "id": "station_5",
+    "slug": "station_5",
     "file": "station_5.json",
     "name": "Station-5",
     "description": "Programme und Binaersystem",
@@ -52,6 +57,7 @@
   {
     "uid": "808487f9-eb09-4b41-b887-0baf82b2b92d",
     "id": "station_6",
+    "slug": "station_6",
     "file": "station_6.json",
     "name": "Station-6",
     "description": "Dateien und URLs",
@@ -62,6 +68,7 @@
   {
     "uid": "6dfc8316-45d3-4737-838c-811419709d9c",
     "id": "station_7",
+    "slug": "station_7",
     "file": "station_7.json",
     "name": "Station-7",
     "description": "Netzwerke und Kuerzel",
@@ -72,6 +79,7 @@
   {
     "uid": "0c0dc60a-6d20-4e16-9f71-d926f143c874",
     "id": "station_8",
+    "slug": "station_8",
     "file": "station_8.json",
     "name": "Station-8",
     "description": "Cloud und Steuerung",

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -50,6 +50,7 @@ CREATE INDEX idx_results_name ON results(name);
 CREATE TABLE IF NOT EXISTS catalogs (
     uid TEXT PRIMARY KEY,
     id TEXT UNIQUE NOT NULL,
+    slug TEXT UNIQUE NOT NULL,
     file TEXT NOT NULL,
     name TEXT NOT NULL,
     description TEXT,

--- a/migrations/20240621_add_slug_column_to_catalogs.sql
+++ b/migrations/20240621_add_slug_column_to_catalogs.sql
@@ -1,0 +1,4 @@
+ALTER TABLE catalogs ADD COLUMN IF NOT EXISTS slug TEXT;
+UPDATE catalogs SET slug = id WHERE slug IS NULL OR slug = '';
+ALTER TABLE catalogs ALTER COLUMN slug SET NOT NULL;
+ALTER TABLE catalogs ADD CONSTRAINT catalogs_slug_unique UNIQUE(slug);

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function getUsedIds() {
-    const set = new Set(catalogs.map(c => c.id));
+    const set = new Set(catalogs.map(c => c.slug || c.id));
     document
       .querySelectorAll('.catalog-row .cat-id')
       .forEach(el => set.add(el.value.trim()));
@@ -268,7 +268,7 @@ document.addEventListener('DOMContentLoaded', function () {
   let initial = [];
 
   function loadCatalog(id) {
-    const cat = catalogs.find(c => c.id === id);
+    const cat = catalogs.find(c => (c.slug || c.id) === id);
     if (!cat) return;
     catalogFile = cat.file;
     fetch('/kataloge/' + catalogFile, { headers: { 'Accept': 'application/json' } })
@@ -290,13 +290,13 @@ document.addEventListener('DOMContentLoaded', function () {
       catSelect.innerHTML = '';
       catalogs.forEach(c => {
         const opt = document.createElement('option');
-        opt.value = c.id;
-        opt.textContent = c.name || c.id;
+        opt.value = c.slug || c.id;
+        opt.textContent = c.name || c.slug || c.id;
         catSelect.appendChild(opt);
       });
       renderCatalogs(catalogs);
       const params = new URLSearchParams(window.location.search);
-      const id = params.get('katalog') || (catalogs[0] && catalogs[0].id);
+      const id = params.get('katalog') || (catalogs[0] && (catalogs[0].slug || catalogs[0].id));
       if (id) {
         catSelect.value = id;
         loadCatalog(id);
@@ -314,14 +314,14 @@ document.addEventListener('DOMContentLoaded', function () {
     fetch('/kataloge/' + cat.file, { method: 'DELETE' })
       .then(r => {
         if (!r.ok) throw new Error(r.statusText);
-        catalogs = catalogs.filter(c => c.id !== cat.id);
-        const opt = catSelect.querySelector('option[value="' + cat.id + '"]');
+        catalogs = catalogs.filter(c => (c.slug || c.id) !== (cat.slug || cat.id));
+        const opt = catSelect.querySelector('option[value="' + (cat.slug || cat.id) + '"]');
         opt?.remove();
         row.remove();
         if (catalogs[0]) {
-          if (catSelect.value === cat.id) {
-            catSelect.value = catalogs[0].id;
-            loadCatalog(catalogs[0].id);
+          if (catSelect.value === (cat.slug || cat.id)) {
+            catSelect.value = catalogs[0].slug || catalogs[0].id;
+            loadCatalog(catalogs[0].slug || catalogs[0].id);
           }
         } else {
           catalogFile = '';
@@ -340,7 +340,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const row = document.createElement('tr');
     row.className = 'catalog-row';
     if (cat.new) row.dataset.new = 'true';
-    row.dataset.id = cat.id || '';
+    row.dataset.id = cat.slug || cat.id || '';
     row.dataset.file = cat.file || '';
     row.dataset.initialFile = cat.file || '';
     row.dataset.uid = cat.uid || crypto.randomUUID();
@@ -359,7 +359,7 @@ document.addEventListener('DOMContentLoaded', function () {
     idInput.className = 'uk-input cat-id';
     idInput.placeholder = 'ID';
     idInput.id = rowId + '-id';
-    idInput.value = cat.id || '';
+    idInput.value = cat.slug || cat.id || '';
     idCell.appendChild(idInput);
 
     const nameCell = document.createElement('td');
@@ -459,6 +459,7 @@ document.addEventListener('DOMContentLoaded', function () {
         return {
           uid: row.dataset.uid,
           id,
+          slug: id,
           file,
           name: row.querySelector('.cat-name').value.trim(),
           description: row.querySelector('.cat-desc').value.trim(),
@@ -938,8 +939,8 @@ document.addEventListener('DOMContentLoaded', function () {
         catSelect.innerHTML = '';
         catalogs.forEach(c => {
           const opt = document.createElement('option');
-          opt.value = c.id;
-          opt.textContent = c.name || c.id;
+          opt.value = c.slug || c.id;
+          opt.textContent = c.name || c.slug || c.id;
           catSelect.appendChild(opt);
         });
         notify('Katalogliste gespeichert', 'success');

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -224,8 +224,10 @@
       return;
     }
     catalogs = catalogs.slice().sort((a,b) => {
-      if(a.id === undefined || b.id === undefined) return 0;
-      return a.id.localeCompare(b.id);
+      const sa = a.slug || a.id;
+      const sb = b.slug || b.id;
+      if(sa === undefined || sb === undefined) return 0;
+      return sa.localeCompare(sb);
     });
 
     const grid = document.createElement('div');
@@ -239,15 +241,15 @@
       card.addEventListener('click', () => {
         const localSolved = new Set(JSON.parse(sessionStorage.getItem('quizSolved') || '[]'));
         if((window.quizConfig || {}).competitionMode && localSolved.has(cat.uid)){
-          const remaining = catalogs.filter(c => !localSolved.has(c.uid)).map(c => c.name || c.id).join(', ');
-          showCatalogSolvedModal(cat.name || cat.id, remaining);
+          const remaining = catalogs.filter(c => !localSolved.has(c.uid)).map(c => c.name || c.slug || c.id).join(', ');
+          showCatalogSolvedModal(cat.name || cat.slug || cat.id, remaining);
           return;
         }
-        history.replaceState(null, '', '?katalog=' + cat.id);
-        loadQuestions(cat.id, cat.file, cat.raetsel_buchstabe, cat.uid, cat.name || cat.id, cat.description || '', cat.comment || '');
+        history.replaceState(null, '', '?katalog=' + (cat.slug || cat.id));
+        loadQuestions(cat.slug || cat.id, cat.file, cat.raetsel_buchstabe, cat.uid, cat.name || cat.slug || cat.id, cat.description || '', cat.comment || '');
       });
       const title = document.createElement('h3');
-      title.textContent = cat.name || cat.id;
+      title.textContent = cat.name || cat.slug || cat.id;
       const desc = document.createElement('p');
       desc.textContent = cat.description || '';
       card.appendChild(title);
@@ -457,20 +459,20 @@
     const id = params.get('katalog');
     const proceed = async () => {
       const solvedNow = await buildSolvedSet(cfg);
-      const selected = catalogs.find(c => c.id === id);
+      const selected = catalogs.find(c => (c.slug || c.id) === id);
       if(selected){
           if(cfg.competitionMode && solvedNow.has(selected.uid)){
-            const remaining = catalogs.filter(c => !solvedNow.has(c.uid)).map(c => c.name || c.id).join(', ');
+            const remaining = catalogs.filter(c => !solvedNow.has(c.uid)).map(c => c.name || c.slug || c.id).join(', ');
             if(catalogs.length && solvedNow.size === catalogs.length){
               showAllSolvedModal();
               return;
             } else {
-              showCatalogSolvedModal(selected.name || selected.id, remaining);
+              showCatalogSolvedModal(selected.name || selected.slug || selected.id, remaining);
               showSelection(catalogs, solvedNow);
               return;
             }
           }
-        loadQuestions(selected.id, selected.file, selected.raetsel_buchstabe, selected.uid, selected.name || selected.id, selected.description || '', selected.comment || '');
+        loadQuestions(selected.slug || selected.id, selected.file, selected.raetsel_buchstabe, selected.uid, selected.name || selected.slug || selected.id, selected.description || '', selected.comment || '');
       }else{
         showSelection(catalogs, solvedNow);
       }

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -110,12 +110,13 @@ $catalogDir = "$base/data/kataloge";
 $catalogsFile = "$catalogDir/catalogs.json";
 if (is_readable($catalogsFile)) {
     $catalogs = json_decode(file_get_contents($catalogsFile), true) ?? [];
-    $catStmt = $pdo->prepare('INSERT INTO catalogs(uid,id,file,name,description,qrcode_url,raetsel_buchstabe,comment) VALUES(?,?,?,?,?,?,?,?)');
+    $catStmt = $pdo->prepare('INSERT INTO catalogs(uid,id,slug,file,name,description,qrcode_url,raetsel_buchstabe,comment) VALUES(?,?,?,?,?,?,?,?,?)');
     $qStmt = $pdo->prepare('INSERT INTO questions(catalog_id,type,prompt,options,answers,terms,items) VALUES(?,?,?,?,?,?,?)');
     foreach ($catalogs as $cat) {
         $catStmt->execute([
             $cat['uid'] ?? '',
             $cat['id'] ?? '',
+            $cat['slug'] ?? ($cat['id'] ?? ''),
             $cat['file'] ?? '',
             $cat['name'] ?? '',
             $cat['description'] ?? null,

--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -23,9 +23,9 @@ class CatalogController
         $accept = strtolower($request->getHeaderLine('Accept'));
 
         if ($accept === '' || strpos($accept, 'application/json') === false) {
-            $id = pathinfo($file, PATHINFO_FILENAME);
+            $slug = $this->service->slugByFile($file) ?? pathinfo($file, PATHINFO_FILENAME);
             return $response
-                ->withHeader('Location', '/?katalog=' . urlencode($id))
+                ->withHeader('Location', '/?katalog=' . urlencode($slug))
                 ->withStatus(302);
         }
 

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -29,9 +29,9 @@ class HomeController
 
         if (($cfg['competitionMode'] ?? false) === true) {
             $params = $request->getQueryParams();
-            $id = $params['katalog'] ?? '';
-            $allowedIds = array_map(static fn($c) => $c['id'] ?? '', $catalogs);
-            if ($id === '' || !in_array($id, $allowedIds, true)) {
+            $slug = $params['katalog'] ?? '';
+            $allowedSlugs = array_map(static fn($c) => $c['slug'] ?? '', $catalogs);
+            if ($slug === '' || !in_array($slug, $allowedSlugs, true)) {
                 return $response
                     ->withHeader('Location', '/help')
                     ->withStatus(302);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -346,7 +346,7 @@
             <div class="export-card uk-card uk-card-default uk-card-body">
               <h4 class="uk-card-title">{{ c.name }}</h4>
               <p>{{ c.description }}</p>
-              {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ c.id : '?katalog=' ~ c.id %}
+              {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ c.slug : '?katalog=' ~ c.slug %}
               <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000&label=0" alt="QR" width="96" height="96">
             </div>
           </div>

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -21,7 +21,7 @@
                             <div class="uk-text-small uk-margin-small-top">{{ katalog.beschreibung }}</div>
                         </div>
                         <div class="uk-width-auto@s uk-width-1-1">
-                            {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ katalog.id : '?katalog=' ~ katalog.id %}
+                            {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ katalog.slug : '?katalog=' ~ katalog.slug %}
                             <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
                             <button class="uk-button uk-button-danger uk-button-small uk-width-1-1">Löschen</button>
                         </div>

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -14,7 +14,7 @@ class CatalogServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
         $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id TEXT NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
         return $pdo;
     }
@@ -23,7 +23,7 @@ class CatalogServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT);');
         $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id TEXT NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
         return $pdo;
     }
@@ -36,6 +36,7 @@ class CatalogServiceTest extends TestCase
         $catalog = [[
             'uid' => 'uid1',
             'id' => 'cat1',
+            'slug' => 'cat1',
             'file' => $file,
             'name' => 'Test',
             'comment' => ''
@@ -54,6 +55,7 @@ class CatalogServiceTest extends TestCase
         $catalog = [[
             'uid' => 'uid4',
             'id' => 'nc',
+            'slug' => 'nc',
             'file' => 'nc.json',
             'name' => 'NC',
             'comment' => 'ignored',
@@ -79,6 +81,7 @@ class CatalogServiceTest extends TestCase
         $service->write('catalogs.json', [[
             'uid' => 'uid2',
             'id' => 'del',
+            'slug' => 'del',
             'file' => $file,
             'name' => 'Del',
             'comment' => ''
@@ -99,6 +102,7 @@ class CatalogServiceTest extends TestCase
         $service->write('catalogs.json', [[
             'uid' => 'uid3',
             'id' => 'qid',
+            'slug' => 'qid',
             'file' => $file,
             'name' => 'Q',
             'comment' => ''


### PR DESCRIPTION
## Summary
- introduce slug as frontend handle for catalogs
- route catalogs and templates via slug
- include slug in catalog JSON data
- adjust tests, JS and docs

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546e494080832b9c13d20f9dd5806a