### PR TITLE
Increase desktop width for info card

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -360,7 +360,19 @@ body.dark-mode .sticky-actions {
   border: 1.5px solid #f3f4f6;
   padding: 2rem 1.5rem;
   margin: 1.5rem auto;
-  max-width: 500px;
+  max-width: 700px;
+}
+
+@media (min-width: 960px) {
+  .modern-info-card {
+    max-width: 900px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .modern-info-card {
+    max-width: 1100px;
+  }
 }
 
 .modern-info-card .uk-card-title {


### PR DESCRIPTION
## Summary
- widen `.modern-info-card` using UIkit breakpoints

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b22e925d8832bb297a19583b0fe60