### PR TITLE
Fix PHPStan memory limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ COPY . /var/www
 RUN composer install --no-interaction --prefer-dist --no-progress
 
 # run static analysis during image build
-RUN if [ -f vendor/bin/phpstan ]; then vendor/bin/phpstan --no-progress; fi
+# increase memory limit for phpstan to avoid out-of-memory errors
+RUN if [ -f vendor/bin/phpstan ]; then vendor/bin/phpstan --no-progress --memory-limit=512M; fi
 
 # entrypoint to install dependencies if host volume lacks vendor/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- run PHPStan with 512M memory in Dockerfile

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- ❌ `composer install` *(fails: command not found)*
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855dba37620832b9aab9bf2e0f034d3