### PR TITLE
Fix docs to list all five question types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Mit dieser App zeigen wir, was heute schon möglich ist, wenn Menschen und versc
 ## Überblick
 
 - **Flexibel einsetzbar**: Fragenkataloge im JSON-Format lassen sich bequem austauschen oder erweitern.
-- **Drei Fragetypen**: Sortieren, Zuordnen und Multiple Choice bieten Abwechslung für jede Zielgruppe.
+- **Fünf Fragetypen**: Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe bieten Abwechslung für jede Zielgruppe.
 - **QR-Code-Login & Dunkelmodus**: Optionaler QR-Code-Login für schnelles Anmelden und ein zuschaltbares dunkles Design steigern den Komfort.
 - **Persistente Speicherung**: Konfigurationen, Kataloge und Ergebnisse liegen in einer PostgreSQL-Datenbank.
 

--- a/docs-jtd/faq.md
+++ b/docs-jtd/faq.md
@@ -15,7 +15,7 @@ Scanne an der ersten Station den QR-Code oder öffne den bereitgestellten Link. 
 Ja, die Oberfläche passt sich jedem Gerät an – ob Handy, Tablet oder PC.
 
 ### Welche Fragetypen gibt es?
-Das Quiz bietet Sortieren, Zuordnen und Multiple Choice.
+Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe.
 
 ### Wie bediene ich Drag & Drop?
 Halte ein Element gedrückt und ziehe es an die gewünschte Stelle.

--- a/docs-jtd/fragenkataloge.md
+++ b/docs-jtd/fragenkataloge.md
@@ -20,5 +20,5 @@ Ein Eintrag kann zudem ein Feld `raetsel_buchstabe` enthalten, das den Buchstabe
 - `DELETE /kataloge/{file}` entfernt die Datei.
 - `DELETE /kataloge/{file}/{index}` löscht eine Frage anhand des Index.
 
-Die Fragetypen umfassen Sortieren, Zuordnen und Multiple Choice. Dank des Puzzlewort-Features kann nach jeder Runde ein Buchstabe angezeigt werden, bis sich das Lösungswort ergibt.
+Die Fragetypen umfassen Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe. Dank des Puzzlewort-Features kann nach jeder Runde ein Buchstabe angezeigt werden, bis sich das Lösungswort ergibt.
 

--- a/docs-jtd/index.md
+++ b/docs-jtd/index.md
@@ -15,7 +15,7 @@ Die Anwendung entstand als Machbarkeitsstudie, um das Potenzial moderner Code-As
 Weitere Highlights sind unter anderem:
 
 - **Flexibel einsetzbar:** Kataloge im JSON-Format lassen sich einfach austauschen oder erweitern.
-- **Drei Fragetypen:** Sortieren, Zuordnen und Multiple Choice bieten Abwechslung für alle Teilnehmer.
+- **Fünf Fragetypen:** Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe bieten Abwechslung für alle Teilnehmer.
 - **QR-Code-Login & Dunkelmodus:** Komfortables Spielen auf allen Geräten.
 - **Persistente Speicherung:** Alle Daten liegen zentral in PostgreSQL.
 

--- a/docs-jtd/marketing.md
+++ b/docs-jtd/marketing.md
@@ -11,7 +11,7 @@ toc: true
 ## Überblick
 
 - **Flexibel einsetzbar:** Fragenkataloge im JSON-Format lassen sich bequem austauschen oder erweitern.
-- **Drei Fragetypen:** Sortieren, Zuordnen und Multiple Choice bieten Abwechslung für jede Zielgruppe.
+- **Fünf Fragetypen:** Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe bieten Abwechslung für jede Zielgruppe.
 - **QR-Code-Login & Dunkelmodus:** Optionaler QR-Code-Login für schnelles Anmelden und ein zuschaltbares dunkles Design steigern den Komfort.
 - **Persistente Speicherung:** Konfigurationen, Kataloge und Ergebnisse liegen in einer PostgreSQL-Datenbank.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,7 @@ Scanne an der ersten Station den QR-Code oder öffne den bereitgestellten Link. 
 Ja, die Oberfläche passt sich jedem Gerät an – ob Handy, Tablet oder PC.
 
 ### Welche Fragetypen gibt es?
-Das Quiz bietet Sortieren, Zuordnen, Multiple Choice und den neuen Typ "Foto mit Texteingabe".
+Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe.
 
 ### Wie bediene ich Drag & Drop?
 Halte ein Element gedrückt und ziehe es an die gewünschte Stelle.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hohe Performance standen dabei im Mittelpunkt.
 Weitere Highlights sind:
 
 - **Flexibel einsetzbar**: Kataloge im JSON-Format lassen sich einfach austauschen.
-- **Vier Fragetypen**: Sortieren, Zuordnen, Multiple Choice und Foto mit Texteingabe.
+- **Fünf Fragetypen**: Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe.
 - **QR-Code-Login & Dunkelmodus** für komfortables Spielen auf allen Geräten.
 - **Persistente Speicherung** in PostgreSQL.
 

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -48,7 +48,7 @@
       <li>
         <a class="uk-accordion-title" href="#">Welche Fragetypen gibt es?</a>
         <div class="uk-accordion-content">
-          <p>Das Quiz bietet Sortieren, Zuordnen und Multiple Choice.</p>
+          <p>Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe.</p>
         </div>
       </li>
       <li>


### PR DESCRIPTION
## Summary
- fix FAQ and marketing pages to list 5 question types
- mention Swipe-Karten and Foto mit Texteingabe everywhere

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685afe39c290832bae163a14e7a0286a