### PR TITLE
Allow manual team entry when camera fails

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -400,12 +400,14 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
         }catch(err){
           console.error('QR scanner start failed.', err);
           document.getElementById('login-qr').textContent = 'QR-Scanner konnte nicht gestartet werden.';
+          showManualInput();
         }
         flipBtn.disabled = cameras.length < 2;
       };
       const startScanner = async () => {
         if(typeof Html5Qrcode === 'undefined'){
           document.getElementById('login-qr').textContent = 'QR-Scanner nicht verfügbar.';
+          showManualInput();
           return;
         }
         scanner = new Html5Qrcode('login-qr');
@@ -425,11 +427,35 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
         }catch(err){
           console.error('Camera list error.', err);
           document.getElementById('login-qr').textContent = 'Kamera konnte nicht initialisiert werden.';
+          showManualInput();
         }
       };
       const flipBtn = modal.querySelector('#login-qr-flip');
       const stopBtn = modal.querySelector('#login-qr-stop');
       flipBtn.disabled = true;
+      function showManualInput(){
+        const container = document.getElementById('login-qr');
+        container.innerHTML = '<input id="manual-team-name" class="uk-input" type="text" placeholder="Teamname eingeben">' +
+          '<button id="manual-team-submit" class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Weiter</button>';
+        flipBtn.classList.add('uk-hidden');
+        const input = container.querySelector('#manual-team-name');
+        container.querySelector('#manual-team-submit').addEventListener('click', () => {
+          const name = (input.value || '').trim();
+          if(name){
+            setStored('quizUser', name);
+            stopScanner();
+            UIkit.modal(modal).hide();
+            onDone();
+          }
+        });
+        input.addEventListener('keydown', (ev) => {
+          if(ev.key === 'Enter'){
+            ev.preventDefault();
+            container.querySelector('#manual-team-submit').click();
+          }
+        });
+        input.focus();
+      }
       const trapFocus = (e) => {
         if(e.key === 'Tab'){
           e.preventDefault();

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1003,12 +1003,14 @@ function runQuiz(questions, skipIntro){
         }catch(err){
           console.error('QR scanner start failed.', err);
           document.getElementById('qr-reader').textContent = 'QR-Scanner konnte nicht gestartet werden.';
+          showManualInput();
         }
         flipBtn.disabled = cameras.length < 2;
       };
       const startScanner = async () => {
         if(typeof Html5Qrcode === 'undefined'){
           document.getElementById('qr-reader').textContent = 'QR-Scanner nicht verfügbar.';
+          showManualInput();
           return;
         }
         scanner = new Html5Qrcode('qr-reader');
@@ -1028,11 +1030,35 @@ function runQuiz(questions, skipIntro){
         }catch(err){
           console.error('Camera list error.', err);
           document.getElementById('qr-reader').textContent = 'Kamera konnte nicht initialisiert werden.';
+          showManualInput();
         }
       };
       const flipBtn = modal.querySelector('#qr-reader-flip');
       const stopBtn = modal.querySelector('#qr-reader-stop');
       flipBtn.disabled = true;
+      function showManualInput(){
+        const container = document.getElementById('qr-reader');
+        container.innerHTML = '<input id="manual-team-name" class="uk-input" type="text" placeholder="Teamname eingeben">' +
+          '<button id="manual-team-submit" class="uk-button uk-button-primary uk-width-1-1 uk-margin-top">Weiter</button>';
+        flipBtn.classList.add('uk-hidden');
+        const input = container.querySelector('#manual-team-name');
+        container.querySelector('#manual-team-submit').addEventListener('click', () => {
+          const name = (input.value || '').trim();
+          if(name){
+            setStored('quizUser', name);
+            stopScanner();
+            UIkit.modal(modal).hide();
+            next();
+          }
+        });
+        input.addEventListener('keydown', (ev) => {
+          if(ev.key === 'Enter'){
+            ev.preventDefault();
+            container.querySelector('#manual-team-submit').click();
+          }
+        });
+        input.focus();
+      }
       const trapFocus = (e) => {
         if(e.key === 'Tab'){
           e.preventDefault();


### PR DESCRIPTION
## Summary
- add manual team entry field when QR scanner fails
- submit manual team name also via Enter key

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686533dc20f8832bacd9f23702370b09