### PR TITLE
Fix UTF-8 special characters in PDF

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -261,7 +261,8 @@ class QrController
 
         libxml_use_internal_errors(true);
         $doc = new \DOMDocument();
-        $doc->loadHTML('<div>' . $html . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        // Force UTF-8 parsing to correctly handle special characters like ö,ä or ü
+        $doc->loadHTML('<?xml encoding="UTF-8"><div>' . $html . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         $this->renderHtmlNode($pdf, $doc->documentElement);
     }
 


### PR DESCRIPTION
## Summary
- ensure DOMDocument parses HTML as UTF-8 when rendering PDFs

## Testing
- `pytest`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2bd1a558832b8fa62c310d27f7d0