### PR TITLE
Enable soft hyphen placeholders

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -64,6 +64,11 @@ body.uk-padding {
   margin-top: 1em;
 }
 
+.question h4,
+.question-preview h4 {
+  overflow-wrap: break-word;
+}
+
 #results-slideshow {
   position: relative;
   min-height: 2.5em;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -40,6 +40,10 @@ document.addEventListener('DOMContentLoaded', function () {
     return id;
   }
 
+  function insertSoftHyphens(text){
+    return text ? text.replace(/\/-/g, '\u00AD') : '';
+  }
+
   function updatePuzzleFeedbackUI() {
     if (!puzzleIcon || !puzzleLabel) return;
     if (puzzleFeedback.trim().length > 0) {
@@ -656,7 +660,8 @@ document.addEventListener('DOMContentLoaded', function () {
         swipe: 'Karten nach links oder rechts wischen.',
         photoText: 'Foto aufnehmen und passende Antwort eingeben.'
       };
-      typeInfo.textContent = map[typeSelect.value] || '';
+      const base = map[typeSelect.value] || '';
+      typeInfo.textContent = base + ' Versteckte Umbrüche kannst du mit "\/-" einfügen.';
     }
     updateInfo();
     typeSelect.addEventListener('change', () => {
@@ -906,13 +911,13 @@ document.addEventListener('DOMContentLoaded', function () {
     function updatePreview() {
       preview.innerHTML = '';
       const h = document.createElement('h4');
-      h.textContent = prompt.value || 'Vorschau';
+      h.textContent = insertSoftHyphens(prompt.value || 'Vorschau');
       preview.appendChild(h);
       if (typeSelect.value === 'sort') {
         const ul = document.createElement('ul');
         Array.from(fields.querySelectorAll('.item')).forEach(i => {
           const li = document.createElement('li');
-          li.textContent = i.value;
+          li.textContent = insertSoftHyphens(i.value);
           ul.appendChild(li);
         });
         preview.appendChild(ul);
@@ -922,7 +927,7 @@ document.addEventListener('DOMContentLoaded', function () {
           const term = r.querySelector('.term').value;
           const def = r.querySelector('.definition').value;
           const li = document.createElement('li');
-          li.textContent = term + ' – ' + def;
+          li.textContent = insertSoftHyphens(term) + ' – ' + insertSoftHyphens(def);
           ul.appendChild(li);
         });
         preview.appendChild(ul);
@@ -932,7 +937,7 @@ document.addEventListener('DOMContentLoaded', function () {
           const text = r.querySelector('.card-text').value;
           const check = r.querySelector('.card-correct').checked;
           const li = document.createElement('li');
-          li.textContent = text + (check ? ' ✓' : '');
+          li.textContent = insertSoftHyphens(text) + (check ? ' ✓' : '');
           ul.appendChild(li);
         });
         preview.appendChild(ul);
@@ -946,7 +951,7 @@ document.addEventListener('DOMContentLoaded', function () {
           const input = r.querySelector('.option');
           const check = r.querySelector('.answer').checked;
           const li = document.createElement('li');
-          li.textContent = input.value + (check ? ' ✓' : '');
+          li.textContent = insertSoftHyphens(input.value) + (check ? ' ✓' : '');
           if (check) li.classList.add('uk-text-success');
           ul.appendChild(li);
         });

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -90,6 +90,10 @@ async function fetchLatestPuzzleEntry(name, catalog){
 window.formatPuzzleTime = formatPuzzleTime;
 window.fetchLatestPuzzleEntry = fetchLatestPuzzleEntry;
 
+function insertSoftHyphens(text){
+  return text ? text.replace(/\/-/g, '\u00AD') : '';
+}
+
 function runQuiz(questions, skipIntro){
   // Konfiguration laden und einstellen, ob der "Antwort prüfen"-Button
   // eingeblendet werden soll
@@ -350,7 +354,7 @@ function runQuiz(questions, skipIntro){
     div.className = 'question';
     div.setAttribute('uk-scrollspy', 'cls: uk-animation-slide-bottom-small; target: > *; delay: 100');
     const h = document.createElement('h4');
-    h.textContent = q.prompt;
+    h.textContent = insertSoftHyphens(q.prompt);
     div.appendChild(h);
     const instr = document.createElement('p');
     instr.id = 'sort-desc-' + idx;
@@ -369,7 +373,7 @@ function runQuiz(questions, skipIntro){
       li.setAttribute('role','listitem');
       li.tabIndex = 0;
       li.setAttribute('aria-grabbed','false');
-      li.textContent = text;
+      li.textContent = insertSoftHyphens(text);
       ul.appendChild(li);
     });
     div.appendChild(ul);
@@ -438,7 +442,7 @@ function runQuiz(questions, skipIntro){
     div.className = 'question';
     div.setAttribute('uk-scrollspy', 'cls: uk-animation-slide-bottom-small; target: > *; delay: 100');
     const h = document.createElement('h4');
-    h.textContent = q.prompt;
+    h.textContent = insertSoftHyphens(q.prompt);
     div.appendChild(h);
     const assignDesc = document.createElement('p');
     assignDesc.id = 'assign-desc-' + idx;
@@ -464,7 +468,7 @@ function runQuiz(questions, skipIntro){
       li.tabIndex = 0;
       li.setAttribute('aria-grabbed','false');
       li.dataset.term = t.term;
-      li.textContent = t.term;
+      li.textContent = insertSoftHyphens(t.term);
       termList.appendChild(li);
     });
     left.appendChild(termList);
@@ -482,7 +486,7 @@ function runQuiz(questions, skipIntro){
       dz.dataset.definition = t.definition;
       dz.setAttribute('aria-label', 'Dropzone f\u00fcr ' + t.definition);
       dz.setAttribute('aria-dropeffect', 'move');
-      dz.textContent = t.definition;
+      dz.textContent = insertSoftHyphens(t.definition);
       rightCol.appendChild(dz);
     });
     grid.appendChild(rightCol);
@@ -543,7 +547,7 @@ function runQuiz(questions, skipIntro){
           animation: 150,
             onAdd: evt => {
             const item = evt.item;
-            zone.textContent = zone.dataset.definition + ' \u2013 ' + item.textContent;
+            zone.textContent = insertSoftHyphens(zone.dataset.definition) + ' \u2013 ' + item.textContent;
             zone.dataset.dropped = item.dataset.term;
             item.remove();
           }
@@ -564,7 +568,7 @@ function runQuiz(questions, skipIntro){
     div.querySelectorAll('.dropzone').forEach(zone => {
       zone.addEventListener('keydown', e => {
         if((e.key === 'Enter' || e.key === ' ') && div._selectedTerm){
-          zone.textContent = zone.dataset.definition + ' \u2013 ' + div._selectedTerm.textContent;
+          zone.textContent = insertSoftHyphens(zone.dataset.definition) + ' \u2013 ' + div._selectedTerm.textContent;
           zone.dataset.dropped = div._selectedTerm.dataset.term;
           div._selectedTerm.style.visibility = 'hidden';
           div._selectedTerm.setAttribute('aria-grabbed','false');
@@ -600,7 +604,7 @@ function runQuiz(questions, skipIntro){
       li.tabIndex = 0;
       li.setAttribute('aria-grabbed','false');
       li.dataset.term = t.term;
-      li.textContent = t.term;
+      li.textContent = insertSoftHyphens(t.term);
       termList.appendChild(li);
     });
     termList.querySelectorAll('li').forEach(li => {
@@ -613,7 +617,7 @@ function runQuiz(questions, skipIntro){
       });
     });
     div.querySelectorAll('.dropzone').forEach(zone => {
-      zone.textContent = zone.dataset.definition;
+      zone.textContent = insertSoftHyphens(zone.dataset.definition);
       delete zone.dataset.dropped;
     });
     feedback.textContent = '';
@@ -642,7 +646,7 @@ function runQuiz(questions, skipIntro){
     div.className = 'question';
     div.setAttribute('uk-scrollspy', 'cls: uk-animation-slide-bottom-small; target: > *; delay: 100');
     const h = document.createElement('h4');
-    h.textContent = q.prompt;
+    h.textContent = insertSoftHyphens(q.prompt);
     div.appendChild(h);
 
     const options = document.createElement('div');
@@ -661,7 +665,7 @@ function runQuiz(questions, skipIntro){
       input.name = 'mc' + idx;
       input.value = i;
       label.appendChild(input);
-      label.append(' ' + q.options[orig]);
+      label.append(' ' + insertSoftHyphens(q.options[orig]));
       options.appendChild(label);
     });
 
@@ -703,7 +707,7 @@ function runQuiz(questions, skipIntro){
     div.className = 'question';
     div.setAttribute('uk-scrollspy', 'cls: uk-animation-slide-bottom-small; target: > *; delay: 100');
     const h = document.createElement('h4');
-    h.textContent = q.prompt;
+    h.textContent = insertSoftHyphens(q.prompt);
     div.appendChild(h);
 
     const container = document.createElement('div');
@@ -743,7 +747,7 @@ function runQuiz(questions, skipIntro){
     controls.appendChild(rightBtn);
 
     const leftStatic = document.createElement('div');
-    leftStatic.textContent = '\u2B05 ' + (q.leftLabel || 'Falsch');
+    leftStatic.textContent = '\u2B05 ' + insertSoftHyphens(q.leftLabel || 'Falsch');
     leftStatic.style.position = 'absolute';
     leftStatic.style.left = '0';
     leftStatic.style.top = '50%';
@@ -755,7 +759,7 @@ function runQuiz(questions, skipIntro){
     container.appendChild(leftStatic);
 
     const rightStatic = document.createElement('div');
-    rightStatic.textContent = (q.rightLabel || 'Richtig') + ' \u27A1';
+    rightStatic.textContent = insertSoftHyphens(q.rightLabel || 'Richtig') + ' \u27A1';
     rightStatic.style.position = 'absolute';
     rightStatic.style.right = '0';
     rightStatic.style.top = '50%';
@@ -799,7 +803,7 @@ function runQuiz(questions, skipIntro){
         const off = (cards.length - i - 1) * 4;
         card.style.transform = `translate(0,-${off}px)`;
         card.style.zIndex = i;
-        card.textContent = c.text;
+        card.textContent = insertSoftHyphens(c.text);
         if(i === cards.length - 1){
           card.addEventListener('pointerdown', start);
           card.addEventListener('pointermove', move);
@@ -902,7 +906,7 @@ function runQuiz(questions, skipIntro){
     div.className = 'question';
     div.setAttribute('uk-scrollspy', 'cls: uk-animation-slide-bottom-small; target: > *; delay: 100');
     const h = document.createElement('h4');
-    h.textContent = q.prompt;
+    h.textContent = insertSoftHyphens(q.prompt);
     div.appendChild(h);
 
     const text = document.createElement('input');

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -8,6 +8,10 @@ function setStored(key, value){
     localStorage.setItem(key, value);
   }catch(e){}
 }
+
+function insertSoftHyphens(text){
+  return text ? text.replace(/\/-/g, '\u00AD') : '';
+}
 document.addEventListener('DOMContentLoaded', () => {
   const resultsBtn = document.getElementById('show-results-btn');
   const puzzleBtn = document.getElementById('check-puzzle-btn');
@@ -100,11 +104,11 @@ document.addEventListener('DOMContentLoaded', () => {
     card.className = 'uk-card uk-card-muted uk-card-body question-preview';
     const title = document.createElement('h5');
     const cat = q.catalogName || catMap[q.catalog] || q.catalog;
-    title.textContent = cat;
+    title.textContent = insertSoftHyphens(cat);
     card.appendChild(title);
 
     const h = document.createElement('h4');
-    h.textContent = q.prompt || '';
+    h.textContent = insertSoftHyphens(q.prompt || '');
     card.appendChild(h);
 
     const type = q.type || 'mc';
@@ -112,7 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const ul = document.createElement('ul');
       q.items.forEach(it => {
         const li = document.createElement('li');
-        li.textContent = it;
+        li.textContent = insertSoftHyphens(it);
         ul.appendChild(li);
       });
       card.appendChild(ul);
@@ -120,7 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const ul = document.createElement('ul');
       q.terms.forEach(p => {
         const li = document.createElement('li');
-        li.textContent = (p.term || '') + ' – ' + (p.definition || '');
+        li.textContent = insertSoftHyphens(p.term || '') + ' – ' + insertSoftHyphens(p.definition || '');
         ul.appendChild(li);
       });
       card.appendChild(ul);
@@ -128,7 +132,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const ul = document.createElement('ul');
       q.cards.forEach(c => {
         const li = document.createElement('li');
-        li.textContent = c.text + (c.correct ? ' ✓' : '');
+        li.textContent = insertSoftHyphens(c.text) + (c.correct ? ' ✓' : '');
         ul.appendChild(li);
       });
       card.appendChild(ul);
@@ -139,7 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
         q.options.forEach((opt, i) => {
           const li = document.createElement('li');
           const correct = answers.includes(i);
-          li.textContent = opt + (correct ? ' ✓' : '');
+          li.textContent = insertSoftHyphens(opt) + (correct ? ' ✓' : '');
           if(correct) li.classList.add('uk-text-success');
           ul.appendChild(li);
         });


### PR DESCRIPTION
## Summary
- add helper to replace `/-` with soft hyphens
- show hint for inserting hidden breaks below question type dropdown
- apply replacement in admin preview, quiz runtime and summary view
- wrap question headings to break long words

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bab084c24832ba2cce02ee2196d23