### PR TITLE
Fix QR PDF generation for WebP logos

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -16,6 +16,7 @@ use Endroid\QrCode\ErrorCorrectionLevel;
 use Endroid\QrCode\Label\Font\NotoSans;
 use Endroid\QrCode\RoundBlockSizeMode;
 use FPDF;
+use Intervention\Image\ImageManagerStatic as Image;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -173,8 +174,21 @@ class QrController
         $qrSize = 20.0; // mm
         $headerHeight = max(25.0, $qrSize + 10.0); // ensure QR code fits
 
+        $logoTmp = null;
         if (is_readable($logoPath)) {
+            $ext = strtolower(pathinfo($logoPath, PATHINFO_EXTENSION));
+            if ($ext === 'webp') {
+                $logoTmp = tempnam(sys_get_temp_dir(), 'logo');
+                if ($logoTmp !== false) {
+                    $logoTmp .= '.png';
+                    Image::make($logoPath)->encode('png')->save($logoTmp);
+                    $logoPath = $logoTmp;
+                }
+            }
             $pdf->Image($logoPath, 10, 10, 20, 0, 'PNG');
+            if ($logoTmp !== null && is_file($logoTmp)) {
+                unlink($logoTmp);
+            }
         }
 
         $pdf->SetXY(10, 10);

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -29,4 +29,32 @@ class QrControllerTest extends TestCase
         $this->assertSame('application/pdf', $response->getHeaderLine('Content-Type'));
         $this->assertNotEmpty((string) $response->getBody());
     }
+
+    public function testQrPdfWithWebpLogo(): void
+    {
+        $configPath = __DIR__ . '/../../data/config.json';
+        $backup = file_get_contents($configPath);
+        $cfg = json_decode((string) $backup, true);
+        $cfg['logoPath'] = '/logo.webp';
+        file_put_contents($configPath, json_encode($cfg, JSON_PRETTY_PRINT));
+
+        $logoPath = __DIR__ . '/../../data/logo.webp';
+        $img = imagecreatetruecolor(1, 1);
+        ob_start();
+        imagewebp($img);
+        $data = ob_get_clean();
+        file_put_contents($logoPath, (string) $data);
+        imagedestroy($img);
+
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/qr.pdf?t=Test');
+        $response = $app->handle($request);
+
+        unlink($logoPath);
+        file_put_contents($configPath, (string) $backup);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/pdf', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
+    }
 }


### PR DESCRIPTION
## Summary
- convert WebP logos to PNG when building QR PDFs
- test WebP logo support in QrController

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b17932238832bb5a2fab1aa71cd0e