### PR TITLE
Implement PDF export for team results

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1117,6 +1117,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   const resultsResetBtn = document.getElementById('resultsResetBtn');
   const resultsDownloadBtn = document.getElementById('resultsDownloadBtn');
+  const resultsPdfBtn = document.getElementById('resultsPdfBtn');
 
   resultsResetBtn?.addEventListener('click', function (e) {
     e.preventDefault();
@@ -1157,6 +1158,11 @@ document.addEventListener('DOMContentLoaded', function () {
         console.error(err);
       notify('Fehler beim Herunterladen', 'danger');
     });
+  });
+
+  resultsPdfBtn?.addEventListener('click', function (e) {
+    e.preventDefault();
+    window.open('/results.pdf', '_blank');
   });
 
   // --------- Teams/Personen ---------

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -428,7 +428,7 @@ class QrController
                         $level = (int)substr($tag, 1);
                         $sizes = [1 => 16, 2 => 14, 3 => 12, 4 => 11, 5 => 11, 6 => 11];
                         $this->fontStack[] = [$current[0], $current[1], $current[2]];
-                        $pdf->SetFont($current[0], 'B', $sizes[$level] ?? $current[2]);
+                        $pdf->SetFont($current[0], 'B', $sizes[$level]);
                         $this->renderHtmlNode($pdf, $child);
                         // Further reduce the spacing after headings
                         $pdf->Ln(2);

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -37,7 +37,7 @@ class ResultService
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($rows as &$row) {
             foreach (["options","answers","terms","items"] as $k) {
-                if (isset($row[$k]) && $row[$k] !== null) {
+                if (isset($row[$k])) {
                     $row[$k] = json_decode((string)$row[$k], true);
                 } else {
                     unset($row[$k]);
@@ -65,7 +65,7 @@ class ResultService
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($rows as &$row) {
             foreach (["options", "answers", "terms", "items"] as $k) {
-                if (isset($row[$k]) && $row[$k] !== null) {
+                if (isset($row[$k])) {
                     $row[$k] = json_decode((string) $row[$k], true);
                 } else {
                     unset($row[$k]);

--- a/src/routes.php
+++ b/src/routes.php
@@ -125,6 +125,7 @@ return function (\Slim\App $app) {
     $app->get('/results.json', [$resultController, 'get']);
     $app->get('/question-results.json', [$resultController, 'getQuestions']);
     $app->get('/results/download', [$resultController, 'download']);
+    $app->get('/results.pdf', [$resultController, 'pdf']);
     $app->post('/results', [$resultController, 'post']);
     $app->delete('/results', [$resultController, 'delete']);
     $app->get('/config.json', [$configController, 'get']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -335,7 +335,10 @@
         <ul id="resultsPagination" class="uk-pagination uk-flex-center"></ul>
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="resultsResetBtn" class="uk-button uk-button-default" uk-tooltip="title: Löscht alle gespeicherten Ergebnisse; pos: right">Zurücksetzen</button>
-          <button id="resultsDownloadBtn" class="uk-button uk-button-primary" uk-tooltip="title: Ergebnisse herunterladen; pos: right">Herunterladen</button>
+          <div class="uk-flex">
+            <button id="resultsPdfBtn" class="uk-button uk-button-primary uk-margin-right" uk-icon="icon: file-pdf" uk-tooltip="title: PDF generieren; pos: right">Auswertung öffnen</button>
+            <button id="resultsDownloadBtn" class="uk-button uk-button-primary" uk-tooltip="title: Ergebnisse herunterladen; pos: right">Herunterladen</button>
+          </div>
         </div>
 
         <div id="resultsResetModal" uk-modal>

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -15,4 +15,24 @@ class ResultControllerTest extends TestCase
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
+
+    public function testResultsPdfIsGenerated(): void
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time) VALUES('Team1','cat',1,3,5,0)");
+
+        $cfg = new \App\Service\ConfigService($pdo);
+        $svc = new \App\Service\ResultService($pdo);
+        $ctrl = new \App\Controller\ResultController($svc, $cfg, sys_get_temp_dir());
+
+        $req = $this->createRequest('GET', '/results.pdf');
+        $response = $ctrl->pdf($req, new \Slim\Psr7\Response());
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/pdf', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string)$response->getBody());
+    }
 }


### PR DESCRIPTION
## Summary
- add PDF generation in `ResultController` for all teams
- register new route `/results.pdf`
- include a button on the admin results tab to trigger PDF download
- handle PDF generation event in admin.js
- minor static analysis fixes

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpstan`
- `vendor/bin/phpunit` *(fails: PDO driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864eb2fcb2c832baabe24d7bc8bee81