### PR TITLE
Adjust logo dimensions in PDF

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -179,7 +179,8 @@ class QrController
                 $img->encode('png')->save($logoTemp, 80);
                 $logoFile = $logoTemp;
             }
-            $pdf->Image($logoFile, 10, 10, 20, 0, 'PNG');
+            // Display the logo with the same dimensions as the QR code
+            $pdf->Image($logoFile, 10, 10, $qrSize, $qrSize, 'PNG');
         }
 
         $pdf->SetXY(10, 10);


### PR DESCRIPTION
## Summary
- make the PDF logo render at the same size as the QR code

## Testing
- `vendor/bin/phpunit` *(fails: PDOException and other errors)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_685b24faf508832b84cc205180f5bfde