### PR TITLE
Adjust AwardService output formatting

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -281,7 +281,7 @@ class ResultController
             $congrats = $awardService->buildText($team, $rankings);
             if ($congrats) {
                 $pdf->Ln(8);
-                $pdf->SetFont('Arial', 'B', 12);
+                $pdf->SetFont('Arial', '', 12);
                 $pdf->SetX($imgX);
                 $block = mb_strtoupper($congrats, 'UTF-8');
                 $pdf->MultiCell($imgWidth, 6, $this->sanitizePdfText($block));


### PR DESCRIPTION
## Summary
- remove bold formatting from AwardService text in team PDF

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686527be3a3c832b806cd669eb04bb56