### PR TITLE
Show photo evidence in results PDF

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -188,6 +188,7 @@ class ResultController
         $results = $this->service->getAll();
         $catalogMax = [];
         $scores = [];
+        $photos = [];
         foreach ($results as $row) {
             $team = (string)($row['name'] ?? '');
             $cat = (string)($row['catalog'] ?? '');
@@ -198,6 +199,9 @@ class ResultController
             }
             if (!isset($scores[$team][$cat]) || $correct > $scores[$team][$cat]) {
                 $scores[$team][$cat] = $correct;
+            }
+            if (!empty($row['photo'])) {
+                $photos[$team] = true;
             }
         }
         $maxPoints = array_sum($catalogMax);
@@ -250,6 +254,9 @@ class ResultController
             $pdf->SetFont('Arial', '', 14);
             $text = sprintf('Punkte: %d von %d', $points, $maxPoints);
             $pdf->Cell($pdf->GetPageWidth() - 20, 8, $text, 0, 2, 'C');
+            if (isset($photos[$team])) {
+                $pdf->Cell($pdf->GetPageWidth() - 20, 6, 'Beweisfoto abgegeben', 0, 2, 'C');
+            }
 
             $footerY = $pdf->GetPageHeight() - 10;
             $pdf->SetLineWidth(0.2);


### PR DESCRIPTION
## Summary
- highlight teams that submitted proof photos in the results PDF

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Tests: 50, Errors: 33)*
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686503f42f60832bbe83a91104b6fb9d