### PR TITLE
Add Helm chart for quiz deployment

### DIFF
--- a/helm/sommerfest-quiz/.helmignore
+++ b/helm/sommerfest-quiz/.helmignore
@@ -1,0 +1,3 @@
+# Patterns to ignore when packaging Helm chart
+.DS_Store
+.git/

--- a/helm/sommerfest-quiz/Chart.yaml
+++ b/helm/sommerfest-quiz/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: sommerfest-quiz
+version: 0.1.0
+description: Helm chart to deploy the Sommerfest Quiz application with PostgreSQL

--- a/helm/sommerfest-quiz/templates/_helpers.tpl
+++ b/helm/sommerfest-quiz/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{- define "sommerfest-quiz.fullname" -}}
+{{- default .Chart.Name .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "sommerfest-quiz.name" -}}
+{{- .Chart.Name -}}
+{{- end -}}

--- a/helm/sommerfest-quiz/templates/db-init-job.yaml
+++ b/helm/sommerfest-quiz/templates/db-init-job.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "sommerfest-quiz.fullname" . }}-db-init
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: init
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POSTGRES_DSN
+              value: "pgsql:host={{ include \"sommerfest-quiz.fullname\" . }}-postgresql;dbname={{ .Values.database.name }}"
+            - name: POSTGRES_USER
+              value: {{ .Values.database.user | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.database.password | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.database.name | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ include "sommerfest-quiz.fullname" . }}-postgresql -U {{ .Values.database.user }}; do
+                sleep 2
+              done
+              psql -h {{ include "sommerfest-quiz.fullname" . }}-postgresql -U {{ .Values.database.user }} -d {{ .Values.database.name }} -f docs/schema.sql
+              php scripts/import_to_pgsql.php

--- a/helm/sommerfest-quiz/templates/deployment.yaml
+++ b/helm/sommerfest-quiz/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sommerfest-quiz.fullname" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "sommerfest-quiz.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "sommerfest-quiz.name" . }}
+    spec:
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POSTGRES_DSN
+              value: "pgsql:host={{ include \"sommerfest-quiz.fullname\" . }}-postgresql;dbname={{ .Values.database.name }}"
+            - name: POSTGRES_USER
+              value: {{ .Values.database.user | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.database.password | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.database.name | quote }}
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: data
+              mountPath: /var/www/data
+      volumes:
+        - name: data
+{{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "sommerfest-quiz.fullname" . }}-data
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/helm/sommerfest-quiz/templates/postgresql-deployment.yaml
+++ b/helm/sommerfest-quiz/templates/postgresql-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "sommerfest-quiz.fullname" . }}-postgresql
+spec:
+  serviceName: {{ include "sommerfest-quiz.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "sommerfest-quiz.name" . }}-postgresql
+  template:
+    metadata:
+      labels:
+        app: {{ include "sommerfest-quiz.name" . }}-postgresql
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.database.image }}
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.database.user | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.database.password | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.database.name | quote }}
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: pgdata
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.persistence.dbSize }}

--- a/helm/sommerfest-quiz/templates/postgresql-service.yaml
+++ b/helm/sommerfest-quiz/templates/postgresql-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sommerfest-quiz.fullname" . }}-postgresql
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: {{ include "sommerfest-quiz.name" . }}-postgresql

--- a/helm/sommerfest-quiz/templates/pvc.yaml
+++ b/helm/sommerfest-quiz/templates/pvc.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sommerfest-quiz.fullname" . }}-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.dataSize }}
+{{- end }}

--- a/helm/sommerfest-quiz/templates/service.yaml
+++ b/helm/sommerfest-quiz/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sommerfest-quiz.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ include "sommerfest-quiz.name" . }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: 8080

--- a/helm/sommerfest-quiz/values.yaml
+++ b/helm/sommerfest-quiz/values.yaml
@@ -1,0 +1,19 @@
+image:
+  repository: sommerfest-quiz
+  tag: latest
+  pullPolicy: IfNotPresent
+
+database:
+  image: postgres:15
+  user: quiz
+  password: quiz
+  name: quiz
+
+service:
+  type: ClusterIP
+  port: 8080
+
+persistence:
+  enabled: true
+  dataSize: 1Gi
+  dbSize: 1Gi


### PR DESCRIPTION
## Summary
- add a new Helm chart `sommerfest-quiz` for Kubernetes deployment
- include Deployment/Service, PostgreSQL StatefulSet, DB init Job and persistent volumes

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `vendor/bin/phpcs --version` *(fails: No such file or directory)*
- `vendor/bin/phpstan --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685852842a80832bbe4956484e5b2f84