### PR TITLE
Track per-question results

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Alle Resultate werden in der Datenbank abgelegt. Die API bietet folgende Endpunk
 - `POST /results` – fügt ein neues Ergebnis hinzu.
 - `DELETE /results` – löscht alle Einträge.
 - `GET /results/download` – erzeugt eine CSV-Datei mit allen Resultaten.
+- `GET /question-results.json` – listet falsch beantwortete Fragen.
 
 
 ### Passwort ändern

--- a/docs-jtd/teams-ergebnisse.md
+++ b/docs-jtd/teams-ergebnisse.md
@@ -19,6 +19,7 @@ Alle Resultate werden in der Datenbank abgelegt. Die API bietet folgende Endpunk
 - `POST /results` – fügt ein neues Ergebnis hinzu.
 - `DELETE /results` – löscht alle Einträge.
 - `GET /results/download` – erzeugt eine CSV-Datei mit allen Resultaten.
+- `GET /question-results.json` – listet falsch beantwortete Fragen.
 
 Diese Funktionen ermöglichen eine einfache Auswertung und Archivierung der Spielergebnisse.
 

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -47,6 +47,19 @@ CREATE TABLE IF NOT EXISTS results (
 CREATE INDEX idx_results_catalog ON results(catalog);
 CREATE INDEX idx_results_name ON results(name);
 
+-- Per-question answer log
+CREATE TABLE IF NOT EXISTS question_results (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    catalog TEXT NOT NULL,
+    question_id INTEGER NOT NULL,
+    attempt INTEGER NOT NULL,
+    correct INTEGER NOT NULL
+);
+CREATE INDEX idx_qresults_catalog ON question_results(catalog);
+CREATE INDEX idx_qresults_name ON question_results(name);
+CREATE INDEX idx_qresults_question ON question_results(question_id);
+
 -- Catalog definitions
 CREATE TABLE IF NOT EXISTS catalogs (
     uid TEXT PRIMARY KEY,

--- a/migrations/20240628_create_question_results.sql
+++ b/migrations/20240628_create_question_results.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS question_results (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    catalog TEXT NOT NULL,
+    question_id INTEGER NOT NULL,
+    attempt INTEGER NOT NULL,
+    correct INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_qresults_catalog ON question_results(catalog);
+CREATE INDEX IF NOT EXISTS idx_qresults_name ON question_results(name);
+CREATE INDEX IF NOT EXISTS idx_qresults_question ON question_results(question_id);

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -218,10 +218,11 @@ function runQuiz(questions, skipIntro){
       window.startConfetti();
     }
     const catalog = sessionStorage.getItem('quizCatalog') || 'unknown';
+    const wrong = results.map((r,i)=> r ? null : i+1).filter(v=>v!==null);
     fetch('/results', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: user, catalog, correct: score, total: questionCount })
+      body: JSON.stringify({ name: user, catalog, correct: score, total: questionCount, wrong })
     }).catch(()=>{});
     const solved = JSON.parse(sessionStorage.getItem('quizSolved') || '[]');
     if(solved.indexOf(catalog) === -1){

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -82,8 +82,12 @@ document.addEventListener('DOMContentLoaded', () => {
     UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
     closeBtn.addEventListener('click', () => ui.hide());
 
-    Promise.all([fetchCatalogMap(), fetch('/results.json').then(r => r.json())])
-      .then(([catMap, rows]) => {
+    Promise.all([
+      fetchCatalogMap(),
+      fetch('/results.json').then(r => r.json()),
+      fetch('/question-results.json').then(r => r.json())
+    ])
+      .then(([catMap, rows, qrows]) => {
         const filtered = rows.filter(row => row.name === user);
         const map = new Map();
         filtered.forEach(r => {
@@ -115,6 +119,21 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         table.appendChild(tb);
         if(tbodyContainer) tbodyContainer.appendChild(table);
+
+        const wrong = qrows.filter(row => row.name === user && !row.correct);
+        if (wrong.length) {
+          const h = document.createElement('h4');
+          h.textContent = 'Falsch beantwortete Fragen';
+          const ul = document.createElement('ul');
+          wrong.forEach(w => {
+            const li = document.createElement('li');
+            const cat = catMap[w.catalog] || w.catalog;
+            li.textContent = `${cat}: ${w.prompt}`;
+            ul.appendChild(li);
+          });
+          tbodyContainer?.appendChild(h);
+          tbodyContainer?.appendChild(ul);
+        }
       })
       .catch(() => {
         if(tbodyContainer) tbodyContainer.textContent = 'Fehler beim Laden';

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -42,6 +42,16 @@ class ResultController
     }
 
     /**
+     * Return per-question results as JSON.
+     */
+    public function getQuestions(Request $request, Response $response): Response
+    {
+        $content = json_encode($this->service->getQuestionResults(), JSON_PRETTY_PRINT);
+        $response->getBody()->write($content);
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    /**
      * Download all results as a CSV file.
      */
     public function download(Request $request, Response $response): Response

--- a/src/routes.php
+++ b/src/routes.php
@@ -123,6 +123,7 @@ return function (\Slim\App $app) {
     $app->get('/admin/kataloge', AdminCatalogController::class)->add(new AdminAuthMiddleware());
     $app->get('/results', [$resultController, 'page']);
     $app->get('/results.json', [$resultController, 'get']);
+    $app->get('/question-results.json', [$resultController, 'getQuestions']);
     $app->get('/results/download', [$resultController, 'download']);
     $app->post('/results', [$resultController, 'post']);
     $app->delete('/results', [$resultController, 'delete']);

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -40,6 +40,13 @@
         {% endfor %}
       </tbody>
     </table>
+    <h3 class="uk-heading-bullet">Falsch beantwortete Fragen</h3>
+    <table class="uk-table uk-table-divider">
+      <thead>
+        <tr><th>Name</th><th>Katalog</th><th>Frage</th></tr>
+      </thead>
+      <tbody id="wrongTableBody"></tbody>
+    </table>
     <ul id="resultsPagination" class="uk-pagination uk-flex-center"></ul>
   </div>
 {% endblock %}

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class ResultControllerTest extends TestCase
+{
+    public function testQuestionResultsEndpoint(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/question-results.json');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -64,4 +64,28 @@ class ResultServiceTest extends TestCase
         $stmt = $pdo->query('SELECT photo FROM results');
         $this->assertSame('/photo/test.jpg', $stmt->fetchColumn());
     }
+
+    public function testAddStoresQuestionResults(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $pdo->exec('CREATE TABLE question_results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, question_id INTEGER NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL);');
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
+        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES('u1',1,'cat1','c.json','C')");
+        $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u1',1,'text','Q1')");
+        $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u1',2,'text','Q2')");
+
+        $service = new ResultService($pdo);
+        $service->add(['name' => 'Team', 'catalog' => 'cat1', 'correct' => 1, 'total' => 2, 'wrong' => [2]]);
+
+        $stmt = $pdo->query('SELECT question_id, correct FROM question_results ORDER BY id');
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $this->assertCount(2, $rows);
+        $this->assertSame('1', (string)$rows[0]['question_id']);
+        $this->assertSame('1', (string)$rows[0]['correct']);
+        $this->assertSame('2', (string)$rows[1]['question_id']);
+        $this->assertSame('0', (string)$rows[1]['correct']);
+    }
 }


### PR DESCRIPTION
## Summary
- extend schema with `question_results`
- log incorrect answers in `ResultService`
- expose `/question-results.json` endpoint
- upload wrong question ids from quiz frontend
- show wrong answers on results and summary views
- document new endpoint
- add basic tests

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_68592c1e3170832b96b5a94449cc4f4f