### PR TITLE
Update photo consent text

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1244,7 +1244,7 @@ function runQuiz(questions, skipIntro){
       '<div class="uk-modal-dialog uk-modal-body">' +
         '<div class="uk-card uk-card-default uk-card-body uk-padding-small uk-width-1-1">' +
           '<p class="uk-text-small">Hinweis zum Hochladen von Gruppenfotos:<br>' +
-            'Mit dem Upload eines Fotos bestätigen Sie, dass alle abgebildeten Personen der Verwendung des Fotos im Rahmen der Veranstaltung zustimmen. Das Hochladen ist freiwillig. Die Fotos werden ausschließlich für die Dokumentation der Veranstaltung verwendet und nach der Veranstaltung von der Onlineplattform gelöscht.' +
+            'Ich bestätige, dass alle auf dem Foto abgebildeten Personen vor der Aufnahme darüber informiert wurden, dass das Gruppenfoto zu Dokumentationszwecken erstellt und ggf. veröffentlicht wird. Alle Anwesenden hatten Gelegenheit, der Aufnahme zu widersprechen, indem sie den Aufnahmebereich verlassen oder dies ausdrücklich mitteilen konnten.' +
           '</p>' +
           '<div class="uk-margin-small-bottom">' +
             '<label class="uk-form-label" for="photo-input">Beweisfoto auswählen</label>' +

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -310,7 +310,7 @@ document.addEventListener('DOMContentLoaded', () => {
       '<div class="uk-modal-dialog uk-modal-body">' +
         '<div class="uk-card uk-card-default uk-card-body uk-padding-small uk-width-1-1">' +
           '<p class="uk-text-small">Hinweis zum Hochladen von Gruppenfotos:<br>' +
-            'Mit dem Upload eines Fotos bestätigen Sie, dass alle abgebildeten Personen der Verwendung des Fotos im Rahmen der Veranstaltung zustimmen. Das Hochladen ist freiwillig. Die Fotos werden ausschließlich für die Dokumentation der Veranstaltung verwendet und nach der Veranstaltung von der Onlineplattform gelöscht.' +
+            'Ich bestätige, dass alle auf dem Foto abgebildeten Personen vor der Aufnahme darüber informiert wurden, dass das Gruppenfoto zu Dokumentationszwecken erstellt und ggf. veröffentlicht wird. Alle Anwesenden hatten Gelegenheit, der Aufnahme zu widersprechen, indem sie den Aufnahmebereich verlassen oder dies ausdrücklich mitteilen konnten.' +
           '</p>' +
           '<div class="uk-margin-small-bottom">' +
             '<label class="uk-form-label" for="photo-input">Beweisfoto auswählen</label>' +


### PR DESCRIPTION
## Summary
- update text for consent before uploading photos

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: `composer` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864e85286d8832bbf098a2b8a227035