### PR TITLE
Fix PhotoConsentService initialization order

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -61,6 +61,7 @@ return function (\Slim\App $app) {
     $catalogService = new CatalogService($pdo);
     $resultService = new ResultService($pdo);
     $teamService = new TeamService($pdo);
+    $consentService = new PhotoConsentService($pdo);
 
     $configController = new ConfigController($configService);
     $catalogController = new CatalogController($catalogService);
@@ -83,7 +84,6 @@ return function (\Slim\App $app) {
         __DIR__ . '/../data',
         __DIR__ . '/../backup'
     );
-    $consentService = new PhotoConsentService($pdo);
     $exportController = new ExportController(
         $configService,
         $catalogService,


### PR DESCRIPTION
## Summary
- initialize PhotoConsentService before passing it to controllers

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554bd97fdc832bb4720ed2f38fb62e