### PR TITLE
Fix catalog name display in CSV export

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -161,7 +161,7 @@ class ResultController
         return [
             (string)($r['name'] ?? ''),
             (int)($r['attempt'] ?? 0),
-            (string)($r['catalog'] ?? ''),
+            (string)($r['catalogName'] ?? $r['catalog'] ?? ''),
             (int)($r['correct'] ?? 0),
             (int)($r['total'] ?? 0),
             date('Y-m-d H:i', (int)($r['time'] ?? 0)),


### PR DESCRIPTION
## Summary
- show catalog name if available when exporting results to CSV

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6859bb72ddb8832b843738d86776a905