### PR TITLE
Fix summary catalog names

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -257,7 +257,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function fetchCatalogMap() {
     if (catalogMap) return Promise.resolve(catalogMap);
-    return fetch('/kataloge/catalogs.json')
+    return fetch('/kataloge/catalogs.json', { headers: { 'Accept': 'application/json' } })
       .then(r => r.json())
       .then(list => {
         const map = {};

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let catalogMap = null;
   function fetchCatalogMap() {
     if (catalogMap) return Promise.resolve(catalogMap);
-    return fetch('/kataloge/catalogs.json')
+    return fetch('/kataloge/catalogs.json', { headers: { 'Accept': 'application/json' } })
       .then(r => r.json())
       .then(list => {
         const map = {};


### PR DESCRIPTION
## Summary
- ensure catalog list is fetched as JSON
- same fix for admin results script

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bc0e9534832b85e7b5572be11d69