### PR TITLE
Show team name in summary results modal

### DIFF
--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -129,6 +129,7 @@ document.addEventListener('DOMContentLoaded', () => {
     modal.setAttribute('aria-modal', 'true');
     modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">' +
       '<h3 class="uk-modal-title uk-text-center">Ergebnisübersicht</h3>' +
+      '<p class="uk-text-center">' + user + '</p>' +
       '<div id="team-results" class="uk-overflow-auto"></div>' +
       '<button class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Schließen</button>' +
       '</div>';


### PR DESCRIPTION
## Summary
- show the current team name under the "Ergebnisübersicht" heading in the summary modal

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_6859bf58125c832b9c5da4adf0857bf4