### PR TITLE
Fix catalog page button label

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -403,7 +403,7 @@
       if(!cfg.competitionMode || hasCatalog){
         const btn = document.createElement('button');
         btn.className = 'uk-button uk-button-primary';
-        btn.textContent = 'Starten';
+        btn.textContent = 'Los geht es!';
         if(cfg.buttonColor){
           btn.style.backgroundColor = cfg.buttonColor;
           btn.style.borderColor = cfg.buttonColor;

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -933,7 +933,7 @@ function runQuiz(questions){
 
     const startBtn = document.createElement('button');
     startBtn.className = 'uk-button uk-button-primary uk-button-large';
-    startBtn.textContent = 'UND LOS';
+    startBtn.textContent = 'Los geht es!';
     styleButton(startBtn);
     // Zeigt bisherige Ergebnisse als kleine Slideshow an
     stats.textContent = 'Noch keine Ergebnisse vorhanden.';


### PR DESCRIPTION
## Summary
- use "Los geht es!" for quiz start button
- keep QR scan buttons labeled as before

## Testing
- `pytest tests`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_68547ccca3d0832ba9dd63b2ee9b9af5