### PR TITLE
Fix cascade deletion of questions

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -69,7 +69,7 @@ CREATE TABLE IF NOT EXISTS questions (
     answers JSONB,
     terms JSONB,
     items JSONB,
-    FOREIGN KEY (catalog_id) REFERENCES catalogs(id)
+    FOREIGN KEY (catalog_id) REFERENCES catalogs(id) ON DELETE CASCADE
 );
 CREATE INDEX idx_questions_catalog ON questions(catalog_id);
 

--- a/migrations/20240622_add_cascade_to_questions.sql
+++ b/migrations/20240622_add_cascade_to_questions.sql
@@ -1,0 +1,3 @@
+ALTER TABLE questions DROP CONSTRAINT IF EXISTS questions_catalog_id_fkey;
+ALTER TABLE questions ADD CONSTRAINT questions_catalog_id_fkey
+    FOREIGN KEY (catalog_id) REFERENCES catalogs(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- cascade delete questions when their catalog is removed
- provide migration to update existing databases

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685475229114832b8f5ad29857ba6c7b