### PR TITLE
Fix award text for places 2 and 3

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -299,7 +299,14 @@ class ResultController
             if ($awards !== []) {
                 $pdf->Ln(8);
                 $pdf->SetFont('Arial', 'B', 18);
-                $pdf->Cell($pdf->GetPageWidth() - 20, 9, 'HERZLICHEN GLÜCKWUNSCH!', 0, 2, 'C');
+                $pdf->Cell(
+                    $pdf->GetPageWidth() - 20,
+                    9,
+                    $this->sanitizePdfText('HERZLICHEN GLÜCKWUNSCH!'),
+                    0,
+                    2,
+                    'C'
+                );
                 $pdf->Ln(3);
                 $pdf->SetFont('Arial', 'B', 14);
                 $pdf->Cell($pdf->GetPageWidth() - 20, 7, 'AUSZEICHNUNGEN:', 0, 2, 'C');
@@ -323,7 +330,7 @@ class ResultController
                     $pdf->Cell($pdf->GetPageWidth() - 20, 6, $this->sanitizePdfText($title), 0, 2, 'C');
                     $pdf->SetFont('Arial', 'I', 10);
                     $pdf->SetTextColor(0, 0, 0);
-                    $pdf->MultiCell($imgWidth, 5, $this->sanitizePdfText($a['desc']), 0, 'C');
+                    $pdf->MultiCell($pdf->GetPageWidth() - 20, 5, $this->sanitizePdfText($a['desc']), 0, 'C');
                     $pdf->Ln(1);
                 }
             }

--- a/src/Service/AwardService.php
+++ b/src/Service/AwardService.php
@@ -126,7 +126,9 @@ class AwardService
         foreach ($rankings as $key => $list) {
             foreach ($list as $entry) {
                 if ($entry['team'] === $team) {
-                    $lines[] = sprintf('• %s (Platz %d): %s', $info[$key]['title'], $entry['place'], $info[$key]['desc']);
+                    $place = (int) $entry['place'];
+                    $desc = $this->placeDescription($key, $place, $info[$key]['desc']);
+                    $lines[] = sprintf('• %s (Platz %d): %s', $info[$key]['title'], $place, $desc);
                 }
             }
         }
@@ -173,16 +175,35 @@ class AwardService
         foreach ($rankings as $key => $entries) {
             foreach ($entries as $entry) {
                 if ($entry['team'] === $team) {
+                    $place = (int) $entry['place'];
+                    $desc = $this->placeDescription($key, $place, $info[$key]['desc']);
                     $list[] = [
-                        'place' => (int) $entry['place'],
+                        'place' => $place,
                         'title' => $info[$key]['title'],
-                        'desc' => $info[$key]['desc'],
+                        'desc' => $desc,
                     ];
                 }
             }
         }
 
         return $list;
+    }
+
+    private function placeDescription(string $key, int $place, string $default): string
+    {
+        return match ($place) {
+            2 => match ($key) {
+                'puzzle' => 'zweit schnellstes Lösen des Rätselworts',
+                'points' => 'zweit bestes Team mit den meisten Lösungen aller Fragen',
+                default => $default,
+            },
+            3 => match ($key) {
+                'puzzle' => 'dritt schnellstes Lösen des Rätselworts',
+                'points' => 'dritt bestes Team mit den meisten Lösungen aller Fragen',
+                default => $default,
+            },
+            default => $default,
+        };
     }
 
     /**

--- a/tests/Service/AwardServiceTest.php
+++ b/tests/Service/AwardServiceTest.php
@@ -23,7 +23,7 @@ class AwardServiceTest extends TestCase
 
         $text = $svc->buildText('Team', $rankings);
         $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
-            . "• Rätselwort-Bestzeit (Platz 2): schnellstes Lösen des Rätselworts";
+            . "• Rätselwort-Bestzeit (Platz 2): zweit schnellstes Lösen des Rätselworts";
         $this->assertSame($expected, $text);
     }
 
@@ -46,9 +46,9 @@ class AwardServiceTest extends TestCase
 
         $text = $svc->buildText('Team', $rankings);
         $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
-            . "• Rätselwort-Bestzeit (Platz 2): schnellstes Lösen des Rätselworts\n"
+            . "• Rätselwort-Bestzeit (Platz 2): zweit schnellstes Lösen des Rätselworts\n"
             . "• Katalogmeister (Platz 1): Team, das alle Kataloge am schnellsten durchgespielt hat\n"
-            . "• Highscore-Champions (Platz 2): Team mit den meisten Lösungen aller Fragen";
+            . "• Highscore-Champions (Platz 2): zweit bestes Team mit den meisten Lösungen aller Fragen";
         $this->assertSame($expected, $text);
     }
 
@@ -67,7 +67,7 @@ class AwardServiceTest extends TestCase
 
         $text = $svc->buildText('Team', $rankings);
         $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
-            . "• Rätselwort-Bestzeit (Platz 3): schnellstes Lösen des Rätselworts";
+            . "• Rätselwort-Bestzeit (Platz 3): dritt schnellstes Lösen des Rätselworts";
         $this->assertSame($expected, $text);
     }
 
@@ -90,9 +90,9 @@ class AwardServiceTest extends TestCase
         ];
 
         $expected = "Herzlichen Glückwunsch! Ihr habt folgende Auszeichnungen erreicht:\n"
-            . "• Rätselwort-Bestzeit (Platz 3): schnellstes Lösen des Rätselworts\n"
+            . "• Rätselwort-Bestzeit (Platz 3): dritt schnellstes Lösen des Rätselworts\n"
             . "• Katalogmeister (Platz 1): Team, das alle Kataloge am schnellsten durchgespielt hat\n"
-            . "• Highscore-Champions (Platz 2): Team mit den meisten Lösungen aller Fragen";
+            . "• Highscore-Champions (Platz 2): zweit bestes Team mit den meisten Lösungen aller Fragen";
         $text = $svc->buildText('Team', $rankings);
         $this->assertSame($expected, $text);
     }


### PR DESCRIPTION
## Summary
- adjust AwardService to describe 2nd and 3rd places
- convert congratulation text before writing it to the PDF
- center award descriptions in the PDF
- update AwardService tests

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652d154c9c832bb09c1cf6861e4fae