### PR TITLE
Add database export feature

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1117,6 +1117,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // --------- Passwort ändern ---------
   const passSaveBtn = document.getElementById('passSaveBtn');
   const importJsonBtn = document.getElementById('importJsonBtn');
+  const exportJsonBtn = document.getElementById('exportJsonBtn');
   const newPass = document.getElementById('newPass');
   const newPassRepeat = document.getElementById('newPassRepeat');
 
@@ -1160,6 +1161,19 @@ document.addEventListener('DOMContentLoaded', function () {
       .catch(err => {
         console.error(err);
         notify('Fehler beim Import', 'danger');
+      });
+  });
+
+  exportJsonBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    fetch('/export', { method: 'POST' })
+      .then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        notify('Export abgeschlossen', 'success');
+      })
+      .catch(err => {
+        console.error(err);
+        notify('Fehler beim Export', 'danger');
       });
   });
 

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\CatalogService;
+use App\Service\ConfigService;
+use App\Service\ResultService;
+use App\Service\TeamService;
+use App\Service\PhotoConsentService;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+class ExportController
+{
+    private ConfigService $config;
+    private CatalogService $catalogs;
+    private ResultService $results;
+    private TeamService $teams;
+    private PhotoConsentService $consents;
+    private string $dataDir;
+
+    public function __construct(
+        ConfigService $config,
+        CatalogService $catalogs,
+        ResultService $results,
+        TeamService $teams,
+        PhotoConsentService $consents,
+        string $dataDir
+    ) {
+        $this->config = $config;
+        $this->catalogs = $catalogs;
+        $this->results = $results;
+        $this->teams = $teams;
+        $this->consents = $consents;
+        $this->dataDir = rtrim($dataDir, '/');
+    }
+
+    public function post(Request $request, Response $response): Response
+    {
+        $cfg = $this->config->getJson();
+        if ($cfg !== null) {
+            file_put_contents($this->dataDir . '/config.json', $cfg . "\n");
+        }
+
+        $teams = $this->teams->getAll();
+        file_put_contents(
+            $this->dataDir . '/teams.json',
+            json_encode($teams, JSON_PRETTY_PRINT) . "\n"
+        );
+
+        $results = $this->results->getAll();
+        file_put_contents(
+            $this->dataDir . '/results.json',
+            json_encode($results, JSON_PRETTY_PRINT) . "\n"
+        );
+
+        $consents = $this->consents->getAll();
+        file_put_contents(
+            $this->dataDir . '/photo_consents.json',
+            json_encode($consents, JSON_PRETTY_PRINT) . "\n"
+        );
+
+        $catalogDir = $this->dataDir . '/kataloge';
+        if (!is_dir($catalogDir)) {
+            mkdir($catalogDir, 0777, true);
+        }
+        $catalogs = $this->catalogs->read('catalogs.json');
+        if ($catalogs !== null) {
+            file_put_contents($catalogDir . '/catalogs.json', $catalogs . "\n");
+            $cats = json_decode($catalogs, true) ?? [];
+            foreach ($cats as $cat) {
+                if (!isset($cat['file'])) {
+                    continue;
+                }
+                $file = basename((string)$cat['file']);
+                $data = $this->catalogs->read($file);
+                if ($data !== null) {
+                    file_put_contents($catalogDir . '/' . $file, $data . "\n");
+                }
+            }
+        }
+
+        return $response->withStatus(204);
+    }
+}

--- a/src/Service/PhotoConsentService.php
+++ b/src/Service/PhotoConsentService.php
@@ -20,4 +20,15 @@ class PhotoConsentService
         $stmt = $this->pdo->prepare('INSERT INTO photo_consents(team,time) VALUES(?,?)');
         $stmt->execute([$team, $time]);
     }
+
+    /**
+     * Retrieve all stored photo consents.
+     *
+     * @return array<int, array{team:string,time:int}>
+     */
+    public function getAll(): array
+    {
+        $stmt = $this->pdo->query('SELECT team,time FROM photo_consents ORDER BY id');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -24,6 +24,7 @@ use App\Controller\ResultController;
 use App\Controller\TeamController;
 use App\Controller\PasswordController;
 use App\Controller\ImportController;
+use App\Controller\ExportController;
 use App\Controller\QrController;
 use App\Controller\LogoController;
 use App\Controller\SummaryController;
@@ -48,6 +49,7 @@ require_once __DIR__ . '/Controller/QrController.php';
 require_once __DIR__ . '/Controller/LogoController.php';
 require_once __DIR__ . '/Controller/SummaryController.php';
 require_once __DIR__ . '/Controller/EvidenceController.php';
+require_once __DIR__ . '/Controller/ExportController.php';
 
 use App\Infrastructure\Database;
 use App\Infrastructure\Migrations\Migrator;
@@ -74,6 +76,14 @@ return function (\Slim\App $app) {
     $summaryController = new SummaryController($configService);
     $importController = new ImportController($catalogService, __DIR__ . '/../data');
     $consentService = new PhotoConsentService($pdo);
+    $exportController = new ExportController(
+        $configService,
+        $catalogService,
+        $resultService,
+        $teamService,
+        $consentService,
+        __DIR__ . '/../data'
+    );
     $evidenceController = new EvidenceController(
         $resultService,
         $consentService,
@@ -116,6 +126,7 @@ return function (\Slim\App $app) {
     $app->post('/teams.json', [$teamController, 'post']);
     $app->post('/password', [$passwordController, 'post']);
     $app->post('/import', [$importController, 'post']);
+    $app->post('/export', [$exportController, 'post']);
     $app->get('/qr.png', [$qrController, 'image']);
     $app->get('/logo.png', [$logoController, 'get'])->setArgument('ext', 'png');
     $app->post('/logo.png', [$logoController, 'post']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -406,6 +406,7 @@
             </div>
           </div>
           <div class="uk-margin uk-flex uk-flex-right">
+            <button id="exportJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Datenbank als JSON exportieren; pos: right">Exportieren</button>
             <button id="importJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Fragenkataloge aus JSON importieren; pos: right">Importieren</button>
             <button id="passSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Neues Passwort speichern; pos: right">Speichern</button>
           </div>

--- a/tests/Service/PhotoConsentServiceTest.php
+++ b/tests/Service/PhotoConsentServiceTest.php
@@ -24,4 +24,19 @@ class PhotoConsentServiceTest extends TestCase
         $this->assertSame('TeamA', $data[0]['team']);
         $this->assertSame(456, (int)$data[1]['time']);
     }
+
+    public function testGetAllReturnsStoredConsents(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL);');
+        $svc = new PhotoConsentService($pdo);
+        $svc->add('TeamA', 1);
+        $svc->add('TeamB', 2);
+
+        $data = $svc->getAll();
+        $this->assertCount(2, $data);
+        $this->assertSame('TeamA', $data[0]['team']);
+        $this->assertSame(2, (int)$data[1]['time']);
+    }
 }


### PR DESCRIPTION
## Summary
- add ExportController to write database contents back to JSON files
- enable export button in admin password tab
- implement `getAll()` in PhotoConsentService for exporting
- wire up `/export` route and JS handling
- test new PhotoConsentService method

## Testing
- `php` and `composer` were unavailable, so tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_68553cc50e04832b9aa06bfff0449163