### PR TITLE
Fix failing migration due to missing column

### DIFF
--- a/migrations/20240622_add_cascade_to_questions.sql
+++ b/migrations/20240622_add_cascade_to_questions.sql
@@ -1,3 +1,11 @@
-ALTER TABLE questions DROP CONSTRAINT IF EXISTS questions_catalog_id_fkey;
-ALTER TABLE questions ADD CONSTRAINT questions_catalog_id_fkey
-    FOREIGN KEY (catalog_id) REFERENCES catalogs(id) ON DELETE CASCADE;
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'questions' AND column_name = 'catalog_id'
+    ) THEN
+        ALTER TABLE questions DROP CONSTRAINT IF EXISTS questions_catalog_id_fkey;
+        ALTER TABLE questions ADD CONSTRAINT questions_catalog_id_fkey
+            FOREIGN KEY (catalog_id) REFERENCES catalogs(id) ON DELETE CASCADE;
+    END IF;
+END$$;


### PR DESCRIPTION
## Summary
- avoid referencing the old `catalog_id` column when it doesn't exist

## Testing
- `composer --no-interaction test` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6855ee0d0404832ba45a805c37d89c57