### PR TITLE
Fix migration for duplicate catalog IDs

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -49,7 +49,7 @@ CREATE INDEX idx_results_name ON results(name);
 -- Catalog definitions
 CREATE TABLE IF NOT EXISTS catalogs (
     uid TEXT PRIMARY KEY,
-    id TEXT UNIQUE NOT NULL,
+    id TEXT NOT NULL,
     slug TEXT UNIQUE NOT NULL,
     file TEXT NOT NULL,
     name TEXT NOT NULL,

--- a/migrations/20240623_drop_id_unique_constraint.sql
+++ b/migrations/20240623_drop_id_unique_constraint.sql
@@ -1,1 +1,3 @@
 ALTER TABLE catalogs DROP CONSTRAINT IF EXISTS catalogs_id_unique;
+
+ALTER TABLE catalogs DROP CONSTRAINT IF EXISTS catalogs_id_key;

--- a/migrations/20240624_use_catalog_uid.sql
+++ b/migrations/20240624_use_catalog_uid.sql
@@ -1,12 +1,32 @@
 ALTER TABLE questions ADD COLUMN IF NOT EXISTS catalog_uid TEXT;
-UPDATE questions q
-    SET catalog_uid = c.uid
-    FROM catalogs c
-    WHERE c.id = q.catalog_id OR c.slug = q.catalog_id;
-ALTER TABLE questions DROP CONSTRAINT IF EXISTS questions_catalog_id_fkey;
-ALTER TABLE questions ADD CONSTRAINT questions_catalog_uid_fkey
-    FOREIGN KEY (catalog_uid) REFERENCES catalogs(uid) ON DELETE CASCADE;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'questions' AND column_name = 'catalog_id'
+    ) THEN
+        EXECUTE $$UPDATE questions q
+            SET catalog_uid = c.uid
+            FROM catalogs c
+            WHERE c.id = q.catalog_id OR c.slug = q.catalog_id$$;
+        ALTER TABLE questions DROP CONSTRAINT IF EXISTS questions_catalog_id_fkey;
+        ALTER TABLE questions DROP COLUMN IF EXISTS catalog_id;
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'questions_catalog_uid_fkey'
+    ) THEN
+        ALTER TABLE questions ADD CONSTRAINT questions_catalog_uid_fkey
+            FOREIGN KEY (catalog_uid) REFERENCES catalogs(uid) ON DELETE CASCADE;
+    END IF;
+END$$;
+
 DROP INDEX IF EXISTS idx_questions_catalog;
-CREATE INDEX idx_questions_catalog ON questions(catalog_uid);
-ALTER TABLE questions DROP COLUMN IF EXISTS catalog_id;
+CREATE INDEX IF NOT EXISTS idx_questions_catalog ON questions(catalog_uid);
+
 ALTER TABLE questions ALTER COLUMN catalog_uid SET NOT NULL;


### PR DESCRIPTION
## Summary
- remove leftover unique constraint on catalogs.id
- update schema docs to match migration

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ccafc9c8832b9400a38c27c4cefd