### PR TITLE
Add H3/H4/H5 buttons for catalog comments

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -110,6 +110,12 @@ document.addEventListener('DOMContentLoaded', function () {
       case 'h3':
         wrapSelection(commentTextarea, '<h3>', '</h3>');
         break;
+      case 'h4':
+        wrapSelection(commentTextarea, '<h4>', '</h4>');
+        break;
+      case 'h5':
+        wrapSelection(commentTextarea, '<h5>', '</h5>');
+        break;
       case 'bold':
         wrapSelection(commentTextarea, '<strong>', '</strong>');
         break;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -196,6 +196,8 @@
             <div id="catalogCommentToolbar" class="uk-margin-small-bottom">
               <button class="uk-button uk-button-default" type="button" data-format="h2">H2</button>
               <button class="uk-button uk-button-default" type="button" data-format="h3">H3</button>
+              <button class="uk-button uk-button-default" type="button" data-format="h4">H4</button>
+              <button class="uk-button uk-button-default" type="button" data-format="h5">H5</button>
               <button class="uk-button uk-button-default" type="button" data-format="bold"><strong>B</strong></button>
               <button class="uk-button uk-button-default" type="button" data-format="italic"><em>I</em></button>
             </div>


### PR DESCRIPTION
## Summary
- add H4 button in catalog comment editor toolbar
- handle new H4 format in admin JS

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68593f67079c832bb8b66951d2b02335