### PR TITLE
Enhance team PDF layout

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -286,21 +286,46 @@ class ResultController
             }
 
             $pdf->SetXY(10, $y + 15);
-            $pdf->SetFont('Arial', 'B', 20);
+            $pdf->SetFont('Arial', 'B', 24);
             $pdf->Cell($pdf->GetPageWidth() - 20, 10, $this->sanitizePdfText($team), 0, 2, 'C');
             $pdf->SetFont('Arial', '', 14);
             $denom = $answered > 0 ? $answered : $maxPoints;
             $text = sprintf('Punkte: %d von %d', $points, $denom);
+            $pdf->SetTextColor(120, 120, 120);
             $pdf->Cell($pdf->GetPageWidth() - 20, 8, $text, 0, 2, 'C');
+            $pdf->SetTextColor(0, 0, 0);
 
-            $congrats = $awardService->buildText($team, $rankings);
-            if ($congrats) {
+            $awards = $awardService->getAwards($team, $rankings);
+            if ($awards !== []) {
                 $pdf->Ln(8);
-                $pdf->SetFont('Arial', '', 12);
-                $pdf->SetX($imgX);
-                $block = mb_strtoupper($congrats, 'UTF-8');
-                $pdf->MultiCell($imgWidth, 6, $this->sanitizePdfText($block));
+                $pdf->SetFont('Arial', 'B', 18);
+                $pdf->Cell($pdf->GetPageWidth() - 20, 9, 'HERZLICHEN GLÜCKWUNSCH!', 0, 2, 'C');
+                $pdf->Ln(3);
+                $pdf->SetFont('Arial', 'B', 14);
+                $pdf->Cell($pdf->GetPageWidth() - 20, 7, 'AUSZEICHNUNGEN:', 0, 2, 'C');
                 $pdf->Ln(2);
+                foreach ($awards as $a) {
+                    switch ((int) $a['place']) {
+                        case 1:
+                            $pdf->SetTextColor(212, 175, 55);
+                            break;
+                        case 2:
+                            $pdf->SetTextColor(192, 192, 192);
+                            break;
+                        case 3:
+                            $pdf->SetTextColor(205, 127, 50);
+                            break;
+                        default:
+                            $pdf->SetTextColor(0, 0, 0);
+                    }
+                    $title = sprintf('%d. %s', (int) $a['place'], $a['title']);
+                    $pdf->SetFont('Arial', 'B', 12);
+                    $pdf->Cell($pdf->GetPageWidth() - 20, 6, $this->sanitizePdfText($title), 0, 2, 'C');
+                    $pdf->SetFont('Arial', 'I', 10);
+                    $pdf->SetTextColor(0, 0, 0);
+                    $pdf->MultiCell($imgWidth, 5, $this->sanitizePdfText($a['desc']), 0, 'C');
+                    $pdf->Ln(1);
+                }
             }
 
             if (!empty($photos[$team])) {

--- a/src/Service/AwardService.php
+++ b/src/Service/AwardService.php
@@ -140,6 +140,52 @@ class AwardService
     }
 
     /**
+     * Get structured award information for a team.
+     *
+     * @param string $team team name
+     * @param array{
+     *     puzzle:list<array{team:string,place:int}>,
+     *     catalog:list<array{team:string,place:int}>,
+     *     points:list<array{team:string,place:int}>
+     * } $rankings
+     * @param array<string,array{title:string,desc:string}>|null $info
+     * @return list<array{place:int,title:string,desc:string}>
+     */
+    public function getAwards(string $team, array $rankings, ?array $info = null): array
+    {
+        $defaults = [
+            'catalog' => [
+                'title' => 'Katalogmeister',
+                'desc' => 'Team, das alle Kataloge am schnellsten durchgespielt hat',
+            ],
+            'points' => [
+                'title' => 'Highscore-Champions',
+                'desc' => 'Team mit den meisten Lösungen aller Fragen',
+            ],
+            'puzzle' => [
+                'title' => 'Rätselwort-Bestzeit',
+                'desc' => 'schnellstes Lösen des Rätselworts',
+            ],
+        ];
+        $info = $info ? $info + $defaults : $defaults;
+
+        $list = [];
+        foreach ($rankings as $key => $entries) {
+            foreach ($entries as $entry) {
+                if ($entry['team'] === $team) {
+                    $list[] = [
+                        'place' => (int) $entry['place'],
+                        'title' => $info[$key]['title'],
+                        'desc' => $info[$key]['desc'],
+                    ];
+                }
+            }
+        }
+
+        return $list;
+    }
+
+    /**
      * Join a list with commas and "und" before the last item.
      *
      * @param list<string> $items


### PR DESCRIPTION
## Summary
- add `getAwards` helper to `AwardService`
- style team results PDF with congratulatory header and colored awards section

## Testing
- `pytest -q`
- `npx jest -q` *(fails: Need to install jest)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686529dd9720832baa56af1e0df0c5ad