### PR TITLE
Add frontend word break guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 - **templates/** – Twig-Vorlagen für Startseite und FAQ
 - **data/kataloge/** – Fragenkataloge im JSON-Format
 - **src/** – PHP-Code mit Routen, Controllern und Services
+- **docs/** – Zusätzliche Dokumentation, z.B. [Richtlinien zur Worttrennung](docs/frontend-word-break.md)
 
 ## Schnellstart
 

--- a/docs/frontend-word-break.md
+++ b/docs/frontend-word-break.md
@@ -1,0 +1,82 @@
+# Richtlinien zur Worttrennung im Frontend
+
+Damit **lange Wörter im HTML** bei einem Zeilenumbruch automatisch korrekt getrennt werden, können folgende CSS- und HTML-Regeln verwendet werden.
+
+## 1. CSS: Automatisches Umbrechen langer Wörter
+
+### a) `word-break`
+
+```css
+word-break: break-all;
+```
+
+* Trennt Wörter an beliebiger Stelle, wenn nötig.
+
+### b) `overflow-wrap` / `word-wrap`
+
+```css
+overflow-wrap: break-word;
+/* oder: word-wrap: break-word; */
+```
+
+* Bricht lange Wörter nur um, wenn erforderlich.
+* **Empfohlen**: `overflow-wrap: break-word;` für natürliches Verhalten.
+
+## 2. HTML: Optionale Trennstellen setzen
+
+### a) Weiche Trennstellen mit `&shy;`
+
+```html
+Super&shy;kalifragilistik&shy;expialigetisch
+```
+
+Beim Zeilenumbruch wird dann an dieser Stelle getrennt.
+
+## 3. Beispiel
+
+**CSS-Lösung (empfohlen):**
+
+```html
+<div class="text">
+  EinSuperExtremLangewortOhneLeerzeichenDasGetrenntWerdenSoll
+</div>
+```
+
+```css
+.text {
+  overflow-wrap: break-word;
+}
+```
+
+## 4. Spezialfall: Silbentrennung
+
+Für sprachspezifische Trennung kann das CSS-Attribut `hyphens` genutzt werden:
+
+```css
+.text {
+  hyphens: auto;
+  overflow-wrap: break-word;
+}
+```
+
+Im HTML sollte das Attribut `lang` gesetzt werden:
+
+```html
+<div class="text" lang="de">
+  Silbentrennungsbeispiel
+</div>
+```
+
+## Zusammenfassung
+
+* Allgemein:
+  ```css
+  overflow-wrap: break-word;
+  ```
+* Echte Silbentrennung:
+  ```css
+  hyphens: auto;
+  overflow-wrap: break-word;
+  ```
+* Manuelle Trennstellen mit `&shy;` im HTML.
+


### PR DESCRIPTION
## Summary
- add documentation on how to break long words in HTML
- link the new guideline from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560d40b5e0832b8eb2c60daa1efec1