### PR TITLE
Update admin catalog labels

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -26,7 +26,7 @@
   </div>
   <ul id="adminTabs" uk-tab>
     <li class="uk-active" data-help="Logo hochladen und Vorschau ansehen. Seitentitel, Überschrift und Untertitel festlegen. Hintergrund- und Buttonfarbe wählen. Optional den Button 'Antwort prüfen' und den QR-Code-Login aktivieren. 'Zurücksetzen' lädt gespeicherte Werte, 'Speichern' übernimmt Änderungen."><a href="#">Veranstaltung konfigurieren</a></li>
-    <li data-help="Fragenkataloge anlegen oder bearbeiten. Jede Zeile enthält ID, Name, Beschreibung und optional einen Buchstaben für das Rätselwort. IDs lassen sich bearbeiten. 'Hinzufügen' erstellt einen neuen Katalog, das rote × entfernt einen Eintrag. Speichern übernimmt die Änderungen."><a href="#">Kataloge</a></li>
+    <li data-help="Fragenkataloge anlegen oder bearbeiten. Jede Zeile enthält einen Slug, Name, Beschreibung und optional einen Buchstaben für das Rätselwort. Der Slug kann angepasst werden. 'Hinzufügen' erstellt einen neuen Katalog, das rote × entfernt einen Eintrag. Speichern übernimmt die Änderungen."><a href="#">Kataloge</a></li>
     <li data-help="Nach Auswahl eines Katalogs einzelne Fragen bearbeiten oder neue anlegen. 'Neue Frage' fügt eine weitere hinzu, 'Zurücksetzen' verwirft Änderungen, 'Speichern' sichert den gesamten Katalog."><a href="#">Fragen anpassen</a></li>
     <li data-help="Teilnehmerliste pflegen. Über 'Hinzufügen' Teams oder Personen ergänzen. Die Checkbox beschränkt die Teilnahme auf gelistete Namen. Speichern aktualisiert die Liste."><a href="#">Teams/Personen</a></li>
     <li data-help="Gespeicherte Ergebnisse mit richtigen Antworten und Zeit einsehen. 'Zurücksetzen' löscht alle Daten, 'Herunterladen' exportiert sie als CSV."><a href="#">Ergebnisse</a></li>
@@ -218,7 +218,7 @@
               <thead>
                 <tr>
                   <th></th>
-                  <th>ID</th>
+                  <th>Slug</th>
                   <th>Name</th>
                   <th>Beschreibung</th>
                   <th>Buchstabe</th>


### PR DESCRIPTION
## Summary
- fix tab help text for catalog management
- rename ID column header to Slug

## Testing
- `vendor/bin/phpunit` *(fails: No such file)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_68555ae82b2c832b9198e1537180754f