### PR TITLE
Fix catalog reorder unique constraint error

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -50,7 +50,7 @@ CREATE INDEX idx_results_name ON results(name);
 -- Catalog definitions
 CREATE TABLE IF NOT EXISTS catalogs (
     uid TEXT PRIMARY KEY,
-    sort_order INTEGER UNIQUE NOT NULL,
+    sort_order INTEGER NOT NULL,
     slug TEXT UNIQUE NOT NULL,
     file TEXT NOT NULL,
     name TEXT NOT NULL,
@@ -59,6 +59,9 @@ CREATE TABLE IF NOT EXISTS catalogs (
     raetsel_buchstabe TEXT,
     comment TEXT
 );
+ALTER TABLE catalogs
+    ADD CONSTRAINT catalogs_unique_sort_order
+    UNIQUE(sort_order) DEFERRABLE INITIALLY DEFERRED;
 
 -- Questions belonging to catalogs
 CREATE TABLE IF NOT EXISTS questions (

--- a/migrations/20240627_make_catalog_sort_order_deferrable.sql
+++ b/migrations/20240627_make_catalog_sort_order_deferrable.sql
@@ -1,0 +1,21 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'catalogs'
+            AND constraint_name = 'catalogs_sort_order_unique'
+    ) THEN
+        ALTER TABLE catalogs DROP CONSTRAINT catalogs_sort_order_unique;
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'catalogs'
+            AND constraint_name = 'catalogs_unique_sort_order'
+    ) THEN
+        ALTER TABLE catalogs DROP CONSTRAINT catalogs_unique_sort_order;
+    END IF;
+END$$;
+
+ALTER TABLE catalogs
+    ADD CONSTRAINT catalogs_unique_sort_order
+    UNIQUE(sort_order) DEFERRABLE INITIALLY DEFERRED;


### PR DESCRIPTION
## Summary
- fix unique constraint for catalog sort order by making it deferrable
- document new constraint in schema

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6855fbf729f8832bb627ff3c04911390