### PR TITLE
Implement backup management

### DIFF
--- a/src/Service/PhotoConsentService.php
+++ b/src/Service/PhotoConsentService.php
@@ -31,4 +31,23 @@ class PhotoConsentService
         $stmt = $this->pdo->query('SELECT team,time FROM photo_consents ORDER BY id');
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
+
+    /**
+     * Replace all stored consents with the provided list.
+     *
+     * @param list<array<string, mixed>> $consents
+     */
+    public function saveAll(array $consents): void
+    {
+        $this->pdo->beginTransaction();
+        $this->pdo->exec('DELETE FROM photo_consents');
+        $stmt = $this->pdo->prepare('INSERT INTO photo_consents(team,time) VALUES(?,?)');
+        foreach ($consents as $row) {
+            $stmt->execute([
+                (string)($row['team'] ?? ''),
+                (int)($row['time'] ?? 0),
+            ]);
+        }
+        $this->pdo->commit();
+    }
 }

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -87,4 +87,32 @@ class ResultService
             $upd->execute([$path, $id]);
         }
     }
+
+    /**
+     * Replace all results with the provided list.
+     *
+     * @param list<array<string, mixed>> $results
+     */
+    public function saveAll(array $results): void
+    {
+        $this->pdo->beginTransaction();
+        $this->pdo->exec('DELETE FROM results');
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO results(name,catalog,attempt,correct,total,time,puzzleTime,photo) '
+            . 'VALUES(?,?,?,?,?,?,?,?)'
+        );
+        foreach ($results as $row) {
+            $stmt->execute([
+                (string)($row['name'] ?? ''),
+                (string)($row['catalog'] ?? ''),
+                (int)($row['attempt'] ?? 1),
+                (int)($row['correct'] ?? 0),
+                (int)($row['total'] ?? 0),
+                (int)($row['time'] ?? time()),
+                isset($row['puzzleTime']) ? (int)$row['puzzleTime'] : null,
+                isset($row['photo']) ? (string)$row['photo'] : null,
+            ]);
+        }
+        $this->pdo->commit();
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -74,7 +74,15 @@ return function (\Slim\App $app) {
     $qrController = new QrController();
     $logoController = new LogoController($configService);
     $summaryController = new SummaryController($configService);
-    $importController = new ImportController($catalogService, __DIR__ . '/../data');
+    $importController = new ImportController(
+        $catalogService,
+        $configService,
+        $resultService,
+        $teamService,
+        $consentService,
+        __DIR__ . '/../data',
+        __DIR__ . '/../backup'
+    );
     $consentService = new PhotoConsentService($pdo);
     $exportController = new ExportController(
         $configService,
@@ -82,8 +90,10 @@ return function (\Slim\App $app) {
         $resultService,
         $teamService,
         $consentService,
-        __DIR__ . '/../data'
+        __DIR__ . '/../data',
+        __DIR__ . '/../backup'
     );
+    $backupController = new BackupController(__DIR__ . '/../backup');
     $evidenceController = new EvidenceController(
         $resultService,
         $consentService,
@@ -126,7 +136,11 @@ return function (\Slim\App $app) {
     $app->post('/teams.json', [$teamController, 'post']);
     $app->post('/password', [$passwordController, 'post']);
     $app->post('/import', [$importController, 'post']);
+    $app->post('/import/{name}', [$importController, 'import']);
     $app->post('/export', [$exportController, 'post']);
+    $app->get('/backups', [$backupController, 'list']);
+    $app->get('/backups/{name}/download', [$backupController, 'download']);
+    $app->delete('/backups/{name}', [$backupController, 'delete']);
     $app->get('/qr.png', [$qrController, 'image']);
     $app->get('/logo.png', [$logoController, 'get'])->setArgument('ext', 'png');
     $app->post('/logo.png', [$logoController, 'post']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -411,6 +411,15 @@
             <button id="passSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Neues Passwort speichern; pos: right">Speichern</button>
           </div>
         </form>
+        <h3 class="uk-heading-bullet">Backups</h3>
+        <table class="uk-table uk-table-divider">
+          <thead>
+            <tr><th>Ordner</th><th>Aktionen</th></tr>
+          </thead>
+          <tbody id="backupTableBody">
+            <tr><td colspan="2">Keine Backups</td></tr>
+          </tbody>
+        </table>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
## Summary
- support storing backups in timestamped folders
- manage backup import/export via new controller
- list, download and delete backups in admin UI
- wire endpoints and JS actions

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685548b21b54832bbd935f2c29dee02a