### PR TITLE
Swap puzzle and end buttons

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -292,7 +292,12 @@ function runQuiz(questions, skipIntro){
         puzzleBtn.textContent = 'Rätselwort überprüfen';
         styleButton(puzzleBtn);
         puzzleBtn.addEventListener('click', () => showPuzzleCheck(puzzleBtn, attemptKey));
-        summaryEl.appendChild(puzzleBtn);
+        const endBtn = summaryEl.querySelector('#end-station-btn');
+        if(endBtn){
+          summaryEl.insertBefore(puzzleBtn, endBtn);
+        } else {
+          summaryEl.appendChild(puzzleBtn);
+        }
       }
     }
 
@@ -1041,6 +1046,7 @@ function runQuiz(questions, skipIntro){
     } else {
       const endBtn = document.createElement('button');
       endBtn.textContent = 'Station beenden';
+      endBtn.id = 'end-station-btn';
       endBtn.className = 'uk-button uk-button-primary uk-margin-top';
       styleButton(endBtn);
       endBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- keep `Station beenden` as last button by inserting puzzle button before it
- mark `Station beenden` button with id for easy lookup

## Testing
- `python3 tests/test_html_validity.py -v`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685ac181a270832b9fde7fc2f4cb5c90