### PR TITLE
Add puzzle word verification

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1023,7 +1023,8 @@ function runQuiz(questions, skipIntro){
     UIkit.util.on(modal, 'shown', () => { input.focus(); });
     function handleCheck(){
       const expected = (window.quizConfig && window.quizConfig.puzzleWord) ? window.quizConfig.puzzleWord.toLowerCase() : '';
-      const val = (input.value || '').trim().toLowerCase();
+      const valRaw = (input.value || '').trim();
+      const val = valRaw.toLowerCase();
       if(val && val === expected){
         const custom = (window.quizConfig && window.quizConfig.puzzleFeedback) ? window.quizConfig.puzzleFeedback.trim() : '';
         feedback.textContent = custom || 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
@@ -1036,7 +1037,7 @@ function runQuiz(questions, skipIntro){
         fetch('/results', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: user, catalog, puzzleTime: ts })
+          body: JSON.stringify({ name: user, catalog, puzzleTime: ts, puzzleAnswer: valRaw })
         }).catch(()=>{});
         const infoEl = summaryEl.querySelector('#puzzle-info');
         fetchLatestPuzzleEntry(user, catalog).then(entry => {

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -217,7 +217,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const expected = (window.quizConfig && window.quizConfig.puzzleWord) ? window.quizConfig.puzzleWord : '';
     const custom = (window.quizConfig && window.quizConfig.puzzleFeedback) ? window.quizConfig.puzzleFeedback.trim() : '';
     function handleCheck(){
-        const val = (input.value || '').trim().toLowerCase();
+        const valRaw = (input.value || '').trim();
+        const val = valRaw.toLowerCase();
         if(val && val === expected.toLowerCase()){
           feedback.textContent = custom || 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
           feedback.className = 'uk-margin-top uk-text-center uk-text-success';
@@ -229,7 +230,7 @@ document.addEventListener('DOMContentLoaded', () => {
           fetch('/results', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: userName, catalog, puzzleTime: ts })
+            body: JSON.stringify({ name: userName, catalog, puzzleTime: ts, puzzleAnswer: valRaw })
           }).catch(()=>{});
           updatePuzzleInfo();
           input.disabled = true;

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -82,7 +82,11 @@ class ResultController
                 $name = (string)($data['name'] ?? '');
                 $catalog = (string)($data['catalog'] ?? '');
                 $time = (int)$data['puzzleTime'];
-                $this->service->markPuzzle($name, $catalog, $time);
+                $answer = (string)($data['puzzleAnswer'] ?? '');
+                $expected = (string)($this->config->getConfig()['puzzleWord'] ?? '');
+                if ($answer !== '' && strcasecmp(trim($answer), $expected) === 0) {
+                    $this->service->markPuzzle($name, $catalog, $time);
+                }
             } else {
                 $this->service->add($data);
             }


### PR DESCRIPTION
## Summary
- verify puzzle word in `ResultController::post`
- send puzzle answer when solving puzzle

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_6859c3a024e8832b88e8a8c6cf147ce1