### PR TITLE
Update team table usage

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -26,8 +26,9 @@ CREATE TABLE IF NOT EXISTS config (
 
 -- Teams list (names only)
 CREATE TABLE IF NOT EXISTS teams (
-    id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL
+    sort_order INTEGER UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    uid UUID DEFAULT gen_random_uuid() PRIMARY KEY NOT NULL
 );
 CREATE UNIQUE INDEX idx_team_name ON teams(name);
 

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -17,7 +17,7 @@ class TeamService
 
     public function getAll(): array
     {
-        $stmt = $this->pdo->query('SELECT name FROM teams ORDER BY id');
+        $stmt = $this->pdo->query('SELECT name FROM teams ORDER BY sort_order');
         return array_map(fn($r) => $r['name'], $stmt->fetchAll(PDO::FETCH_ASSOC));
     }
 
@@ -28,9 +28,9 @@ class TeamService
     {
         $this->pdo->beginTransaction();
         $this->pdo->exec('DELETE FROM teams');
-        $stmt = $this->pdo->prepare('INSERT INTO teams(name) VALUES(?)');
-        foreach ($teams as $name) {
-            $stmt->execute([$name]);
+        $stmt = $this->pdo->prepare('INSERT INTO teams(sort_order,name) VALUES(?,?)');
+        foreach ($teams as $i => $name) {
+            $stmt->execute([$i + 1, $name]);
         }
         $this->pdo->commit();
     }

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -22,7 +22,7 @@ class ImportControllerTest extends TestCase
         $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT);');
         $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
         $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER UNIQUE, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
-        $pdo->exec('CREATE TABLE teams(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL);');
+        $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY);');
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
         $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL);');
 


### PR DESCRIPTION
## Summary
- align team table handling with new uid/sort_order schema
- update import script to set sort order
- fix tests and schema documentation

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855eb5d1a64832ba2f1fa413cf409e2