### PR TITLE
Fill Jekyll docs with German handbook

### DIFF
--- a/docs-jtd/barrierefreiheit.md
+++ b/docs-jtd/barrierefreiheit.md
@@ -7,4 +7,12 @@ toc: true
 
 # Barrierefreiheit
 
-Diese Seite beschreibt die zugänglichen Funktionen der App und wie sie Inklusion unterstützt.
+Das Frontend bietet mehrere Funktionen, die die Nutzung für alle Besucherinnen und Besucher erleichtern:
+
+- Ausführliche ARIA-Beschriftungen auf Bedienelementen und Formularfeldern.
+- Tastatursteuerung für Sortier- und Zuordnungsfragen samt versteckten Hinweisen.
+- Fortschrittsbalken mit `aria-valuenow` und Live-Ansage der aktuellen Frage.
+- Umschaltbarer Dunkel- und Hochkontrastmodus.
+
+Diese Maßnahmen verbessern die Zugänglichkeit, ersetzen jedoch keine individuelle Prüfung der Barrierefreiheit.
+

--- a/docs-jtd/datenschutz.md
+++ b/docs-jtd/datenschutz.md
@@ -7,4 +7,49 @@ toc: true
 
 # Datenschutz & rechtliche Hinweise
 
-Die Anwendung speichert standardmäßig keine personenbezogenen Daten. Details finden sich in der serverseitigen Datenschutzerklärung.
+## 1. Verantwortlicher
+
+Verantwortlich für die Datenverarbeitung im Rahmen dieser Anwendung ist:
+René Buske
+Weidenbusch 8
+14532 Kleinmachnow
+E-Mail: [info@calhelp.de](mailto:info@calhelp.de)
+
+## 2. Zweck der Datenverarbeitung
+
+Die Quiz-App dient der Durchführung eines digitalen Quiz im Rahmen der Sommerfeier 2025. Die Erhebung und Verarbeitung von Daten erfolgt ausschließlich zur Bereitstellung und Verbesserung des Quiz-Angebots.
+
+## 3. Art und Umfang der erhobenen Daten
+
+**Keine Erhebung personenbezogener Daten:** Es werden keinerlei personenbezogene Daten (wie Name, E-Mail, Adresse etc.) abgefragt, gespeichert oder verarbeitet.
+
+**Quiz-Daten:** Bei der Nutzung der App werden lediglich pseudonymisierte Daten wie frei gewählte Benutzernamen, erzielte Punktzahlen und ggf. technische Informationen zum Ablauf des Quiz verarbeitet.
+
+**Serverdatei (Veranstaltungsname.csv):** Bei aktivierter Speicherung werden Pseudonyme, Katalogname, Versuch, Punktzahl und Zeitpunkt serverseitig gesichert. Die Ablage erfolgt anonymisiert und konform zur DSGVO.
+
+## 4. Speicherung und Löschung
+
+**Serverseitige Speicherung:** Je nach Konfiguration werden Quiz-Ergebnisse anonymisiert auf dem Server gespeichert. Diese Speicherung erfolgt entsprechend den Anforderungen der DSGVO.
+
+**Lokal gespeicherte Daten:** Sofern lokal gespeichert wird (z. B. im Browser-Storage), verbleiben die Daten ausschließlich auf dem Endgerät des Nutzers und werden nicht an Dritte übermittelt.
+
+**Löschung:** Alle gespeicherten Daten werden spätestens nach Abschluss des Quiz-Events gelöscht oder anonymisiert.
+
+## 5. Keine Weitergabe an Dritte
+
+Es findet keine Übermittlung oder Weitergabe von Daten an Dritte statt.
+
+## 6. Cookies und Tracking
+
+Die App setzt ein technisch notwendiges Session-Cookie (`PHPSESSID`), das für den Betrieb erforderlich ist. Dieses Cookie enthält keine personenbezogenen Daten und wird nach Beenden des Browsers gelöscht. Ein darüber hinaus gehendes Tracking findet nicht statt.
+
+## 7. Rechte der Nutzer
+
+Da keine personenbezogenen Daten verarbeitet werden, bestehen keine Betroffenenrechte im Sinne der DSGVO bezüglich Auskunft, Berichtigung, Löschung oder Übertragbarkeit.
+
+## 8. Kontakt
+
+Für Fragen zum Datenschutz oder zur Anwendung wenden Sie sich bitte an [info@calhelp.de](mailto:info@calhelp.de).
+
+*Hinweis: Diese Datenschutzerklärung basiert auf dem aktuellen Stand der Technik und des Projekts. CalHelp übernimmt keine Verantwortung für bereits durch Administrator:innen eingegebene personenbezogene Daten. Sollte sich der Funktionsumfang ändern oder die App personenbezogene Daten erheben, ist eine Anpassung dieser Datenschutzerklärung erforderlich.*
+

--- a/docs-jtd/faq.md
+++ b/docs-jtd/faq.md
@@ -7,4 +7,36 @@ toc: true
 
 # Häufige Fragen
 
-Hier sammeln wir Antworten auf häufig gestellte Fragen.
+### Wie starte ich das Quiz?
+Scanne an der ersten Station den QR-Code oder öffne den bereitgestellten Link. Wähle deinen Namen aus und schon geht es los.
+
+### Kann ich das Quiz unterwegs spielen?
+Ja, die Oberfläche passt sich jedem Gerät an – ob Handy, Tablet oder PC.
+
+### Welche Fragetypen gibt es?
+Das Quiz bietet Sortieren, Zuordnen und Multiple Choice.
+
+### Wie bediene ich Drag & Drop?
+Halte ein Element gedrückt und ziehe es an die gewünschte Stelle.
+
+### Gibt es einen Dunkelmodus?
+Ja. Über das Mond-Symbol oben rechts lässt sich die dunkle Ansicht einschalten.
+
+### Was passiert mit meinen Ergebnissen?
+Die Punkte werden anonym gezählt und können am Ende als Statistik exportiert werden.
+
+### Warum wurde das Quiz entwickelt?
+Es zeigt, wie Menschen und KI gemeinsam neue digitale Möglichkeiten schaffen können.
+
+## Unser Anspruch
+
+Bei der Entwicklung wurde besonders geachtet auf:
+
+- **Barrierefreiheit**: Die App ist auch für Menschen mit Einschränkungen gut nutzbar.
+- **Datenschutz**: Die Daten werden vertraulich behandelt.
+- **Schnelle und stabile Nutzung**: Die Anwendung läuft zuverlässig, auch bei vielen Teilnehmenden.
+- **Einfache Bedienung**: Alle Funktionen sind selbsterklärend.
+- **Funktioniert auf allen Geräten**: Handy, Tablet oder PC – freie Wahl.
+- **Nachhaltigkeit**: Die App wurde ressourcenschonend umgesetzt.
+- **Offene Schnittstellen**: Sie lässt sich leicht mit anderen Systemen verbinden.
+

--- a/docs-jtd/fragenkataloge.md
+++ b/docs-jtd/fragenkataloge.md
@@ -7,4 +7,17 @@ toc: true
 
 # Kataloge & Fragetypen
 
-Alles zu Fragenformaten, Import/Export und dem Puzzlewort.
+`data/kataloge/catalogs.json` listet alle verfügbaren Kataloge mit `slug`, Name und optionaler QR-Code-Adresse. Die Reihenfolge bestimmt das Feld `sort_order`. Jede Frage speichert die zugehörige `catalog_uid`.
+
+Ein Eintrag kann zudem ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt.
+
+## API-Endpunkte
+
+- `GET /kataloge/{file}` liefert den JSON-Katalog oder leitet im Browser auf `/?katalog=slug` um.
+- `PUT /kataloge/{file}` legt eine neue Datei an.
+- `POST /kataloge/{file}` überschreibt einen vorhandenen Katalog.
+- `DELETE /kataloge/{file}` entfernt die Datei.
+- `DELETE /kataloge/{file}/{index}` löscht eine Frage anhand des Index.
+
+Die Fragetypen umfassen Sortieren, Zuordnen und Multiple Choice. Dank des Puzzlewort-Features kann nach jeder Runde ein Buchstabe angezeigt werden, bis sich das Lösungswort ergibt.
+

--- a/docs-jtd/funktionsweise.md
+++ b/docs-jtd/funktionsweise.md
@@ -7,4 +7,14 @@ toc: true
 
 # Funktionsweise & Highlights
 
-Diese Seite erklärt kurz, wie die App funktioniert und welche technischen Besonderheiten sie auszeichnen.
+Das Spiel ist für mehrere Stationen ausgelegt, die auf einer Karte markiert sind. An jeder Station scannt ihr mit dem Smartphone den dort angebrachten QR-Code und öffnet den Link – und schon kann es losgehen.
+
+1. **QR-Code scannen** – Nach dem Öffnen eines Stations-Links scannt ihr euren Team-QR-Code. Nur bekannte Teams werden zugelassen.
+2. **Quiz starten** – Nach erfolgreichem Login startet automatisch der passende Fragenkatalog für die Station. Ein gelöster Katalog kann während der Rally nicht erneut gestartet werden.
+3. **Fragen beantworten** – Jede Frage zeigt nur den Button "Weiter". Die Antwort wird direkt geprüft. Ob sie richtig war, erfahrt ihr am Ende des jeweiligen Katalogs.
+4. **Buchstabe sammeln** – Nach jeder Runde erscheint ein Buchstabe des Rätselworts. Schritt für Schritt ergibt sich die Lösung.
+5. **Rätseln & Foto hochladen** – Wer das Rätselwort errät, kann es direkt eingeben. Es darf außerdem ein Beweisfoto hochgeladen werden. Die kreativsten Teamfotos werden am Ende prämiert.
+6. **Ergebnisse & Rangliste** – Nach Abschluss aller Stationen erscheint ein Link zur persönlichen Ergebnisübersicht. Dort oder im Adminbereich gibt es eine Rangliste mit den besten Platzierungen.
+
+Viel Spaß bei der Rally und beim gemeinsamen Mitfiebern!
+

--- a/docs-jtd/impressum.md
+++ b/docs-jtd/impressum.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Impressum
+nav_order: 15
+---
+
+Angaben gemäß § 5 TMG
+
+René Buske
+Weidenbusch 8
+14532 Kleinmachnow
+Deutschland
+
+E-Mail: [office@calhelp.de](mailto:office@calhelp.de)
+
+**Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:**
+René Buske
+Weidenbusch 8
+14532 Kleinmachnow
+
+Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz: DE 259645623
+
+## Haftungsausschluss
+
+Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung für die Inhalte externer Links. Für den Inhalt der verlinkten Seiten sind ausschließlich deren Betreiber verantwortlich.
+
+## Urheberrecht
+
+Die durch den Seitenbetreiber erstellten Inhalte und Werke auf dieser Website unterliegen dem deutschen Urheberrecht. Beiträge Dritter sind als solche gekennzeichnet.
+
+## Quellcode
+
+Der Quellcode dieser Anwendung ist unter der MIT-Lizenz auf GitHub verfügbar: <https://github.com/bastelix/sommerfest-quiz>
+

--- a/docs-jtd/index.md
+++ b/docs-jtd/index.md
@@ -6,4 +6,14 @@ nav_order: 1
 
 # Willkommen zum Sommerfest-Quiz
 
-Eine kurze Einleitung zum Projekt mit App-Charme und einem zentralen Aufruf zum Mitmachen.
+Das **Sommerfest-Quiz** ist eine leichtgewichtige Web-App für Veranstaltungen. Sie basiert auf dem Slim Framework und nutzt UIkit3 für ein responsives Design. Fragenkataloge, Teams und Ergebnisse werden in einer PostgreSQL-Datenbank gespeichert und können bequem per JSON importiert oder exportiert werden.
+
+Die Anwendung entstand als Machbarkeitsstudie, um das Potenzial moderner Code-Assistenten in der Praxis zu erproben. Besonderer Wert wurde auf Barrierefreiheit, Datenschutz und eine hohe Performance gelegt.
+
+Weitere Highlights sind unter anderem:
+
+- **Flexibel einsetzbar:** Kataloge im JSON-Format lassen sich einfach austauschen oder erweitern.
+- **Drei Fragetypen:** Sortieren, Zuordnen und Multiple Choice bieten Abwechslung für alle Teilnehmer.
+- **QR-Code-Login & Dunkelmodus:** Komfortables Spielen auf allen Geräten.
+- **Persistente Speicherung:** Alle Daten liegen zentral in PostgreSQL.
+

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -7,4 +7,36 @@ toc: true
 
 # Installation & Schnellstart
 
-Schritt-für-Schritt: Docker & lokal, Composer, Datenbank, Erststart und Troubleshooting.
+1. **Abhängigkeiten installieren**
+   ```bash
+   composer install
+   ```
+   Beim ersten Aufruf wird eine `composer.lock` angelegt und alle benötigten Pakete werden geladen. Wer die Anwendung ohne Docker betreibt, muss diesen Schritt manuell ausführen.
+
+2. **Server starten** (lokal für Tests)
+   ```bash
+   php -S localhost:8080 -t public public/router.php
+   ```
+   Danach ist das Quiz unter <http://localhost:8080> erreichbar.
+
+3. **Optional: PostgreSQL-Datenbank vorbereiten**
+   ```bash
+   export POSTGRES_DSN="pgsql:host=localhost;dbname=quiz"
+   export POSTGRES_USER=quiz
+   export POSTGRES_PASSWORD=quiz
+   psql -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql
+   for f in migrations/*.sql; do psql -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f "$f"; done
+   ```
+   Alternativ lassen sich Schema- und Datenimport auch im Docker-Container ausführen:
+   ```bash
+   docker-compose exec slim bash -c \
+     'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && php scripts/import_to_pgsql.php'
+   ```
+
+4. **JSON-Daten importieren**
+   ```bash
+   php scripts/import_to_pgsql.php
+   ```
+
+Das mitgelieferte `docker-compose.yml` startet die Anwendung samt Reverse Proxy. Daten werden dauerhaft in einem Volume gesichert, Beweisfotos bleiben im Ordner `data/photos` erhalten. Die Domain und weitere Parameter lassen sich über die Datei `.env` anpassen.
+

--- a/docs-jtd/konfiguration.md
+++ b/docs-jtd/konfiguration.md
@@ -7,4 +7,35 @@ toc: true
 
 # Einstellungen & Anpassungen
 
-Erklärung aller Konfigurationsoptionen, vom Design bis zu den Katalogen.
+Alle wesentlichen Optionen stehen in `data/config.json` und werden beim ersten Import in die Datenbank übernommen. Änderungen lassen sich später über die Administration speichern.
+
+```json
+{
+  "displayErrorDetails": true,
+  "QRUser": true,
+  "logoPath": "/logo.png",
+  "pageTitle": "Modernes Quiz mit UIkit",
+  "header": "Sommerfest 2025",
+  "subheader": "Willkommen beim Veranstaltungsquiz",
+  "backgroundColor": "#ffffff",
+  "buttonColor": "#1e87f0",
+  "CheckAnswerButton": "no",
+  "adminUser": "admin",
+  "adminPass": "...",
+  "QRRestrict": false,
+  "competitionMode": false,
+  "teamResults": true,
+  "photoUpload": true,
+  "puzzleWordEnabled": true,
+  "puzzleWord": "",
+  "puzzleFeedback": "",
+  "postgres_dsn": "pgsql:host=postgres;dbname=quiz",
+  "postgres_user": "quiz",
+  "postgres_pass": "quiz"
+}
+```
+
+Optional kann `baseUrl` gesetzt werden, um in QR-Codes komplette Links zu erzeugen. Der Parameter `competitionMode` verhindert Wiederholungen bereits gelöster Kataloge. Über `teamResults` wird gesteuert, ob Teams ihre Ergebnisse einsehen dürfen, und `photoUpload` aktiviert den Upload von Beweisfotos.
+
+Konfigurationswerte können per GET auf `/config.json` abgerufen und per POST aktualisiert werden.
+

--- a/docs-jtd/lizenz.md
+++ b/docs-jtd/lizenz.md
@@ -7,4 +7,67 @@ toc: true
 
 # Lizenz, Haftung, Impressum
 
-Das Projekt steht unter der [MIT-Lizenz](../LICENSE). Keine Gewähr für Richtigkeit und Vollständigkeit.
+Diese Anwendung steht unter der [MIT-Lizenz](https://opensource.org/licenses/MIT). Den vollständigen Text finden Sie auch in der Datei `LICENSE`.
+
+## Disclaimer / Hinweis
+
+Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer Zusammenarbeit zwischen menschlicher Erfahrung und künstlicher Intelligenz. Während Ideen, Organisation und Praxiswissen von Menschen stammen, wurden alle Codezeilen von OpenAI Codex geschrieben. Für die Konzepte kam ChatGPT zum Einsatz, bei der Fehlersuche half GitHub Copilot und das Logo wurde von der KI Sora entworfen.
+
+Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial moderner Codeassistenten zu erproben. Barrierefreiheit, Datenschutz und hohe Performance standen im Mittelpunkt.
+
+Mit dieser App zeigen wir, was heute möglich ist, wenn Menschen und KI gemeinsam digitale Ideen entwickeln.
+
+## MIT-Lizenz (Deutsch)
+
+```
+MIT-Lizenz
+
+Copyright (c) 2025 calhelp
+
+Hiermit wird unentgeltlich jeder Person, die eine Kopie der Software
+und der zugehörigen Dokumentationsdateien (die "Software") erhält,
+die Erlaubnis erteilt, uneingeschränkt mit der Software zu verfahren,
+einschließlich aber nicht beschränkt auf die Rechte, die Software zu
+nutzen, zu kopieren, zu modifizieren, zusammenzuführen, zu veröffentlichen,
+zu verbreiten, zu unterlizenzieren und/oder zu verkaufen, sowie Personen,
+denen die Software bereitgestellt wird, diese Rechte zu gewähren, vorbehaltlich
+der folgenden Bedingungen:
+
+Der obige Urheberrechtsvermerk und dieser Erlaubnisvermerk sind in allen
+Kopien oder wesentlichen Teilen der Software beizulegen.
+
+DIE SOFTWARE WIRD OHNE JEDE AUSDRÜCKLICHE ODER STILLSCHWEIGENDE GEWÄHRLEISTUNG
+BEREITGESTELLT, EINSCHLIEßLICH UND NICHT BESCHRÄNKT AUF DIE GEWÄHRLEISTUNGEN
+DER MARKTGÄNGIGKEIT, DER EIGNUNG FÜR EINEN BESTIMMTEN ZWECK UND DER NICHTVERLETZUNG.
+IN KEINEM FALL SIND DIE AUTOREN ODER URHEBERRECHTSINHABER FÜR JEGLICHE ANSPRÜCHE,
+SCHÄDEN ODER SONSTIGE HAFTUNGEN VERANTWORTLICH, OB IN EINEM VERTRAGSVERHÄLTNIS,
+EINER UNERLAUBTEN HANDLUNG ODER ANDERWEITIG, DIE SICH AUS DER SOFTWARE ODER DER
+NUTZUNG ODER ANDEREN GESCHÄFTEN MIT DER SOFTWARE ERGEBEN.
+```
+
+## MIT License (English)
+
+```
+MIT License
+
+Copyright (c) 2025 calhelp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+

--- a/docs-jtd/marketing.md
+++ b/docs-jtd/marketing.md
@@ -7,4 +7,31 @@ toc: true
 
 # Vorteile & Nutzen
 
-Hier beschreiben wir den Mehrwert der App für Veranstalterinnen und Veranstalter.
+## Überblick
+
+- **Flexibel einsetzbar:** Fragenkataloge im JSON-Format lassen sich bequem austauschen oder erweitern.
+- **Drei Fragetypen:** Sortieren, Zuordnen und Multiple Choice bieten Abwechslung für jede Zielgruppe.
+- **QR-Code-Login & Dunkelmodus:** Optionaler QR-Code-Login für schnelles Anmelden und ein zuschaltbares dunkles Design steigern den Komfort.
+- **Persistente Speicherung:** Konfigurationen, Kataloge und Ergebnisse liegen in einer PostgreSQL-Datenbank.
+
+## Highlights
+
+- **Einfache Installation** – Nur Composer-Abhängigkeiten installieren und einen PHP-Server starten.
+- **Intuitives UI** – Komplett auf UIkit3 basierendes Frontend mit flüssigen Animationen und responsive Design.
+- **Stark anpassbar** – Farben, Logo und Texte lassen sich über `data/config.json` anpassen.
+- **Backup per JSON** – Alle Daten lassen sich exportieren und wieder importieren.
+- **Automatische Bildkompression** – Hochgeladene Fotos werden standardmäßig verkleinert und komprimiert.
+- **Rätselwort und Foto-Einwilligung** – Optionales Puzzlewort-Spiel mit DSGVO-konformen Foto-Uploads.
+
+## Fokus der Entwicklung
+
+- **Barrierefreiheit**: Die App ist für alle zugänglich, auch für Menschen mit Einschränkungen.
+- **Datenschutz**: Die Daten sind sicher und werden vertraulich behandelt.
+- **Schnelle und stabile Nutzung**: Auch bei vielen Teilnehmenden läuft die App zuverlässig.
+- **Einfache Bedienung**: Die Nutzung ist leicht und selbsterklärend.
+- **Geräteunabhängigkeit**: Funktioniert auf allen Geräten – Handy, Tablet oder PC.
+- **Nachhaltigkeit**: Die Umsetzung ist ressourcenschonend.
+- **Offene Schnittstellen**: Die App lässt sich problemlos mit anderen Systemen verbinden.
+
+Dieses Projekt zeigt, wie Mensch und KI gemeinsam neue digitale Möglichkeiten schaffen können.
+

--- a/docs-jtd/teams-ergebnisse.md
+++ b/docs-jtd/teams-ergebnisse.md
@@ -7,4 +7,17 @@ toc: true
 
 # Teams, Login & Ergebnis-Export
 
-Teammanagement, QR-Login sowie Export der Resultate und Datenschutz beim Foto-Upload.
+## Teams und QR-Code-Login
+
+In `data/teams.json` lassen sich Teilnehmernamen speichern. `GET /teams.json` ruft die Liste ab, `POST /teams.json` speichert sie. Ein optionales Häkchen "Nur Teams/Personen aus der Liste dürfen teilnehmen" aktiviert eine Zugangsbeschränkung via QR-Code. QR-Codes können direkt in der Oberfläche generiert werden.
+
+## Ergebnisse
+
+Alle Resultate werden in der Datenbank abgelegt. Die API bietet folgende Endpunkte:
+- `GET /results.json` – liefert alle gespeicherten Ergebnisse.
+- `POST /results` – fügt ein neues Ergebnis hinzu.
+- `DELETE /results` – löscht alle Einträge.
+- `GET /results/download` – erzeugt eine CSV-Datei mit allen Resultaten.
+
+Diese Funktionen ermöglichen eine einfache Auswertung und Archivierung der Spielergebnisse.
+

--- a/docs-jtd/verwaltung.md
+++ b/docs-jtd/verwaltung.md
@@ -7,4 +7,25 @@ toc: true
 
 # Admin-Bereich & Nutzerverwaltung
 
-Hinweise zum Umgang mit dem Adminbereich, Rechten und Rollen.
+## Authentifizierung
+
+Der Zugang zum Administrationsbereich erfolgt über `/login`. Nach einem erfolgreichen POST mit gültigen Daten wird eine Session gesetzt und der Browser zur Route `/admin` weitergeleitet. Die Middleware `AdminAuthMiddleware` schützt alle Admin-Routen und leitet bei fehlender Session zum Login um.
+
+## Administrationsoberfläche
+
+Unter `/admin` stehen folgende Tabs zur Verfügung:
+1. **Veranstaltung konfigurieren** – Einstellungen wie Logo, Farben und Texte.
+2. **Kataloge** – Fragenkataloge erstellen und verwalten.
+3. **Fragen anpassen** – Fragen eines Katalogs hinzufügen, bearbeiten oder löschen.
+4. **Teams/Personen** – Teilnehmerlisten pflegen, optional als Login-Beschränkung.
+5. **Ergebnisse** – Spielstände einsehen und herunterladen.
+6. **Passwort ändern** – Administrationspasswort setzen.
+
+## Weitere Funktionen
+
+- **Passwort ändern:** Ein POST auf `/password` speichert ein neues Admin-Passwort in `config.json`.
+- **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue Datei hochladen.
+- **Ergebnisse exportieren:** Alle Resultate können als CSV-Datei heruntergeladen werden.
+
+Die API ermöglicht so die komplette Verwaltung eines Quizsystems und ist sowohl lokal als auch im Netzwerk schnell einsatzbereit.
+


### PR DESCRIPTION
## Summary
- update docs-jtd with detailed content from existing pages
- add new Impressum page

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpcs` *(fails: command not found)*
- `vendor/bin/phpstan` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685896dc2224832b852dc075ab99c15f