### PR TITLE
Track answered questions per team in PDF

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -193,6 +193,7 @@ class ResultController
         $catalogMax = [];
         $scores = [];
         $photos = [];
+        $teamTotals = [];
         foreach ($results as $row) {
             $team = (string)($row['name'] ?? '');
             $cat = (string)($row['catalog'] ?? '');
@@ -203,6 +204,9 @@ class ResultController
             }
             if (!isset($scores[$team][$cat]) || $correct > $scores[$team][$cat]) {
                 $scores[$team][$cat] = $correct;
+            }
+            if (!isset($teamTotals[$team][$cat]) || $total > $teamTotals[$team][$cat]) {
+                $teamTotals[$team][$cat] = $total;
             }
             if (!empty($row['photo'])) {
                 $photos[$team][] = (string)$row['photo'];
@@ -226,6 +230,7 @@ class ResultController
         foreach ($teams as $team) {
             $cats = $scores[$team] ?? [];
             $points = array_sum($cats);
+            $answered = array_sum($teamTotals[$team] ?? []);
 
             $pdf->AddPage();
 
@@ -262,7 +267,8 @@ class ResultController
             $pdf->SetFont('Arial', 'B', 20);
             $pdf->Cell($pdf->GetPageWidth() - 20, 10, $this->sanitizePdfText($team), 0, 2, 'C');
             $pdf->SetFont('Arial', '', 14);
-            $text = sprintf('Punkte: %d von %d', $points, $maxPoints);
+            $denom = $answered > 0 ? $answered : $maxPoints;
+            $text = sprintf('Punkte: %d von %d', $points, $denom);
             $pdf->Cell($pdf->GetPageWidth() - 20, 8, $text, 0, 2, 'C');
 
 

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -41,6 +41,7 @@ class ResultControllerTest extends TestCase
         $pdf = (string)$response->getBody();
         $this->assertNotEmpty($pdf);
         $this->assertStringContainsString('Team1', $pdf);
+        $this->assertStringContainsString('Punkte: 3 von 5', $pdf);
         $this->assertGreaterThan(
             1,
             substr_count($pdf, '/Subtype /Image'),


### PR DESCRIPTION
## Summary
- store the highest total per team and catalog
- show points out of the answered questions per team when generating the PDF
- ensure PDF test checks for updated points display

## Testing
- `python3 -m pytest tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `./vendor/bin/phpunit --no-coverage` *(fails: no database schema)*

------
https://chatgpt.com/codex/tasks/task_e_6865164a2a50832b96c1b0802614ee31