### PR TITLE
Mask example passwords in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
    # Datenbankparameter setzen (Beispielwerte)
    export POSTGRES_DSN="pgsql:host=localhost;dbname=quiz"
    export POSTGRES_USER=quiz
-   export POSTGRES_PASSWORD=quiz
+   export POSTGRES_PASSWORD=***
    export POSTGRES_DB=quiz
 
    # Schema importieren
@@ -262,7 +262,7 @@ Alle wesentlichen Einstellungen stehen in `data/config.json` und werden beim ers
   "buttonColor": "#1e87f0",
   "CheckAnswerButton": "no",
   "adminUser": "admin",
-  "adminPass": "$2b$12$RoNQr1KMGXROQTS1hhqfruEYsr27wiHPgc6hcI71BIpb6./zu6BM2",
+  "adminPass": "***",
   "QRRestrict": false,
   "competitionMode": false,
   "teamResults": true,
@@ -272,7 +272,7 @@ Alle wesentlichen Einstellungen stehen in `data/config.json` und werden beim ers
   "puzzleFeedback": "",
   "postgres_dsn": "pgsql:host=postgres;dbname=quiz",
   "postgres_user": "quiz",
-  "postgres_pass": "quiz"
+  "postgres_pass": "***"
 }
 ```
 

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -24,7 +24,7 @@ toc: true
    ```bash
    export POSTGRES_DSN="pgsql:host=localhost;dbname=quiz"
    export POSTGRES_USER=quiz
-   export POSTGRES_PASSWORD=quiz
+   export POSTGRES_PASSWORD=***
    psql -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql
    for f in migrations/*.sql; do psql -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f "$f"; done
    ```

--- a/docs-jtd/konfiguration.md
+++ b/docs-jtd/konfiguration.md
@@ -32,7 +32,7 @@ Alle wesentlichen Optionen stehen in `data/config.json` und werden beim ersten I
   "puzzleFeedback": "",
   "postgres_dsn": "pgsql:host=postgres;dbname=quiz",
   "postgres_user": "quiz",
-  "postgres_pass": "quiz"
+  "postgres_pass": "***"
 }
 ```
 


### PR DESCRIPTION
## Summary
- hide example credentials in README
- mask POSTGRES password in installation docs
- mask database password in configuration docs

## Testing
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685904898784832b81ccf1e7cc7d3784