### PR TITLE
Add icon library to InviteText editor

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -387,3 +387,5 @@ body.dark-mode .sticky-actions {
   }
 }
 
+
+.icon-picker-grid button { width: 32px; height: 32px; padding: 0; font-size: 20px; line-height: 1; }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -98,6 +98,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const inviteSaveBtn = document.getElementById('inviteTextSave');
   const inviteModal = UIkit.modal('#inviteTextModal');
   const inviteToolbar = document.getElementById('inviteTextToolbar');
+  const symbolDropdown = document.getElementById('symbolDropdown');
   const commentTextarea = document.getElementById('catalogCommentTextarea');
   const commentSaveBtn = document.getElementById('catalogCommentSave');
   const commentModal = UIkit.modal('#catalogCommentModal');
@@ -169,6 +170,17 @@ document.addEventListener('DOMContentLoaded', function () {
         wrapSelection(inviteTextarea, '<em>', '</em>');
         break;
     }
+  });
+  symbolDropdown?.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-symbol]');
+    if (!btn || !inviteTextarea) return;
+    let symbol = btn.dataset.symbol;
+    const fallback = { '①': '1', '②': '2', '③': '3', '④': '4', '⑤': '5', '⑥': '6', '⑦': '7', '⑧': '8', '⑨': '9', '⑩': '10', '•': '-' };
+    if (document.fonts && !document.fonts.check(`16px ${getComputedStyle(inviteTextarea).fontFamily}`, symbol)) {
+      symbol = fallback[symbol] || symbol;
+    }
+    wrapSelection(inviteTextarea, symbol, '');
+    UIkit.dropdown(symbolDropdown).hide();
   });
   if (cfgFields.logoFile && cfgFields.logoPreview) {
     const bar = document.getElementById('cfgLogoProgress');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -431,6 +431,26 @@
               <button class="uk-button uk-button-default" type="button" data-format="h5">H5</button>
               <button class="uk-button uk-button-default" type="button" data-format="bold"><strong>B</strong></button>
               <button class="uk-button uk-button-default" type="button" data-format="italic"><em>I</em></button>
+              <button id="symbolPickerBtn" class="uk-button uk-button-default" type="button">🛠️ Symbole einfügen</button>
+              <div id="symbolDropdown" uk-dropdown="mode: click; pos: bottom-left">
+                <div class="icon-picker-grid uk-grid-small uk-child-width-auto" uk-grid>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="✓" uk-tooltip="title: Häkchen">✓</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="•" uk-tooltip="title: Aufzählungspunkt">•</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="→" uk-tooltip="title: Pfeil">→</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="★" uk-tooltip="title: Stern">★</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="⚡" uk-tooltip="title: Blitz">⚡</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="①" uk-tooltip="title: 1">①</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="②" uk-tooltip="title: 2">②</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="③" uk-tooltip="title: 3">③</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="④" uk-tooltip="title: 4">④</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="⑤" uk-tooltip="title: 5">⑤</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="⑥" uk-tooltip="title: 6">⑥</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="⑦" uk-tooltip="title: 7">⑦</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="⑧" uk-tooltip="title: 8">⑧</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="⑨" uk-tooltip="title: 9">⑨</button>
+                  <button class="uk-button uk-button-default" type="button" data-symbol="⑩" uk-tooltip="title: 10">⑩</button>
+                </div>
+              </div>
             </div>
             <textarea id="inviteTextTextarea" class="uk-textarea" rows="5" placeholder="Text eingeben..."></textarea>
             <div class="uk-flex uk-flex-right uk-margin-top">


### PR DESCRIPTION
## Summary
- add symbol picker dropdown in InviteText modal
- implement insertion of chosen symbol at cursor position
- check font support and fall back to ASCII symbols
- style icon grid

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b14eb9040832bb3cc49e2990be782