### PR TITLE
Fix backup restore button label

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1177,7 +1177,7 @@ document.addEventListener('DOMContentLoaded', function () {
           const actionTd = document.createElement('td');
           const imp = document.createElement('button');
           imp.className = 'uk-button uk-button-primary uk-margin-small-right';
-          imp.textContent = 'Importieren';
+          imp.textContent = 'Wiederherstellen';
           imp.addEventListener('click', () => {
             fetch('/import/' + encodeURIComponent(name), { method: 'POST' })
               .then(r => {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -415,7 +415,7 @@
         <h3 class="uk-heading-bullet">Sicherungen</h3>
         <div class="uk-margin uk-flex uk-flex-right">
           <button id="exportJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Datenbank als JSON exportieren; pos: right">Backup erstellen</button>
-          <button id="importJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Fragenkataloge aus JSON importieren; pos: right">Importieren</button>
+          <button id="importJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Fragenkataloge aus JSON importieren; pos: right">Wiederherstellen</button>
         </div>
         <table class="uk-table uk-table-divider">
           <thead>


### PR DESCRIPTION
## Summary
- rename backup import button to "Wiederherstellen"

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6856121f6c04832baabd970ffb91d06b