### PR TITLE
Fix sort_order migration

### DIFF
--- a/migrations/20240625_use_sort_order.sql
+++ b/migrations/20240625_use_sort_order.sql
@@ -1,5 +1,24 @@
-ALTER TABLE catalogs RENAME COLUMN id TO sort_order;
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'catalogs' AND column_name = 'id'
+    ) THEN
+        ALTER TABLE catalogs RENAME COLUMN id TO sort_order;
+    END IF;
+END$$;
+
 ALTER TABLE catalogs ALTER COLUMN sort_order TYPE INTEGER USING sort_order::integer;
-ALTER TABLE catalogs ADD CONSTRAINT catalogs_sort_order_unique UNIQUE(sort_order);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'catalogs_sort_order_unique'
+    ) THEN
+        ALTER TABLE catalogs ADD CONSTRAINT catalogs_sort_order_unique UNIQUE(sort_order);
+    END IF;
+END$$;
+
 ALTER TABLE questions ADD COLUMN IF NOT EXISTS sort_order INTEGER UNIQUE;
 UPDATE questions SET sort_order = id WHERE sort_order IS NULL;


### PR DESCRIPTION
## Summary
- skip rename when `id` column is missing
- add unique constraint conditionally in migration script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f114a110832b9fda9a407e548ced