### PR TITLE
Fix handbook icon

### DIFF
--- a/public/js/custom-icons.js
+++ b/public/js/custom-icons.js
@@ -1,5 +1,5 @@
 UIkit.icon.add({
   sun: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>',
   moon: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>',
-  handbook: '<svg width="20" height="20" viewBox="0 0 20 20"><path d="M11,10h2.6l0.4-3H11V5.3c0-0.9,0.2-1.5,1.5-1.5H14V1.1c-0.3,0-1-0.1-2.1-0.1C9.6,1,8,2.4,8,5v2H5.5v3H8v8h3V10z"/></svg>'
+  handbook: '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5A2.5 2.5 0 0 1 5.5 2H10v13H5.5A2.5 2.5 0 0 0 3 17.5V4.5z"/><path d="M17 17.5A2.5 2.5 0 0 0 14.5 15H10V2h4.5A2.5 2.5 0 0 1 17 4.5v13z"/></svg>'
 });


### PR DESCRIPTION
## Summary
- update the handbook UI icon to show an open-book instead of Facebook symbol

## Testing
- `pytest`
- `python3 tests/test_html_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6858a2d74808832b9416dab5544dc67a