### PR TITLE
Improve puzzle word verification reliability

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -1,6 +1,15 @@
 /* global UIkit, Html5Qrcode, generateUserName */
 // Lädt die verfügbaren Fragenkataloge und startet nach Auswahl das Quiz
 (function(){
+  function setStored(key, value){
+    try{
+      sessionStorage.setItem(key, value);
+      localStorage.setItem(key, value);
+    }catch(e){}
+  }
+  function getStored(key){
+    return sessionStorage.getItem(key) || localStorage.getItem(key);
+  }
   function setSubHeader(text){
     const headerEl = document.getElementById('quiz-header');
     if(!headerEl) return;
@@ -72,7 +81,7 @@
     const headerEl = document.getElementById('quiz-header');
     if(!headerEl) return;
     let nameEl = document.getElementById('quiz-user-name');
-    const user = sessionStorage.getItem('quizUser');
+    const user = getStored('quizUser');
     if(!nameEl){
       if(!user) return;
       nameEl = document.createElement('p');
@@ -119,7 +128,7 @@
   }
 
   async function loadQuestions(id, file, letter, uid, name, desc, comment){
-    sessionStorage.setItem('quizCatalog', uid || id);
+    setStored('quizCatalog', uid || id);
     sessionStorage.setItem('quizCatalogName', name || id);
     if(desc !== undefined){
       sessionStorage.setItem('quizCatalogDesc', desc);
@@ -327,7 +336,7 @@
           bypass.style.color = '#fff';
         }
         bypass.addEventListener('click', () => {
-          sessionStorage.setItem('quizUser', generateUserName());
+          setStored('quizUser', generateUserName());
           sessionStorage.removeItem('quizSolved');
           updateUserName();
           onDone();
@@ -370,7 +379,7 @@
               alert('Unbekanntes oder nicht berechtigtes Team/Person');
               return;
             }
-              sessionStorage.setItem('quizUser', name);
+              setStored('quizUser', name);
               sessionStorage.removeItem('quizSolved');
               updateUserName();
             stopScanner();
@@ -441,7 +450,7 @@
             alert('Nur Registrierung per QR-Code erlaubt');
             return;
           }
-          sessionStorage.setItem('quizUser', generateUserName());
+          setStored('quizUser', generateUserName());
           sessionStorage.removeItem('quizSolved');
           updateUserName();
           onDone();
@@ -463,7 +472,7 @@
         const r = await fetch('/results.json', {headers:{'Accept':'application/json'}});
         if(r.ok){
           const data = await r.json();
-          const user = sessionStorage.getItem('quizUser');
+          const user = getStored('quizUser');
           data.forEach(entry => {
             if(entry.name === user){
               solved.add(entry.catalog);
@@ -483,7 +492,14 @@
     if(cfg.QRRestrict){
       sessionStorage.removeItem('quizUser');
       sessionStorage.removeItem('quizSolved');
+      localStorage.removeItem('quizUser');
     }
+    ['quizUser','quizCatalog'].forEach(k => {
+      const v = localStorage.getItem(k);
+      if(v && !sessionStorage.getItem(k)){
+        sessionStorage.setItem(k, v);
+      }
+    });
     applyConfig();
     updateUserName();
     const catalogs = await loadCatalogList();
@@ -512,9 +528,9 @@
     if((window.quizConfig || {}).QRUser){
       showLogin(proceed, !!id);
     }else{
-      if(!sessionStorage.getItem('quizUser')){
+      if(!getStored('quizUser')){
           if(!cfg.QRRestrict){
-            sessionStorage.setItem('quizUser', generateUserName());
+            setStored('quizUser', generateUserName());
             sessionStorage.removeItem('quizSolved');
           }
         }

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -1,4 +1,13 @@
 /* global UIkit */
+function getStored(key){
+  return sessionStorage.getItem(key) || localStorage.getItem(key);
+}
+function setStored(key, value){
+  try{
+    sessionStorage.setItem(key, value);
+    localStorage.setItem(key, value);
+  }catch(e){}
+}
 document.addEventListener('DOMContentLoaded', () => {
   const resultsBtn = document.getElementById('show-results-btn');
   const puzzleBtn = document.getElementById('check-puzzle-btn');
@@ -12,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
     photoBtn.remove();
   }
   const puzzleInfo = document.getElementById('puzzle-solved-text');
-  const user = sessionStorage.getItem('quizUser') || '';
+  const user = getStored('quizUser') || '';
 
   let catalogMap = null;
   function fetchCatalogMap() {
@@ -55,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function updatePuzzleInfo(){
     const solved = sessionStorage.getItem('puzzleSolved') === 'true';
-    const catalog = sessionStorage.getItem('quizCatalog') || 'unknown';
+    const catalog = getStored('quizCatalog') || 'unknown';
     if(solved){
       if (puzzleBtn) puzzleBtn.remove();
       fetchEntry(user, catalog).then(entry => {
@@ -217,8 +226,8 @@ document.addEventListener('DOMContentLoaded', () => {
     function handleCheck(){
         const valRaw = (input.value || '').trim();
         const ts = Math.floor(Date.now()/1000);
-        const userName = sessionStorage.getItem('quizUser') || '';
-        const catalog = sessionStorage.getItem('quizCatalog') || 'unknown';
+        const userName = getStored('quizUser') || '';
+        const catalog = getStored('quizCatalog') || 'unknown';
         fetch('/results', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- persist quiz user and catalog in `localStorage`
- restore stored values on page load
- update puzzle checking to use persistent storage

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(failed: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a2d9eb458832bab49cd6c1a7b43e6