### PR TITLE
Use numeric catalog ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ standardmäßig `https://` vorangestellt.
 
 ## Anpassung
 
-Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition besitzt nun ein `slug`, über das der Katalog im Frontend aufgerufen wird. Das bisherige `id` dient nur noch der Sortierung und kann bei Bedarf angepasst werden.
+Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition besitzt nun ein `slug`, über das der Katalog im Frontend aufgerufen wird. Das bisherige `id` dient nur noch der Sortierung, liegt jetzt als Ganzzahl vor und wird automatisch beim Speichern vergeben.
 
 QR-Codes können pro Eintrag über `qr_image` oder `qrcode_url` hinterlegt werden. Neben Data-URIs und lokalen Pfaden werden dabei nun auch HTTP- oder HTTPS-URLs unterstützt.
 
@@ -283,7 +283,7 @@ Unter `/admin` stehen folgende Tabs zur Verfügung:
 6. **Passwort ändern** – Administrationspasswort setzen.
 
 ### Fragenkataloge
-`data/kataloge/catalogs.json` listet verfügbare Kataloge mit `slug`, Name und optionaler QR-Code-Adresse. Das Feld `id` dient nur noch der internen Sortierung. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:
+`data/kataloge/catalogs.json` listet verfügbare Kataloge mit `slug`, Name und optionaler QR-Code-Adresse. Das Feld `id` wird automatisch als fortlaufende Zahl vergeben und dient nur der internen Sortierung. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:
 - `GET /kataloge/{file}` liefert den JSON-Katalog oder leitet im Browser auf `/?katalog=slug` um.
 - `PUT /kataloge/{file}` legt eine neue Datei an.
 - `POST /kataloge/{file}` überschreibt einen Katalog mit gesendeten Daten.

--- a/data-default/kataloge/catalogs.json
+++ b/data-default/kataloge/catalogs.json
@@ -1,7 +1,7 @@
 [
   {
     "uid": "340da4f1-d796-49c2-aeaf-932280de5167",
-    "id": "station_1",
+    "id": 1,
     "slug": "station_1",
     "file": "station_1.json",
     "name": "Station-1",
@@ -12,7 +12,7 @@
   },
   {
     "uid": "d0e42823-2da0-4858-a827-7d5d5d164d7d",
-    "id": "station_2",
+    "id": 2,
     "slug": "station_2",
     "file": "station_2.json",
     "name": "Station-2",
@@ -23,7 +23,7 @@
   },
   {
     "uid": "14a904ff-cfbf-4ac5-85e0-b70222e9b31c",
-    "id": "station_3",
+    "id": 3,
     "slug": "station_3",
     "file": "station_3.json",
     "name": "Station-3",
@@ -34,7 +34,7 @@
   },
   {
     "uid": "f1da5d20-c668-44ba-a1a6-7297fe9539c0",
-    "id": "station_4",
+    "id": 4,
     "slug": "station_4",
     "file": "station_4.json",
     "name": "Station-4",
@@ -45,7 +45,7 @@
   },
   {
     "uid": "588eae96-0999-4124-a13a-e282e149c341",
-    "id": "station_5",
+    "id": 5,
     "slug": "station_5",
     "file": "station_5.json",
     "name": "Station-5",
@@ -56,7 +56,7 @@
   },
   {
     "uid": "808487f9-eb09-4b41-b887-0baf82b2b92d",
-    "id": "station_6",
+    "id": 6,
     "slug": "station_6",
     "file": "station_6.json",
     "name": "Station-6",
@@ -67,7 +67,7 @@
   },
   {
     "uid": "6dfc8316-45d3-4737-838c-811419709d9c",
-    "id": "station_7",
+    "id": 7,
     "slug": "station_7",
     "file": "station_7.json",
     "name": "Station-7",
@@ -78,7 +78,7 @@
   },
   {
     "uid": "0c0dc60a-6d20-4e16-9f71-d926f143c874",
-    "id": "station_8",
+    "id": 8,
     "slug": "station_8",
     "file": "station_8.json",
     "name": "Station-8",

--- a/data/kataloge/catalogs.json
+++ b/data/kataloge/catalogs.json
@@ -1,7 +1,7 @@
 [
   {
     "uid": "340da4f1-d796-49c2-aeaf-932280de5167",
-    "id": "station_1",
+    "id": 1,
     "slug": "station_1",
     "file": "station_1.json",
     "name": "Station-1",
@@ -12,7 +12,7 @@
   },
   {
     "uid": "d0e42823-2da0-4858-a827-7d5d5d164d7d",
-    "id": "station_2",
+    "id": 2,
     "slug": "station_2",
     "file": "station_2.json",
     "name": "Station-2",
@@ -23,7 +23,7 @@
   },
   {
     "uid": "14a904ff-cfbf-4ac5-85e0-b70222e9b31c",
-    "id": "station_3",
+    "id": 3,
     "slug": "station_3",
     "file": "station_3.json",
     "name": "Station-3",
@@ -34,7 +34,7 @@
   },
   {
     "uid": "f1da5d20-c668-44ba-a1a6-7297fe9539c0",
-    "id": "station_4",
+    "id": 4,
     "slug": "station_4",
     "file": "station_4.json",
     "name": "Station-4",
@@ -45,7 +45,7 @@
   },
   {
     "uid": "588eae96-0999-4124-a13a-e282e149c341",
-    "id": "station_5",
+    "id": 5,
     "slug": "station_5",
     "file": "station_5.json",
     "name": "Station-5",
@@ -56,7 +56,7 @@
   },
   {
     "uid": "808487f9-eb09-4b41-b887-0baf82b2b92d",
-    "id": "station_6",
+    "id": 6,
     "slug": "station_6",
     "file": "station_6.json",
     "name": "Station-6",
@@ -67,7 +67,7 @@
   },
   {
     "uid": "6dfc8316-45d3-4737-838c-811419709d9c",
-    "id": "station_7",
+    "id": 7,
     "slug": "station_7",
     "file": "station_7.json",
     "name": "Station-7",
@@ -78,7 +78,7 @@
   },
   {
     "uid": "0c0dc60a-6d20-4e16-9f71-d926f143c874",
-    "id": "station_8",
+    "id": 8,
     "slug": "station_8",
     "file": "station_8.json",
     "name": "Station-8",

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -372,7 +372,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const row = document.createElement('tr');
     row.className = 'catalog-row';
     if (cat.new) row.dataset.new = 'true';
-    row.dataset.id = cat.slug || cat.id || '';
+    row.dataset.id = cat.id !== undefined ? String(cat.id) : '';
+    row.dataset.slug = cat.slug || '';
     row.dataset.file = cat.file || '';
     row.dataset.initialFile = cat.file || '';
     row.dataset.uid = cat.uid || crypto.randomUUID();
@@ -389,9 +390,9 @@ document.addEventListener('DOMContentLoaded', function () {
     const idInput = document.createElement('input');
     idInput.type = 'text';
     idInput.className = 'uk-input cat-id';
-    idInput.placeholder = 'ID';
+    idInput.placeholder = 'Slug';
     idInput.id = rowId + '-id';
-    idInput.value = cat.slug || cat.id || '';
+    idInput.value = cat.slug || '';
     idCell.appendChild(idInput);
 
     const nameCell = document.createElement('td');
@@ -456,9 +457,9 @@ document.addEventListener('DOMContentLoaded', function () {
     delCell.appendChild(del);
 
     function update() {
-      const id = idInput.value.trim();
-      row.dataset.id = id;
-      row.dataset.file = id ? id + '.json' : '';
+      const slug = idInput.value.trim();
+      row.dataset.slug = slug;
+      row.dataset.file = slug ? slug + '.json' : '';
     }
     idInput.addEventListener('input', update);
     update();
@@ -479,19 +480,20 @@ document.addEventListener('DOMContentLoaded', function () {
     catalogList.innerHTML = '';
     list
       .slice()
-      .sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }))
+      .sort((a, b) => (a.id || 0) - (b.id || 0))
       .forEach(cat => catalogList.appendChild(createCatalogRow(cat)));
   }
 
   function collectCatalogs() {
     return Array.from(catalogList.querySelectorAll('.catalog-row'))
-      .map(row => {
-        const id = row.querySelector('.cat-id').value.trim();
-        const file = id ? id + '.json' : '';
+      .map((row, idx) => {
+        const slug = row.querySelector('.cat-id').value.trim();
+        const file = slug ? slug + '.json' : '';
+        row.dataset.id = String(idx + 1);
         return {
           uid: row.dataset.uid,
-          id,
-          slug: id,
+          id: idx + 1,
+          slug,
           file,
           name: row.querySelector('.cat-name').value.trim(),
           description: row.querySelector('.cat-desc').value.trim(),
@@ -499,8 +501,7 @@ document.addEventListener('DOMContentLoaded', function () {
           comment: row.querySelector('.cat-comment').value.trim()
         };
       })
-      .filter(c => c.id)
-      .sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+      .filter(c => c.slug);
   }
 
   // Rendert alle Fragen im Editor neu
@@ -914,7 +915,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   newCatBtn.addEventListener('click', function (e) {
     e.preventDefault();
-    catalogList.appendChild(createCatalogRow({ id: '', file: '', name: '', description: '', raetsel_buchstabe: '', new: true }));
+    catalogList.appendChild(createCatalogRow({ id: '', slug: '', file: '', name: '', description: '', raetsel_buchstabe: '', new: true }));
   });
 
   catalogsSaveBtn?.addEventListener('click', async e => {

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -52,8 +52,11 @@ class CatalogService
             if ($this->hasCommentColumn()) {
                 $fields .= ',comment';
             }
-            $stmt = $this->pdo->query("SELECT $fields FROM catalogs ORDER BY id");
+            $stmt = $this->pdo->query("SELECT $fields FROM catalogs ORDER BY CAST(id AS INTEGER)");
             $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            foreach ($data as &$row) {
+                $row['id'] = (int)$row['id'];
+            }
             if (!$this->hasCommentColumn()) {
                 foreach ($data as &$row) {
                     $row['comment'] = '';


### PR DESCRIPTION
## Summary
- represent catalog IDs as integers
- generate numeric IDs when saving catalogs in admin UI
- ensure catalogs are sorted numerically in the interface
- update documentation

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_685485663a94832b84bc7ea7f93384e0