### PR TITLE
Add GitHub Pages documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,23 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,13 @@
+# Projekt\u00fcberblick
+
+Das Sommerfest-Quiz ist eine leichtgewichtige Web-Applikation zum Durchf\u00fchren von Quizrunden auf Veranstaltungen. Die Anwendung setzt auf das Slim Framework und nutzt UIkit3 f\u00fcr ein responsives Design. Fragenkataloge, Teilnehmer und Ergebnisse werden in einer PostgreSQL-Datenbank gespeichert und k\u00f6nnen per JSON importiert oder exportiert werden.
+
+## Spielregeln
+
+1. Jedes Team meldet sich \u00fcber einen QR-Code oder manuell mit einem Namen an.
+2. Ein Fragenkatalog kann Sortier-, Zuordnungs- und Multiple-Choice-Aufgaben enthalten.
+3. Die Punktezahl h\u00e4ngt von der Anzahl korrekt gel\u00f6ster Aufgaben ab.
+4. Optional kann zu jeder Frage ein Buchstabe f\u00fcr ein R\u00e4tselwort vergeben werden.
+5. Nachdem alle Fragen beantwortet wurden, wird die Gesamtwertung angezeigt. Bei aktivem Wettkampfmodus sind Wiederholungen nicht m\u00f6glich.
+
+Weitere Details zur Einrichtung finden Sie im [Haupt-README](../README.md).

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,0 +1,12 @@
+# Administration
+
+Die Administrationsoberfl\u00e4che erreichen Sie \u00fcber `/admin` nach einem erfolgreichen Login. Folgende Bereiche stehen zur Verf\u00fcgung:
+
+1. **Veranstaltung konfigurieren** – Farben, Logos und Texte anpassen.
+2. **Kataloge** – Fragenkataloge anlegen und verwalten.
+3. **Fragen anpassen** – Bestehende Fragen \u00e4ndern oder neue hinzuf\u00fcgen.
+4. **Teams/Personen** – Teilnehmerlisten pflegen und optional den Zugang einschr\u00e4nken.
+5. **Ergebnisse** – Spielst\u00e4nde einsehen und als CSV herunterladen.
+6. **Passwort \u00e4ndern** – Das Administrationspasswort setzen.
+
+Weitere Funktionen wie der QR-Code-Login oder der Wettkampfmodus lassen sich in der Datei `data/config.json` aktivieren.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# Sommerfest-Quiz Dokumentation
+
+Willkommen bei der Dokumentation des **Sommerfest-Quiz**. Diese Seite wird automatisch
+auf [GitHub Pages](https://pages.github.com/) bereitgestellt und fasst alle wichtigen
+Informationen zum Projekt zusammen.
+
+- [Projektüberblick](about.md)
+- [Spielregeln](about.md#spielregeln)
+- [Administration](admin.md)
+
+Weitere Hinweise zur Frontend-Gestaltung finden Sie in [Richtlinien zur Worttrennung](frontend-word-break.md).


### PR DESCRIPTION
## Summary
- add docs for GitHub Pages
- document quiz overview, rules and admin interface
- create workflow to deploy docs to GitHub Pages

## Testing
- `pytest -q tests/test_html_validity.py tests/test_json_validity.py`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68586357c364832b821007eeae3288d2