### PR TITLE
Disable camera flip button until cameras available

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -361,6 +361,7 @@
           scanner.stop().then(()=>scanner.clear()).catch(()=>{});
           scanner = null;
         }
+        flipBtn.disabled = true;
       };
       const startCamera = () => {
         const camId = cameras[camIndex].id;
@@ -393,6 +394,7 @@
             return;
           }
           cameras = cams;
+          flipBtn.disabled = cameras.length < 2;
           camIndex = 0;
           const backIdx = cams.findIndex(c => /back|rear|environment/i.test(c.label));
           if(backIdx >= 0) camIndex = backIdx;
@@ -404,6 +406,7 @@
       };
       const flipBtn = modal.querySelector('#login-qr-flip');
       const stopBtn = modal.querySelector('#login-qr-stop');
+      flipBtn.disabled = true;
       const trapFocus = (e) => {
         if(e.key === 'Tab'){
           e.preventDefault();

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -988,6 +988,7 @@ function runQuiz(questions, skipIntro){
           scanner.stop().then(()=>scanner.clear()).catch(()=>{});
           scanner = null;
         }
+        flipBtn.disabled = true;
       };
       const startCamera = () => {
         const camId = cameras[camIndex].id;
@@ -1013,6 +1014,7 @@ function runQuiz(questions, skipIntro){
             return;
           }
           cameras = cams;
+          flipBtn.disabled = cameras.length < 2;
           camIndex = 0;
           const backIdx = cams.findIndex(c => /back|rear|environment/i.test(c.label));
           if(backIdx >= 0) camIndex = backIdx;
@@ -1024,6 +1026,7 @@ function runQuiz(questions, skipIntro){
       };
       const flipBtn = modal.querySelector('#qr-reader-flip');
       const stopBtn = modal.querySelector('#qr-reader-stop');
+      flipBtn.disabled = true;
       const trapFocus = (e) => {
         if(e.key === 'Tab'){
           e.preventDefault();


### PR DESCRIPTION
## Summary
- make camera flip buttons disabled by default
- enable the flip option only if at least two cameras exist
- disable flip again when stopping the scanner

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb53dc5b8832ba1dde9c8bb204744