### PR TITLE
Add manual tooltip

### DIFF
--- a/public/Impressum.html
+++ b/public/Impressum.html
@@ -43,6 +43,13 @@
         <li><a href="Lizenz.html">Lizenz</a></li>
       </ul>
     </div>
+    <div class="uk-navbar-right">
+      <ul class="uk-navbar-nav">
+        <li>
+          <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="book" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
+        </li>
+      </ul>
+    </div>
   </nav>
   <script src="/js/uikit.min.js"></script>
 </body>

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -19,6 +19,13 @@
         <li><a href="/lizenz">Lizenz</a></li>
       </ul>
     </div>
+    <div class="uk-navbar-right">
+      <ul class="uk-navbar-nav">
+        <li>
+          <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="book" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
+        </li>
+      </ul>
+    </div>
   </nav>
   <script src="/js/uikit.min.js"></script>
   <script src="/js/i18n/de-de.js"></script>


### PR DESCRIPTION
## Summary
- use UIkit tooltip for the handbook link in the footer
- apply same change in the static Impressum page

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68589a51b914832b80c4bd17a3f43adb