### PR TITLE
Fix catalog ranking to check all catalogs

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -24,16 +24,24 @@ class ResultController
     private ResultService $service;
     private ConfigService $config;
     private TeamService $teams;
+    private CatalogService $catalogs;
     private string $photoDir;
 
     /**
      * Inject dependencies and define photo directory.
      */
-    public function __construct(ResultService $service, ConfigService $config, TeamService $teams, string $photoDir)
+    public function __construct(
+        ResultService $service,
+        ConfigService $config,
+        TeamService $teams,
+        CatalogService $catalogs,
+        string $photoDir
+    )
     {
         $this->service = $service;
         $this->config = $config;
         $this->teams = $teams;
+        $this->catalogs = $catalogs;
         $this->photoDir = rtrim($photoDir, '/');
     }
 
@@ -221,8 +229,15 @@ class ResultController
         }
         $maxPoints = array_sum($catalogMax);
 
+        $catalogCount = 0;
+        $catsJson = $this->catalogs->read('catalogs.json');
+        if ($catsJson !== null) {
+            $list = json_decode($catsJson, true) ?: [];
+            $catalogCount = count($list);
+        }
+
         $awardService = new AwardService();
-        $rankings = $awardService->computeRankings($results, count($catalogMax));
+        $rankings = $awardService->computeRankings($results, $catalogCount);
 
         $cfg = $this->config->getConfig();
         $title = (string)($cfg['header'] ?? '');

--- a/src/routes.php
+++ b/src/routes.php
@@ -71,6 +71,7 @@ return function (\Slim\App $app) {
         $resultService,
         $configService,
         $teamService,
+        $catalogService,
         __DIR__ . '/../data/photos'
     );
     $teamController = new TeamController($teamService);

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -31,7 +31,8 @@ class ResultControllerTest extends TestCase
         $cfg = new \App\Service\ConfigService($pdo);
         $svc = new \App\Service\ResultService($pdo);
         $teams = new \App\Service\TeamService($pdo);
-        $ctrl = new \App\Controller\ResultController($svc, $cfg, $teams, sys_get_temp_dir());
+        $catalogs = new \App\Service\CatalogService($pdo);
+        $ctrl = new \App\Controller\ResultController($svc, $cfg, $teams, $catalogs, sys_get_temp_dir());
 
         $req = $this->createRequest('GET', '/results.pdf');
         $response = $ctrl->pdf($req, new \Slim\Psr7\Response());


### PR DESCRIPTION
## Summary
- inject `CatalogService` into `ResultController`
- use all known catalogs when computing PDF rankings
- pass the service in `routes.php`
- update controller test

## Testing
- `pytest -q`
- `node tests/test_results_rankings.js`
- `node tests/test_competition_mode.js`
- ❌ `phpunit` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686525224c5c832bbdf8cfe003fa50ae