### PR TITLE
Show photo evidence in results PDF

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -186,8 +186,10 @@ class ResultController
     {
         $teams = $this->teams->getAll();
         $results = $this->service->getAll();
+        $questionResults = $this->service->getQuestionResults();
         $catalogMax = [];
         $scores = [];
+        $photos = [];
         foreach ($results as $row) {
             $team = (string)($row['name'] ?? '');
             $cat = (string)($row['catalog'] ?? '');
@@ -198,6 +200,15 @@ class ResultController
             }
             if (!isset($scores[$team][$cat]) || $correct > $scores[$team][$cat]) {
                 $scores[$team][$cat] = $correct;
+            }
+            if (!empty($row['photo'])) {
+                $photos[$team] = true;
+            }
+        }
+        foreach ($questionResults as $qr) {
+            $team = (string)($qr['name'] ?? '');
+            if (!empty($qr['photo'])) {
+                $photos[$team] = true;
             }
         }
         $maxPoints = array_sum($catalogMax);
@@ -250,6 +261,9 @@ class ResultController
             $pdf->SetFont('Arial', '', 14);
             $text = sprintf('Punkte: %d von %d', $points, $maxPoints);
             $pdf->Cell($pdf->GetPageWidth() - 20, 8, $text, 0, 2, 'C');
+            if (isset($photos[$team])) {
+                $pdf->Cell($pdf->GetPageWidth() - 20, 6, 'Beweisfoto abgegeben', 0, 2, 'C');
+            }
 
             $footerY = $pdf->GetPageHeight() - 10;
             $pdf->SetLineWidth(0.2);

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -23,6 +23,8 @@ class ResultControllerTest extends TestCase
         $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
         $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time) VALUES('Team1','cat',1,3,5,0)");
+        $pdo->exec('CREATE TABLE question_results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, question_id INTEGER NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, answer_text TEXT, photo TEXT, consent BOOLEAN);');
+        $pdo->exec("INSERT INTO question_results(name,catalog,question_id,attempt,correct,photo) VALUES('Team1','cat',1,1,1,'/path/foo.jpg')");
         $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY);');
         $pdo->exec("INSERT INTO teams(sort_order,name,uid) VALUES(1,'Team1','1')");
 
@@ -39,5 +41,6 @@ class ResultControllerTest extends TestCase
         $pdf = (string)$response->getBody();
         $this->assertNotEmpty($pdf);
         $this->assertStringContainsString('Team1', $pdf);
+        $this->assertStringContainsString('Beweisfoto abgegeben', $pdf);
     }
 }


### PR DESCRIPTION
## Summary
- highlight teams that submitted proof photos in the results PDF
- include photos uploaded per question in the detection logic
- cover indicator text in tests

## Testing
- `composer install --ignore-platform-req=ext-intl`
- `vendor/bin/phpunit` *(fails: 33 errors, 7 failures)*
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686503f42f60832bbe83a91104b6fb9d