### PR TITLE
Implement header in QR PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
 __pycache__/
 
+vendor/
+.phpunit.result.cache
+
 .env

--- a/src/routes.php
+++ b/src/routes.php
@@ -74,7 +74,7 @@ return function (\Slim\App $app) {
     );
     $teamController = new TeamController($teamService);
     $passwordController = new PasswordController($configService);
-    $qrController = new QrController();
+    $qrController = new QrController($configService);
     $logoController = new LogoController($configService);
     $summaryController = new SummaryController($configService);
     $importController = new ImportController(


### PR DESCRIPTION
## Summary
- ignore vendor and PHPUnit cache
- inject `ConfigService` into `QrController`
- add header with logo, title and subtitle in generated PDF
- update routes to pass config service

## Testing
- `vendor/bin/phpunit` *(fails: could not find driver)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_685b098df9ec832b9d0c3011dc027bc0