### PR TITLE
Add refresh button to statistics tab

### DIFF
--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -2,6 +2,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const tbody = document.getElementById('statsTableBody');
   const filter = document.getElementById('statsFilter');
+  const refreshBtn = document.getElementById('statsRefreshBtn');
 
   let data = [];
   let catalogMap = null;
@@ -110,5 +111,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   filter?.addEventListener('change', applyFilter);
+  refreshBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    load();
+  });
+
+  if (refreshBtn && typeof UIkit !== 'undefined') {
+    UIkit.icon(refreshBtn);
+  }
+
   load();
 });

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -353,9 +353,12 @@
       <div class="uk-container uk-container-large">
         <div class="uk-flex uk-flex-between uk-flex-middle">
           <h2 class="uk-heading-bullet">Statistik</h2>
-          <select id="statsFilter" class="uk-select uk-width-small">
-            <option value="">Alle</option>
-          </select>
+          <div class="uk-flex uk-flex-middle">
+            <select id="statsFilter" class="uk-select uk-width-small uk-margin-right">
+              <option value="">Alle</option>
+            </select>
+            <button id="statsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="Aktualisieren" aria-label="Aktualisieren"></button>
+          </div>
         </div>
         <div style="overflow-x: auto">
         <table class="uk-table uk-table-divider uk-table-responsive">


### PR DESCRIPTION
## Summary
- add refresh button in admin statistics section
- reload statistics data via new button

## Testing
- `pytest -q tests/test_json_validity.py tests/test_html_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_685b8a9bbe8c832b91564d35927e72da