### PR TITLE
Extend results reset to clear question results

### DIFF
--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -145,11 +145,12 @@ class ResultService
     }
 
     /**
-     * Remove all result entries.
+     * Remove all result entries including per-question logs.
      */
     public function clear(): void
     {
         $this->pdo->exec('DELETE FROM results');
+        $this->pdo->exec('DELETE FROM question_results');
     }
 
     /**

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -103,4 +103,19 @@ class ResultServiceTest extends TestCase
         $this->assertSame('2', (string)$rows[1]['question_id']);
         $this->assertSame('0', (string)$rows[1]['correct']);
     }
+
+    public function testClearRemovesResultsAndQuestionResults(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $pdo->exec('CREATE TABLE question_results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, question_id INTEGER NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, answer_text TEXT, photo TEXT, consent INTEGER);');
+        $service = new ResultService($pdo);
+        $service->add([ 'name' => 'Team', 'catalog' => 'cat1', 'correct' => 1, 'total' => 1 ]);
+        $service->clear();
+        $resCount = (int) $pdo->query('SELECT COUNT(*) FROM results')->fetchColumn();
+        $qresCount = (int) $pdo->query('SELECT COUNT(*) FROM question_results')->fetchColumn();
+        $this->assertSame(0, $resCount);
+        $this->assertSame(0, $qresCount);
+    }
 }


### PR DESCRIPTION
## Summary
- clear `question_results` when resetting results
- test that `clear()` removes data from `question_results`

## Testing
- `node tests/test_competition_mode.js`
- `pytest -q tests/test_json_validity.py`
- `python tests/test_html_validity.py`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad0a538c4832bb0880ac9ed90a328