### PR TITLE
Fix AwardService ranking placement

### DIFF
--- a/tests/Service/AwardServiceTest.php
+++ b/tests/Service/AwardServiceTest.php
@@ -13,14 +13,17 @@ class AwardServiceTest extends TestCase
     {
         $svc = new AwardService();
         $rankings = [
-            'puzzle' => ['First', 'Team'],
+            'puzzle' => [
+                ['team' => 'First', 'place' => 1],
+                ['team' => 'Team', 'place' => 2],
+            ],
             'catalog' => [],
             'points' => [],
         ];
 
         $text = $svc->buildText('Team', $rankings);
         $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
-            . "• Rätselwort-Bestzeit: schnellstes Lösen des Rätselworts";
+            . "• Rätselwort-Bestzeit (Platz 2): schnellstes Lösen des Rätselworts";
         $this->assertSame($expected, $text);
     }
 
@@ -28,16 +31,24 @@ class AwardServiceTest extends TestCase
     {
         $svc = new AwardService();
         $rankings = [
-            'puzzle' => ['A', 'Team'],
-            'catalog' => ['Team'],
-            'points' => ['B', 'Team'],
+            'puzzle' => [
+                ['team' => 'A', 'place' => 1],
+                ['team' => 'Team', 'place' => 2],
+            ],
+            'catalog' => [
+                ['team' => 'Team', 'place' => 1],
+            ],
+            'points' => [
+                ['team' => 'B', 'place' => 1],
+                ['team' => 'Team', 'place' => 2],
+            ],
         ];
 
         $text = $svc->buildText('Team', $rankings);
         $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
-            . "• Rätselwort-Bestzeit: schnellstes Lösen des Rätselworts\n"
-            . "• Katalogmeister: Team, das alle Kataloge am schnellsten durchgespielt hat\n"
-            . "• Highscore-Champions: Team mit den meisten Lösungen aller Fragen";
+            . "• Rätselwort-Bestzeit (Platz 2): schnellstes Lösen des Rätselworts\n"
+            . "• Katalogmeister (Platz 1): Team, das alle Kataloge am schnellsten durchgespielt hat\n"
+            . "• Highscore-Champions (Platz 2): Team mit den meisten Lösungen aller Fragen";
         $this->assertSame($expected, $text);
     }
 
@@ -45,14 +56,18 @@ class AwardServiceTest extends TestCase
     {
         $svc = new AwardService();
         $rankings = [
-            'puzzle' => ['A', 'B', 'Team'],
+            'puzzle' => [
+                ['team' => 'A', 'place' => 1],
+                ['team' => 'B', 'place' => 2],
+                ['team' => 'Team', 'place' => 3],
+            ],
             'catalog' => [],
             'points' => [],
         ];
 
         $text = $svc->buildText('Team', $rankings);
         $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
-            . "• Rätselwort-Bestzeit: schnellstes Lösen des Rätselworts";
+            . "• Rätselwort-Bestzeit (Platz 3): schnellstes Lösen des Rätselworts";
         $this->assertSame($expected, $text);
     }
 
@@ -60,15 +75,24 @@ class AwardServiceTest extends TestCase
     {
         $svc = new AwardService();
         $rankings = [
-            'puzzle' => ['A', 'B', 'Team'],
-            'catalog' => ['Team'],
-            'points' => ['A', 'Team'],
+            'puzzle' => [
+                ['team' => 'A', 'place' => 1],
+                ['team' => 'B', 'place' => 2],
+                ['team' => 'Team', 'place' => 3],
+            ],
+            'catalog' => [
+                ['team' => 'Team', 'place' => 1],
+            ],
+            'points' => [
+                ['team' => 'A', 'place' => 1],
+                ['team' => 'Team', 'place' => 2],
+            ],
         ];
 
         $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
-            . "• Rätselwort-Bestzeit: schnellstes Lösen des Rätselworts\n"
-            . "• Katalogmeister: Team, das alle Kataloge am schnellsten durchgespielt hat\n"
-            . "• Highscore-Champions: Team mit den meisten Lösungen aller Fragen";
+            . "• Rätselwort-Bestzeit (Platz 3): schnellstes Lösen des Rätselworts\n"
+            . "• Katalogmeister (Platz 1): Team, das alle Kataloge am schnellsten durchgespielt hat\n"
+            . "• Highscore-Champions (Platz 2): Team mit den meisten Lösungen aller Fragen";
         $text = $svc->buildText('Team', $rankings);
         $this->assertSame($expected, $text);
     }


### PR DESCRIPTION
## Summary
- track placement in AwardService rankings
- show placement numbers when building award text
- adjust AwardService tests for new output

## Testing
- `node tests/test_results_rankings.js`
- `python3 -m pytest -q`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686524313da0832b8f9c9c4b85ff06b9