### PR TITLE
Show photo evidence in results PDF

### DIFF
--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -23,6 +23,8 @@ class ResultControllerTest extends TestCase
         $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
         $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time) VALUES('Team1','cat',1,3,5,0)");
+        $pdo->exec('CREATE TABLE question_results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, question_id INTEGER NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, answer_text TEXT, photo TEXT, consent BOOLEAN);');
+        $pdo->exec("INSERT INTO question_results(name,catalog,question_id,attempt,correct,photo) VALUES('Team1','cat',1,1,1,'/path/foo.jpg')");
         $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY);');
         $pdo->exec("INSERT INTO teams(sort_order,name,uid) VALUES(1,'Team1','1')");
 
@@ -39,5 +41,10 @@ class ResultControllerTest extends TestCase
         $pdf = (string)$response->getBody();
         $this->assertNotEmpty($pdf);
         $this->assertStringContainsString('Team1', $pdf);
+        $this->assertGreaterThan(
+            1,
+            substr_count($pdf, '/Subtype /Image'),
+            'Photo should be embedded in PDF'
+        );
     }
 }


### PR DESCRIPTION
## Summary
- embed the first uploaded proof photo for each team in the PDF
- convert WebP photos to PNG before insertion
- update tests to look for an embedded image instead of text

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686503f42f60832bbe83a91104b6fb9d