### PR TITLE
Fix EXIF orientation for uploaded photos

### DIFF
--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -74,7 +74,10 @@ class EvidenceController
             return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
         }
 
-        $img = Image::make($file->getStream());
+        $tmpPath = tempnam(sys_get_temp_dir(), 'upload_');
+        $file->moveTo($tmpPath);
+
+        $img = Image::make($tmpPath);
         if (function_exists('exif_read_data')) {
             try {
                 $img->orientate();
@@ -87,6 +90,7 @@ class EvidenceController
             $constraint->upsize();
         });
         $img->encode('jpg')->save($target, 70);
+        unlink($tmpPath);
 
         $this->consent->add($team, time());
 


### PR DESCRIPTION
## Summary
- handle evidence uploads through a temporary file
- rotate based on EXIF data before saving

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686582f408b8832b8cfaf4bebeed4067