### PR TITLE
Add JSON backup migration

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1117,6 +1117,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // --------- Passwort ändern ---------
   const passSaveBtn = document.getElementById('passSaveBtn');
   const importJsonBtn = document.getElementById('importJsonBtn');
+  const migrateJsonBtn = document.getElementById('migrateJsonBtn');
   const exportJsonBtn = document.getElementById('exportJsonBtn');
   const newPass = document.getElementById('newPass');
   const newPassRepeat = document.getElementById('newPassRepeat');
@@ -1153,6 +1154,17 @@ document.addEventListener('DOMContentLoaded', function () {
               })
               .catch(() => notify('Fehler beim Import', 'danger'));
           });
+          const mig = document.createElement('button');
+          mig.className = 'uk-button uk-button-default uk-margin-small-right';
+          mig.textContent = 'Migrieren';
+          mig.addEventListener('click', () => {
+            fetch('/migrate/' + encodeURIComponent(name), { method: 'POST' })
+              .then(r => {
+                if (!r.ok) throw new Error(r.statusText);
+                notify('Migration abgeschlossen', 'success');
+              })
+              .catch(() => notify('Fehler bei der Migration', 'danger'));
+          });
           const dl = document.createElement('button');
           dl.className = 'uk-button uk-button-default uk-margin-small-right';
           dl.textContent = 'Download';
@@ -1181,6 +1193,7 @@ document.addEventListener('DOMContentLoaded', function () {
               .catch(() => notify('Fehler beim Löschen', 'danger'));
           });
           actionTd.appendChild(imp);
+          actionTd.appendChild(mig);
           actionTd.appendChild(dl);
           actionTd.appendChild(del);
           tr.appendChild(nameTd);
@@ -1231,6 +1244,19 @@ document.addEventListener('DOMContentLoaded', function () {
       .catch(err => {
         console.error(err);
         notify('Fehler beim Import', 'danger');
+      });
+  });
+
+  migrateJsonBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    fetch('/migrate', { method: 'POST' })
+      .then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        notify('Migration abgeschlossen', 'success');
+      })
+      .catch(err => {
+        console.error(err);
+        notify('Fehler bei der Migration', 'danger');
       });
   });
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -139,6 +139,8 @@ return function (\Slim\App $app) {
     $app->post('/password', [$passwordController, 'post']);
     $app->post('/import', [$importController, 'post']);
     $app->post('/import/{name}', [$importController, 'import']);
+    $app->post('/migrate', [$importController, 'migrate']);
+    $app->post('/migrate/{name}', [$importController, 'migrate']);
     $app->post('/export', [$exportController, 'post']);
     $app->get('/backups', [$backupController, 'list']);
     $app->get('/backups/{name}/download', [$backupController, 'download']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -415,7 +415,8 @@
         <h3 class="uk-heading-bullet">Sicherungen</h3>
         <div class="uk-margin uk-flex uk-flex-right">
           <button id="exportJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Datenbank als JSON exportieren; pos: right">Backup erstellen</button>
-          <button id="importJsonBtn" class="uk-button uk-button-default" uk-tooltip="title: Fragenkataloge aus JSON importieren; pos: right">Importieren</button>
+          <button id="importJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Fragenkataloge aus JSON importieren; pos: right">Importieren</button>
+          <button id="migrateJsonBtn" class="uk-button uk-button-default" uk-tooltip="title: Altes Backup ins neue Format übertragen; pos: right">Migrieren</button>
         </div>
         <table class="uk-table uk-table-divider">
           <thead>

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -5,24 +5,40 @@ namespace Tests\Controller;
 
 use App\Controller\ImportController;
 use App\Service\CatalogService;
+use App\Service\ConfigService;
+use App\Service\ResultService;
+use App\Service\TeamService;
+use App\Service\PhotoConsentService;
 use Tests\TestCase;
 use Slim\Psr7\Response;
 use PDO;
 
 class ImportControllerTest extends TestCase
 {
-    private function createService(): CatalogService
+    private function createServices(): array
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT);');
         $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, id TEXT NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
         $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
-        return new CatalogService($pdo);
+        $pdo->exec('CREATE TABLE teams(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL);');
+        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL);');
+
+        return [
+            new CatalogService($pdo),
+            new ConfigService($pdo),
+            new ResultService($pdo),
+            new TeamService($pdo),
+            new PhotoConsentService($pdo),
+            $pdo,
+        ];
     }
 
     public function testImport(): void
     {
-        $service = $this->createService();
+        [$catalog, $config, $results, $teams, $consents] = $this->createServices();
         $tmp = sys_get_temp_dir() . '/import_' . uniqid();
         mkdir($tmp . '/kataloge', 0777, true);
         file_put_contents($tmp . '/kataloge/catalogs.json', json_encode([
@@ -32,11 +48,11 @@ class ImportControllerTest extends TestCase
             ['type'=>'text','prompt'=>'Q']
         ], JSON_PRETTY_PRINT));
 
-        $controller = new ImportController($service, $tmp);
+        $controller = new ImportController($catalog, $config, $results, $teams, $consents, $tmp, $tmp);
         $request = $this->createRequest('POST', '/import');
         $response = $controller->post($request, new Response());
         $this->assertEquals(204, $response->getStatusCode());
-        $questions = json_decode($service->read('c1.json'), true);
+        $questions = json_decode($catalog->read('c1.json'), true);
         $this->assertCount(1, $questions);
         $this->assertSame('Q', $questions[0]['prompt']);
 


### PR DESCRIPTION
## Summary
- add Migrieren button in admin backup section
- implement migrate routes and controller logic
- update admin JS to handle migration
- extend tests for new ImportController signature

## Testing
- `node tests/test_competition_mode.js`
- `python3 tests/test_json_validity.py`
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6855580f06f0832b8cff34c5db1dc622