### PR TITLE
Mark correct answers in admin preview

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -831,9 +831,12 @@ document.addEventListener('DOMContentLoaded', function () {
         preview.appendChild(ul);
       } else {
         const ul = document.createElement('ul');
-        Array.from(fields.querySelectorAll('.option')).forEach(o => {
+        Array.from(fields.querySelectorAll('.option-row')).forEach(r => {
+          const input = r.querySelector('.option');
+          const check = r.querySelector('.answer').checked;
           const li = document.createElement('li');
-          li.textContent = o.value;
+          li.textContent = input.value + (check ? ' ✓' : '');
+          if (check) li.classList.add('uk-text-success');
           ul.appendChild(li);
         });
         preview.appendChild(ul);


### PR DESCRIPTION
## Summary
- highlight correct multiple-choice options when previewing questions in the admin UI

## Testing
- `phpunit` *(fails: command not found)*
- `pytest -q tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68590aa4750c832bb2c25a25aa0ea8aa