### PR TITLE
Fix puzzle word check for UTF‑8 characters

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -84,7 +84,9 @@ class ResultController
                 $time = (int)$data['puzzleTime'];
                 $answer = (string)($data['puzzleAnswer'] ?? '');
                 $expected = (string)($this->config->getConfig()['puzzleWord'] ?? '');
-                if ($answer !== '' && strcasecmp(trim($answer), $expected) === 0) {
+                $a = mb_strtolower(trim($answer), 'UTF-8');
+                $e = mb_strtolower($expected, 'UTF-8');
+                if ($a !== '' && $a === $e) {
                     $this->service->markPuzzle($name, $catalog, $time);
                 }
             } else {


### PR DESCRIPTION
## Summary
- improve puzzle word check to use `mb_strtolower`

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6859c6c35080832b9ca86ea6173285c9