### PR TITLE
Refine award text logic

### DIFF
--- a/src/Service/AwardService.php
+++ b/src/Service/AwardService.php
@@ -126,20 +126,29 @@ class AwardService
         }
 
         $sentences = [];
+        $hasPrevious = false;
+
         if (!empty($placeMap[1])) {
             $parts = [];
             foreach ($placeMap[1] as $k) {
                 $parts[] = sprintf('%s – %s', $info[$k]['title'], $info[$k]['desc']);
             }
             $sentences[] = 'Herzlichen Glückwunsch! Ihr seid ' . $this->join($parts) . '.';
+            $hasPrevious = true;
         }
+
         if (!empty($placeMap[2])) {
             $titles = array_map(fn($k) => $info[$k]['title'], $placeMap[2]);
-            $sentences[] = 'Auch in der Kategorie ' . $this->join($titles) . ' habt ihr einen tollen zweiten Platz erreicht.';
+            $intro = $hasPrevious ? 'Auch in ' : 'In ';
+            $category = count($titles) === 1 ? 'der Kategorie ' : 'den Kategorien ';
+            $sentences[] = $intro . $category . $this->join($titles) . ' habt ihr einen tollen zweiten Platz erreicht.';
+            $hasPrevious = true;
         }
+
         if (!empty($placeMap[3])) {
             $titles = array_map(fn($k) => $info[$k]['title'], $placeMap[3]);
-            $sentences[] = 'Und in ' . $this->join($titles) . ' wart ihr unter den Top 3!';
+            $intro = $hasPrevious ? 'Und in ' : 'In ';
+            $sentences[] = $intro . $this->join($titles) . ' wart ihr unter den Top 3!';
         }
 
         return implode(' ', $sentences);

--- a/tests/Service/AwardServiceTest.php
+++ b/tests/Service/AwardServiceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\AwardService;
+use Tests\TestCase;
+
+class AwardServiceTest extends TestCase
+{
+    public function testSecondPlaceStandaloneSingleCategory(): void
+    {
+        $svc = new AwardService();
+        $rankings = [
+            'puzzle' => ['First', 'Team'],
+            'catalog' => [],
+            'points' => [],
+        ];
+
+        $text = $svc->buildText('Team', $rankings);
+        $this->assertSame(
+            'In der Kategorie Rätselwort-Bestzeit habt ihr einen tollen zweiten Platz erreicht.',
+            $text
+        );
+    }
+
+    public function testSecondPlaceAfterFirstMultipleCategories(): void
+    {
+        $svc = new AwardService();
+        $rankings = [
+            'puzzle' => ['A', 'Team'],
+            'catalog' => ['Team'],
+            'points' => ['B', 'Team'],
+        ];
+
+        $text = $svc->buildText('Team', $rankings);
+        $expected = 'Herzlichen Glückwunsch! Ihr seid Katalogmeister – Team, '
+            . 'das alle Kataloge am schnellsten durchgespielt hat. '
+            . 'Auch in den Kategorien Rätselwort-Bestzeit und Highscore-Champions '
+            . 'habt ihr einen tollen zweiten Platz erreicht.';
+        $this->assertSame($expected, $text);
+    }
+
+    public function testThirdPlaceOnly(): void
+    {
+        $svc = new AwardService();
+        $rankings = [
+            'puzzle' => ['A', 'B', 'Team'],
+            'catalog' => [],
+            'points' => [],
+        ];
+
+        $text = $svc->buildText('Team', $rankings);
+        $this->assertSame('In Rätselwort-Bestzeit wart ihr unter den Top 3!', $text);
+    }
+
+    public function testFullCombination(): void
+    {
+        $svc = new AwardService();
+        $rankings = [
+            'puzzle' => ['A', 'B', 'Team'],
+            'catalog' => ['Team'],
+            'points' => ['A', 'Team'],
+        ];
+
+        $expected = 'Herzlichen Glückwunsch! Ihr seid Katalogmeister – Team, '
+            . 'das alle Kataloge am schnellsten durchgespielt hat. '
+            . 'Auch in der Kategorie Highscore-Champions habt ihr einen tollen zweiten Platz erreicht. '
+            . 'Und in Rätselwort-Bestzeit wart ihr unter den Top 3!';
+        $text = $svc->buildText('Team', $rankings);
+        $this->assertSame($expected, $text);
+    }
+}


### PR DESCRIPTION
## Summary
- adjust AwardService intros for second and third places
- add tests for AwardService output

## Testing
- `vendor/bin/phpstan analyse --no-progress`
- `vendor/bin/phpunit tests/Service/AwardServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68651ebd4494832bbba25abe364b5ae1