### PR TITLE
Fix camera flip by recreating scanner

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -424,10 +424,11 @@
         flipBtn.disabled = true;
         try{
           await scanner.stop();
+          await scanner.clear();
+          scanner = new Html5Qrcode('login-qr');
         }catch(e){
-          // ignore stop errors
+          console.warn('Fehler beim Stoppen oder Clearen:', e);
         }
-        scanner.clear();
         camIndex = (camIndex + 1) % cameras.length;
         await startCamera();
       });

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1044,10 +1044,11 @@ function runQuiz(questions, skipIntro){
         flipBtn.disabled = true;
         try{
           await scanner.stop();
+          await scanner.clear();
+          scanner = new Html5Qrcode('qr-reader');
         }catch(e){
-          // ignore stop errors
+          console.warn('Fehler beim Stoppen oder Clearen:', e);
         }
-        scanner.clear();
         camIndex = (camIndex + 1) % cameras.length;
         await startCamera();
       });


### PR DESCRIPTION
## Summary
- recreate Html5Qrcode scanner after clear so the flip button works on first try

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `phpunit` *(fails: vendor dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf449260832ba5c033b248d40e02