### PR TITLE
Update QR code defaults in PDF

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -135,7 +135,7 @@ class QrController
             return $response->withStatus(400);
         }
 
-        $fg     = (string)($params['fg'] ?? '23b45a');
+        $fg     = (string)($params['fg'] ?? '0000ff');
         $bg     = (string)($params['bg'] ?? 'ffffff');
         $size   = (int)($params['s'] ?? 300);
         $margin = (int)($params['m'] ?? 20);
@@ -147,7 +147,7 @@ class QrController
             ->size($size)
             ->margin($margin)
             ->backgroundColor($this->parseColor($bg, new Color(255, 255, 255)))
-            ->foregroundColor($this->parseColor($fg, new Color(35, 180, 90)));
+            ->foregroundColor($this->parseColor($fg, new Color(0, 0, 255)));
 
         $result = $builder
             ->roundBlockSizeMode(RoundBlockSizeMode::Margin)
@@ -167,7 +167,7 @@ class QrController
         $subtitle = (string)($cfg['subheader'] ?? '');
         $logoPath = __DIR__ . '/../../data/logo.png';
         // Height of the header area in which logo, titles and QR code are placed
-        $qrSize = 70.0; // mm
+        $qrSize = 20.0; // mm
         $headerHeight = max(25.0, $qrSize + 10.0); // ensure QR code fits
 
         if (is_readable($logoPath)) {


### PR DESCRIPTION
## Summary
- render default PDF QR code in blue
- shrink QR code size to 20mm

## Testing
- `vendor/bin/phpcs` *(fails: Function closing brace must go on the next line; etc.)*
- `vendor/bin/phpstan` *(fails: found 2 errors)*
- `vendor/bin/phpunit` *(fails: 45 errors)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685b10a8bf2c832b95c9adedd0145837