### PR TITLE
Sort catalog cards by id

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -245,11 +245,15 @@
       container.appendChild(p);
       return;
     }
-    catalogs = catalogs.slice().sort((a,b) => {
+    catalogs = catalogs.slice().sort((a, b) => {
+      const ia = parseInt(a.id, 10);
+      const ib = parseInt(b.id, 10);
+      if(!Number.isNaN(ia) && !Number.isNaN(ib)){
+        return ia - ib;
+      }
       const sa = a.slug || a.id;
       const sb = b.slug || b.id;
-      if(sa === undefined || sb === undefined) return 0;
-      return sa.localeCompare(sb);
+      return String(sa).localeCompare(String(sb));
     });
 
     const grid = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure catalog cards on the frontend overview are ordered by numeric id

## Testing
- `pytest -q`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551516fc4c832b8c1105b66f7dae31