### PR TITLE
Fix PDF logo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Backups lassen sich über `/export` erstellen und per `/import` wiederherstellen
 entfernt werden.
 
 ### Logo hochladen
-Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue PNG- oder WebP-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert.
+Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue PNG- oder WebP-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert. Die Datei landet im Verzeichnis `data/`, damit auch PDFs das Logo einbinden können.
 
 ### Sicherheit und Haftung
 Die Software wird unter der MIT-Lizenz bereitgestellt und erfolgt ohne Gewähr. Die Urheber haften nicht für Schäden, die aus der Nutzung entstehen. Die integrierten Maßnahmen zur Barrierefreiheit verbessern die Zugänglichkeit, sie ersetzen jedoch keine individuelle Prüfung.

--- a/docs-jtd/konfiguration.md
+++ b/docs-jtd/konfiguration.md
@@ -36,6 +36,8 @@ Alle wesentlichen Optionen stehen in `data/config.json` und werden beim ersten I
 }
 ```
 
+Das hochgeladene Logo wird in `data/` gespeichert und über `logoPath` referenziert, typischerweise als `/logo.png`.
+
 Optional kann `baseUrl` gesetzt werden, um in QR-Codes komplette Links zu erzeugen. Der Parameter `competitionMode` verhindert Wiederholungen bereits gelöster Kataloge. Über `teamResults` wird gesteuert, ob Teams ihre Ergebnisse einsehen dürfen, und `photoUpload` aktiviert den Upload von Beweisfotos. `puzzleWordEnabled` schaltet das Rätselwort frei und `puzzleFeedback` definiert den Erfolgshinweis nach der Lösung.
 
 Konfigurationswerte können per GET auf `/config.json` abgerufen und per POST aktualisiert werden.

--- a/docs-jtd/verwaltung.md
+++ b/docs-jtd/verwaltung.md
@@ -30,7 +30,7 @@ Der Statistik-Tab listet jede Antwort mit Name, Versuch, Katalog, Frage, Antwort
 
 - **Administration:** Ein POST auf `/password` speichert ein neues Admin-Passwort in `config.json`. Über `/export` kann ein JSON-Backup erstellt und per `/import` wieder eingespielt werden. 
   Die Route `/backups` listet vorhandene Sicherungen.
-- **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue Datei hochladen.
+- **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue Datei hochladen. Das Bild wird dabei im Ordner `data/` gespeichert, sodass PDFs es einbinden können.
 - **Ergebnisse exportieren:** Alle Resultate können als CSV-Datei heruntergeladen werden.
 Die API ermöglicht so die komplette Verwaltung eines Quizsystems und ist sowohl lokal als auch im Netzwerk schnell einsatzbereit.
 

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -166,7 +166,7 @@ class QrController
         $cfg = $this->config->getConfig();
         $title = (string)($cfg['header'] ?? '');
         $subtitle = (string)($cfg['subheader'] ?? '');
-        $logoFile = __DIR__ . '/../../' . ltrim($cfg['logoPath'] ?? '', '/');
+        $logoFile = __DIR__ . '/../../data/' . ltrim((string)($cfg['logoPath'] ?? ''), '/');
         $logoTemp = null;
         // Height of the header area in which logo, titles and QR code are placed
         $qrSize = 20.0; // mm


### PR DESCRIPTION
## Summary
- fix QR controller to use logo file from data directory
- document logo location in README and docs

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml --dont-report-useless-tests` *(fails: PDO exceptions and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_685b235fed58832bb933c64b718e616c