### PR TITLE
Fix handbook icon

### DIFF
--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -22,7 +22,7 @@
     <div class="uk-navbar-right">
       <ul class="uk-navbar-nav">
         <li>
-          <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="book" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
+          <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="icon: book; ratio: 2" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- ensure the handbook button uses the UIkit icon syntax

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6858a02e6fa0832bb8a57251254d133e