### PR TITLE
Add short tooltips for catalog headers

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -218,11 +218,11 @@
               <thead>
                 <tr>
                   <th uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></th>
-                  <th uk-tooltip="title: Eindeutiger Name in der URL; pos: top">Slug</th>
-                  <th uk-tooltip="title: Angezeigter Titel des Katalogs; pos: top">Name</th>
-                  <th uk-tooltip="title: Beschreibung auf der Startseite des Katalogs; pos: top">Beschreibung</th>
-                  <th uk-tooltip="title: Buchstabe für das Rätselwort; pos: top">Buchstabe</th>
-                  <th uk-tooltip="title: Interne Notiz; pos: top">Kommentar</th>
+                  <th uk-tooltip="title: URL-Name; pos: top">Slug</th>
+                  <th uk-tooltip="title: Katalogtitel; pos: top">Name</th>
+                  <th uk-tooltip="title: Katalogbeschreibung; pos: top">Beschreibung</th>
+                  <th uk-tooltip="title: Rätselbuchstabe; pos: top">Buchstabe</th>
+                  <th uk-tooltip="title: Notiz; pos: top">Kommentar</th>
                   <th uk-tooltip="title: Katalog entfernen; pos: top"></th>
                 </tr>
               </thead>


### PR DESCRIPTION
## Summary
- shorten catalog header tooltips

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py -vv`
- ❌ `composer install` *(fails: command not found)*
- ❌ `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685936a79ba8832b9993ce5ac0114f9e