### PR TITLE
Update team placeholder text

### DIFF
--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -31,7 +31,7 @@ class HelpController
         }
 
         if (!empty($cfg['inviteText'])) {
-            $cfg['inviteText'] = str_ireplace('[team]', 'Team', (string)$cfg['inviteText']);
+            $cfg['inviteText'] = str_ireplace('[team]', 'Team´s', (string)$cfg['inviteText']);
         }
 
         return $view->render($response, 'help.twig', ['config' => $cfg]);

--- a/tests/Controller/HelpControllerTest.php
+++ b/tests/Controller/HelpControllerTest.php
@@ -35,7 +35,7 @@ class HelpControllerTest extends TestCase
         $request = $this->createRequest('GET', '/help');
         $response = $app->handle($request);
 
-        $this->assertStringContainsString('Hallo Team!', (string)$response->getBody());
+        $this->assertStringContainsString('Hallo Team´s!', (string)$response->getBody());
 
         unlink($dbFile);
     }


### PR DESCRIPTION
## Summary
- replace `[TEAM]` placeholder with `Team´s` in HelpController
- update corresponding unit test

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: DSN errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b32df5984832b82c87ba80c0058ee