### PR TITLE
Add catalog import function

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1116,6 +1116,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // --------- Passwort ändern ---------
   const passSaveBtn = document.getElementById('passSaveBtn');
+  const importJsonBtn = document.getElementById('importJsonBtn');
   const newPass = document.getElementById('newPass');
   const newPassRepeat = document.getElementById('newPassRepeat');
 
@@ -1145,7 +1146,20 @@ document.addEventListener('DOMContentLoaded', function () {
       })
       .catch(err => {
         console.error(err);
-        notify('Fehler beim Speichern', 'danger');
+      notify('Fehler beim Speichern', 'danger');
+    });
+  });
+
+  importJsonBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    fetch('/import', { method: 'POST' })
+      .then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        notify('Import abgeschlossen', 'success');
+      })
+      .catch(err => {
+        console.error(err);
+        notify('Fehler beim Import', 'danger');
       });
   });
 

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\CatalogService;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+class ImportController
+{
+    private CatalogService $service;
+    private string $dataDir;
+
+    public function __construct(CatalogService $service, string $dataDir)
+    {
+        $this->service = $service;
+        $this->dataDir = rtrim($dataDir, '/');
+    }
+
+    public function post(Request $request, Response $response): Response
+    {
+        $catalogDir = $this->dataDir . '/kataloge';
+        $catalogsFile = $catalogDir . '/catalogs.json';
+        if (!is_readable($catalogsFile)) {
+            return $response->withStatus(404);
+        }
+        $catalogs = json_decode((string)file_get_contents($catalogsFile), true) ?? [];
+        $this->service->write('catalogs.json', $catalogs);
+        foreach ($catalogs as $cat) {
+            if (!isset($cat['file'])) {
+                continue;
+            }
+            $file = basename((string)$cat['file']);
+            $path = $catalogDir . '/' . $file;
+            if (!is_readable($path)) {
+                continue;
+            }
+            $questions = json_decode((string)file_get_contents($path), true) ?? [];
+            $this->service->write($file, $questions);
+        }
+        return $response->withStatus(204);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -23,6 +23,7 @@ use App\Service\PhotoConsentService;
 use App\Controller\ResultController;
 use App\Controller\TeamController;
 use App\Controller\PasswordController;
+use App\Controller\ImportController;
 use App\Controller\QrController;
 use App\Controller\LogoController;
 use App\Controller\SummaryController;
@@ -71,6 +72,7 @@ return function (\Slim\App $app) {
     $qrController = new QrController();
     $logoController = new LogoController($configService);
     $summaryController = new SummaryController($configService);
+    $importController = new ImportController($catalogService, __DIR__ . '/../data');
     $consentService = new PhotoConsentService($pdo);
     $evidenceController = new EvidenceController(
         $resultService,
@@ -113,6 +115,7 @@ return function (\Slim\App $app) {
     $app->get('/teams.json', [$teamController, 'get']);
     $app->post('/teams.json', [$teamController, 'post']);
     $app->post('/password', [$passwordController, 'post']);
+    $app->post('/import', [$importController, 'post']);
     $app->get('/qr.png', [$qrController, 'image']);
     $app->get('/logo.png', [$logoController, 'get'])->setArgument('ext', 'png');
     $app->post('/logo.png', [$logoController, 'post']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -406,6 +406,7 @@
             </div>
           </div>
           <div class="uk-margin uk-flex uk-flex-right">
+            <button id="importJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Fragenkataloge aus JSON importieren; pos: right">Importieren</button>
             <button id="passSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Neues Passwort speichern; pos: right">Speichern</button>
           </div>
         </form>

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Controller\ImportController;
+use App\Service\CatalogService;
+use Tests\TestCase;
+use Slim\Psr7\Response;
+use PDO;
+
+class ImportControllerTest extends TestCase
+{
+    private function createService(): CatalogService
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_id TEXT NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
+        return new CatalogService($pdo);
+    }
+
+    public function testImport(): void
+    {
+        $service = $this->createService();
+        $tmp = sys_get_temp_dir() . '/import_' . uniqid();
+        mkdir($tmp . '/kataloge', 0777, true);
+        file_put_contents($tmp . '/kataloge/catalogs.json', json_encode([
+            ['uid'=>'u1','id'=>'c1','slug'=>'c1','file'=>'c1.json','name'=>'Cat']
+        ], JSON_PRETTY_PRINT));
+        file_put_contents($tmp . '/kataloge/c1.json', json_encode([
+            ['type'=>'text','prompt'=>'Q']
+        ], JSON_PRETTY_PRINT));
+
+        $controller = new ImportController($service, $tmp);
+        $request = $this->createRequest('POST', '/import');
+        $response = $controller->post($request, new Response());
+        $this->assertEquals(204, $response->getStatusCode());
+        $questions = json_decode($service->read('c1.json'), true);
+        $this->assertCount(1, $questions);
+        $this->assertSame('Q', $questions[0]['prompt']);
+
+        unlink($tmp . '/kataloge/c1.json');
+        unlink($tmp . '/kataloge/catalogs.json');
+        rmdir($tmp . '/kataloge');
+        rmdir($tmp);
+    }
+}


### PR DESCRIPTION
## Summary
- add ImportController to import catalog JSON files
- wire new /import route and controller
- add button in password tab to trigger import
- handle import on client side via admin.js
- test ImportController

## Testing
- `phpunit` *(fails: composer/phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855139c16c8832b82f86cbe8d698f9a