### PR TITLE
Persist catalog order with sort_order

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Unter `/admin` stehen folgende Tabs zur Verfügung:
 6. **Passwort ändern** – Administrationspasswort setzen.
 
 ### Fragenkataloge
-`data/kataloge/catalogs.json` listet verfügbare Kataloge mit `slug`, Name und optionaler QR-Code-Adresse. Das Feld `id` wird dabei als `sort_order` interpretiert und dient nur der internen Sortierung. Jede Frage speichert die zugehörige `catalog_uid`. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:
+`data/kataloge/catalogs.json` listet verfügbare Kataloge mit `slug`, Name und optionaler QR-Code-Adresse. Die Reihenfolge wird durch das Feld `sort_order` bestimmt. Jede Frage speichert die zugehörige `catalog_uid`. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:
 - `GET /kataloge/{file}` liefert den JSON-Katalog oder leitet im Browser auf `/?katalog=slug` um.
 - `PUT /kataloge/{file}` legt eine neue Datei an.
 - `POST /kataloge/{file}` überschreibt einen Katalog mit gesendeten Daten.

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -259,15 +259,15 @@
       card.addEventListener('click', () => {
         const localSolved = new Set(JSON.parse(sessionStorage.getItem('quizSolved') || '[]'));
         if((window.quizConfig || {}).competitionMode && localSolved.has(cat.uid)){
-          const remaining = catalogs.filter(c => !localSolved.has(c.uid)).map(c => c.name || c.slug || c.id).join(', ');
-          showCatalogSolvedModal(cat.name || cat.slug || cat.id, remaining);
+          const remaining = catalogs.filter(c => !localSolved.has(c.uid)).map(c => c.name || c.slug || c.sort_order).join(', ');
+          showCatalogSolvedModal(cat.name || cat.slug || cat.sort_order, remaining);
           return;
         }
-        history.replaceState(null, '', '?katalog=' + (cat.slug || cat.id));
-        loadQuestions(cat.slug || cat.id, cat.file, cat.raetsel_buchstabe, cat.uid, cat.name || cat.slug || cat.id, cat.description || '', cat.comment || '');
+        history.replaceState(null, '', '?katalog=' + (cat.slug || cat.sort_order));
+        loadQuestions(cat.slug || cat.sort_order, cat.file, cat.raetsel_buchstabe, cat.uid, cat.name || cat.slug || cat.sort_order, cat.description || '', cat.comment || '');
       });
       const title = document.createElement('h3');
-      title.textContent = cat.name || cat.slug || cat.id;
+      title.textContent = cat.name || cat.slug || cat.sort_order;
       const desc = document.createElement('p');
       desc.textContent = cat.description || '';
       card.appendChild(title);
@@ -481,10 +481,10 @@
     const id = params.get('katalog');
     const proceed = async () => {
       const solvedNow = await buildSolvedSet(cfg);
-      const selected = catalogs.find(c => (c.slug || c.id) === id);
+      const selected = catalogs.find(c => (c.slug || c.sort_order) === id);
       if(selected){
           if(cfg.competitionMode && solvedNow.has(selected.uid)){
-            const remaining = catalogs.filter(c => !solvedNow.has(c.uid)).map(c => c.name || c.slug || c.id).join(', ');
+            const remaining = catalogs.filter(c => !solvedNow.has(c.uid)).map(c => c.name || c.slug || c.sort_order).join(', ');
             if(catalogs.length && solvedNow.size === catalogs.length){
               showAllSolvedModal();
               return;

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -242,9 +242,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const map = {};
         if (Array.isArray(list)) {
           list.forEach(c => {
-            const name = c.name || c.id || '';
+            const name = c.name || c.sort_order || '';
             if (c.uid) map[c.uid] = name;
-            if (c.id) map[c.id] = name;
+            if (c.sort_order) map[c.sort_order] = name;
           });
         }
         catalogMap = map;

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -22,9 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const map = {};
         if (Array.isArray(list)) {
           list.forEach(c => {
-            const name = c.name || c.id || '';
+            const name = c.name || c.sort_order || '';
             if (c.uid) map[c.uid] = name;
-            if (c.id) map[c.id] = name;
+            if (c.sort_order) map[c.sort_order] = name;
           });
         }
         catalogMap = map;

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -28,12 +28,12 @@ class AdminController
         if ($catalogsJson !== null) {
             $catalogs = json_decode($catalogsJson, true) ?? [];
             foreach ($catalogs as $c) {
-                $name = $c['name'] ?? ($c['id'] ?? '');
+                $name = $c['name'] ?? ($c['sort_order'] ?? '');
                 if (isset($c['uid'])) {
                     $catMap[$c['uid']] = $name;
                 }
-                if (isset($c['id'])) {
-                    $catMap[$c['id']] = $name;
+                if (isset($c['sort_order'])) {
+                    $catMap[$c['sort_order']] = $name;
                 }
             }
         }

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -89,12 +89,12 @@ class ResultController
         if ($json !== null) {
             $list = json_decode($json, true) ?: [];
             foreach ($list as $c) {
-                $name = $c['name'] ?? ($c['id'] ?? '');
+                $name = $c['name'] ?? ($c['sort_order'] ?? '');
                 if (isset($c['uid'])) {
                     $map[$c['uid']] = $name;
                 }
-                if (isset($c['id'])) {
-                    $map[$c['id']] = $name;
+                if (isset($c['sort_order'])) {
+                    $map[$c['sort_order']] = $name;
                 }
             }
         }

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -56,14 +56,14 @@ class CatalogService
     public function read(string $file): ?string
     {
         if ($file === 'catalogs.json') {
-            $fields = 'uid,sort_order AS id,slug,file,name,description,qrcode_url,raetsel_buchstabe';
+            $fields = 'uid,sort_order,slug,file,name,description,qrcode_url,raetsel_buchstabe';
             if ($this->hasCommentColumn()) {
                 $fields .= ',comment';
             }
             $stmt = $this->pdo->query("SELECT $fields FROM catalogs ORDER BY sort_order");
             $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
             foreach ($data as &$row) {
-                $row['id'] = (int)$row['id'];
+                $row['sort_order'] = (int)$row['sort_order'];
             }
             if (!$this->hasCommentColumn()) {
                 foreach ($data as &$row) {
@@ -145,9 +145,9 @@ class CatalogService
                     $updateClauses[$col] .= ' WHEN ? THEN ?';
                     $params[] = $uid;
                     if ($col === 'slug') {
-                        $params[] = $cat['slug'] ?? ($cat['id'] ?? '');
+                        $params[] = $cat['slug'] ?? '';
                     } elseif ($col === 'sort_order') {
-                        $params[] = $cat['id'] ?? null;
+                        $params[] = $cat['sort_order'] ?? null;
                     } else {
                         $params[] = $cat[$col] ?? null;
                     }
@@ -170,8 +170,8 @@ class CatalogService
             foreach ($data as $cat) {
                 $row = [
                     $cat['uid'] ?? '',
-                    $cat['id'] ?? '',
-                    $cat['slug'] ?? ($cat['id'] ?? ''),
+                    $cat['sort_order'] ?? '',
+                    $cat['slug'] ?? '',
                     $cat['file'] ?? '',
                     $cat['name'] ?? '',
                     $cat['description'] ?? null,

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -35,7 +35,7 @@ class CatalogServiceTest extends TestCase
         $file = 'test.json';
         $catalog = [[
             'uid' => 'uid1',
-            'id' => 'cat1',
+            'sort_order' => 'cat1',
             'slug' => 'cat1',
             'file' => $file,
             'name' => 'Test',
@@ -54,7 +54,7 @@ class CatalogServiceTest extends TestCase
         $service = new CatalogService($pdo);
         $catalog = [[
             'uid' => 'uid4',
-            'id' => 'nc',
+            'sort_order' => 'nc',
             'slug' => 'nc',
             'file' => 'nc.json',
             'name' => 'NC',
@@ -80,7 +80,7 @@ class CatalogServiceTest extends TestCase
         $file = 'del.json';
         $service->write('catalogs.json', [[
             'uid' => 'uid2',
-            'id' => 'del',
+            'sort_order' => 'del',
             'slug' => 'del',
             'file' => $file,
             'name' => 'Del',
@@ -101,7 +101,7 @@ class CatalogServiceTest extends TestCase
         $file = 'q.json';
         $service->write('catalogs.json', [[
             'uid' => 'uid3',
-            'id' => 'qid',
+            'sort_order' => 'qid',
             'slug' => 'qid',
             'file' => $file,
             'name' => 'Q',
@@ -124,14 +124,14 @@ class CatalogServiceTest extends TestCase
         $pdo = $this->createPdo();
         $service = new CatalogService($pdo);
         $initial = [
-            ['uid' => 'u1', 'id' => 1, 'slug' => 'a', 'file' => 'a.json', 'name' => 'A', 'comment' => ''],
-            ['uid' => 'u2', 'id' => 2, 'slug' => 'b', 'file' => 'b.json', 'name' => 'B', 'comment' => ''],
+            ['uid' => 'u1', 'sort_order' => 1, 'slug' => 'a', 'file' => 'a.json', 'name' => 'A', 'comment' => ''],
+            ['uid' => 'u2', 'sort_order' => 2, 'slug' => 'b', 'file' => 'b.json', 'name' => 'B', 'comment' => ''],
         ];
         $service->write('catalogs.json', $initial);
 
         $reordered = [
-            ['uid' => 'u1', 'id' => 2, 'slug' => 'a', 'file' => 'a.json', 'name' => 'A', 'comment' => ''],
-            ['uid' => 'u2', 'id' => 1, 'slug' => 'b', 'file' => 'b.json', 'name' => 'B', 'comment' => ''],
+            ['uid' => 'u1', 'sort_order' => 2, 'slug' => 'a', 'file' => 'a.json', 'name' => 'A', 'comment' => ''],
+            ['uid' => 'u2', 'sort_order' => 1, 'slug' => 'b', 'file' => 'b.json', 'name' => 'B', 'comment' => ''],
         ];
         $service->write('catalogs.json', $reordered);
         $list = json_decode($service->read('catalogs.json'), true);
@@ -144,16 +144,16 @@ class CatalogServiceTest extends TestCase
         $pdo = $this->createPdo();
         $service = new CatalogService($pdo);
         $initial = [
-            ['uid' => 'u1', 'id' => 1, 'slug' => 'a', 'file' => 'a.json', 'name' => 'One', 'comment' => ''],
-            ['uid' => 'u2', 'id' => 2, 'slug' => 'b', 'file' => 'b.json', 'name' => 'Two', 'comment' => ''],
-            ['uid' => 'u3', 'id' => 3, 'slug' => 'c', 'file' => 'c.json', 'name' => 'Three', 'comment' => ''],
+            ['uid' => 'u1', 'sort_order' => 1, 'slug' => 'a', 'file' => 'a.json', 'name' => 'One', 'comment' => ''],
+            ['uid' => 'u2', 'sort_order' => 2, 'slug' => 'b', 'file' => 'b.json', 'name' => 'Two', 'comment' => ''],
+            ['uid' => 'u3', 'sort_order' => 3, 'slug' => 'c', 'file' => 'c.json', 'name' => 'Three', 'comment' => ''],
         ];
         $service->write('catalogs.json', $initial);
 
         $reordered = [
-            ['uid' => 'u2', 'id' => 1, 'slug' => 'b', 'file' => 'b.json', 'name' => 'Two', 'comment' => ''],
-            ['uid' => 'u1', 'id' => 2, 'slug' => 'a', 'file' => 'a.json', 'name' => 'One', 'comment' => ''],
-            ['uid' => 'u3', 'id' => 3, 'slug' => 'c', 'file' => 'c.json', 'name' => 'Three', 'comment' => ''],
+            ['uid' => 'u2', 'sort_order' => 1, 'slug' => 'b', 'file' => 'b.json', 'name' => 'Two', 'comment' => ''],
+            ['uid' => 'u1', 'sort_order' => 2, 'slug' => 'a', 'file' => 'a.json', 'name' => 'One', 'comment' => ''],
+            ['uid' => 'u3', 'sort_order' => 3, 'slug' => 'c', 'file' => 'c.json', 'name' => 'Three', 'comment' => ''],
         ];
         $service->write('catalogs.json', $reordered);
         $rows = json_decode($service->read('catalogs.json'), true);


### PR DESCRIPTION
## Summary
- keep catalog sorting in sync with new `sort_order` field
- adjust client scripts and tests for updated property
- document catalog sort_order usage

## Testing
- `node tests/test_competition_mode.js`
- `pytest -q tests/test_html_validity.py tests/test_json_validity.py`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f79b6aa4832b8697dae3389b5a70