### PR TITLE
Add Statistik admin tab

### DIFF
--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -1,0 +1,114 @@
+/* global UIkit */
+document.addEventListener('DOMContentLoaded', () => {
+  const tbody = document.getElementById('statsTableBody');
+  const filter = document.getElementById('statsFilter');
+
+  let data = [];
+  let catalogMap = null;
+
+  function fetchCatalogMap() {
+    if (catalogMap) return Promise.resolve(catalogMap);
+    return fetch('/kataloge/catalogs.json', { headers: { 'Accept': 'application/json' } })
+      .then(r => r.json())
+      .then(list => {
+        const map = {};
+        if (Array.isArray(list)) {
+          list.forEach(c => {
+            const name = c.name || '';
+            if (c.uid) map[c.uid] = name;
+            if (c.sort_order) map[c.sort_order] = name;
+            if (c.slug) map[c.slug] = name;
+          });
+        }
+        catalogMap = map;
+        return map;
+      })
+      .catch(() => {
+        catalogMap = {};
+        return catalogMap;
+      });
+  }
+
+  function renderTable(rows) {
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    if (!rows.length) {
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = 7;
+      td.textContent = 'Keine Daten';
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+      return;
+    }
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      const cells = [
+        r.name,
+        r.attempt,
+        r.catalogName || r.catalog,
+        r.prompt || '',
+        r.answer_text || '',
+        r.correct ? '✓' : '✗'
+      ];
+      cells.forEach((c, idx) => {
+        const td = document.createElement('td');
+        td.textContent = c;
+        tr.appendChild(td);
+      });
+      const photoTd = document.createElement('td');
+      if (r.photo) {
+        const a = document.createElement('a');
+        a.className = 'uk-inline';
+        a.href = r.photo;
+        a.dataset.caption = 'Beweisfoto';
+        a.dataset.attrs = 'class: uk-inverse-light';
+        const img = document.createElement('img');
+        img.src = r.photo;
+        img.alt = 'Beweisfoto';
+        img.className = 'proof-thumb';
+        a.appendChild(img);
+        photoTd.appendChild(a);
+      }
+      tr.appendChild(photoTd);
+      tbody.appendChild(tr);
+    });
+  }
+
+  function updateFilterOptions() {
+    if (!filter) return;
+    const names = Array.from(new Set(data.map(r => r.name))).sort();
+    filter.innerHTML = '<option value="">Alle</option>';
+    names.forEach(n => {
+      const opt = document.createElement('option');
+      opt.value = n;
+      opt.textContent = n;
+      filter.appendChild(opt);
+    });
+  }
+
+  function applyFilter() {
+    const name = filter && filter.value ? filter.value : '';
+    const rows = name ? data.filter(r => r.name === name) : data;
+    renderTable(rows);
+  }
+
+  function load() {
+    Promise.all([
+      fetchCatalogMap(),
+      fetch('/question-results.json').then(r => r.json())
+    ])
+      .then(([catMap, rows]) => {
+        rows.forEach(r => {
+          if (!r.catalogName && catMap[r.catalog]) r.catalogName = catMap[r.catalog];
+        });
+        data = rows;
+        updateFilterOptions();
+        applyFilter();
+      })
+      .catch(err => console.error(err));
+  }
+
+  filter?.addEventListener('change', applyFilter);
+  load();
+});

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -30,6 +30,7 @@
     <li data-help="Nach Auswahl eines Katalogs einzelne Fragen bearbeiten oder neue anlegen. 'Neue Frage' fügt eine weitere hinzu, 'Zurücksetzen' verwirft Änderungen, 'Speichern' sichert den gesamten Katalog."><a href="#">Fragen anpassen</a></li>
     <li data-help="Teilnehmerliste pflegen. Über 'Hinzufügen' Teams oder Personen ergänzen. Die Checkbox beschränkt die Teilnahme auf gelistete Namen. Speichern aktualisiert die Liste."><a href="#">Teams/Personen</a></li>
     <li data-help="Gespeicherte Ergebnisse mit richtigen Antworten und Zeit einsehen. 'Zurücksetzen' löscht alle Daten, 'Herunterladen' exportiert sie als CSV."><a href="#">Ergebnisse</a></li>
+    <li data-help="Einzelne Antworten analysieren. Tabelle filtert nach Teams/Personen."><a href="#">Statistik</a></li>
     <li data-help="QR-Codes für alle Kataloge und Teams anzeigen, um Quizlinks oder Anmeldungen weiterzugeben. 'Drucken' erstellt eine übersichtliche Liste."><a href="#">Zusammenfassung</a></li>
     <li data-help="Administrationspasswort ändern und Sicherungen verwalten."><a href="#">Administration</a></li>
   </ul>
@@ -351,6 +352,24 @@
     <li>
       <div class="uk-container uk-container-large">
         <div class="uk-flex uk-flex-between uk-flex-middle">
+          <h2 class="uk-heading-bullet">Statistik</h2>
+          <select id="statsFilter" class="uk-select uk-width-small">
+            <option value="">Alle</option>
+          </select>
+        </div>
+        <div style="overflow-x: auto">
+        <table class="uk-table uk-table-divider uk-table-responsive">
+          <thead>
+            <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Frage</th><th>Antwort</th><th>Richtig</th><th>Beweisfoto</th></tr>
+          </thead>
+          <tbody id="statsTableBody" uk-lightbox="nav: thumbnav; slidenav: false"></tbody>
+        </table>
+        </div>
+      </div>
+    </li>
+    <li>
+      <div class="uk-container uk-container-large">
+        <div class="uk-flex uk-flex-between uk-flex-middle">
           <div>
             <h2 class="uk-heading-bullet">{{ config.header }}</h2>
             <p>{{ config.subheader }}</p>
@@ -461,4 +480,5 @@
   <script src="/js/admin.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/results.js"></script>
+  <script src="/js/stats.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Statistik tab to admin interface
- show per-question results in a filterable table
- include new script `stats.js`

## Testing
- `node tests/test_competition_mode.js`
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_685acc8c7394832ba8757d43e97bee34