### PR TITLE
Customize docs theme

### DIFF
--- a/docs-jtd/_config.yml
+++ b/docs-jtd/_config.yml
@@ -10,3 +10,15 @@ plugins:
 toc:
   min_level: 2
   max_level: 3
+
+# GitHub Repo-Button
+github:
+  url: https://github.com/bastelix/sommerfest-quiz
+
+color:
+  primary: "#5e81ac"
+  accent: "#88c0d0"
+
+# Footer-Text
+footer: |
+  © 2025 Sommerfest Quiz. Made with ❤️ in Potsdam.


### PR DESCRIPTION
## Summary
- configure docs-jtd theme colors, repo button, and footer text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589be0aa0c832bade7bd7ac120f9a7