### PR TITLE
Fix team PDF text

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -264,9 +264,7 @@ class ResultController
             $pdf->SetFont('Arial', '', 14);
             $text = sprintf('Punkte: %d von %d', $points, $maxPoints);
             $pdf->Cell($pdf->GetPageWidth() - 20, 8, $text, 0, 2, 'C');
-            if (isset($photos[$team])) {
-                $pdf->Cell($pdf->GetPageWidth() - 20, 6, 'Beweisfoto abgegeben', 0, 2, 'C');
-            }
+
 
             if (!empty($photos[$team])) {
                 $rel = (string) $photos[$team][0];


### PR DESCRIPTION
## Summary
- remove the "Beweisfoto abgegeben" line from the team stats PDF

## Testing
- `./vendor/bin/phpunit` *(fails: could not set up database)*

------
https://chatgpt.com/codex/tasks/task_e_686511c3983c832bb9b69815f2245034