### PR TITLE
Fix missing BackupController import

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -29,6 +29,7 @@ use App\Controller\QrController;
 use App\Controller\LogoController;
 use App\Controller\SummaryController;
 use App\Controller\EvidenceController;
+use App\Controller\BackupController;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
@@ -50,6 +51,7 @@ require_once __DIR__ . '/Controller/LogoController.php';
 require_once __DIR__ . '/Controller/SummaryController.php';
 require_once __DIR__ . '/Controller/EvidenceController.php';
 require_once __DIR__ . '/Controller/ExportController.php';
+require_once __DIR__ . '/Controller/BackupController.php';
 
 use App\Infrastructure\Database;
 use App\Infrastructure\Migrations\Migrator;


### PR DESCRIPTION
## Summary
- import BackupController in routes
- load BackupController file

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68554cdae720832b8cd1f788c617088e