### PR TITLE
Fix catalog name display in results

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -263,9 +263,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const map = {};
         if (Array.isArray(list)) {
           list.forEach(c => {
-            const name = c.name || c.sort_order || '';
+            const name = c.name || '';
             if (c.uid) map[c.uid] = name;
             if (c.sort_order) map[c.sort_order] = name;
+            if (c.slug) map[c.slug] = name;
           });
         }
         catalogMap = map;
@@ -285,6 +286,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ])
       .then(([catMap, rows, qrows]) => {
         rows.forEach(r => {
+          if (!r.catalogName && catMap[r.catalog]) r.catalogName = catMap[r.catalog];
           if (catMap[r.catalog]) r.catalog = catMap[r.catalog];
         });
         rows.sort((a, b) => b.time - a.time);
@@ -297,6 +299,7 @@ document.addEventListener('DOMContentLoaded', () => {
         renderRankings(rankings);
 
         qrows.forEach(r => {
+          if (!r.catalogName && catMap[r.catalog]) r.catalogName = catMap[r.catalog];
           if (catMap[r.catalog]) r.catalog = catMap[r.catalog];
         });
         const wrongOnly = qrows.filter(r => !r.correct);

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -23,9 +23,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const map = {};
         if (Array.isArray(list)) {
           list.forEach(c => {
-            const name = c.name || c.sort_order || '';
+            const name = c.name || '';
             if (c.uid) map[c.uid] = name;
             if (c.sort_order) map[c.sort_order] = name;
+            if (c.slug) map[c.slug] = name;
           });
         }
         catalogMap = map;

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -34,7 +34,7 @@ class AdminController
         if ($catalogsJson !== null) {
             $catalogs = json_decode($catalogsJson, true) ?? [];
             foreach ($catalogs as $c) {
-                $name = $c['name'] ?? ($c['sort_order'] ?? '');
+                $name = $c['name'] ?? '';
                 if (isset($c['uid'])) {
                     $catMap[$c['uid']] = $name;
                 }

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -105,7 +105,7 @@ class ResultController
         if ($json !== null) {
             $list = json_decode($json, true) ?: [];
             foreach ($list as $c) {
-                $name = $c['name'] ?? ($c['sort_order'] ?? '');
+                $name = $c['name'] ?? '';
                 if (isset($c['uid'])) {
                     $map[$c['uid']] = $name;
                 }


### PR DESCRIPTION
## Summary
- ensure JS and controllers use catalog `name` for result labels
- avoid slug or order fallback to keep user-friendly display

## Testing
- `node tests/test_competition_mode.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859b76444f8832b87d80346fdfa4267