### PR TITLE
Add bulk invitation PDF download

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -378,6 +378,12 @@ document.addEventListener('DOMContentLoaded', function () {
     window.print();
   });
 
+  const openInvitesBtn = document.getElementById('openInvitesBtn');
+  openInvitesBtn?.addEventListener('click', function (e) {
+    e.preventDefault();
+    window.open('/invites.pdf', '_blank');
+  });
+
   document.querySelectorAll('.qr-print-btn').forEach(btn => {
     btn.addEventListener('click', e => {
       e.preventDefault();

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\ConfigService;
+use App\Service\TeamService;
 
 use Endroid\QrCode\Builder\Builder;
 use Endroid\QrCode\Writer\PngWriter;
@@ -26,6 +27,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 class QrController
 {
     private ConfigService $config;
+    private TeamService $teams;
     /**
      * Stack for keeping track of currently selected PDF font.
      * Each entry is an array with [family, style, size].
@@ -37,9 +39,10 @@ class QrController
     /**
      * Inject configuration service dependency.
      */
-    public function __construct(ConfigService $config)
+    public function __construct(ConfigService $config, TeamService $teams)
     {
         $this->config = $config;
+        $this->teams = $teams;
     }
 
     /**
@@ -236,6 +239,105 @@ class QrController
         return $response
             ->withHeader('Content-Type', 'application/pdf')
             ->withHeader('Content-Disposition', 'inline; filename="qr.pdf"');
+    }
+
+    /**
+     * Render a PDF with invitations for all teams.
+     */
+    public function pdfAll(Request $request, Response $response): Response
+    {
+        $params = $request->getQueryParams();
+        $fg     = (string)($params['fg'] ?? '0000ff');
+        $bg     = (string)($params['bg'] ?? 'ffffff');
+        $size   = (int)($params['s'] ?? 300);
+        $margin = (int)($params['m'] ?? 20);
+
+        $teams = $this->teams->getAll();
+
+        $cfg = $this->config->getConfig();
+        $title = (string)($cfg['header'] ?? '');
+        $subtitle = (string)($cfg['subheader'] ?? '');
+        $logoPath = __DIR__ . '/../../data/' . ltrim((string)($cfg['logoPath'] ?? ''), '/');
+
+        $pdf = new FPDF();
+
+        foreach ($teams as $team) {
+            $builder = Builder::create()
+                ->writer(new PngWriter())
+                ->data($team)
+                ->encoding(new Encoding('UTF-8'))
+                ->size($size)
+                ->margin($margin)
+                ->backgroundColor($this->parseColor($bg, new Color(255, 255, 255)))
+                ->foregroundColor($this->parseColor($fg, new Color(0, 0, 255)));
+
+            $result = $builder
+                ->roundBlockSizeMode(RoundBlockSizeMode::Margin)
+                ->build();
+
+            $png = $result->getString();
+            $tmp = tempnam(sys_get_temp_dir(), 'qr');
+            if ($tmp !== false) {
+                file_put_contents($tmp, $png);
+            }
+
+            $pdf->AddPage();
+
+            $logoFile = $logoPath;
+            $logoTemp = null;
+            $qrSize = 20.0;
+            $headerHeight = max(25.0, $qrSize + 5.0);
+
+            if (is_readable($logoFile)) {
+                if (str_ends_with(strtolower($logoFile), '.webp')) {
+                    $img = Image::make($logoFile);
+                    $logoTemp = tempnam(sys_get_temp_dir(), 'logo') . '.png';
+                    $img->encode('png')->save($logoTemp, 80);
+                    $logoFile = $logoTemp;
+                }
+                $pdf->Image($logoFile, 10, 10, $qrSize, $qrSize, 'PNG');
+            }
+
+            $pdf->SetXY(10, 10);
+            $pdf->SetFont('Arial', 'B', 16);
+            $pdf->Cell($pdf->GetPageWidth() - 20, 8, $title, 0, 2, 'C');
+            $pdf->SetFont('Arial', '', 12);
+            $pdf->Cell($pdf->GetPageWidth() - 20, 6, $subtitle, 0, 2, 'C');
+
+            $y = 10 + $headerHeight - 2;
+            $pdf->SetLineWidth(0.2);
+            $pdf->Line(10, $y, $pdf->GetPageWidth() - 10, $y);
+
+            if ($tmp !== false) {
+                $qrX = $pdf->GetPageWidth() - 10 - $qrSize;
+                $qrY = 10.0;
+                $pdf->Image($tmp, $qrX, $qrY, $qrSize, $qrSize, 'PNG');
+                unlink($tmp);
+            }
+
+            if ($logoTemp !== null) {
+                unlink($logoTemp);
+            }
+
+            $pdf->SetXY(10, $y + 5);
+            $invite = (string)($cfg['inviteText'] ?? '');
+            if ($invite !== '') {
+                $invite = str_ireplace('[team]', $team ?: 'Team', $invite);
+                $pdf->SetFont('Arial', '', 11);
+                $this->renderHtml($pdf, $invite, 'Arial', '', 11);
+            }
+
+            $footerY = $pdf->GetPageHeight() - 10;
+            $pdf->SetLineWidth(0.2);
+            $pdf->Line(10, $footerY, $pdf->GetPageWidth() - 10, $footerY);
+        }
+
+        $output = $pdf->Output('S');
+
+        $response->getBody()->write($output);
+        return $response
+            ->withHeader('Content-Type', 'application/pdf')
+            ->withHeader('Content-Disposition', 'inline; filename="invites.pdf"');
     }
 
     /**

--- a/src/routes.php
+++ b/src/routes.php
@@ -74,7 +74,7 @@ return function (\Slim\App $app) {
     );
     $teamController = new TeamController($teamService);
     $passwordController = new PasswordController($configService);
-    $qrController = new QrController($configService);
+    $qrController = new QrController($configService, $teamService);
     $logoController = new LogoController($configService);
     $summaryController = new SummaryController($configService);
     $importController = new ImportController(
@@ -146,6 +146,7 @@ return function (\Slim\App $app) {
     $app->delete('/backups/{name}', [$backupController, 'delete']);
     $app->get('/qr.png', [$qrController, 'image']);
     $app->get('/qr.pdf', [$qrController, 'pdf']);
+    $app->get('/invites.pdf', [$qrController, 'pdfAll']);
     $app->get('/logo.png', [$logoController, 'get'])->setArgument('ext', 'png');
     $app->post('/logo.png', [$logoController, 'post']);
     $app->get('/logo.webp', [$logoController, 'get'])->setArgument('ext', 'webp');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -417,12 +417,13 @@
           </div>
           {% endfor %}
         </div>
-        <div class="uk-margin uk-flex uk-flex-right">
+        <div class="uk-margin uk-flex">
           <button id="inviteTextBtn" class="uk-button uk-button-default uk-margin-right" type="button" uk-toggle="target: #inviteTextModal">
             <span id="inviteTextIcon" uk-icon="icon: pencil"></span>
             <span id="inviteTextLabel">Einladungstext eingeben</span>
           </button>
-          <button id="summaryPrintBtn" class="uk-button uk-button-default" uk-tooltip="title: Zusammenfassung drucken; pos: right">Drucken</button>
+          <button id="summaryPrintBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Übersicht drucken; pos: right">Übersicht Drucken</button>
+          <button id="openInvitesBtn" class="uk-button uk-button-default" uk-tooltip="title: Alle Einladungen öffnen; pos: right">Einladungen öffnen</button>
         </div>
         <div id="inviteTextModal" uk-modal>
           <div class="uk-modal-dialog uk-modal-body">

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -38,7 +38,8 @@ class QrControllerTest extends TestCase
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
         $cfg = new \App\Service\ConfigService($pdo);
-        $qr = new \App\Controller\QrController($cfg);
+        $teams = new \App\Service\TeamService($pdo);
+        $qr = new \App\Controller\QrController($cfg, $teams);
         $logo = new \App\Controller\LogoController($cfg);
 
         $req = $this->createRequest('GET', '/qr.pdf?t=Demo');
@@ -67,12 +68,33 @@ class QrControllerTest extends TestCase
         $pdo->exec("INSERT INTO config(inviteText) VALUES('Hallo [Team]!');");
 
         $cfg = new \App\Service\ConfigService($pdo);
-        $qr  = new \App\Controller\QrController($cfg);
+        $teams = new \App\Service\TeamService($pdo);
+        $qr  = new \App\Controller\QrController($cfg, $teams);
 
         $req = $this->createRequest('GET', '/qr.pdf?t=Demo');
         $response = $qr->pdf($req, new Response());
         $pdf = (string)$response->getBody();
 
         $this->assertStringContainsString('Hallo Demo!', $pdf);
+    }
+
+    public function testAllInvitationsPdfIsGenerated(): void
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY);');
+        $pdo->exec("INSERT INTO teams(sort_order,name,uid) VALUES(1,'A','1'),(2,'B','2')");
+
+        $cfg = new \App\Service\ConfigService($pdo);
+        $teams = new \App\Service\TeamService($pdo);
+        $qr  = new \App\Controller\QrController($cfg, $teams);
+
+        $req = $this->createRequest('GET', '/invites.pdf');
+        $response = $qr->pdfAll($req, new Response());
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/pdf', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string)$response->getBody());
     }
 }


### PR DESCRIPTION
## Summary
- reposition invite-text button and rename the print button
- add an "Einladungen öffnen" button
- support generating invitation PDFs for all teams
- wire up new route and tests

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: could not find driver and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685bbfe61be8832ba19963629db8e394