### PR TITLE
Remove unused migration endpoint

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1150,7 +1150,6 @@ document.addEventListener('DOMContentLoaded', function () {
   // --------- Passwort ändern ---------
   const passSaveBtn = document.getElementById('passSaveBtn');
   const importJsonBtn = document.getElementById('importJsonBtn');
-  const migrateJsonBtn = document.getElementById('migrateJsonBtn');
   const exportJsonBtn = document.getElementById('exportJsonBtn');
   const newPass = document.getElementById('newPass');
   const newPassRepeat = document.getElementById('newPassRepeat');
@@ -1187,17 +1186,6 @@ document.addEventListener('DOMContentLoaded', function () {
               })
               .catch(() => notify('Fehler beim Import', 'danger'));
           });
-          const mig = document.createElement('button');
-          mig.className = 'uk-button uk-button-default uk-margin-small-right';
-          mig.textContent = 'Migrieren';
-          mig.addEventListener('click', () => {
-            fetch('/migrate/' + encodeURIComponent(name), { method: 'POST' })
-              .then(r => {
-                if (!r.ok) throw new Error(r.statusText);
-                notify('Migration abgeschlossen', 'success');
-              })
-              .catch(() => notify('Fehler bei der Migration', 'danger'));
-          });
           const dl = document.createElement('button');
           dl.className = 'uk-button uk-button-default uk-margin-small-right';
           dl.textContent = 'Download';
@@ -1226,7 +1214,6 @@ document.addEventListener('DOMContentLoaded', function () {
               .catch(() => notify('Fehler beim Löschen', 'danger'));
           });
           actionTd.appendChild(imp);
-          actionTd.appendChild(mig);
           actionTd.appendChild(dl);
           actionTd.appendChild(del);
           tr.appendChild(nameTd);
@@ -1280,18 +1267,6 @@ document.addEventListener('DOMContentLoaded', function () {
       });
   });
 
-  migrateJsonBtn?.addEventListener('click', e => {
-    e.preventDefault();
-    fetch('/migrate', { method: 'POST' })
-      .then(r => {
-        if (!r.ok) throw new Error(r.statusText);
-        notify('Migration abgeschlossen', 'success');
-      })
-      .catch(err => {
-        console.error(err);
-        notify('Fehler bei der Migration', 'danger');
-      });
-  });
 
   exportJsonBtn?.addEventListener('click', e => {
     e.preventDefault();

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -44,15 +44,6 @@ class ImportController
         return $this->importFromDir($this->dataDir, $response);
     }
 
-    public function migrate(Request $request, Response $response, array $args): Response
-    {
-        $dir = basename((string)($args['name'] ?? ''));
-        if ($dir === '') {
-            return $this->migrateFromDir($this->dataDir, $response);
-        }
-        return $this->migrateFromDir($this->backupDir . '/' . $dir, $response);
-    }
-
     public function import(Request $request, Response $response, array $args): Response
     {
         $dir = basename((string)($args['name'] ?? ''));
@@ -113,58 +104,4 @@ class ImportController
         return $response->withStatus(204);
     }
 
-    private function migrateFromDir(string $dir, Response $response): Response
-    {
-        $catalogDir = $dir . '/kataloge';
-        $catalogsFile = $catalogDir . '/catalogs.json';
-        if (!is_readable($catalogsFile)) {
-            return $response->withStatus(404);
-        }
-        $catalogs = json_decode((string)file_get_contents($catalogsFile), true) ?? [];
-        foreach ($catalogs as &$cat) {
-            if (!isset($cat['uid']) || $cat['uid'] === '') {
-                $cat['uid'] = bin2hex(random_bytes(16));
-            }
-        }
-        unset($cat);
-        $this->catalogs->write('catalogs.json', $catalogs);
-        foreach ($catalogs as $cat) {
-            if (!isset($cat['file'])) {
-                continue;
-            }
-            $path = $catalogDir . '/' . basename((string)$cat['file']);
-            if (!is_readable($path)) {
-                continue;
-            }
-            $questions = json_decode((string)file_get_contents($path), true) ?? [];
-            $this->catalogs->write(basename((string)$cat['file']), $questions);
-        }
-        $teamsFile = $dir . '/teams.json';
-        if (is_readable($teamsFile)) {
-            $teams = json_decode((string)file_get_contents($teamsFile), true) ?? [];
-            if (is_array($teams)) {
-                $this->teams->saveAll($teams);
-            }
-        }
-        $resultsFile = $dir . '/results.json';
-        if (is_readable($resultsFile)) {
-            $results = json_decode((string)file_get_contents($resultsFile), true) ?? [];
-            if (is_array($results)) {
-                $this->results->saveAll($results);
-            }
-        }
-        $consentsFile = $dir . '/photo_consents.json';
-        if (is_readable($consentsFile)) {
-            $consents = json_decode((string)file_get_contents($consentsFile), true) ?? [];
-            if (is_array($consents)) {
-                $this->consents->saveAll($consents);
-            }
-        }
-        $cfgFile = $dir . '/config.json';
-        if (is_readable($cfgFile)) {
-            $cfg = json_decode((string)file_get_contents($cfgFile), true) ?? [];
-            $this->config->saveConfig($cfg);
-        }
-        return $response->withStatus(204);
-    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -139,8 +139,6 @@ return function (\Slim\App $app) {
     $app->post('/password', [$passwordController, 'post']);
     $app->post('/import', [$importController, 'post']);
     $app->post('/import/{name}', [$importController, 'import']);
-    $app->post('/migrate', [$importController, 'migrate']);
-    $app->post('/migrate/{name}', [$importController, 'migrate']);
     $app->post('/export', [$exportController, 'post']);
     $app->get('/backups', [$backupController, 'list']);
     $app->get('/backups/{name}/download', [$backupController, 'download']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -416,7 +416,6 @@
         <div class="uk-margin uk-flex uk-flex-right">
           <button id="exportJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Datenbank als JSON exportieren; pos: right">Backup erstellen</button>
           <button id="importJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Fragenkataloge aus JSON importieren; pos: right">Importieren</button>
-          <button id="migrateJsonBtn" class="uk-button uk-button-default" uk-tooltip="title: Altes Backup ins neue Format übertragen; pos: right">Migrieren</button>
         </div>
         <table class="uk-table uk-table-divider">
           <thead>


### PR DESCRIPTION
## Summary
- delete unused migration API and its routes
- drop migration buttons from admin UI and JavaScript

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685610979df4832b9502b61427d8f43a