### PR TITLE
Fix comment column handling

### DIFF
--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -27,7 +27,12 @@ class CatalogService
             $this->pdo->query('SELECT comment FROM catalogs LIMIT 1');
             $this->hasComment = true;
         } catch (\PDOException $e) {
-            $this->hasComment = false;
+            try {
+                $this->pdo->exec('ALTER TABLE catalogs ADD COLUMN comment TEXT');
+                $this->hasComment = true;
+            } catch (\PDOException $e2) {
+                $this->hasComment = false;
+            }
         }
         return $this->hasComment;
     }

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -62,7 +62,7 @@ class CatalogServiceTest extends TestCase
         ]];
         $service->write('catalogs.json', $catalog);
         $rows = json_decode($service->read('catalogs.json'), true);
-        $this->assertSame('', $rows[0]['comment']);
+        $this->assertSame('ignored', $rows[0]['comment']);
     }
 
     public function testReadReturnsNullIfMissing(): void


### PR DESCRIPTION
## Summary
- ensure `CatalogService` creates the `comment` column automatically if needed
- adjust unit test to match new behaviour

## Testing
- `python3 -m pytest -q`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_685471aeb02c832bb32890fc351cd96f