### PR TITLE
Update results ranking logic with catalog count

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ Alle Resultate werden in der Datenbank abgelegt. Die API bietet folgende Endpunk
 Die Ergebnisübersicht zeigt drei Ranglisten. Der Titel „Katalogmeister" basiert
 auf dem Zeitpunkt, an dem ein Team seinen letzten noch offenen Fragenkatalog
 abgeschlossen hat. Wer hier die früheste Zeit erreicht, führt die Liste an.
+Um überhaupt in dieser Liste zu erscheinen, müssen alle Kataloge aus
+`data/kataloge/catalogs.json` vollständig gelöst sein.
 
 ### Statistik
 Im Statistik-Tab lassen sich alle gegebenen Antworten detailliert auswerten. Die Tabelle zeigt Name, Versuch, Katalog,

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -1,4 +1,5 @@
 /* global UIkit */
+let catalogCount = 0;
 document.addEventListener('DOMContentLoaded', () => {
   const tbody = document.getElementById('resultsTableBody');
   const wrongBody = document.getElementById('wrongTableBody');
@@ -157,7 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
     puzzleArr.sort((a, b) => a.raw - b.raw);
     const puzzleList = puzzleArr.slice(0, 3);
 
-    const totalCats = catalogs.size;
+    const totalCats = catalogCount || catalogs.size;
     const finishers = [];
     catTimes.forEach((map, name) => {
       if (map.size === totalCats) {
@@ -266,12 +267,15 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(list => {
         const map = {};
         if (Array.isArray(list)) {
+          catalogCount = list.length;
           list.forEach(c => {
             const name = c.name || '';
             if (c.uid) map[c.uid] = name;
             if (c.sort_order) map[c.sort_order] = name;
             if (c.slug) map[c.slug] = name;
           });
+        } else {
+          catalogCount = 0;
         }
         catalogMap = map;
         return map;

--- a/tests/test_results_rankings.js
+++ b/tests/test_results_rankings.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const code = fs.readFileSync('public/js/results.js', 'utf8');
+const fmtMatch = code.match(/function formatTime\(ts\)[\s\S]*?\n\s*\}/);
+const rankMatch = code.match(/function computeRankings\(rows\) \{[\s\S]*?return { puzzleList, catalogList, pointsList };\n\s*\}/);
+if (!fmtMatch || !rankMatch) {
+  throw new Error('Functions not found');
+}
+const context = { catalogCount: 3, console };
+context.formatTime = vm.runInNewContext('(' + fmtMatch[0] + ')', context);
+const computeRankings = vm.runInNewContext('(' + rankMatch[0] + ')', context);
+
+const rows = [
+  { name: 'Team1', catalog: 'A', correct: 3, time: 10 }
+];
+let r = computeRankings(rows);
+assert.strictEqual(r.catalogList.length, 0);
+
+rows.push({ name: 'Team1', catalog: 'B', correct: 2, time: 20 });
+rows.push({ name: 'Team1', catalog: 'C', correct: 1, time: 30 });
+
+r = computeRankings(rows);
+assert.strictEqual(r.catalogList.length, 1);
+assert.strictEqual(r.catalogList[0].name, 'Team1');
+console.log('ok');


### PR DESCRIPTION
## Summary
- track total catalog count from `catalogs.json`
- rely on global catalog count when computing rankings
- document catalog master requirement
- add regression test for `computeRankings`

## Testing
- `python3 -m pytest tests/test_html_validity.py -q`
- `python3 -m pytest tests/test_json_validity.py -q`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpunit tests/Controller/ResultControllerTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685b8e166400832b8b78d45b019f0516