### PR TITLE
Update award text format

### DIFF
--- a/src/Service/AwardService.php
+++ b/src/Service/AwardService.php
@@ -113,45 +113,19 @@ class AwardService
         ];
         $info = $info ? $info + $defaults : $defaults;
 
-        $placeMap = [];
+        $lines = [];
         foreach ($rankings as $key => $list) {
-            $pos = array_search($team, $list, true);
-            if ($pos !== false) {
-                $placeMap[$pos + 1][] = $key;
+            if (in_array($team, $list, true)) {
+                $lines[] = sprintf('• %s: %s', $info[$key]['title'], $info[$key]['desc']);
             }
         }
 
-        if ($placeMap === []) {
+        if ($lines === []) {
             return null;
         }
 
-        $sentences = [];
-        $hasPrevious = false;
-
-        if (!empty($placeMap[1])) {
-            $parts = [];
-            foreach ($placeMap[1] as $k) {
-                $parts[] = sprintf('%s – %s', $info[$k]['title'], $info[$k]['desc']);
-            }
-            $sentences[] = 'Herzlichen Glückwunsch! Ihr seid ' . $this->join($parts) . '.';
-            $hasPrevious = true;
-        }
-
-        if (!empty($placeMap[2])) {
-            $titles = array_map(fn($k) => $info[$k]['title'], $placeMap[2]);
-            $intro = $hasPrevious ? 'Auch in ' : 'In ';
-            $category = count($titles) === 1 ? 'der Kategorie ' : 'den Kategorien ';
-            $sentences[] = $intro . $category . $this->join($titles) . ' habt ihr einen tollen zweiten Platz erreicht.';
-            $hasPrevious = true;
-        }
-
-        if (!empty($placeMap[3])) {
-            $titles = array_map(fn($k) => $info[$k]['title'], $placeMap[3]);
-            $intro = $hasPrevious ? 'Und in ' : 'In ';
-            $sentences[] = $intro . $this->join($titles) . ' wart ihr unter den Top 3!';
-        }
-
-        return implode(' ', $sentences);
+        return "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
+            . implode("\n", $lines);
     }
 
     /**

--- a/tests/Service/AwardServiceTest.php
+++ b/tests/Service/AwardServiceTest.php
@@ -19,10 +19,9 @@ class AwardServiceTest extends TestCase
         ];
 
         $text = $svc->buildText('Team', $rankings);
-        $this->assertSame(
-            'In der Kategorie Rätselwort-Bestzeit habt ihr einen tollen zweiten Platz erreicht.',
-            $text
-        );
+        $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
+            . "• Rätselwort-Bestzeit: schnellstes Lösen des Rätselworts";
+        $this->assertSame($expected, $text);
     }
 
     public function testSecondPlaceAfterFirstMultipleCategories(): void
@@ -35,10 +34,10 @@ class AwardServiceTest extends TestCase
         ];
 
         $text = $svc->buildText('Team', $rankings);
-        $expected = 'Herzlichen Glückwunsch! Ihr seid Katalogmeister – Team, '
-            . 'das alle Kataloge am schnellsten durchgespielt hat. '
-            . 'Auch in den Kategorien Rätselwort-Bestzeit und Highscore-Champions '
-            . 'habt ihr einen tollen zweiten Platz erreicht.';
+        $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
+            . "• Rätselwort-Bestzeit: schnellstes Lösen des Rätselworts\n"
+            . "• Katalogmeister: Team, das alle Kataloge am schnellsten durchgespielt hat\n"
+            . "• Highscore-Champions: Team mit den meisten Lösungen aller Fragen";
         $this->assertSame($expected, $text);
     }
 
@@ -52,7 +51,9 @@ class AwardServiceTest extends TestCase
         ];
 
         $text = $svc->buildText('Team', $rankings);
-        $this->assertSame('In Rätselwort-Bestzeit wart ihr unter den Top 3!', $text);
+        $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
+            . "• Rätselwort-Bestzeit: schnellstes Lösen des Rätselworts";
+        $this->assertSame($expected, $text);
     }
 
     public function testFullCombination(): void
@@ -64,10 +65,10 @@ class AwardServiceTest extends TestCase
             'points' => ['A', 'Team'],
         ];
 
-        $expected = 'Herzlichen Glückwunsch! Ihr seid Katalogmeister – Team, '
-            . 'das alle Kataloge am schnellsten durchgespielt hat. '
-            . 'Auch in der Kategorie Highscore-Champions habt ihr einen tollen zweiten Platz erreicht. '
-            . 'Und in Rätselwort-Bestzeit wart ihr unter den Top 3!';
+        $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
+            . "• Rätselwort-Bestzeit: schnellstes Lösen des Rätselworts\n"
+            . "• Katalogmeister: Team, das alle Kataloge am schnellsten durchgespielt hat\n"
+            . "• Highscore-Champions: Team mit den meisten Lösungen aller Fragen";
         $text = $svc->buildText('Team', $rankings);
         $this->assertSame($expected, $text);
     }


### PR DESCRIPTION
## Summary
- simplify award text logic to output bullet list of awards
- adjust AwardService tests for new bullet list output

## Testing
- `node tests/test_results_rankings.js`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652245ed4c832bb88001d4bf808357