### PR TITLE
Add camera flip for QR scanner

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -349,15 +349,37 @@
       modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">'+
         '<h3 class="uk-modal-title uk-text-center">Who I AM</h3>'+
         '<div id="login-qr" class="uk-margin" style="max-width:320px;margin:0 auto;width:100%"></div>'+
+        '<button id="login-qr-flip" class="uk-button uk-button-default uk-width-1-1">Kamera wechseln</button>'+
         '<button id="login-qr-stop" class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Abbrechen</button>'+
       '</div>';
       let scanner;
       let opener;
+      let cameras = [];
+      let camIndex = 0;
       const stopScanner = () => {
         if(scanner){
           scanner.stop().then(()=>scanner.clear()).catch(()=>{});
           scanner = null;
         }
+      };
+      const startCamera = () => {
+        const camId = cameras[camIndex].id;
+        scanner.start(camId, { fps:10, qrbox:250 }, text => {
+          const name = text.trim();
+          if(cfg.QRRestrict && allowed.indexOf(name) === -1){
+            alert('Unbekanntes oder nicht berechtigtes Team/Person');
+            return;
+          }
+          setStored('quizUser', name);
+          sessionStorage.removeItem('quizSolved');
+          updateUserName();
+          stopScanner();
+          UIkit.modal(modal).hide();
+          onDone();
+        }).catch(err => {
+          console.error('QR scanner start failed.', err);
+          document.getElementById('login-qr').textContent = 'QR-Scanner konnte nicht gestartet werden.';
+        });
       };
       const startScanner = () => {
         if(typeof Html5Qrcode === 'undefined'){
@@ -370,30 +392,17 @@
             document.getElementById('login-qr').textContent = 'Keine Kamera gefunden.';
             return;
           }
-          let cam = cams[0].id;
-          const back = cams.find(c => /back|rear|environment/i.test(c.label));
-          if(back) cam = back.id;
-          scanner.start(cam, { fps:10, qrbox:250 }, text => {
-            const name = text.trim();
-            if(cfg.QRRestrict && allowed.indexOf(name) === -1){
-              alert('Unbekanntes oder nicht berechtigtes Team/Person');
-              return;
-            }
-              setStored('quizUser', name);
-              sessionStorage.removeItem('quizSolved');
-              updateUserName();
-            stopScanner();
-            UIkit.modal(modal).hide();
-            onDone();
-          }).catch(err => {
-            console.error('QR scanner start failed.', err);
-            document.getElementById('login-qr').textContent = 'QR-Scanner konnte nicht gestartet werden.';
-          });
+          cameras = cams;
+          camIndex = 0;
+          const backIdx = cams.findIndex(c => /back|rear|environment/i.test(c.label));
+          if(backIdx >= 0) camIndex = backIdx;
+          startCamera();
         }).catch(err => {
           console.error('Camera list error.', err);
           document.getElementById('login-qr').textContent = 'Kamera konnte nicht initialisiert werden.';
         });
       };
+      const flipBtn = modal.querySelector('#login-qr-flip');
       const stopBtn = modal.querySelector('#login-qr-stop');
       const trapFocus = (e) => {
         if(e.key === 'Tab'){
@@ -401,6 +410,14 @@
           stopBtn.focus();
         }
       };
+      flipBtn.addEventListener('click', () => {
+        if(!scanner || cameras.length < 2) return;
+        scanner.stop().then(() => {
+          scanner.clear();
+          camIndex = (camIndex + 1) % cameras.length;
+          startCamera();
+        }).catch(()=>{});
+      });
       scanBtn.addEventListener('click', (e) => {
         opener = e.currentTarget;
         UIkit.modal(modal).show();


### PR DESCRIPTION
## Summary
- add new flip button to switch between available cameras when scanning QR codes
- implement camera cycling logic for quiz and catalog login modals

## Testing
- `pytest tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb14e654c832bb7c3895ed617264d