### PR TITLE
Improve camera initialization error message

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -426,7 +426,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
           await startCamera();
         }catch(err){
           console.error('Camera list error.', err);
-          document.getElementById('login-qr').textContent = 'Kamera konnte nicht initialisiert werden.';
+          document.getElementById('login-qr').textContent = 'Kamera konnte nicht initialisiert werden. Bitte erlaube den Kamerazugriff im Browser oder in den Geräteeinstellungen. Lade die Seite danach neu.';
           showManualInput();
         }
       };

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1029,7 +1029,7 @@ function runQuiz(questions, skipIntro){
           await startCamera();
         }catch(err){
           console.error('Camera list error.', err);
-          document.getElementById('qr-reader').textContent = 'Kamera konnte nicht initialisiert werden.';
+          document.getElementById('qr-reader').textContent = 'Kamera konnte nicht initialisiert werden. Bitte erlaube den Kamerazugriff im Browser oder in den Geräteeinstellungen. Lade die Seite danach neu.';
           showManualInput();
         }
       };


### PR DESCRIPTION
## Summary
- clarify camera initialization error hint in quiz and catalog views

## Testing
- `pytest tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865393dc090832b8b4a72e0c5886cf8