### PR TITLE
Fix catalog import mapping

### DIFF
--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -129,7 +129,7 @@ if (is_readable($catalogsFile)) {
             $questions = json_decode(file_get_contents($file), true) ?? [];
             foreach ($questions as $q) {
                 $qStmt->execute([
-                    $cat['id'] ?? '',
+                    $cat['slug'] ?? ($cat['id'] ?? ''),
                     $q['type'] ?? '',
                     $q['prompt'] ?? '',
                     isset($q['options']) ? json_encode($q['options']) : null,

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -146,7 +146,7 @@ class CatalogService
         $qStmt = $this->pdo->prepare('INSERT INTO questions(catalog_id,type,prompt,options,answers,terms,items) VALUES(?,?,?,?,?,?,?)');
         foreach ($data as $q) {
             $qStmt->execute([
-                $cat['id'],
+                $cat['slug'],
                 $q['type'] ?? '',
                 $q['prompt'] ?? '',
                 isset($q['options']) ? json_encode($q['options']) : null,


### PR DESCRIPTION
## Summary
- store quiz questions using catalog slug instead of the numeric id
- adjust pgsql import script accordingly

## Testing
- `pytest -q tests/test_html_validity.py tests/test_json_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_68551973200c832b998e88f122d8f6c9