### PR TITLE
Display invite text on help page

### DIFF
--- a/templates/help.twig
+++ b/templates/help.twig
@@ -28,6 +28,11 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small">
+    {% if config.inviteText %}
+    <div class="uk-card uk-card-default uk-card-body uk-margin">
+      {{ config.inviteText|raw }}
+    </div>
+    {% endif %}
     <div class="uk-card uk-card-default uk-card-body uk-margin">
       <h2 class="uk-heading-bullet">So funktioniert das Spiel</h2>
       <p>Es gibt verschiedene Stationen, die auf der Karte markiert sind. An jeder Station scannt ihr mit eurem Handy oder Tablet den dort angebrachten QR-Code und öffnet den Link – und schon kann's losgehen.</p>


### PR DESCRIPTION
## Summary
- display `config.inviteText` if available on `/help`

## Testing
- `node tests/test_competition_mode.js`
- `pytest -q`
- ❌ `phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1c0d643c832b858917359ef17d5c