### PR TITLE
Move disclaimer to license page

### DIFF
--- a/templates/help.twig
+++ b/templates/help.twig
@@ -59,15 +59,6 @@
       </ul>
       <p class="uk-text-lead uk-margin-top">Viel Spaß bei der Rally, beim Raten, Punkte sammeln und natürlich beim gemeinsamen Mitfiebern!</p>
     </div>
-    <div class="uk-card uk-card-default uk-card-body uk-margin">
-      <h3 class="uk-heading-bullet">Disclaimer / Hinweis</h3>
-        <p>Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer spannenden Zusammenarbeit zwischen menschlicher Erfahrung und k&uuml;nstlicher Intelligenz. W&auml;hrend Ideen, Organisation und jede Menge Praxiswissen von Menschen stammen, wurden alle Codezeilen experimentell komplett von OpenAI Codex geschrieben. F&uuml;r die kreativen Konzepte und Inhalte kam ChatGPT 4.1 zum Einsatz, bei der Fehlersuche half Github Copilot und das Logo wurde von der KI Sora entworfen.</p>
-        <p>Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial moderner Codeassistenten in der Praxis zu erproben.</p>
-        <p>Im Mittelpunkt stand die Zug&auml;nglichkeit f&uuml;r alle Nutzergruppen &ndash; daher ist die Anwendung barrierefrei gestaltet und eignet sich auch f&uuml;r Menschen mit Einschr&auml;nkungen. Datenschutz und Sicherheit werden konsequent beachtet, sodass alle Daten gesch&uuml;tzt sind.</p>
-        <p>Die App zeichnet sich durch eine hohe Performance und Stabilit&auml;t auch bei vielen gleichzeitigen Teilnehmenden aus. Das Bedienkonzept ist selbsterkl&auml;rend, wodurch eine schnelle und intuitive Nutzung auf allen Endger&auml;ten &ndash; ob Smartphone, Tablet oder Desktop &ndash; gew&auml;hrleistet wird.</p>
-        <p>Zudem wurde auf eine ressourcenschonende Arbeitsweise und eine unkomplizierte Anbindung an andere Systeme Wert gelegt.</p>
-      <p>Mit dieser App zeigen wir, was heute schon m&ouml;glich ist, wenn Menschen und verschiedene KI-Tools wie ChatGPT, Codex, Copilot und Sora gemeinsam an neuen digitalen Ideen t&uuml;fteln.</p>
-    </div>
   </div>
 {% endblock %}
 

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -30,6 +30,15 @@
   <div class="uk-container uk-container-small legal-container">
     <h1 class="uk-heading-divider uk-hidden">Lizenz</h1>
     <p>Diese Anwendung steht unter der <a href="https://opensource.org/licenses/MIT">MIT-Lizenz</a>. Den vollständigen Text finden Sie auch untenstehend sowie in der Datei <code>LICENSE</code>.</p>
+    <div class="uk-card uk-card-default uk-card-body uk-margin">
+      <h3 class="uk-heading-bullet">Disclaimer / Hinweis</h3>
+        <p>Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer spannenden Zusammenarbeit zwischen menschlicher Erfahrung und k&uuml;nstlicher Intelligenz. W&auml;hrend Ideen, Organisation und jede Menge Praxiswissen von Menschen stammen, wurden alle Codezeilen experimentell komplett von OpenAI Codex geschrieben. F&uuml;r die kreativen Konzepte und Inhalte kam ChatGPT 4.1 zum Einsatz, bei der Fehlersuche half Github Copilot und das Logo wurde von der KI Sora entworfen.</p>
+        <p>Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial moderner Codeassistenten in der Praxis zu erproben.</p>
+        <p>Im Mittelpunkt stand die Zug&auml;nglichkeit f&uuml;r alle Nutzergruppen &ndash; daher ist die Anwendung barrierefrei gestaltet und eignet sich auch f&uuml;r Menschen mit Einschr&auml;nkungen. Datenschutz und Sicherheit werden konsequent beachtet, sodass alle Daten gesch&uuml;tzt sind.</p>
+        <p>Die App zeichnet sich durch eine hohe Performance und Stabilit&auml;t auch bei vielen gleichzeitigen Teilnehmenden aus. Das Bedienkonzept ist selbsterkl&auml;rend, wodurch eine schnelle und intuitive Nutzung auf allen Endger&auml;ten &ndash; ob Smartphone, Tablet oder Desktop &ndash; gew&auml;hrleistet wird.</p>
+        <p>Zudem wurde auf eine ressourcenschonende Arbeitsweise und eine unkomplizierte Anbindung an andere Systeme Wert gelegt.</p>
+      <p>Mit dieser App zeigen wir, was heute schon m&ouml;glich ist, wenn Menschen und verschiedene KI-Tools wie ChatGPT, Codex, Copilot und Sora gemeinsam an neuen digitalen Ideen t&uuml;fteln.</p>
+    </div>
     <h2 class="uk-heading-bullet">MIT-Lizenz (Deutsch)</h2>
 <pre class="uk-text-small">
 MIT-Lizenz


### PR DESCRIPTION
## Summary
- remove disclaimer from help page
- add the disclaimer block to the license page

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856149e7658832baf270c50d1d336fc