### PR TITLE
Use catalog names in results display

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -266,6 +266,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const name = c.name || c.sort_order || '';
             if (c.uid) map[c.uid] = name;
             if (c.sort_order) map[c.sort_order] = name;
+            if (c.slug) map[c.slug] = name;
           });
         }
         catalogMap = map;
@@ -285,7 +286,9 @@ document.addEventListener('DOMContentLoaded', () => {
     ])
       .then(([catMap, rows, qrows]) => {
         rows.forEach(r => {
-          if (catMap[r.catalog]) r.catalog = catMap[r.catalog];
+          if (catMap[r.catalog]) {
+            r.catalogName = catMap[r.catalog];
+          }
         });
         rows.sort((a, b) => b.time - a.time);
         resultsData = rows;
@@ -297,7 +300,9 @@ document.addEventListener('DOMContentLoaded', () => {
         renderRankings(rankings);
 
         qrows.forEach(r => {
-          if (catMap[r.catalog]) r.catalog = catMap[r.catalog];
+          if (catMap[r.catalog]) {
+            r.catalogName = catMap[r.catalog];
+          }
         });
         const wrongOnly = qrows.filter(r => !r.correct);
         renderWrongTable(wrongOnly);

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const name = c.name || c.sort_order || '';
             if (c.uid) map[c.uid] = name;
             if (c.sort_order) map[c.sort_order] = name;
+            if (c.slug) map[c.slug] = name;
           });
         }
         catalogMap = map;
@@ -65,6 +66,61 @@ document.addEventListener('DOMContentLoaded', () => {
     }else{
       if(puzzleInfo) puzzleInfo.textContent = '';
     }
+  }
+
+  function renderQuestionPreview(q, catMap){
+    const card = document.createElement('div');
+    card.className = 'uk-card uk-card-muted uk-card-body question-preview';
+    const title = document.createElement('h5');
+    const cat = q.catalogName || catMap[q.catalog] || q.catalog;
+    title.textContent = cat;
+    card.appendChild(title);
+
+    const h = document.createElement('h4');
+    h.textContent = q.prompt || '';
+    card.appendChild(h);
+
+    const type = q.type || 'mc';
+    if(type === 'sort' && Array.isArray(q.items)){
+      const ul = document.createElement('ul');
+      q.items.forEach(it => {
+        const li = document.createElement('li');
+        li.textContent = it;
+        ul.appendChild(li);
+      });
+      card.appendChild(ul);
+    }else if(type === 'assign' && Array.isArray(q.terms)){
+      const ul = document.createElement('ul');
+      q.terms.forEach(p => {
+        const li = document.createElement('li');
+        li.textContent = (p.term || '') + ' – ' + (p.definition || '');
+        ul.appendChild(li);
+      });
+      card.appendChild(ul);
+    }else if(type === 'swipe' && Array.isArray(q.cards)){
+      const ul = document.createElement('ul');
+      q.cards.forEach(c => {
+        const li = document.createElement('li');
+        li.textContent = c.text + (c.correct ? ' ✓' : '');
+        ul.appendChild(li);
+      });
+      card.appendChild(ul);
+    }else{
+      const ul = document.createElement('ul');
+      if(Array.isArray(q.options)){
+        const answers = Array.isArray(q.answers) ? q.answers : [];
+        q.options.forEach((opt, i) => {
+          const li = document.createElement('li');
+          const correct = answers.includes(i);
+          li.textContent = opt + (correct ? ' ✓' : '');
+          if(correct) li.classList.add('uk-text-success');
+          ul.appendChild(li);
+        });
+      }
+      card.appendChild(ul);
+    }
+
+    return card;
   }
 
   function showResults(){
@@ -127,15 +183,7 @@ document.addEventListener('DOMContentLoaded', () => {
           h.textContent = 'Falsch beantwortete Fragen';
           tbodyContainer?.appendChild(h);
           wrong.forEach(w => {
-            const card = document.createElement('div');
-            card.className = 'uk-card uk-card-muted uk-card-body question-preview';
-            const title = document.createElement('h5');
-            const cat = w.catalogName || catMap[w.catalog] || w.catalog;
-            title.textContent = cat;
-            const prompt = document.createElement('p');
-            prompt.textContent = w.prompt || '';
-            card.appendChild(title);
-            card.appendChild(prompt);
+            const card = renderQuestionPreview(w, catMap);
             tbodyContainer?.appendChild(card);
           });
         }

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -34,7 +34,17 @@ class ResultService
             . 'OR c.slug = r.catalog '
             . 'ORDER BY r.id';
         $stmt = $this->pdo->query($sql);
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($rows as &$row) {
+            foreach (["options","answers","terms","items"] as $k) {
+                if (isset($row[$k]) && $row[$k] !== null) {
+                    $row[$k] = json_decode((string)$row[$k], true);
+                } else {
+                    unset($row[$k]);
+                }
+            }
+        }
+        return $rows;
     }
 
     /**
@@ -43,7 +53,8 @@ class ResultService
     public function getQuestionResults(): array
     {
         $sql = 'SELECT qr.name, qr.catalog, qr.question_id, qr.attempt, qr.correct,' .
-            ' q.prompt, c.name AS catalogName '
+            ' q.type, q.prompt, q.options, q.answers, q.terms, q.items,' .
+            ' c.name AS catalogName '
             . 'FROM question_results qr '
             . 'LEFT JOIN questions q ON q.id = qr.question_id '
             . 'LEFT JOIN catalogs c ON c.uid = q.catalog_uid '
@@ -51,7 +62,17 @@ class ResultService
             . 'OR c.slug = qr.catalog '
             . 'ORDER BY qr.id';
         $stmt = $this->pdo->query($sql);
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($rows as &$row) {
+            foreach (["options", "answers", "terms", "items"] as $k) {
+                if (isset($row[$k]) && $row[$k] !== null) {
+                    $row[$k] = json_decode((string) $row[$k], true);
+                } else {
+                    unset($row[$k]);
+                }
+            }
+        }
+        return $rows;
     }
 
     /**


### PR DESCRIPTION
## Summary
- include catalog slug mapping when loading catalog names
- preserve catalog UIDs internally and use the mapped name for display only

## Testing
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6859b9f1754c832b93b6bd2368c6a738