### PR TITLE
Fix puzzle feedback display in summary

### DIFF
--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -272,7 +272,11 @@ document.addEventListener('DOMContentLoaded', () => {
               setTimeout(() => { feedback.textContent = ''; }, 3000);
             }
             if(data.success){
-              feedback.textContent = 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
+              const cfg = window.quizConfig || {};
+              const msg = (cfg.puzzleFeedback && cfg.puzzleFeedback.trim())
+                ? cfg.puzzleFeedback
+                : 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
+              feedback.textContent = msg;
               feedback.className = 'uk-margin-top uk-text-center uk-text-success';
               sessionStorage.setItem('puzzleSolved', 'true');
               sessionStorage.setItem('puzzleTime', String(ts));


### PR DESCRIPTION
## Summary
- display configured puzzle feedback text when puzzle solved in summary

## Testing
- `vendor/bin/phpunit` *(fails: could not find driver)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6864eb6501c0832b9335dafea7312bc3