### PR TITLE
Fix invite text encoding for FPDF

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -200,6 +200,7 @@ class QrController
             $invite = preg_replace('/<p[^>]*>(.*?)<\/p>/i', "$1\n", $invite);
             $invite = strip_tags($invite);
             $invite = html_entity_decode($invite);
+            $invite = $this->sanitizePdfText($invite);
             $pdf->SetFont('Arial', '', 11);
             $pdf->MultiCell($pdf->GetPageWidth() - 20, 6, $invite);
         }
@@ -210,6 +211,16 @@ class QrController
         return $response
             ->withHeader('Content-Type', 'application/pdf')
             ->withHeader('Content-Disposition', 'inline; filename="qr.pdf"');
+    }
+
+    /**
+     * Convert a UTF-8 string to ISO-8859-1 and remove unsupported characters.
+     */
+    private function sanitizePdfText(string $text): string
+    {
+        // Remove characters outside ISO-8859-1
+        $text = preg_replace('/[^\x00-\xFF]/u', '', $text);
+        return utf8_decode($text);
     }
 
     /**


### PR DESCRIPTION
## Summary
- sanitize invite text before using it in PDF
- convert to Latin-1 and drop unsupported characters

## Testing
- `pytest -q tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b14d88a88832b940818f10f4f0d1b