### PR TITLE
Update comment editor headings

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -104,11 +104,11 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!btn) return;
     const fmt = btn.dataset.format;
     switch (fmt) {
-      case 'h1':
-        wrapSelection(commentTextarea, '<h1>', '</h1>');
-        break;
       case 'h2':
         wrapSelection(commentTextarea, '<h2>', '</h2>');
+        break;
+      case 'h3':
+        wrapSelection(commentTextarea, '<h3>', '</h3>');
         break;
       case 'bold':
         wrapSelection(commentTextarea, '<strong>', '</strong>');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -194,8 +194,8 @@
           <div class="uk-modal-dialog uk-modal-body">
             <h2 class="uk-modal-title">Kommentar zum Katalog</h2>
             <div id="catalogCommentToolbar" class="uk-margin-small-bottom">
-              <button class="uk-button uk-button-default" type="button" data-format="h1">H1</button>
               <button class="uk-button uk-button-default" type="button" data-format="h2">H2</button>
+              <button class="uk-button uk-button-default" type="button" data-format="h3">H3</button>
               <button class="uk-button uk-button-default" type="button" data-format="bold"><strong>B</strong></button>
               <button class="uk-button uk-button-default" type="button" data-format="italic"><em>I</em></button>
             </div>


### PR DESCRIPTION
## Summary
- update editor toolbar buttons from H1/H2 to H2/H3
- adjust JS tag wrapping logic

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_685521da5b58832bb1ebc0a7bf292c49