### PR TITLE
Add Jekyll RTD docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+title: Sommerfest Quiz Dokumentation
+theme: jekyll-rtd-theme

--- a/docs/datenschutz.md
+++ b/docs/datenschutz.md
@@ -1,0 +1,50 @@
+---
+layout: default
+title: Datenschutzerklärung
+---
+
+## 1. Verantwortlicher
+
+Verantwortlich für die Datenverarbeitung im Rahmen dieser Anwendung ist:
+René Buske  
+Weidenbusch 8  
+14532 Kleinmachnow  
+E-Mail: [info@calhelp.de](mailto:info@calhelp.de)
+
+## 2. Zweck der Datenverarbeitung
+
+Die Quiz-App dient der Durchführung eines digitalen Quiz im Rahmen der Sommerfeier 2025. Die Erhebung und Verarbeitung von Daten erfolgt ausschließlich zur Bereitstellung und Verbesserung des Quiz-Angebots.
+
+## 3. Art und Umfang der erhobenen Daten
+
+**Keine Erhebung personenbezogener Daten:** Es werden keinerlei personenbezogene Daten (wie Name, E-Mail, Adresse etc.) abgefragt, gespeichert oder verarbeitet.
+
+**Quiz-Daten:** Bei der Nutzung der App werden lediglich pseudonymisierte Daten wie frei gewählte Benutzernamen, erzielte Punktzahlen und ggf. technische Informationen zum Ablauf des Quiz verarbeitet.
+
+**Serverdatei (Veranstaltungsname.csv):** Bei aktivierter Speicherung werden Pseudonyme, Katalogname, Versuch, Punktzahl und Zeitpunkt serverseitig gesichert. Die Ablage erfolgt anonymisiert und konform zur DSGVO.
+
+## 4. Speicherung und Löschung
+
+**Serverseitige Speicherung:** Je nach Konfiguration werden Quiz-Ergebnisse anonymisiert auf dem Server gespeichert. Diese Speicherung erfolgt entsprechend den Anforderungen der DSGVO.
+
+**Lokal gespeicherte Daten:** Sofern lokal gespeichert wird (z. B. im Browser-Storage), verbleiben die Daten ausschließlich auf dem Endgerät des Nutzers und werden nicht an Dritte übermittelt.
+
+**Löschung:** Alle gespeicherten Daten werden spätestens nach Abschluss des Quiz-Events gelöscht oder anonymisiert.
+
+## 5. Keine Weitergabe an Dritte
+
+Es findet keine Übermittlung oder Weitergabe von Daten an Dritte statt.
+
+## 6. Cookies und Tracking
+
+Die App setzt ein technisch notwendiges Session-Cookie (`PHPSESSID`), das für den Betrieb erforderlich ist, z. B. für den Admin-Login. Dieses Cookie enthält keine personenbezogenen Daten und wird nach Beenden des Browsers gelöscht. Ein darüber hinaus gehendes Tracking findet nicht statt.
+
+## 7. Rechte der Nutzer
+
+Da keine personenbezogenen Daten verarbeitet werden, bestehen keine Betroffenenrechte im Sinne der DSGVO bezüglich Auskunft, Berichtigung, Löschung oder Übertragbarkeit.
+
+## 8. Kontakt
+
+Für Fragen zum Datenschutz oder zur Anwendung wenden Sie sich bitte an [info@calhelp.de](mailto:info@calhelp.de).
+
+*Hinweis: Diese Datenschutzerklärung basiert auf dem aktuellen Stand der Technik und des Projekts. CalHelp übernimmt keine Verantwortung für bereits durch Administrator:innen eingegebene personenbezogene Daten. Sollte sich der Funktionsumfang ändern oder die App personenbezogene Daten erheben, ist eine Anpassung dieser Datenschutzerklärung erforderlich.*

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: FAQ
+---
+
+## Häufige Fragen
+
+### Wie starte ich das Quiz?
+Scanne an der ersten Station den QR-Code oder öffne den bereitgestellten Link. Wähle deinen Namen aus und schon geht es los.
+
+### Kann ich das Quiz unterwegs spielen?
+Ja, die Oberfläche passt sich jedem Gerät an – ob Handy, Tablet oder PC.
+
+### Welche Fragetypen gibt es?
+Das Quiz bietet Sortieren, Zuordnen und Multiple Choice.
+
+### Wie bediene ich Drag & Drop?
+Halte ein Element gedrückt und ziehe es an die gewünschte Stelle.
+
+### Gibt es einen Dunkelmodus?
+Ja. Über das Mond-Symbol oben rechts lässt sich die dunkle Ansicht einschalten.
+
+### Was passiert mit meinen Ergebnissen?
+Die Punkte werden anonym gezählt und können am Ende als Statistik exportiert werden.
+
+### Warum wurde das Quiz entwickelt?
+Es zeigt, wie Menschen und KI gemeinsam neue digitale Möglichkeiten schaffen können.
+
+## Unser Anspruch
+
+Bei der Entwicklung wurde besonders geachtet auf:
+
+- **Barrierefreiheit**: Die App ist auch für Menschen mit Einschränkungen gut nutzbar.
+- **Datenschutz**: Die Daten werden vertraulich behandelt.
+- **Schnelle und stabile Nutzung**: Die Anwendung läuft zuverlässig, auch bei vielen Teilnehmenden.
+- **Einfache Bedienung**: Alle Funktionen sind selbsterklärend.
+- **Funktioniert auf allen Geräten**: Handy, Tablet oder PC – freie Wahl.
+- **Nachhaltigkeit**: Die App wurde ressourcenschonend umgesetzt.
+- **Offene Schnittstellen**: Sie lässt sich leicht mit anderen Systemen verbinden.

--- a/docs/impressum.md
+++ b/docs/impressum.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: Impressum
+---
+
+Angaben gemäß § 5 TMG
+
+René Buske  
+Weidenbusch 8  
+14532 Kleinmachnow  
+Deutschland
+
+E-Mail: [office@calhelp.de](mailto:office@calhelp.de)
+
+**Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:**  
+René Buske  
+Weidenbusch 8  
+14532 Kleinmachnow
+
+Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz: DE 259645623
+
+## Haftungsausschluss
+
+Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung für die Inhalte externer Links. Für den Inhalt der verlinkten Seiten sind ausschließlich deren Betreiber verantwortlich.
+
+## Urheberrecht
+
+Die durch den Seitenbetreiber erstellten Inhalte und Werke auf dieser Website unterliegen dem deutschen Urheberrecht. Beiträge Dritter sind als solche gekennzeichnet.
+
+## Quellcode
+
+Der Quellcode dieser Anwendung ist unter der MIT-Lizenz auf GitHub verfügbar: <https://github.com/bastelix/sommerfest-quiz>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,30 @@
-# Sommerfest-Quiz Dokumentation
+---
+layout: default
+title: Projekt
+---
 
-Willkommen bei der Dokumentation des **Sommerfest-Quiz**. Diese Seite wird automatisch
-auf [GitHub Pages](https://pages.github.com/) bereitgestellt und fasst alle wichtigen
-Informationen zum Projekt zusammen.
+# Sommerfest-Quiz
 
-- [Projektüberblick](about.md)
-- [Spielregeln](about.md#spielregeln)
-- [Administration](admin.md)
+Das **Sommerfest-Quiz** ist eine Web-App für Veranstaltungen. Die Anwendung basiert
+auf dem Slim Framework und nutzt UIkit3 für ein responsives Design. Fragenkataloge,
+Teilnehmer und Ergebnisse werden in einer PostgreSQL-Datenbank gespeichert und
+können per JSON importiert oder exportiert werden.
 
-Weitere Hinweise zur Frontend-Gestaltung finden Sie in [Richtlinien zur Worttrennung](frontend-word-break.md).
+Die Entwicklung entstand als Machbarkeitsstudie, um das Potenzial moderner
+Code-Assistenten in der Praxis zu testen. Barrierefreiheit, Datenschutz und eine
+hohe Performance standen dabei im Mittelpunkt.
+
+Weitere Highlights sind:
+
+- **Flexibel einsetzbar**: Kataloge im JSON-Format lassen sich einfach austauschen.
+- **Drei Fragetypen**: Sortieren, Zuordnen und Multiple Choice.
+- **QR-Code-Login & Dunkelmodus** für komfortables Spielen auf allen Geräten.
+- **Persistente Speicherung** in PostgreSQL.
+
+## Weitere Seiten
+
+* [Wie läuft das Spiel?](spielablauf.md)
+* [FAQ](faq.md)
+* [Datenschutz](datenschutz.md)
+* [Impressum](impressum.md)
+* [Lizenz](lizenz.md)

--- a/docs/lizenz.md
+++ b/docs/lizenz.md
@@ -1,0 +1,68 @@
+---
+layout: default
+title: Lizenz
+---
+
+Diese Anwendung steht unter der [MIT-Lizenz](https://opensource.org/licenses/MIT). Den vollständigen Text finden Sie auch in der Datei `LICENSE`.
+
+## Disclaimer / Hinweis
+
+Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer Zusammenarbeit zwischen menschlicher Erfahrung und künstlicher Intelligenz. Während Ideen, Organisation und Praxiswissen von Menschen stammen, wurden alle Codezeilen von OpenAI Codex geschrieben. Für die Konzepte kam ChatGPT zum Einsatz, bei der Fehlersuche half GitHub Copilot und das Logo wurde von der KI Sora entworfen.
+
+Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial moderner Codeassistenten zu erproben. Barrierefreiheit, Datenschutz und hohe Performance standen im Mittelpunkt.
+
+Mit dieser App zeigen wir, was heute möglich ist, wenn Menschen und KI gemeinsam digitale Ideen entwickeln.
+
+## MIT-Lizenz (Deutsch)
+
+```
+MIT-Lizenz
+
+Copyright (c) 2025 calhelp
+
+Hiermit wird unentgeltlich jeder Person, die eine Kopie der Software
+und der zugehörigen Dokumentationsdateien (die "Software") erhält,
+die Erlaubnis erteilt, uneingeschränkt mit der Software zu verfahren,
+einschließlich aber nicht beschränkt auf die Rechte, die Software zu
+nutzen, zu kopieren, zu modifizieren, zusammenzuführen, zu veröffentlichen,
+zu verbreiten, zu unterlizenzieren und/oder zu verkaufen, sowie Personen,
+denen die Software bereitgestellt wird, diese Rechte zu gewähren, vorbehaltlich
+der folgenden Bedingungen:
+
+Der obige Urheberrechtsvermerk und dieser Erlaubnisvermerk sind in allen
+Kopien oder wesentlichen Teilen der Software beizulegen.
+
+DIE SOFTWARE WIRD OHNE JEDE AUSDRÜCKLICHE ODER STILLSCHWEIGENDE GEWÄHRLEISTUNG
+BEREITGESTELLT, EINSCHLIESSLICH UND NICHT BESCHRÄNKT AUF DIE GEWÄHRLEISTUNGEN
+DER MARKTGÄNGIGKEIT, DER EIGNUNG FÜR EINEN BESTIMMTEN ZWECK UND DER NICHTVERLETZUNG.
+IN KEINEM FALL SIND DIE AUTOREN ODER URHEBERRECHTSINHABER FÜR JEGLICHE ANSPRÜCHE,
+SCHÄDEN ODER SONSTIGE HAFTUNGEN VERANTWORTLICH, OB IN EINEM VERTRAGSVERHÄLTNIS,
+EINER UNERLAUBTEN HANDLUNG ODER ANDERWEITIG, DIE SICH AUS DER SOFTWARE ODER DER
+NUTZUNG ODER ANDEREN GESCHÄFTEN MIT DER SOFTWARE ERGEBEN.
+```
+
+## MIT License (English)
+
+```
+MIT License
+
+Copyright (c) 2025 calhelp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/spielablauf.md
+++ b/docs/spielablauf.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Wie läuft das Spiel?
+---
+
+## So funktioniert das Spiel
+
+Es gibt verschiedene Stationen, die auf einer Karte markiert sind. An jeder
+Station scannt ihr mit dem Smartphone den dort angebrachten QR-Code und öffnet den Link – und schon kann es losgehen.
+
+1. **QR-Code scannen** – Nach dem Öffnen des Stations-Links scannt ihr euren Team-QR-Code. Nur bekannte Teams werden zugelassen.
+2. **Quiz starten** – Nach dem erfolgreichen Login startet automatisch der passende Fragenkatalog für die Station. Ein einmal gelöster Katalog kann während der Rally nicht noch einmal gestartet werden.
+3. **Fragen beantworten** – Jede Frage zeigt nur den Button "Weiter". Die Antwort wird direkt überprüft. Ob sie richtig war, erfahrt ihr am Ende des jeweiligen Katalogs.
+4. **Buchstabe sammeln** – Nach jeder Runde erscheint ein Buchstabe, der Teil des Rätselworts ist. Schritt für Schritt ergibt sich die Lösung.
+5. **Rätseln & Foto hochladen** – Wer das Rätselwort errät, kann es direkt eingeben. Es kann außerdem ein Beweisfoto hochgeladen werden. Die kreativsten Teamfotos werden am Ende prämiert.
+6. **Ergebnisse & Rangliste** – Nach Abschluss aller Stationen erscheint ein Link zur persönlichen Ergebnisübersicht. Dort oder im Adminbereich gibt es eine Rangliste mit den besten Platzierungen.
+
+Viel Spaß bei der Rally, beim Raten, Punkte sammeln und natürlich beim gemeinsamen Mitfiebern!


### PR DESCRIPTION
## Summary
- switch docs site to Jekyll readthedocs theme
- create docs pages for project overview, how to play, FAQ, privacy, imprint and licence

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685868079400832ba5919a91fff037d1