### PR TITLE
Fix quiz navigation

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -146,9 +146,6 @@ function runQuiz(questions, skipIntro){
   progress.max = questionCount;
   showQuestion(current);
 
-  if(skipIntro){
-    next();
-  }
 
   // Zeigt das Element mit dem angegebenen Index an und aktualisiert den Fortschrittsbalken
   function showQuestion(i){
@@ -179,7 +176,7 @@ function runQuiz(questions, skipIntro){
       headerEl.innerHTML = '';
       headerEl.classList.add('uk-hidden');
     }
-    if(current < questionCount){
+    if(current < questionCount + 1){
       current++;
       showQuestion(current);
     }


### PR DESCRIPTION
## Summary
- fix quiz navigation when skipping intro
- allow moving to summary screen after last question

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`

------
https://chatgpt.com/codex/tasks/task_e_68552a939c4c832b8be4e57a66331e74