### PR TITLE
Fix admin results puzzle time display

### DIFF
--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -26,7 +26,7 @@ class ResultService
      */
     public function getAll(): array
     {
-        $sql = 'SELECT r.name, r.catalog, r.attempt, r.correct, r.total, r.time, r.puzzleTime, r.photo, ' .
+        $sql = 'SELECT r.name, r.catalog, r.attempt, r.correct, r.total, r.time, r.puzzleTime AS "puzzleTime", r.photo, ' .
             'c.name AS catalogName '
             . 'FROM results r '
             . 'LEFT JOIN catalogs c ON c.uid = r.catalog '
@@ -152,7 +152,7 @@ class ResultService
      */
     public function markPuzzle(string $name, string $catalog, int $time): bool
     {
-        $stmt = $this->pdo->prepare('SELECT id,puzzleTime FROM results WHERE name=? AND catalog=? ORDER BY id DESC LIMIT 1');
+        $stmt = $this->pdo->prepare('SELECT id, puzzleTime AS "puzzleTime" FROM results WHERE name=? AND catalog=? ORDER BY id DESC LIMIT 1');
         $stmt->execute([$name, $catalog]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($row) {


### PR DESCRIPTION
## Summary
- preserve the `puzzleTime` column name when fetching results
- alias `puzzleTime` in queries so the JSON field uses the expected casing

## Testing
- `npm test` *(fails: could not find package.json)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aafc539cc832b94090f087808558b