### PR TITLE
Filter puzzle word for guests

### DIFF
--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -28,11 +28,18 @@ class ConfigController
      */
     public function get(Request $request, Response $response): Response
     {
-        $content = $this->service->getJson();
-        if ($content === null) {
+        $cfg = $this->service->getConfig();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        if (empty($_SESSION['admin'])) {
+            $cfg = ConfigService::removePuzzleInfo($cfg);
+        }
+        if ($cfg === []) {
             return $response->withStatus(404);
         }
 
+        $content = json_encode($cfg, JSON_PRETTY_PRINT);
         $response->getBody()->write($content);
         return $response->withHeader('Content-Type', 'application/json');
     }

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -23,6 +23,12 @@ class HelpController
         $view = Twig::fromRequest($request);
         $pdo = Database::connectFromEnv();
         $cfg = (new ConfigService($pdo))->getConfig();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        if (empty($_SESSION['admin'])) {
+            $cfg = ConfigService::removePuzzleInfo($cfg);
+        }
 
         return $view->render($response, 'help.twig', ['config' => $cfg]);
     }

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -24,6 +24,12 @@ class HomeController
         $view = Twig::fromRequest($request);
         $pdo = Database::connectFromEnv();
         $cfg = (new ConfigService($pdo))->getConfig();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        if (empty($_SESSION['admin'])) {
+            $cfg = ConfigService::removePuzzleInfo($cfg);
+        }
 
         $catalogService = new CatalogService($pdo);
 

--- a/src/Controller/SummaryController.php
+++ b/src/Controller/SummaryController.php
@@ -31,6 +31,12 @@ class SummaryController
     {
         $view = Twig::fromRequest($request);
         $cfg = $this->config->getConfig();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        if (empty($_SESSION['admin'])) {
+            $cfg = ConfigService::removePuzzleInfo($cfg);
+        }
         return $view->render($response, 'summary.twig', ['config' => $cfg]);
     }
 }

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -47,6 +47,18 @@ class ConfigService
     }
 
     /**
+     * Remove puzzle word fields from the configuration array.
+     *
+     * @param array<string,mixed> $cfg
+     * @return array<string,mixed>
+     */
+    public static function removePuzzleInfo(array $cfg): array
+    {
+        unset($cfg['puzzleWord'], $cfg['puzzleFeedback']);
+        return $cfg;
+    }
+
+    /**
      * Replace stored configuration with new values.
      */
     public function saveConfig(array $data): void


### PR DESCRIPTION
## Summary
- remove puzzle details for non-admins
- sanitize config before embedding in views
- hide puzzle fields on `/config.json`

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c384309c832b810ab7339e116e4e