### PR TITLE
Fix migration quoting

### DIFF
--- a/migrations/20240624_use_catalog_uid.sql
+++ b/migrations/20240624_use_catalog_uid.sql
@@ -6,10 +6,12 @@ BEGIN
         SELECT 1 FROM information_schema.columns
         WHERE table_name = 'questions' AND column_name = 'catalog_id'
     ) THEN
-        EXECUTE $$UPDATE questions q
+        EXECUTE $upd$
+            UPDATE questions q
             SET catalog_uid = c.uid
             FROM catalogs c
-            WHERE c.id = q.catalog_id OR c.slug = q.catalog_id$$;
+            WHERE c.id = q.catalog_id OR c.slug = q.catalog_id
+        $upd$;
         ALTER TABLE questions DROP CONSTRAINT IF EXISTS questions_catalog_id_fkey;
         ALTER TABLE questions DROP COLUMN IF EXISTS catalog_id;
     END IF;


### PR DESCRIPTION
## Summary
- update quoting in catalog_uid migration to avoid syntax error

## Testing
- `node tests/test_competition_mode.js`
- `pytest -q tests/test_json_validity.py tests/test_html_validity.py`
- ❌ `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ef97e908832b898b2eda3c578ae4