### PR TITLE
Fix EXIF orientation

### DIFF
--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -74,7 +74,13 @@ class EvidenceController
             return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
         }
 
-        $img = Image::make($file->getStream());
+        $stream = $file->getStream();
+        $tmpPath = $stream->getMetadata('uri');
+        if (is_string($tmpPath) && is_file($tmpPath)) {
+            $img = Image::make($tmpPath);
+        } else {
+            $img = Image::make($stream);
+        }
         if (function_exists('exif_read_data')) {
             try {
                 $img->orientate();


### PR DESCRIPTION
## Summary
- fix photo orientation by loading uploaded image from temporary file

## Testing
- `python3 -m pytest -q tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_686582f408b8832b8cfaf4bebeed4067