### PR TITLE
Fix comment card style

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -20,7 +20,7 @@
     if(!block){
       block = document.createElement('div');
       block.dataset.role = 'catalog-comment-block';
-      block.className = 'uk-card uk-card-secondary uk-card-body uk-margin';
+      block.className = 'uk-card uk-card-default uk-card-body uk-margin';
       block.style.whiteSpace = 'pre-wrap';
       headerEl.appendChild(block);
     }


### PR DESCRIPTION
## Summary
- adjust catalog comment block to use the default card style

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855fe60adac832b911926d649892f09