### PR TITLE
Fix style in config settings

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -1,4 +1,5 @@
 <?php
+
 $path = __DIR__ . '/../data/config.json';
 $settings = [];
 if (file_exists($path)) {
@@ -25,8 +26,8 @@ $settings += [
 
 $settings['postgres_dsn'] = getenv('POSTGRES_DSN') ?: ($settings['postgres_dsn'] ?? null);
 $settings['postgres_user'] = getenv('POSTGRES_USER') ?: ($settings['postgres_user'] ?? null);
-$settings['postgres_pass'] = getenv('POSTGRES_PASSWORD') ?: getenv('POSTGRES_PASS') ?: ($settings['postgres_pass'] ?? null);
-
-
+$settings['postgres_pass'] = getenv('POSTGRES_PASSWORD')
+    ?: getenv('POSTGRES_PASS')
+    ?: ($settings['postgres_pass'] ?? null);
 
 return $settings;


### PR DESCRIPTION
## Summary
- fix PSR-12 header formatting in `config/settings.php`
- wrap long line for postgres password settings

## Testing
- `node tests/test_competition_mode.js`
- `pytest -q`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a8c8383c832bab83e8581bfc190b