### PR TITLE
Reduce PDF title spacing

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -321,7 +321,8 @@ class QrController
                         $this->fontStack[] = [$current[0], $current[1], $current[2]];
                         $pdf->SetFont($current[0], 'B', $sizes[$level] ?? $current[2]);
                         $this->renderHtmlNode($pdf, $child);
-                        $pdf->Ln(8);
+                        // Further reduce the spacing after headings
+                        $pdf->Ln(2);
                         array_pop($this->fontStack);
                         $pdf->SetFont($current[0], $current[1], $current[2]);
                         break;


### PR DESCRIPTION
## Summary
- shrink heading spacing in QR PDF generator again

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml --testdox` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b2c53807c832bb04fb16f53da2414