### PR TITLE
Add config fallback for puzzle check

### DIFF
--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -43,7 +43,19 @@ class ConfigService
     {
         $stmt = $this->pdo->query('SELECT * FROM config LIMIT 1');
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $row ? $this->normalizeKeys($row) : [];
+        if ($row) {
+            return $this->normalizeKeys($row);
+        }
+
+        $path = dirname(__DIR__, 2) . '/data/config.json';
+        if (is_readable($path)) {
+            $json = json_decode(file_get_contents($path), true);
+            if (is_array($json)) {
+                return $json;
+            }
+        }
+
+        return [];
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ namespace Tests;
 
 use Exception;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\App;
 use Slim\Factory\AppFactory;
@@ -20,7 +19,6 @@ use App\Application\Middleware\SessionMiddleware;
 
 class TestCase extends PHPUnit_TestCase
 {
-    use ProphecyTrait;
 
     /**
      * @return App

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,4 @@
 <?php
 
 require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/TestCase.php';


### PR DESCRIPTION
## Summary
- fallback to `data/config.json` when the database configuration is empty
- load the base TestCase in bootstrap
- remove unused Prophecy trait from TestCase

## Testing
- `vendor/bin/phpunit` *(fails: could not create database tables)*

------
https://chatgpt.com/codex/tasks/task_e_685a9768da54832b9f1ee533428c831e