### PR TITLE
Enable exif PHP extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN apk add --no-cache libpng libjpeg-turbo freetype libwebp postgresql-client && \
     apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev postgresql-dev $PHPIZE_DEPS && \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp && \
-    docker-php-ext-install gd pdo_pgsql && \
+    docker-php-ext-install gd pdo_pgsql exif && \
     apk del .build-deps
 
 # install composer

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "slim/twig-view": "^3.3",
         "setasign/fpdf": "^1.8",
         "endroid/qr-code": "^5.0",
-        "intervention/image": "^2.7"
+        "intervention/image": "^2.7",
+        "ext-exif": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- install the PHP exif extension in the Docker image
- declare `ext-exif` in composer.json

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653f540d50832bbfb1525f0eb0b78e