### PR TITLE
Fix PDF photo path handling

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -269,7 +269,11 @@ class ResultController
             }
 
             if (!empty($photos[$team])) {
-                $file = $this->photoDir . '/' . ltrim((string) $photos[$team][0], '/');
+                $rel = (string) $photos[$team][0];
+                if (str_starts_with($rel, '/photo/')) {
+                    $rel = substr($rel, 7);
+                }
+                $file = $this->photoDir . '/' . ltrim($rel, '/');
                 if (is_readable($file)) {
                     $tmp = null;
                     if (str_ends_with(strtolower($file), '.webp')) {


### PR DESCRIPTION
## Summary
- trim `/photo/` prefix when resolving evidence paths in PDF

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- ❌ `phpunit` *(failed: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650d5114c4832b87e43f6aea5a2aa4