### PR TITLE
Fix catalog header tooltips

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -175,6 +175,18 @@
     const container = document.getElementById('quiz');
     if(!container) return;
     container.innerHTML = '';
+    const comment = sessionStorage.getItem('quizCatalogComment');
+    if(comment){
+      const note = document.createElement('div');
+      note.className = 'uk-card uk-card-default uk-card-body uk-margin';
+      note.style.whiteSpace = 'pre-wrap';
+      if(comment.indexOf('<') !== -1){
+        note.innerHTML = comment;
+      } else {
+        note.textContent = comment;
+      }
+      container.appendChild(note);
+    }
     const btn = document.createElement('button');
     btn.className = 'uk-button uk-button-primary uk-button-large uk-align-right';
     btn.textContent = 'Los geht es!';

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -217,13 +217,27 @@
             <table class="uk-table uk-table-divider uk-table-small">
               <thead>
                 <tr>
-                  <th uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></th>
-                  <th uk-tooltip="title: Eindeutiger Name in der URL; pos: top">Slug</th>
-                  <th uk-tooltip="title: Angezeigter Titel des Katalogs; pos: top">Name</th>
-                  <th uk-tooltip="title: Beschreibung auf der Startseite des Katalogs; pos: top">Beschreibung</th>
-                  <th uk-tooltip="title: Buchstabe für das Rätselwort; pos: top">Buchstabe</th>
-                  <th uk-tooltip="title: Interne Notiz; pos: top">Kommentar</th>
-                  <th uk-tooltip="title: Katalog entfernen; pos: top"></th>
+                  <th>
+                    <span uk-icon="icon: question" uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></span>
+                  </th>
+                  <th>Slug
+                    <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Eindeutiger Name in der URL; pos: top"></span>
+                  </th>
+                  <th>Name
+                    <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Angezeigter Titel des Katalogs; pos: top"></span>
+                  </th>
+                  <th>Beschreibung
+                    <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Beschreibung auf der Startseite des Katalogs; pos: top"></span>
+                  </th>
+                  <th>Buchstabe
+                    <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Buchstabe für das Rätselwort; pos: top"></span>
+                  </th>
+                  <th>Kommentar
+                    <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Interne Notiz; pos: top"></span>
+                  </th>
+                  <th>
+                    <span uk-icon="icon: question" uk-tooltip="title: Katalog entfernen; pos: top"></span>
+                  </th>
                 </tr>
               </thead>
               <tbody id="catalogList" uk-sortable="group: sortable-group"></tbody>


### PR DESCRIPTION
## Summary
- display explanatory catalog tooltips via question icons
- show the catalog comment as info on the start page

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_685936a79ba8832b9993ce5ac0114f9e