### PR TITLE
Fix puzzle word check

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -85,7 +85,7 @@ class ResultController
                 $answer = (string)($data['puzzleAnswer'] ?? '');
                 $expected = (string)($this->config->getConfig()['puzzleWord'] ?? '');
                 $a = mb_strtolower(trim($answer), 'UTF-8');
-                $e = mb_strtolower($expected, 'UTF-8');
+                $e = mb_strtolower(trim($expected), 'UTF-8');
                 if ($a !== '' && $a === $e) {
                     $this->service->markPuzzle($name, $catalog, $time);
                 }


### PR DESCRIPTION
## Summary
- trim expected puzzle word before comparison to avoid trailing whitespace mismatches

## Testing
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6859c997dccc832bb584e9aef359c056