### PR TITLE
Update admin docs with statistics tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ Unter `/admin` stehen folgende Tabs zur Verfügung:
 3. **Fragen anpassen** – Fragen eines Katalogs hinzufügen, bearbeiten oder löschen.
 4. **Teams/Personen** – Teilnehmerlisten pflegen, optional als Login-Beschränkung.
 5. **Ergebnisse** – Spielstände einsehen und herunterladen.
-6. **Passwort ändern** – Administrationspasswort setzen.
+6. **Statistik** – Einzelne Antworten analysieren und nach Teams filtern.
+7. **Passwort ändern** – Administrationspasswort setzen.
 
 ### Fragenkataloge
 `data/kataloge/catalogs.json` listet verfügbare Kataloge mit `slug`, Name und optionaler QR-Code-Adresse. Die Reihenfolge wird durch das Feld `sort_order` bestimmt. Jede Frage speichert die zugehörige `catalog_uid`. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:
@@ -314,6 +315,11 @@ Alle Resultate werden in der Datenbank abgelegt. Die API bietet folgende Endpunk
 Die Ergebnisübersicht zeigt drei Ranglisten. Der Titel „Katalogmeister" basiert
 auf dem Zeitpunkt, an dem ein Team seinen letzten noch offenen Fragenkatalog
 abgeschlossen hat. Wer hier die früheste Zeit erreicht, führt die Liste an.
+
+### Statistik
+Im Statistik-Tab lassen sich alle gegebenen Antworten detailliert auswerten. Die Tabelle zeigt Name, Versuch, Katalog,
+Frage, Antwort, ob sie korrekt war, und ein optionales Beweisfoto. Über ein Dropdown lässt sich die Ansicht auf einzelne
+Teams oder Personen beschränken.
 
 
 ### Passwort ändern

--- a/docs-jtd/verwaltung.md
+++ b/docs-jtd/verwaltung.md
@@ -20,13 +20,16 @@ Unter `/admin` stehen folgende Tabs zur Verfügung:
 3. **Fragen anpassen** – Fragen eines Katalogs hinzufügen, bearbeiten oder löschen.
 4. **Teams/Personen** – Teilnehmerlisten pflegen, optional als Login-Beschränkung.
 5. **Ergebnisse** – Spielstände einsehen und herunterladen.
-6. **Passwort ändern** – Administrationspasswort setzen.
+6. **Statistik** – Einzelne Antworten analysieren und nach Teams filtern.
+7. **Passwort ändern** – Administrationspasswort setzen.
+
+Der Statistik-Tab listet jede Antwort mit Name, Versuch, Katalog, Frage, Antwort, Richtig-Status und optionalem Beweisfoto. Über ein Auswahlfeld lassen sich die Daten nach Teams oder Personen filtern.
+
 
 ## Weitere Funktionen
 
 - **Passwort ändern:** Ein POST auf `/password` speichert ein neues Admin-Passwort in `config.json`.
 - **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue Datei hochladen.
 - **Ergebnisse exportieren:** Alle Resultate können als CSV-Datei heruntergeladen werden.
-
 Die API ermöglicht so die komplette Verwaltung eines Quizsystems und ist sowohl lokal als auch im Netzwerk schnell einsatzbereit.
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -7,6 +7,8 @@ Die Administrationsoberfl\u00e4che erreichen Sie \u00fcber `/admin` nach einem e
 3. **Fragen anpassen** – Bestehende Fragen \u00e4ndern oder neue hinzuf\u00fcgen.
 4. **Teams/Personen** – Teilnehmerlisten pflegen und optional den Zugang einschr\u00e4nken.
 5. **Ergebnisse** – Spielst\u00e4nde einsehen und als CSV herunterladen.
-6. **Passwort \u00e4ndern** – Das Administrationspasswort setzen.
+6. **Statistik** – Einzelne Antworten analysieren und nach Teams filtern.
+7. **Passwort \u00e4ndern** – Das Administrationspasswort setzen.
+Der Statistik-Tab listet jede Antwort mit Name, Versuch, Katalog, Frage, Antwort, Richtig-Status und optionalem Beweisfoto. Über ein Auswahlfeld lassen sich die Daten nach Teams oder Personen filtern.
 
 Weitere Funktionen wie der QR-Code-Login oder der Wettkampfmodus lassen sich in der Datei `data/config.json` aktivieren.


### PR DESCRIPTION
## Summary
- document the Admin statistics tab in README
- mention the new tab in docs

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685ada2d94fc832b8f4b4f13d55385ec