### PR TITLE
Fix start button alignment

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -176,7 +176,7 @@
     if(!container) return;
     container.innerHTML = '';
     const btn = document.createElement('button');
-    btn.className = 'uk-button uk-button-primary uk-button-large';
+    btn.className = 'uk-button uk-button-primary uk-button-large uk-align-right';
     btn.textContent = 'Los geht es!';
     const cfg = window.quizConfig || {};
     if(cfg.buttonColor){
@@ -419,7 +419,7 @@
     }else{
       if(!cfg.competitionMode || hasCatalog){
         const btn = document.createElement('button');
-        btn.className = 'uk-button uk-button-primary';
+        btn.className = 'uk-button uk-button-primary uk-align-right';
         btn.textContent = 'Los geht es!';
         if(cfg.buttonColor){
           btn.style.backgroundColor = cfg.buttonColor;

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -938,7 +938,7 @@ function runQuiz(questions, skipIntro){
     }
 
     const startBtn = document.createElement('button');
-    startBtn.className = 'uk-button uk-button-primary uk-button-large';
+    startBtn.className = 'uk-button uk-button-primary uk-button-large uk-align-right';
     startBtn.textContent = 'Los geht es!';
     styleButton(startBtn);
     // Zeigt bisherige Ergebnisse als kleine Slideshow an


### PR DESCRIPTION
## Summary
- right-align the 'Los geht es!' buttons in quiz screens

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68561b4c2404832b9571c6db11c148fe