### PR TITLE
Support team placeholders in invite text

### DIFF
--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -30,6 +30,10 @@ class HelpController
             $cfg = ConfigService::removePuzzleInfo($cfg);
         }
 
+        if (!empty($cfg['inviteText'])) {
+            $cfg['inviteText'] = str_ireplace('[team]', 'Team', (string)$cfg['inviteText']);
+        }
+
         return $view->render($response, 'help.twig', ['config' => $cfg]);
     }
 }

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -207,11 +207,17 @@ class QrController
         $pdf->SetXY(10, $y + 5);
         $invite = (string)($cfg['inviteText'] ?? '');
         if ($invite !== '') {
+            $team = (string)($params['t'] ?? '');
+            if ($team === '') {
+                $team = 'Team';
+            }
+            $invite = str_ireplace('[team]', $team, $invite);
             $invite = preg_replace('/<br\s*\/>?/i', "\n", $invite);
             $invite = preg_replace('/<h[1-6]>(.*?)<\/h[1-6]>/i', "$1\n", $invite);
             $invite = preg_replace('/<p[^>]*>(.*?)<\/p>/i', "$1\n", $invite);
             $invite = strip_tags($invite);
             $invite = html_entity_decode($invite);
+            $invite = $this->sanitizePdfText($invite);
             $pdf->SetFont('Arial', '', 11);
             $pdf->MultiCell($pdf->GetPageWidth() - 20, 6, $invite);
         }

--- a/tests/Controller/HelpControllerTest.php
+++ b/tests/Controller/HelpControllerTest.php
@@ -15,4 +15,28 @@ class HelpControllerTest extends TestCase
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
+
+    public function testInvitePlaceholderIsReplaced(): void
+    {
+        $dbFile = tempnam(sys_get_temp_dir(), 'db');
+        $pdo = new \PDO('sqlite:' . $dbFile);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec("INSERT INTO config(inviteText) VALUES('Hallo [Team]!');");
+
+        putenv('POSTGRES_DSN=sqlite:' . $dbFile);
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        $_ENV['POSTGRES_DSN'] = 'sqlite:' . $dbFile;
+        $_ENV['POSTGRES_USER'] = '';
+        $_ENV['POSTGRES_PASSWORD'] = '';
+
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/help');
+        $response = $app->handle($request);
+
+        $this->assertStringContainsString('Hallo Team!', (string)$response->getBody());
+
+        unlink($dbFile);
+    }
 }

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -58,4 +58,21 @@ class QrControllerTest extends TestCase
         unlink($logoFile);
         unlink(dirname(__DIR__, 2) . '/data/logo.png');
     }
+
+    public function testInvitePlaceholderIsReplaced(): void
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec("INSERT INTO config(inviteText) VALUES('Hallo [Team]!');");
+
+        $cfg = new \App\Service\ConfigService($pdo);
+        $qr  = new \App\Controller\QrController($cfg);
+
+        $req = $this->createRequest('GET', '/qr.pdf?t=Demo');
+        $response = $qr->pdf($req, new Response());
+        $pdf = (string)$response->getBody();
+
+        $this->assertStringContainsString('Hallo Demo!', $pdf);
+    }
 }


### PR DESCRIPTION
## Summary
- show team name in QR PDF invite text
- replace `[Team]` placeholder with **Team** on help page
- test placeholder replacement in PDF

## Testing
- `php -v` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1e765fbc832bb34585f3cd60cc4d