### PR TITLE
Add invite text to QR PDF body

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -191,6 +191,19 @@ class QrController
             $pdf->Image($tmp, $qrX, $qrY, $qrSize, $qrSize, 'PNG');
             unlink($tmp);
         }
+
+        $pdf->SetXY(10, $y + 5);
+        $invite = (string)($cfg['inviteText'] ?? '');
+        if ($invite !== '') {
+            $invite = preg_replace('/<br\s*\/>?/i', "\n", $invite);
+            $invite = preg_replace('/<h[1-6]>(.*?)<\/h[1-6]>/i', "$1\n", $invite);
+            $invite = preg_replace('/<p[^>]*>(.*?)<\/p>/i', "$1\n", $invite);
+            $invite = strip_tags($invite);
+            $invite = html_entity_decode($invite);
+            $pdf->SetFont('Arial', '', 11);
+            $pdf->MultiCell($pdf->GetPageWidth() - 20, 6, $invite);
+        }
+
         $output = $pdf->Output('S');
 
         $response->getBody()->write($output);


### PR DESCRIPTION
## Summary
- show configured invitation text inside the generated QR PDF

## Testing
- `vendor/bin/phpcs src/Controller/QrController.php`
- `vendor/bin/phpstan analyse src/Controller/QrController.php`
- `vendor/bin/phpunit tests/Controller/QrControllerTest.php` *(fails: PDOException: DSN must be valid)*

------
https://chatgpt.com/codex/tasks/task_e_685b0f7d0504832b9b02d2fb31494c66