### PR TITLE
Add end station button

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1038,6 +1038,15 @@ function runQuiz(questions, skipIntro){
         }
       });
       div.appendChild(restart);
+    } else {
+      const endBtn = document.createElement('button');
+      endBtn.textContent = 'Station beenden';
+      endBtn.className = 'uk-button uk-button-primary uk-margin-top';
+      styleButton(endBtn);
+      endBtn.addEventListener('click', () => {
+        window.close();
+      });
+      div.appendChild(endBtn);
     }
     return div;
   }


### PR DESCRIPTION
## Summary
- add "Station beenden" button after finishing a catalog in competition mode

## Testing
- `node tests/test_competition_mode.js`
- `pytest -q tests/test_html_validity.py tests/test_json_validity.py`
- `php -v` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abfb30ba4832b9fd91c5e8d29770a