### PR TITLE
Add invitation text editing in admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,13 +270,14 @@ Alle wesentlichen Einstellungen stehen in `data/config.json` und werden beim ers
   "puzzleWordEnabled": true,
   "puzzleWord": "",
   "puzzleFeedback": "",
+  "inviteText": "",
   "postgres_dsn": "pgsql:host=postgres;dbname=quiz",
   "postgres_user": "quiz",
   "postgres_pass": "***"
 }
 ```
 
-Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus, verhindert Wiederholungen bereits abgeschlossener Kataloge und unterbindet die Anzeige der Katalogübersicht. Ein Fragenkatalog kann dann nur über einen direkten QR-Code-Link gestartet werden. Im Wettkampfmodus führt ein Aufruf der Hauptseite ohne gültigen Katalog-Parameter automatisch zur Hilfe-Seite. Über `teamResults` lässt sich steuern, ob Teams nach Abschluss aller Kataloge ihre eigene Ergebnisübersicht angezeigt bekommen. `photoUpload` blendet die Buttons zum Hochladen von Beweisfotos ein oder aus. `puzzleWordEnabled` schaltet das Rätselwort-Spiel frei und `puzzleFeedback` definiert den Text, der nach korrekter Eingabe angezeigt wird.
+Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. Wird dieser Wert nicht angegeben, ermittelt die Anwendung Schema und Host automatisch aus der aktuellen Anfrage. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus, verhindert Wiederholungen bereits abgeschlossener Kataloge und unterbindet die Anzeige der Katalogübersicht. Ein Fragenkatalog kann dann nur über einen direkten QR-Code-Link gestartet werden. Im Wettkampfmodus führt ein Aufruf der Hauptseite ohne gültigen Katalog-Parameter automatisch zur Hilfe-Seite. Über `teamResults` lässt sich steuern, ob Teams nach Abschluss aller Kataloge ihre eigene Ergebnisübersicht angezeigt bekommen. `photoUpload` blendet die Buttons zum Hochladen von Beweisfotos ein oder aus. `puzzleWordEnabled` schaltet das Rätselwort-Spiel frei und `puzzleFeedback` definiert den Text, der nach korrekter Eingabe angezeigt wird. `inviteText` enthält ein optionales Anschreiben für teilnehmende Teams.
 
 `ConfigService` liest und speichert diese Datei. Ein GET auf `/config.json` liefert den aktuellen Inhalt, ein POST auf dieselbe URL speichert geänderte Werte.
 

--- a/data-default/config.json
+++ b/data-default/config.json
@@ -17,6 +17,7 @@
   "puzzleWordEnabled": true,
   "puzzleWord": "",
   "puzzleFeedback": "",
+  "inviteText": "",
   "postgres_dsn": "pgsql:host=postgres;dbname=quiz",
   "postgres_user": "quiz",
   "postgres_pass": "quiz"

--- a/data/config.json
+++ b/data/config.json
@@ -17,6 +17,7 @@
   "puzzleWordEnabled": true,
   "puzzleWord": "",
   "puzzleFeedback": "",
+  "inviteText": "",
   "postgres_dsn": "pgsql:host=postgres;dbname=quiz",
   "postgres_user": "quiz",
   "postgres_pass": "quiz"

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -26,7 +26,8 @@ CREATE TABLE IF NOT EXISTS config (
     photoUpload BOOLEAN,
     puzzleWordEnabled BOOLEAN,
     puzzleWord TEXT,
-    puzzleFeedback TEXT
+    puzzleFeedback TEXT,
+    inviteText TEXT
 );
 
 -- Teams list (names only)

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -51,6 +51,18 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     UIkit.icon(puzzleIcon, { icon: puzzleIcon.getAttribute('uk-icon').split(': ')[1] });
   }
+
+  function updateInviteTextUI() {
+    if (!inviteIcon || !inviteLabel) return;
+    if (inviteText.trim().length > 0) {
+      inviteIcon.setAttribute('uk-icon', 'icon: check');
+      inviteLabel.textContent = 'Einladungstext bearbeiten';
+    } else {
+      inviteIcon.setAttribute('uk-icon', 'icon: pencil');
+      inviteLabel.textContent = 'Einladungstext eingeben';
+    }
+    UIkit.icon(inviteIcon, { icon: inviteIcon.getAttribute('uk-icon').split(': ')[1] });
+  }
   // --------- Konfiguration bearbeiten ---------
   // Ausgangswerte aus der bestehenden Konfiguration
   const cfgInitial = window.quizConfig || {};
@@ -79,6 +91,13 @@ document.addEventListener('DOMContentLoaded', function () {
   const puzzleTextarea = document.getElementById('puzzleFeedbackTextarea');
   const puzzleSaveBtn = document.getElementById('puzzleFeedbackSave');
   const puzzleModal = UIkit.modal('#puzzleFeedbackModal');
+  const inviteTextBtn = document.getElementById('inviteTextBtn');
+  const inviteIcon = document.getElementById('inviteTextIcon');
+  const inviteLabel = document.getElementById('inviteTextLabel');
+  const inviteTextarea = document.getElementById('inviteTextTextarea');
+  const inviteSaveBtn = document.getElementById('inviteTextSave');
+  const inviteModal = UIkit.modal('#inviteTextModal');
+  const inviteToolbar = document.getElementById('inviteTextToolbar');
   const commentTextarea = document.getElementById('catalogCommentTextarea');
   const commentSaveBtn = document.getElementById('catalogCommentSave');
   const commentModal = UIkit.modal('#catalogCommentModal');
@@ -86,6 +105,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const resultsResetModal = UIkit.modal('#resultsResetModal');
   const resultsResetConfirm = document.getElementById('resultsResetConfirm');
   let puzzleFeedback = '';
+  let inviteText = '';
   let currentCommentInput = null;
 
   function wrapSelection(textarea, before, after) {
@@ -121,6 +141,32 @@ document.addEventListener('DOMContentLoaded', function () {
         break;
       case 'italic':
         wrapSelection(commentTextarea, '<em>', '</em>');
+        break;
+    }
+  });
+
+  inviteToolbar?.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-format]');
+    if (!btn) return;
+    const fmt = btn.dataset.format;
+    switch (fmt) {
+      case 'h2':
+        wrapSelection(inviteTextarea, '<h2>', '</h2>');
+        break;
+      case 'h3':
+        wrapSelection(inviteTextarea, '<h3>', '</h3>');
+        break;
+      case 'h4':
+        wrapSelection(inviteTextarea, '<h4>', '</h4>');
+        break;
+      case 'h5':
+        wrapSelection(inviteTextarea, '<h5>', '</h5>');
+        break;
+      case 'bold':
+        wrapSelection(inviteTextarea, '<strong>', '</strong>');
+        break;
+      case 'italic':
+        wrapSelection(inviteTextarea, '<em>', '</em>');
         break;
     }
   });
@@ -190,6 +236,8 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     puzzleFeedback = data.puzzleFeedback || '';
     updatePuzzleFeedbackUI();
+    inviteText = data.inviteText || '';
+    updateInviteTextUI();
     if (cfgFields.puzzleWrap) {
       cfgFields.puzzleWrap.style.display = cfgFields.puzzleEnabled.checked ? '' : 'none';
     }
@@ -207,6 +255,11 @@ document.addEventListener('DOMContentLoaded', function () {
       puzzleTextarea.value = puzzleFeedback;
     }
   });
+  inviteTextBtn?.addEventListener('click', () => {
+    if (inviteTextarea) {
+      inviteTextarea.value = inviteText;
+    }
+  });
   puzzleSaveBtn?.addEventListener('click', () => {
     if (!puzzleTextarea) return;
     puzzleFeedback = puzzleTextarea.value;
@@ -220,6 +273,23 @@ document.addEventListener('DOMContentLoaded', function () {
     }).then(r => {
       if (r.ok) {
         notify('Feedbacktext gespeichert', 'success');
+      }
+    }).catch(() => {});
+  });
+
+  inviteSaveBtn?.addEventListener('click', () => {
+    if (!inviteTextarea) return;
+    inviteText = inviteTextarea.value;
+    updateInviteTextUI();
+    inviteModal.hide();
+    cfgInitial.inviteText = inviteText;
+    fetch('/config.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(cfgInitial)
+    }).then(r => {
+      if (r.ok) {
+        notify('Einladungstext gespeichert', 'success');
       }
     }).catch(() => {});
   });
@@ -261,7 +331,8 @@ document.addEventListener('DOMContentLoaded', function () {
       photoUpload: cfgFields.photoUpload ? cfgFields.photoUpload.checked : cfgInitial.photoUpload,
       puzzleWordEnabled: cfgFields.puzzleEnabled ? cfgFields.puzzleEnabled.checked : cfgInitial.puzzleWordEnabled,
       puzzleWord: cfgFields.puzzleWord ? cfgFields.puzzleWord.value.trim() : cfgInitial.puzzleWord,
-      puzzleFeedback: puzzleFeedback
+      puzzleFeedback: puzzleFeedback,
+      inviteText: inviteText
     });
     fetch('/config.json', {
       method: 'POST',

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -75,7 +75,7 @@ class ConfigService
      */
     public function saveConfig(array $data): void
     {
-        $keys = ['displayErrorDetails','QRUser','logoPath','pageTitle','header','subheader','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback'];
+        $keys = ['displayErrorDetails','QRUser','logoPath','pageTitle','header','subheader','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback','inviteText'];
         $filtered = array_intersect_key($data, array_flip($keys));
         $this->pdo->beginTransaction();
         $this->pdo->exec('DELETE FROM config');
@@ -104,7 +104,7 @@ class ConfigService
      */
     private function normalizeKeys(array $row): array
     {
-        $keys = ['displayErrorDetails','QRUser','logoPath','pageTitle','header','subheader','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback'];
+        $keys = ['displayErrorDetails','QRUser','logoPath','pageTitle','header','subheader','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback','inviteText'];
         $map = [];
         foreach ($keys as $k) {
             $map[strtolower($k)] = $k;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -415,7 +415,29 @@
           {% endfor %}
         </div>
         <div class="uk-margin uk-flex uk-flex-right">
+          <button id="inviteTextBtn" class="uk-button uk-button-default uk-margin-right" type="button" uk-toggle="target: #inviteTextModal">
+            <span id="inviteTextIcon" uk-icon="icon: pencil"></span>
+            <span id="inviteTextLabel">Einladungstext eingeben</span>
+          </button>
           <button id="summaryPrintBtn" class="uk-button uk-button-default" uk-tooltip="title: Zusammenfassung drucken; pos: right">Drucken</button>
+        </div>
+        <div id="inviteTextModal" uk-modal>
+          <div class="uk-modal-dialog uk-modal-body">
+            <h2 class="uk-modal-title">Einladungstext</h2>
+            <div id="inviteTextToolbar" class="uk-margin-small-bottom">
+              <button class="uk-button uk-button-default" type="button" data-format="h2">H2</button>
+              <button class="uk-button uk-button-default" type="button" data-format="h3">H3</button>
+              <button class="uk-button uk-button-default" type="button" data-format="h4">H4</button>
+              <button class="uk-button uk-button-default" type="button" data-format="h5">H5</button>
+              <button class="uk-button uk-button-default" type="button" data-format="bold"><strong>B</strong></button>
+              <button class="uk-button uk-button-default" type="button" data-format="italic"><em>I</em></button>
+            </div>
+            <textarea id="inviteTextTextarea" class="uk-textarea" rows="5" placeholder="Text eingeben..."></textarea>
+            <div class="uk-flex uk-flex-right uk-margin-top">
+              <button id="inviteTextSave" class="uk-button uk-button-primary" type="button">Speichern</button>
+              <button class="uk-button uk-button-default uk-modal-close" type="button">Abbrechen</button>
+            </div>
+          </div>
         </div>
         </div>
       </li>

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -19,7 +19,7 @@ class ImportControllerTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
         $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
         $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT, UNIQUE(catalog_uid, sort_order));');
         $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY);');

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -14,7 +14,7 @@ class ConfigServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
         $service = new ConfigService($pdo);
         $data = ['pageTitle' => 'Demo'];
 
@@ -28,7 +28,7 @@ class ConfigServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
         $service = new ConfigService($pdo);
 
         $this->assertNull($service->getJson());


### PR DESCRIPTION
## Summary
- extend config schema with `inviteText`
- support `inviteText` in ConfigService
- add invitation text button and modal in admin summary
- wire up new modal in admin JS
- document new config option

## Testing
- `composer install --ignore-platform-req=ext-simplexml`
- `./vendor/bin/phpunit` *(fails: missing data source name for PDO)*

------
https://chatgpt.com/codex/tasks/task_e_685b04e7c388832b8b4fbaae82e07aa3