### PR TITLE
Fix catalog names in results list

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -41,6 +41,9 @@ class AdminController
                 if (isset($c['sort_order'])) {
                     $catMap[$c['sort_order']] = $name;
                 }
+                if (isset($c['slug'])) {
+                    $catMap[$c['slug']] = $name;
+                }
             }
         }
         foreach ($results as &$row) {

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -112,6 +112,9 @@ class ResultController
                 if (isset($c['sort_order'])) {
                     $map[$c['sort_order']] = $name;
                 }
+                if (isset($c['slug'])) {
+                    $map[$c['slug']] = $name;
+                }
             }
         }
         foreach ($results as &$row) {

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -31,6 +31,7 @@ class ResultService
             . 'FROM results r '
             . 'LEFT JOIN catalogs c ON c.uid = r.catalog '
             . 'OR CAST(c.sort_order AS TEXT) = r.catalog '
+            . 'OR c.slug = r.catalog '
             . 'ORDER BY r.id';
         $stmt = $this->pdo->query($sql);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -47,6 +48,7 @@ class ResultService
             . 'LEFT JOIN questions q ON q.id = qr.question_id '
             . 'LEFT JOIN catalogs c ON c.uid = q.catalog_uid '
             . 'OR CAST(c.sort_order AS TEXT) = qr.catalog '
+            . 'OR c.slug = qr.catalog '
             . 'ORDER BY qr.id';
         $stmt = $this->pdo->query($sql);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- map slugs to names so the admin results table always shows catalog names
- recognize slug when joining catalogs table for result queries

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b5bb6cf0832bb7f576b9070d2f39