### PR TITLE
Modernize invite text on help page

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -25,11 +25,13 @@ if (is_readable($envFile)) {
 use Slim\Views\Twig;
 use Slim\Views\TwigMiddleware;
 use App\Application\Middleware\SessionMiddleware;
+use App\Twig\UikitExtension;
 
 $settings = require __DIR__ . '/../config/settings.php';
 $app = \Slim\Factory\AppFactory::create();
 
 $twig = Twig::create(__DIR__ . '/../templates', ['cache' => false]);
+$twig->addExtension(new UikitExtension());
 $app->add(TwigMiddleware::create($app, $twig));
 $app->add(new SessionMiddleware());
 

--- a/src/Twig/UikitExtension.php
+++ b/src/Twig/UikitExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class UikitExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('uikitify', [$this, 'uikitify'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function uikitify(string $html): string
+    {
+        $patterns = [
+            '/<h([1-6])([^>]*)>/i',
+            '/<\/h([1-6])>/i',
+            '/<(strong|b)>/i',
+            '/<\/(strong|b)>/i',
+            '/<(em|i)>/i',
+            '/<\/(em|i)>/i',
+        ];
+        $replacements = [
+            '<h$1 class="uk-heading-bullet"$2>',
+            '</h$1>',
+            '<span class="uk-text-bold">',
+            '</span>',
+            '<span class="uk-text-italic">',
+            '</span>',
+        ];
+        return preg_replace($patterns, $replacements, $html);
+    }
+}
+

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -29,8 +29,8 @@
   {% endembed %}
   <div class="uk-container uk-container-small">
     {% if config.inviteText %}
-    <div class="uk-card uk-card-default uk-card-body uk-margin">
-      {{ config.inviteText|raw }}
+    <div class="modern-info-card uk-card uk-card-default uk-card-body uk-box-shadow-medium uk-margin">
+      <article class="uk-article uk-margin-remove">{{ config.inviteText|uikitify|raw }}</article>
     </div>
     {% endif %}
     <div class="uk-card uk-card-default uk-card-body uk-margin">

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,6 +33,7 @@ class TestCase extends PHPUnit_TestCase
         $app = AppFactory::create();
 
         $twig = Twig::create(__DIR__ . '/../templates', ['cache' => false]);
+        $twig->addExtension(new \App\Twig\UikitExtension());
         $app->add(TwigMiddleware::create($app, $twig));
         $app->add(new SessionMiddleware());
 


### PR DESCRIPTION
## Summary
- style invite text on help page with a Twig filter for UIkit
- register the new filter in the app and tests

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1d6673d8832b82984fe27581b623