### PR TITLE
Fix QR PDF generation

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -150,7 +150,9 @@ class QrController
         $pdf = new FPDF();
         $pdf->AddPage();
         if ($tmp !== false) {
-            $pdf->Image($tmp, 20, 20, 70, 70);
+            // Explicitly set the image type to avoid relying on the file
+            // extension which does not exist for our temporary file.
+            $pdf->Image($tmp, 20, 20, 70, 70, 'PNG');
             unlink($tmp);
         }
         $output = $pdf->Output('S');


### PR DESCRIPTION
## Summary
- fix FPDF usage when writing the QR code PDF

## Testing
- `vendor/bin/phpunit tests/Controller/QrControllerTest.php` *(fails: PDO::__construct(): Argument #1 ($dsn) must be a valid data source name)*

------
https://chatgpt.com/codex/tasks/task_e_685b05bb0b78832b9fd88a5a76661823