### PR TITLE
Implement automatic team award messages in PDFs

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -8,6 +8,7 @@ use App\Service\ResultService;
 use App\Service\ConfigService;
 use App\Service\CatalogService;
 use App\Service\TeamService;
+use App\Service\AwardService;
 use App\Infrastructure\Database;
 use FPDF;
 use Intervention\Image\ImageManagerStatic as Image;
@@ -216,6 +217,9 @@ class ResultController
         }
         $maxPoints = array_sum($catalogMax);
 
+        $awardService = new AwardService();
+        $rankings = $awardService->computeRankings($results, count($catalogMax));
+
         $cfg = $this->config->getConfig();
         $title = (string)($cfg['header'] ?? '');
         $subtitle = (string)($cfg['subheader'] ?? '');
@@ -265,6 +269,12 @@ class ResultController
             $text = sprintf('Punkte: %d von %d', $points, $maxPoints);
             $pdf->Cell($pdf->GetPageWidth() - 20, 8, $text, 0, 2, 'C');
 
+            $congrats = $awardService->buildText($team, $rankings);
+            if ($congrats) {
+                $pdf->SetFont('Arial', '', 12);
+                $pdf->MultiCell($pdf->GetPageWidth() - 20, 6, $this->sanitizePdfText($congrats));
+                $pdf->Ln(2);
+            }
 
             if (!empty($photos[$team])) {
                 $rel = (string) $photos[$team][0];

--- a/src/Service/AwardService.php
+++ b/src/Service/AwardService.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Calculate rankings from result data and build congratulation texts.
+ */
+class AwardService
+{
+    /**
+     * Compute top 3 rankings for puzzle time, catalog completion and points.
+     *
+     * @param list<array<string,mixed>> $results
+     * @param int|null $catalogCount total number of catalogs if known
+     * @return array{
+     *     puzzle:list<string>,
+     *     catalog:list<string>,
+     *     points:list<string>
+     * }
+     */
+    public function computeRankings(array $results, ?int $catalogCount = null): array
+    {
+        $catalogs = [];
+        $puzzleTimes = [];
+        $catalogTimes = [];
+        $scores = [];
+
+        foreach ($results as $row) {
+            $team = (string)($row['name'] ?? '');
+            $catalog = (string)($row['catalog'] ?? '');
+            $time = (int)($row['time'] ?? 0);
+            $correct = (int)($row['correct'] ?? 0);
+            $puzzle = isset($row['puzzleTime']) ? (int)$row['puzzleTime'] : null;
+
+            $catalogs[$catalog] = true;
+
+            if ($puzzle !== null) {
+                if (!isset($puzzleTimes[$team]) || $puzzle < $puzzleTimes[$team]) {
+                    $puzzleTimes[$team] = $puzzle;
+                }
+            }
+
+            if (!isset($catalogTimes[$team][$catalog]) || $time < $catalogTimes[$team][$catalog]) {
+                $catalogTimes[$team][$catalog] = $time;
+            }
+
+            if (!isset($scores[$team][$catalog]) || $correct > $scores[$team][$catalog]) {
+                $scores[$team][$catalog] = $correct;
+            }
+        }
+
+        $totalCatalogs = $catalogCount ?? count($catalogs);
+
+        $puzzleList = [];
+        foreach ($puzzleTimes as $team => $t) {
+            $puzzleList[] = ['team' => $team, 'time' => $t];
+        }
+        usort($puzzleList, fn($a, $b) => $a['time'] <=> $b['time']);
+        $puzzleRanks = array_column(array_slice($puzzleList, 0, 3), 'team');
+
+        $finishers = [];
+        foreach ($catalogTimes as $team => $map) {
+            if (count($map) === $totalCatalogs) {
+                $finishers[] = ['team' => $team, 'time' => max($map)];
+            }
+        }
+        usort($finishers, fn($a, $b) => $a['time'] <=> $b['time']);
+        $catalogRanks = array_column(array_slice($finishers, 0, 3), 'team');
+
+        $scoreList = [];
+        foreach ($scores as $team => $map) {
+            $total = array_sum($map);
+            $scoreList[] = ['team' => $team, 'score' => $total];
+        }
+        usort($scoreList, fn($a, $b) => $b['score'] <=> $a['score']);
+        $pointsRanks = array_column(array_slice($scoreList, 0, 3), 'team');
+
+        return [
+            'puzzle' => $puzzleRanks,
+            'catalog' => $catalogRanks,
+            'points' => $pointsRanks,
+        ];
+    }
+
+    /**
+     * Build the congratulation text for a team.
+     *
+     * @param string $team team name
+     * @param array{
+     *     puzzle:list<string>,
+     *     catalog:list<string>,
+     *     points:list<string>
+     * } $rankings
+     * @param array<string,array{title:string,desc:string}>|null $info
+     */
+    public function buildText(string $team, array $rankings, ?array $info = null): ?string
+    {
+        $defaults = [
+            'catalog' => [
+                'title' => 'Katalogmeister',
+                'desc' => 'Team, das alle Kataloge am schnellsten durchgespielt hat',
+            ],
+            'points' => [
+                'title' => 'Highscore-Champions',
+                'desc' => 'Team mit den meisten Lösungen aller Fragen',
+            ],
+            'puzzle' => [
+                'title' => 'Rätselwort-Bestzeit',
+                'desc' => 'schnellstes Lösen des Rätselworts',
+            ],
+        ];
+        $info = $info ? $info + $defaults : $defaults;
+
+        $placeMap = [];
+        foreach ($rankings as $key => $list) {
+            $pos = array_search($team, $list, true);
+            if ($pos !== false) {
+                $placeMap[$pos + 1][] = $key;
+            }
+        }
+
+        if ($placeMap === []) {
+            return null;
+        }
+
+        $sentences = [];
+        if (!empty($placeMap[1])) {
+            $parts = [];
+            foreach ($placeMap[1] as $k) {
+                $parts[] = sprintf('%s – %s', $info[$k]['title'], $info[$k]['desc']);
+            }
+            $sentences[] = 'Herzlichen Glückwunsch! Ihr seid ' . $this->join($parts) . '.';
+        }
+        if (!empty($placeMap[2])) {
+            $titles = array_map(fn($k) => $info[$k]['title'], $placeMap[2]);
+            $sentences[] = 'Auch in der Kategorie ' . $this->join($titles) . ' habt ihr einen tollen zweiten Platz erreicht.';
+        }
+        if (!empty($placeMap[3])) {
+            $titles = array_map(fn($k) => $info[$k]['title'], $placeMap[3]);
+            $sentences[] = 'Und in ' . $this->join($titles) . ' wart ihr unter den Top 3!';
+        }
+
+        return implode(' ', $sentences);
+    }
+
+    /**
+     * Join a list with commas and "und" before the last item.
+     *
+     * @param list<string> $items
+     */
+    private function join(array $items): string
+    {
+        if (count($items) === 0) {
+            return '';
+        }
+        if (count($items) === 1) {
+            return $items[0];
+        }
+        $last = array_pop($items);
+        return implode(', ', $items) . ' und ' . $last;
+    }
+}


### PR DESCRIPTION
## Summary
- compute award rankings from result data
- generate a dynamic congratulations text
- output the text in team PDF pages

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68651ad859ac832bae1eb6610ffd0906