### PR TITLE
Fix results query for updated catalog schema

### DIFF
--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -20,7 +20,8 @@ class ResultService
         $sql = 'SELECT r.name, r.catalog, r.attempt, r.correct, r.total, r.time, r.puzzleTime, r.photo, ' .
             'c.name AS catalogName '
             . 'FROM results r '
-            . 'LEFT JOIN catalogs c ON c.uid = r.catalog OR c.id = r.catalog '
+            . 'LEFT JOIN catalogs c ON c.uid = r.catalog '
+            . 'OR CAST(c.sort_order AS TEXT) = r.catalog '
             . 'ORDER BY r.id';
         $stmt = $this->pdo->query($sql);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- fix join in `ResultService` to use `sort_order` instead of removed `id`

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f3d55eac832bb569d5b573b72020