### PR TITLE
Encode uploaded photos as JPEG

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Das mitgelieferte `docker-compose.yml` startet das Quiz samt Reverse Proxy.
 Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `quizdata` gespeichert. So bleiben eingetragene Teams und Ergebnisse auch nach
 `docker-compose down` erhalten. Hochgeladene Beweisfotos landen im Verzeichnis
-`data/photos` und werden durch das Volume ebenfalls dauerhaft gespeichert. Die
+`data/photos` und werden dort immer als JPEG abgelegt. Durch das Volume bleiben
+die Bilder ebenfalls dauerhaft erhalten. Die
 ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
 wird dadurch ebenfalls persistiert. Zusätzlich läuft ein Adminer-Container,
 der die PostgreSQL-Datenbank über die Subdomain `https://adminer.${DOMAIN}` bereitstellt. Er
@@ -173,7 +174,8 @@ Kompatibilität wird auch `POSTGRES_PASS` noch unterstützt).
 Damit hochgeladene Dateien nicht unnötig groß werden, ist die Bibliothek [Intervention Image](https://image.intervention.io/) nun fest eingebunden.
 Die Controller verkleinern Bilder automatisch auf eine
 maximale Kantenlänge von 1500&nbsp;Pixeln (Beweisfotos) beziehungsweise
-512&nbsp;Pixeln (Logo) und speichern sie mit 70–80&nbsp;% Qualität.
+512&nbsp;Pixeln (Logo) und speichern sie mit 70–80&nbsp;% Qualität
+im JPEG-Format.
 
 Die Anwendung lädt beim Start eine vorhandene `.env`-Datei ein, auch wenn sie
 ohne Docker betrieben wird. Ist `DOMAIN` dort gesetzt, wird für QR-Codes und

--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -61,7 +61,7 @@ class EvidenceController
         $safeUser = preg_replace('/[^A-Za-z0-9_-]/', '_', $user);
         $safeCatalog = preg_replace('/[^A-Za-z0-9_-]/', '_', $catalog);
         $date = date('Y-m-d_H-i-s');
-        $fileName = $safeCatalog . '_' . $date . '.' . $ext;
+        $fileName = $safeCatalog . '_' . $date . '.jpg';
 
         $dir = $this->dir . '/' . $safeUser;
         if (!is_dir($dir)) {
@@ -75,11 +75,12 @@ class EvidenceController
         }
 
         $img = Image::make($file->getStream());
-        $img->resize(1500, 1500, function ($constraint) {
+        $img->orientate();
+        $img->resize(1500, 1500, function ($constraint): void {
             $constraint->aspectRatio();
             $constraint->upsize();
         });
-        $img->save($target, 70);
+        $img->encode('jpg')->save($target, 70);
 
         $this->consent->add($team, time());
 


### PR DESCRIPTION
## Summary
- ensure post() in EvidenceController orientates and encodes uploaded photos as JPG
- store images under `.jpg` filenames
- document that evidence photos are stored as JPEGs

## Testing
- `pytest -q`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686539823fdc832ba7c75d3b8bb0c33d