### PR TITLE
Fix QR camera flip button timing

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -431,10 +431,10 @@
         camIndex = (camIndex + 1) % cameras.length;
         await startCamera();
       });
-      scanBtn.addEventListener('click', (e) => {
+      scanBtn.addEventListener('click', async (e) => {
         opener = e.currentTarget;
         UIkit.modal(modal).show();
-        startScanner();
+        await startScanner();
       });
       UIkit.util.on(modal, 'shown', () => {
         stopBtn.focus();
@@ -463,7 +463,7 @@
       container.appendChild(modal);
       if(autoScan){
         UIkit.modal(modal).show();
-        startScanner();
+        await startScanner();
       }
     }else{
       if(!cfg.competitionMode || hasCatalog){

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1051,10 +1051,10 @@ function runQuiz(questions, skipIntro){
         camIndex = (camIndex + 1) % cameras.length;
         await startCamera();
       });
-      scanBtn.addEventListener('click', (e) => {
+      scanBtn.addEventListener('click', async (e) => {
         opener = e.currentTarget;
         UIkit.modal(modal).show();
-        startScanner();
+        await startScanner();
       });
       UIkit.util.on(modal, 'shown', () => {
         stopBtn.focus();


### PR DESCRIPTION
## Summary
- await `startScanner()` when opening the QR modal
- await `startScanner()` when auto-starting scan

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(not run due to missing composer)*

------
https://chatgpt.com/codex/tasks/task_e_685bba825e34832b9726557ac8010215