### PR TITLE
Fix catalog order update

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -299,6 +299,10 @@ document.addEventListener('DOMContentLoaded', function () {
   let catalogFile = '';
   let initial = [];
 
+  if (catalogList && window.UIkit && UIkit.util) {
+    UIkit.util.on(catalogList, 'moved', saveCatalogOrder);
+  }
+
   function loadCatalog(identifier) {
     const cat = catalogs.find(c => c.uid === identifier || (c.slug || c.id) === identifier);
     if (!cat) return;
@@ -503,6 +507,15 @@ document.addEventListener('DOMContentLoaded', function () {
         };
       })
       .filter(c => c.slug);
+  }
+
+  function saveCatalogOrder() {
+    const data = collectCatalogs();
+    fetch('/kataloge/catalogs.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    }).catch(() => {});
   }
 
   // Rendert alle Fragen im Editor neu

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -111,47 +111,36 @@ class CatalogService
             }
 
             $uids = [];
-            $updateClauses = [
-                'id' => '',
-                'slug' => '',
-                'file' => '',
-                'name' => '',
-                'description' => '',
-                'qrcode_url' => '',
-                'raetsel_buchstabe' => '',
+            foreach ($data as $cat) {
+                $uids[] = $cat['uid'] ?? '';
+            }
+
+            $cols = [
+                'id',
+                'slug',
+                'file',
+                'name',
+                'description',
+                'qrcode_url',
+                'raetsel_buchstabe',
             ];
             if ($this->hasCommentColumn()) {
-                $updateClauses['comment'] = '';
+                $cols[] = 'comment';
             }
+
+            $updateClauses = [];
             $params = [];
-            foreach ($data as $cat) {
-                $uid = $cat['uid'] ?? '';
-                $uids[] = $uid;
-                $updateClauses['id'] .= ' WHEN ? THEN ?';
-                $params[] = $uid;
-                $params[] = $cat['id'] ?? '';
-                $updateClauses['slug'] .= ' WHEN ? THEN ?';
-                $params[] = $uid;
-                $params[] = $cat['slug'] ?? ($cat['id'] ?? '');
-                $updateClauses['file'] .= ' WHEN ? THEN ?';
-                $params[] = $uid;
-                $params[] = $cat['file'] ?? '';
-                $updateClauses['name'] .= ' WHEN ? THEN ?';
-                $params[] = $uid;
-                $params[] = $cat['name'] ?? '';
-                $updateClauses['description'] .= ' WHEN ? THEN ?';
-                $params[] = $uid;
-                $params[] = $cat['description'] ?? null;
-                $updateClauses['qrcode_url'] .= ' WHEN ? THEN ?';
-                $params[] = $uid;
-                $params[] = $cat['qrcode_url'] ?? null;
-                $updateClauses['raetsel_buchstabe'] .= ' WHEN ? THEN ?';
-                $params[] = $uid;
-                $params[] = $cat['raetsel_buchstabe'] ?? null;
-                if ($this->hasCommentColumn()) {
-                    $updateClauses['comment'] .= ' WHEN ? THEN ?';
+            foreach ($cols as $col) {
+                $updateClauses[$col] = '';
+                foreach ($data as $cat) {
+                    $uid = $cat['uid'] ?? '';
+                    $updateClauses[$col] .= ' WHEN ? THEN ?';
                     $params[] = $uid;
-                    $params[] = $cat['comment'] ?? null;
+                    if ($col === 'slug') {
+                        $params[] = $cat['slug'] ?? ($cat['id'] ?? '');
+                    } else {
+                        $params[] = $cat[$col] ?? null;
+                    }
                 }
             }
 

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -138,4 +138,25 @@ class CatalogServiceTest extends TestCase
         $this->assertSame('b', $list[0]['slug']);
         $this->assertSame('a', $list[1]['slug']);
     }
+
+    public function testNamesRemainAfterReorder(): void
+    {
+        $pdo = $this->createPdo();
+        $service = new CatalogService($pdo);
+        $initial = [
+            ['uid' => 'u1', 'id' => 1, 'slug' => 'a', 'file' => 'a.json', 'name' => 'One', 'comment' => ''],
+            ['uid' => 'u2', 'id' => 2, 'slug' => 'b', 'file' => 'b.json', 'name' => 'Two', 'comment' => ''],
+            ['uid' => 'u3', 'id' => 3, 'slug' => 'c', 'file' => 'c.json', 'name' => 'Three', 'comment' => ''],
+        ];
+        $service->write('catalogs.json', $initial);
+
+        $reordered = [
+            ['uid' => 'u2', 'id' => 1, 'slug' => 'b', 'file' => 'b.json', 'name' => 'Two', 'comment' => ''],
+            ['uid' => 'u1', 'id' => 2, 'slug' => 'a', 'file' => 'a.json', 'name' => 'One', 'comment' => ''],
+            ['uid' => 'u3', 'id' => 3, 'slug' => 'c', 'file' => 'c.json', 'name' => 'Three', 'comment' => ''],
+        ];
+        $service->write('catalogs.json', $reordered);
+        $rows = json_decode($service->read('catalogs.json'), true);
+        $this->assertSame(['Two', 'One', 'Three'], array_column($rows, 'name'));
+    }
 }


### PR DESCRIPTION
## Summary
- fix parameter order when persisting catalog list
- test that reordering preserves catalog names

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685583377bb4832b931671cf221503ca