### PR TITLE
Fix handbook icon placement

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -139,8 +139,10 @@ body.uk-padding {
 }
 
 .bottombar .uk-navbar-item {
-  margin-left: 0.5mm;
-  margin-right: 0.5mm;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   display: flex;
   align-items: center;
 }

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -20,11 +20,9 @@
       </ul>
     </div>
     <div class="uk-navbar-right">
-      <ul class="uk-navbar-nav">
-        <li>
-          <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="icon: handbook; ratio: 2" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
-        </li>
-      </ul>
+      <div class="uk-navbar-item">
+        <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="icon: handbook; ratio: 2" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
+      </div>
     </div>
   </nav>
   <script src="/js/uikit.min.js"></script>


### PR DESCRIPTION
## Summary
- fix bottom bar icon spacing
- wrap the handbook icon in `uk-navbar-item`

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858e5dcd538832b858480af03a812bf