### PR TITLE
Verbesserter Kommentar-Infoblock

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -92,6 +92,10 @@ body.dark-mode .topbar {
   border-color: #444;
 }
 
+body.dark-mode .modern-info-card {
+  border-color: #444;
+}
+
 body.dark-mode .uk-icon,
 body.dark-mode .uk-icon-button {
   color: #f5f5f5;

--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -12,6 +12,9 @@ body.high-contrast .uk-card-default {
   color: #000000;
   border-color: #000000;
 }
+body.high-contrast .modern-info-card {
+  border-color: #000000;
+}
 body.high-contrast .uk-button-primary {
   background-color: #000000;
   border-color: #000000;
@@ -69,6 +72,9 @@ body.dark-mode.high-contrast a {
 body.dark-mode.high-contrast .uk-card-default {
   background-color: #000000;
   color: #ffffff;
+  border-color: #ffffff;
+}
+body.dark-mode.high-contrast .modern-info-card {
   border-color: #ffffff;
 }
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -346,3 +346,37 @@ body.dark-mode .sticky-actions {
   width: 100%;
 }
 
+/* Stylized info card for catalog comments */
+.modern-info-card {
+  border-radius: 1.5rem;
+  box-shadow: 0 6px 30px rgba(0,0,0,0.08);
+  border: 1.5px solid #f3f4f6;
+  padding: 2rem 1.5rem;
+  margin: 1.5rem auto;
+  max-width: 500px;
+}
+
+.modern-info-card .uk-card-title {
+  font-size: 1.3rem;
+  margin-bottom: 1rem;
+  color: #1e293b;
+}
+
+.modern-info-card p {
+  font-size: 1.08rem;
+  line-height: 1.8;
+  color: #212529;
+}
+
+.uk-text-danger.uk-text-italic {
+  color: #e54b4b !important;
+  font-style: italic;
+}
+
+@media (max-width: 600px) {
+  .modern-info-card {
+    padding: 1.1rem 0.7rem;
+    max-width: 98vw;
+  }
+}
+

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -20,7 +20,7 @@
     if(!block){
       block = document.createElement('div');
       block.dataset.role = 'catalog-comment-block';
-      block.className = 'uk-card uk-card-default uk-card-body uk-margin';
+      block.className = 'modern-info-card uk-card uk-card-default uk-card-body uk-box-shadow-medium uk-margin';
       block.style.whiteSpace = 'pre-wrap';
       headerEl.appendChild(block);
     }


### PR DESCRIPTION
## Summary
- style catalog comment block as modern info card
- add dark & high contrast variants

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685943ba8a6c832b9c0b5444612a28e7