### PR TITLE
Add catalog comment formatting

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -81,11 +81,43 @@ document.addEventListener('DOMContentLoaded', function () {
   const commentTextarea = document.getElementById('catalogCommentTextarea');
   const commentSaveBtn = document.getElementById('catalogCommentSave');
   const commentModal = UIkit.modal('#catalogCommentModal');
+  const commentToolbar = document.getElementById('catalogCommentToolbar');
   const resultsResetModal = UIkit.modal('#resultsResetModal');
   const resultsResetConfirm = document.getElementById('resultsResetConfirm');
   let puzzleFeedback = '';
   let currentCommentInput = null;
   let logoUploaded = false;
+
+  function wrapSelection(textarea, before, after) {
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const val = textarea.value;
+    textarea.value = val.slice(0, start) + before + val.slice(start, end) + after + val.slice(end);
+    textarea.focus();
+    textarea.selectionStart = start + before.length;
+    textarea.selectionEnd = end + before.length;
+  }
+
+  commentToolbar?.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-format]');
+    if (!btn) return;
+    const fmt = btn.dataset.format;
+    switch (fmt) {
+      case 'h1':
+        wrapSelection(commentTextarea, '<h1>', '</h1>');
+        break;
+      case 'h2':
+        wrapSelection(commentTextarea, '<h2>', '</h2>');
+        break;
+      case 'bold':
+        wrapSelection(commentTextarea, '<strong>', '</strong>');
+        break;
+      case 'italic':
+        wrapSelection(commentTextarea, '<em>', '</em>');
+        break;
+    }
+  });
   if (cfgFields.logoFile && cfgFields.logoPreview) {
     const bar = document.getElementById('cfgLogoProgress');
     UIkit.upload('.js-upload', {

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -23,10 +23,15 @@
       el.className = 'uk-margin-remove-top';
       headerEl.appendChild(el);
     }
-    el.textContent = text || '';
     if(text){
+      if(text.indexOf('<') !== -1){
+        el.innerHTML = text;
+      }else{
+        el.innerHTML = text.replace(/\n/g, '<br>');
+      }
       el.classList.remove('uk-hidden');
     }else{
+      el.innerHTML = '';
       el.classList.add('uk-hidden');
     }
   }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -193,6 +193,12 @@
         <div id="catalogCommentModal" uk-modal>
           <div class="uk-modal-dialog uk-modal-body">
             <h2 class="uk-modal-title">Kommentar zum Katalog</h2>
+            <div id="catalogCommentToolbar" class="uk-margin-small-bottom">
+              <button class="uk-button uk-button-default" type="button" data-format="h1">H1</button>
+              <button class="uk-button uk-button-default" type="button" data-format="h2">H2</button>
+              <button class="uk-button uk-button-default" type="button" data-format="bold"><strong>B</strong></button>
+              <button class="uk-button uk-button-default" type="button" data-format="italic"><em>I</em></button>
+            </div>
             <textarea id="catalogCommentTextarea" class="uk-textarea" rows="5" placeholder="Kommentar eingeben..."></textarea>
             <div class="uk-flex uk-flex-right uk-margin-top">
               <button id="catalogCommentSave" class="uk-button uk-button-primary" type="button">Speichern</button>


### PR DESCRIPTION
## Summary
- add formatting buttons to catalog comment modal
- implement simple markup insertion and rendering on start page

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685478b0540c832b9cfde794f7c29d21