### PR TITLE
Fix migration import reference

### DIFF
--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -126,6 +126,7 @@ class ImportController
                 $cat['uid'] = bin2hex(random_bytes(16));
             }
         }
+        unset($cat);
         $this->catalogs->write('catalogs.json', $catalogs);
         foreach ($catalogs as $cat) {
             if (!isset($cat['file'])) {


### PR DESCRIPTION
## Summary
- fix reference handling in migration

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556f98c174832bbf33079bc976a26a