### PR TITLE
Fix extra blank lines in QR invite PDF

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -213,10 +213,12 @@ class QrController
             }
             $invite = str_ireplace('[team]', $team, $invite);
             $invite = preg_replace('/<br\s*\/>?/i', "\n", $invite);
-            $invite = preg_replace('/<h[1-6]>(.*?)<\/h[1-6]>/i', "$1\n", $invite);
-            $invite = preg_replace('/<p[^>]*>(.*?)<\/p>/i', "$1\n", $invite);
+            $invite = preg_replace('/<h[1-6]>(.*?)<\/h[1-6]>\s*/i', "$1\n", $invite);
+            $invite = preg_replace('/<p[^>]*>\s*(.*?)\s*<\/p>\s*/i', "$1\n", $invite);
             $invite = strip_tags($invite);
             $invite = html_entity_decode($invite);
+            $invite = preg_replace('/\n{2,}/', "\n", $invite);
+            $invite = trim($invite);
             $invite = $this->sanitizePdfText($invite);
             $pdf->SetFont('Arial', '', 11);
             $pdf->MultiCell($pdf->GetPageWidth() - 20, 6, $invite);


### PR DESCRIPTION
## Summary
- trim whitespace and collapse duplicate newlines when generating invitation text for PDF

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b23bf77a4832ba60f166f70311ed1