### PR TITLE
Add tooltips for catalog table headers

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -217,13 +217,13 @@
             <table class="uk-table uk-table-divider uk-table-small">
               <thead>
                 <tr>
-                  <th></th>
-                  <th>Slug</th>
-                  <th>Name</th>
-                  <th>Beschreibung</th>
-                  <th>Buchstabe</th>
-                  <th>Kommentar</th>
-                  <th></th>
+                  <th uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></th>
+                  <th uk-tooltip="title: Eindeutiger Name in der URL; pos: top">Slug</th>
+                  <th uk-tooltip="title: Angezeigter Titel des Katalogs; pos: top">Name</th>
+                  <th uk-tooltip="title: Kurzer Beschreibungstext; pos: top">Beschreibung</th>
+                  <th uk-tooltip="title: Buchstabe für das Rätselwort; pos: top">Buchstabe</th>
+                  <th uk-tooltip="title: Interne Notiz; pos: top">Kommentar</th>
+                  <th uk-tooltip="title: Katalog entfernen; pos: top"></th>
                 </tr>
               </thead>
               <tbody id="catalogList" uk-sortable="group: sortable-group"></tbody>


### PR DESCRIPTION
## Summary
- add helpful tooltips to each column header of the catalog table

## Testing
- `pytest -q`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556f3af65c832ba5a94125213047dd