### PR TITLE
Add example for encoding text with FPDF

### DIFF
--- a/scripts/example_text.html
+++ b/scripts/example_text.html
@@ -1,0 +1,9 @@
+Hallo liebes Team,
+
+bald geht’s los mit unserer Rallye! Damit ihr wisst, wie alles abläuft, findet ihr hier die wichtigsten Schritte übersichtlich erklärt:
+
+<h2>① Station finden</h2>
+Sucht euch auf eurer Karte die nächste Rallye-Station.
+
+<h2>② QR-Code scannen</h2>
+Scannt an der Station mit eurem Handy oder Tablet den QR-Code und öffnet den Link.

--- a/scripts/fpdf_example.php
+++ b/scripts/fpdf_example.php
@@ -1,0 +1,29 @@
+<?php
+// Simple demonstration to render HTML text with FPDF using existing fonts.
+// Usage: php scripts/fpdf_example.php [inputFile]
+
+require __DIR__ . '/../vendor/autoload.php';
+
+
+
+$input = $argv[1] ?? __DIR__ . '/example_text.html';
+if (!is_readable($input)) {
+    fwrite(STDERR, "Input file not found: $input\n");
+    exit(1);
+}
+
+// Load UTF-8 encoded text from file
+$editorText = file_get_contents($input);
+
+// Allow simple formatting tags
+$textPlain = strip_tags($editorText, '<h2><br><p>');
+
+// Convert to ISO-8859-1 for FPDF
+$textForPdf = mb_convert_encoding($textPlain, 'ISO-8859-1', 'UTF-8');
+
+$pdf = new \FPDF();
+$pdf->AddPage();
+$pdf->SetFont('Arial', '', 12);
+$pdf->MultiCell(0, 8, $textForPdf);
+
+$pdf->Output('I', 'editor-output.pdf');


### PR DESCRIPTION
## Summary
- add script `fpdf_example.php` that demonstrates how to render UTF‑8 editor text with FPDF
- include sample HTML file used by the script

## Testing
- `php scripts/fpdf_example.php`
- `vendor/bin/phpunit` *(fails: PDO and related PHP extensions missing)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685b1b8d480c832bb97d83c07bb6951d