### PR TITLE
Implement catalog finish ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,10 @@ Alle Resultate werden in der Datenbank abgelegt. Die API bietet folgende Endpunk
 - `GET /results/download` – erzeugt eine CSV-Datei mit allen Resultaten.
 - `GET /question-results.json` – listet falsch beantwortete Fragen.
 
+Die Ergebnisübersicht zeigt drei Ranglisten. Der Titel „Katalogmeister" basiert
+auf dem Zeitpunkt, an dem ein Team seinen letzten noch offenen Fragenkatalog
+abgeschlossen hat. Wer hier die früheste Zeit erreicht, führt die Liste an.
+
 
 ### Passwort ändern
 Ein POST auf `/password` speichert ein neues Admin-Passwort in `config.json`.

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -158,16 +158,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const puzzleList = puzzleArr.slice(0, 3);
 
     const totalCats = catalogs.size;
-    const catFin = [];
+    const finishers = [];
     catTimes.forEach((map, name) => {
       if (map.size === totalCats) {
-        const arr = Array.from(map.values());
-        const finished = Math.max(...arr);
-        catFin.push({ name, value: formatTime(finished), raw: finished });
+        let last = -Infinity;
+        map.forEach(t => { if (t > last) last = t; });
+        finishers.push({ name, finished: last });
       }
     });
-    catFin.sort((a, b) => a.raw - b.raw);
-    const catalogList = catFin.slice(0, 3);
+    finishers.sort((a, b) => a.finished - b.finished);
+    const catalogList = finishers.slice(0, 3).map(item => ({
+      name: item.name,
+      value: formatTime(item.finished),
+      raw: item.finished
+    }));
 
     const totalScores = [];
     scores.forEach((map, name) => {


### PR DESCRIPTION
## Summary
- compute catalog master based on the time the last catalog was finished
- document catalog master rule in the README

## Testing
- `vendor/bin/phpunit` *(fails: no such file or directory)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685acda03cf0832b99f65694c01ba9f0