### PR TITLE
Improve docs navigation structure

### DIFF
--- a/docs-jtd/_toc.yml
+++ b/docs-jtd/_toc.yml
@@ -1,0 +1,21 @@
+- Start & Überblick:
+    - index.md
+    - marketing.md
+    - funktionsweise.md
+- Einstieg & Setup:
+    - installation.md
+    - konfiguration.md
+- Nutzung & Bedienung:
+    - fragenkataloge.md
+    - teams-ergebnisse.md
+    - verwaltung.md
+- Besondere Funktionen:
+    - barrierefreiheit.md
+    - datenschutz.md
+- Hilfe & Rechtliches:
+    - faq.md
+    - lizenz.md
+    - impressum.md
+    - kontakt.md
+- Entwicklung & Updates:
+    - changelog.md

--- a/docs-jtd/barrierefreiheit.md
+++ b/docs-jtd/barrierefreiheit.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Barrierefreiheit
-nav_order: 9
+nav_order: 1
+parent: Besondere Funktionen
 toc: true
 ---
 

--- a/docs-jtd/bedienung.md
+++ b/docs-jtd/bedienung.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Nutzung & Bedienung
+nav_order: 3
+has_children: true
+---
+
+# Nutzung & Bedienung
+
+Anleitung zur alltäglichen Verwendung des Quiz-Systems.

--- a/docs-jtd/besondere-funktionen.md
+++ b/docs-jtd/besondere-funktionen.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Besondere Funktionen
+nav_order: 4
+has_children: true
+---
+
+# Besondere Funktionen
+
+Details zu Barrierefreiheit und Datenschutz.

--- a/docs-jtd/changelog.md
+++ b/docs-jtd/changelog.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Changelog
-nav_order: 13
+nav_order: 1
+parent: Entwicklung & Updates
 toc: true
 ---
 

--- a/docs-jtd/datenschutz.md
+++ b/docs-jtd/datenschutz.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Datenschutz
-nav_order: 10
+nav_order: 2
+parent: Besondere Funktionen
 toc: true
 ---
 

--- a/docs-jtd/einstieg.md
+++ b/docs-jtd/einstieg.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Einstieg & Setup
+nav_order: 2
+has_children: true
+---
+
+# Einstieg & Setup
+
+Kurze Übersicht über Installation und grundlegende Einstellungen.

--- a/docs-jtd/entwicklung.md
+++ b/docs-jtd/entwicklung.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Entwicklung & Updates
+nav_order: 6
+has_children: true
+---
+
+# Entwicklung & Updates
+
+Aktuelle Informationen zum Projektfortschritt.

--- a/docs-jtd/faq.md
+++ b/docs-jtd/faq.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: FAQ
-nav_order: 11
+nav_order: 1
+parent: Hilfe & Rechtliches
 toc: true
 ---
 

--- a/docs-jtd/fragenkataloge.md
+++ b/docs-jtd/fragenkataloge.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Fragenkataloge
-nav_order: 7
+nav_order: 1
+parent: Nutzung & Bedienung
 toc: true
 ---
 

--- a/docs-jtd/funktionsweise.md
+++ b/docs-jtd/funktionsweise.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Funktionsweise
-nav_order: 2
+nav_order: 3
+parent: Start & Überblick
 toc: true
 ---
 

--- a/docs-jtd/hilfe-rechtliches.md
+++ b/docs-jtd/hilfe-rechtliches.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Hilfe & Rechtliches
+nav_order: 5
+has_children: true
+---
+
+# Hilfe & Rechtliches
+
+Antworten auf häufige Fragen und rechtliche Hinweise.

--- a/docs-jtd/impressum.md
+++ b/docs-jtd/impressum.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Impressum
-nav_order: 15
+nav_order: 3
+parent: Hilfe & Rechtliches
 ---
 
 Angaben gemäß § 5 TMG

--- a/docs-jtd/index.md
+++ b/docs-jtd/index.md
@@ -2,6 +2,8 @@
 layout: default
 title: Start
 nav_order: 1
+parent: Start & Überblick
+permalink: /
 ---
 
 # Willkommen zum Sommerfest-Quiz

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Installation & Schnellstart
-nav_order: 4
+nav_order: 1
+parent: Einstieg & Setup
 toc: true
 ---
 

--- a/docs-jtd/konfiguration.md
+++ b/docs-jtd/konfiguration.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Einstellungen & Anpassungen
-nav_order: 5
+nav_order: 2
+parent: Einstieg & Setup
 toc: true
 ---
 

--- a/docs-jtd/kontakt.md
+++ b/docs-jtd/kontakt.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Kontakt
-nav_order: 14
+nav_order: 4
+parent: Hilfe & Rechtliches
 toc: true
 ---
 

--- a/docs-jtd/lizenz.md
+++ b/docs-jtd/lizenz.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Lizenz & Haftung
-nav_order: 12
+nav_order: 2
+parent: Hilfe & Rechtliches
 toc: true
 ---
 

--- a/docs-jtd/marketing.md
+++ b/docs-jtd/marketing.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Vorteile & Nutzen
-nav_order: 3
+nav_order: 2
+parent: Start & Überblick
 toc: true
 ---
 

--- a/docs-jtd/start-ueberblick.md
+++ b/docs-jtd/start-ueberblick.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Start & Überblick
+nav_order: 1
+has_children: true
+---
+
+# Start & Überblick
+
+Kurze Einführung in das Projekt und Zugriff auf weiterführende Seiten.

--- a/docs-jtd/teams-ergebnisse.md
+++ b/docs-jtd/teams-ergebnisse.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Teams & Ergebnisse
-nav_order: 8
+nav_order: 2
+parent: Nutzung & Bedienung
 toc: true
 ---
 

--- a/docs-jtd/verwaltung.md
+++ b/docs-jtd/verwaltung.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Admin & Nutzerverwaltung
-nav_order: 6
+nav_order: 3
+parent: Nutzung & Bedienung
 toc: true
 ---
 


### PR DESCRIPTION
## Summary
- add main sections for Just the Docs navigation
- link existing pages to their sections
- provide `_toc.yml` for alternative sidebar navigation

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68589d35c52c832bb83da99a6441871f