### PR TITLE
Handle puzzle solution without prior result entry

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -93,6 +93,17 @@ class ResultController
                 $result['normalizedExpected'] = $e;
                 if ($a !== '' && $a === $e) {
                     $result['success'] = $this->service->markPuzzle($name, $catalog, $time);
+                    if (!$result['success']) {
+                        $this->service->add([
+                            'name' => $name,
+                            'catalog' => $catalog,
+                            'correct' => 0,
+                            'total' => 0,
+                            'wrong' => [],
+                            'puzzleTime' => $time,
+                        ]);
+                        $result['success'] = true;
+                    }
                 }
             } else {
                 $this->service->add($data);


### PR DESCRIPTION
## Summary
- ensure the puzzle solution is stored even when no result entry exists

## Testing
- `vendor/bin/phpunit` *(fails: PDO driver issues)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685aac034420832bbc577c39bcd343c2