### PR TITLE
Fix deprecation in QR controller

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -237,7 +237,7 @@ class QrController
     {
         // Remove characters outside ISO-8859-1
         $text = preg_replace('/[^\x00-\xFF]/u', '', $text);
-        return utf8_decode($text);
+        return mb_convert_encoding($text, 'ISO-8859-1', 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid using deprecated `utf8_decode` when generating QR PDFs

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: `PDOException: PDO::__construct(): Argument #1 ($dsn) must be a valid data source name`)*

------
https://chatgpt.com/codex/tasks/task_e_685b197d9bc0832bbf1c210ea3040a47