### PR TITLE
Add footer separator to QR PDF

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -225,6 +225,11 @@ class QrController
             $this->renderHtml($pdf, $invite, 'Arial', '', 11);
         }
 
+        // Draw footer separator about 1 cm from the bottom
+        $footerY = $pdf->GetPageHeight() - 10; // 10 mm margin
+        $pdf->SetLineWidth(0.2);
+        $pdf->Line(10, $footerY, $pdf->GetPageWidth() - 10, $footerY);
+
         $output = $pdf->Output('S');
 
         $response->getBody()->write($output);


### PR DESCRIPTION
## Summary
- add horizontal line footer 1 cm from bottom of QR PDF

## Testing
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_685b340944ac832b91d1416519c54e8f