### PR TITLE
Auto-save catalog order after drag

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -299,6 +299,10 @@ document.addEventListener('DOMContentLoaded', function () {
   let catalogFile = '';
   let initial = [];
 
+  if (catalogList && window.UIkit && UIkit.util) {
+    UIkit.util.on(catalogList, 'moved', saveCatalogOrder);
+  }
+
   function loadCatalog(identifier) {
     const cat = catalogs.find(c => c.uid === identifier || (c.slug || c.id) === identifier);
     if (!cat) return;
@@ -503,6 +507,15 @@ document.addEventListener('DOMContentLoaded', function () {
         };
       })
       .filter(c => c.slug);
+  }
+
+  function saveCatalogOrder() {
+    const data = collectCatalogs();
+    fetch('/kataloge/catalogs.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    }).catch(() => {});
   }
 
   // Rendert alle Fragen im Editor neu


### PR DESCRIPTION
## Summary
- auto-save catalog order when a row is moved

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685583377bb4832b931671cf221503ca