### PR TITLE
Add link to GitHub Pages docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Deploy](https://github.com/bastelix/sommerfest-quiz/actions/workflows/deploy.yml/badge.svg)](https://github.com/bastelix/sommerfest-quiz/actions/workflows/deploy.yml)
 [![HTML Validity Test](https://github.com/bastelix/sommerfest-quiz/actions/workflows/html-validity.yml/badge.svg)](https://github.com/bastelix/sommerfest-quiz/actions/workflows/html-validity.yml)
 
+**Dokumentation:** Die ausführliche Anleitung findest du auf GitHub Pages: <https://bastelix.github.io/sommerfest-quiz/>
+
 Das **Sommerfest-Quiz** ist eine sofort einsetzbare Web-App, mit der Sie Besucherinnen und Besucher spielerisch an Events beteiligen. Dank Slim Framework und UIkit3 funktioniert alles ohne komplizierte Server-Setups direkt im Browser.
 
 ## Disclaimer / Hinweis


### PR DESCRIPTION
## Summary
- link to GitHub Pages documentation at the top of README

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: `bash: vendor/bin/phpunit: No such file or directory`)*
- `composer install` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b0a2ee6d0832bb274ccf29f3d24c9