### PR TITLE
Show remaining catalogs after puzzle solved

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -472,7 +472,7 @@
         const r = await fetch('/results.json', {headers:{'Accept':'application/json'}});
         if(r.ok){
           const data = await r.json();
-          const user = getStored('quizUser');
+          const user = (sessionStorage.getItem('quizUser') || '') || (typeof localStorage !== 'undefined' ? localStorage.getItem('quizUser') : '');
           data.forEach(entry => {
             if(entry.name === user){
               solved.add(entry.catalog);

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -296,6 +296,24 @@ function runQuiz(questions, skipIntro){
       }
     }
 
+    const remainingEl = summaryEl.querySelector('#quiz-remaining');
+    if(remainingEl){
+      try{
+        const dataEl = document.getElementById('catalogs-data');
+        const catalogs = dataEl ? JSON.parse(dataEl.textContent) : [];
+        const solvedSet = new Set(JSON.parse(sessionStorage.getItem('quizSolved') || '[]'));
+        const names = catalogs.filter(c => !solvedSet.has(c.uid || c.slug || c.sort_order))
+          .map(c => c.name || c.slug || c.sort_order);
+        if(names.length){
+          remainingEl.textContent = 'Auf zur nächsten Station. Es fehlen noch: ' + names.join(', ');
+        } else {
+          remainingEl.textContent = '';
+        }
+      }catch(e){
+        remainingEl.textContent = '';
+      }
+    }
+
     if(cfg.photoUpload !== false){
       const photoBtn = document.createElement('button');
       photoBtn.className = 'uk-button uk-button-primary uk-margin-top';
@@ -996,10 +1014,14 @@ function runQuiz(questions, skipIntro){
     const puzzleInfo = document.createElement('p');
     puzzleInfo.id = 'puzzle-info';
     puzzleInfo.className = 'uk-margin-top';
+    const remainingInfo = document.createElement('p');
+    remainingInfo.id = 'quiz-remaining';
+    remainingInfo.className = 'uk-margin-top';
     div.appendChild(h);
     div.appendChild(p);
     div.appendChild(letter);
     div.appendChild(puzzleInfo);
+    div.appendChild(remainingInfo);
     if(!cfg.competitionMode){
       const restart = document.createElement('a');
       restart.href = '/';


### PR DESCRIPTION
## Summary
- add remaining catalog hint below puzzle info in quiz end screen
- expose remaining catalogs message via JS
- adjust competition mode buildSolvedSet helper to avoid external dependency

## Testing
- `python3 -m pytest -q`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_685abafdf41c832ba61b2ea380b21ce7