### PR TITLE
Fix competition mode index display

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -546,11 +546,9 @@
             if(catalogs.length && solvedNow.size === catalogs.length){
               showAllSolvedModal();
               return;
-            } else {
-              showCatalogSolvedModal(selected.name || selected.slug || selected.id, remaining);
-              showSelection(catalogs, solvedNow);
-              return;
             }
+            showCatalogSolvedModal(selected.name || selected.slug || selected.id, remaining);
+            return;
           }
         loadQuestions(selected.slug || selected.id, selected.file, selected.raetsel_buchstabe, selected.uid, selected.name || selected.slug || selected.id, selected.description || '', selected.comment || '');
       }else{


### PR DESCRIPTION
## Summary
- avoid catalog selection page when already solved catalog is opened in competition mode

## Testing
- `vendor/bin/phpunit` *(fails: PDO drivers missing)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_685c1301bbec832bb31d84aec536e33b