### PR TITLE
Add NGINX_DOCKER_GEN_CONTAINER

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     environment:
       - NGINX_PROXY_CONTAINER=nginx-proxy
       - DEFAULT_EMAIL=${LETSENCRYPT_EMAIL}
+      - NGINX_DOCKER_GEN_CONTAINER=nginx-proxy
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./acme:/etc/acme.sh


### PR DESCRIPTION
## Summary
- allow acme-companion to locate docker-gen by explicitly setting `NGINX_DOCKER_GEN_CONTAINER`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855f2ed2600832b9215a8572b3289b1