### PR TITLE
Return puzzle feedback after correct answer

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1197,9 +1197,11 @@ function runQuiz(questions, skipIntro){
           }
           if(data.success){
             if(debugTimer) clearTimeout(debugTimer);
-            const msg = (cfg.puzzleFeedback && cfg.puzzleFeedback.trim())
-              ? cfg.puzzleFeedback
-              : 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
+            const msg = (data.feedback && data.feedback.trim())
+              ? data.feedback
+              : (cfg.puzzleFeedback && cfg.puzzleFeedback.trim())
+                ? cfg.puzzleFeedback
+                : 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
             feedback.textContent = msg;
             feedback.className = 'uk-margin-top uk-text-center uk-text-success';
             sessionStorage.setItem('puzzleSolved', 'true');

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -273,9 +273,11 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if(data.success){
               const cfg = window.quizConfig || {};
-              const msg = (cfg.puzzleFeedback && cfg.puzzleFeedback.trim())
-                ? cfg.puzzleFeedback
-                : 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
+              const msg = (data.feedback && data.feedback.trim())
+                ? data.feedback
+                : (cfg.puzzleFeedback && cfg.puzzleFeedback.trim())
+                  ? cfg.puzzleFeedback
+                  : 'Herzlichen Glückwunsch, das Rätselwort ist korrekt!';
               feedback.textContent = msg;
               feedback.className = 'uk-margin-top uk-text-center uk-text-success';
               sessionStorage.setItem('puzzleSolved', 'true');

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -89,7 +89,9 @@ class ResultController
                 $catalog = (string)($data['catalog'] ?? '');
                 $time = (int)$data['puzzleTime'];
                 $answer = (string)($data['puzzleAnswer'] ?? '');
-                $expected = (string)($this->config->getConfig()['puzzleWord'] ?? '');
+                $cfg = $this->config->getConfig();
+                $expected = (string)($cfg['puzzleWord'] ?? '');
+                $feedback = (string)($cfg['puzzleFeedback'] ?? '');
                 $a = mb_strtolower(trim($answer), 'UTF-8');
                 $e = mb_strtolower(trim($expected), 'UTF-8');
                 $result['answer'] = $answer;
@@ -109,6 +111,7 @@ class ResultController
                         ]);
                         $result['success'] = true;
                     }
+                    $result['feedback'] = $feedback;
                 }
             } else {
                 $this->service->add($data);


### PR DESCRIPTION
## Summary
- include `puzzleFeedback` in the result response when the puzzle is solved
- display the returned feedback in the puzzle check modals

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686503410ae0832b925c7811c06a532e