### PR TITLE
Remove PDF icon from admin results button

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -336,7 +336,7 @@
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="resultsResetBtn" class="uk-button uk-button-default" uk-tooltip="title: Löscht alle gespeicherten Ergebnisse; pos: right">Zurücksetzen</button>
           <div class="uk-flex">
-            <button id="resultsPdfBtn" class="uk-button uk-button-primary uk-margin-right" uk-icon="icon: file-pdf" uk-tooltip="title: PDF generieren; pos: right">Auswertung öffnen</button>
+            <button id="resultsPdfBtn" class="uk-button uk-button-primary uk-margin-right" uk-tooltip="title: PDF generieren; pos: right">Auswertung öffnen</button>
             <button id="resultsDownloadBtn" class="uk-button uk-button-primary" uk-tooltip="title: Ergebnisse herunterladen; pos: right">Herunterladen</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the `uk-icon` attribute so the PDF icon no longer appears on the **Auswertung öffnen** button

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68652a62f3b8832b8a7a193a3dea46db