### PR TITLE
Fix invalid integer cast in catalog listing

### DIFF
--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -52,7 +52,7 @@ class CatalogService
             if ($this->hasCommentColumn()) {
                 $fields .= ',comment';
             }
-            $stmt = $this->pdo->query("SELECT $fields FROM catalogs ORDER BY CAST(id AS INTEGER)");
+            $stmt = $this->pdo->query("SELECT $fields FROM catalogs ORDER BY id");
             $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
             foreach ($data as &$row) {
                 $row['id'] = (int)$row['id'];


### PR DESCRIPTION
## Summary
- avoid casting non-numeric catalog IDs

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685488641c80832b89cb1f4215bd398d