### PR TITLE
Update docs for exif extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ maximale Kantenlänge von 1500&nbsp;Pixeln (Beweisfotos) beziehungsweise
 im JPEG-Format. Fotos werden nach Möglichkeit anhand ihrer EXIF-Daten
 gedreht, sofern die PHP-Installation diese Funktion unterstützt.
 
+**Wichtig:** Die automatische Drehung funktioniert nur, wenn die PHP-Erweiterung `exif` installiert und aktiviert ist. Den Status prüfst du mit:
+```bash
+php -m | grep exif
+```
 
 Die Anwendung lädt beim Start eine vorhandene `.env`-Datei ein, auch wenn sie
 ohne Docker betrieben wird. Ist `DOMAIN` dort gesetzt, wird für QR-Codes und

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -40,4 +40,8 @@ toc: true
    ```
 
  Das mitgelieferte `docker-compose.yml` startet die Anwendung samt Reverse Proxy. Daten werden dauerhaft in einem Volume gesichert, Beweisfotos bleiben als JPEG im Ordner `data/photos` erhalten. Dabei richtet die Anwendung Fotos, sofern möglich, anhand ihrer EXIF-Daten aus. Die Domain und weitere Parameter lassen sich über die Datei `.env` anpassen.
+**Wichtig:** Damit Fotos automatisch gedreht werden können, muss die PHP-Erweiterung `exif` installiert und aktiviert sein. Prüfen lässt sich das mit:
+```bash
+php -m | grep exif
+```
 


### PR DESCRIPTION
## Summary
- mention that PHP exif extension must be enabled for automatic photo rotation
- show command to check for `exif` extension

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_686588c95f5c832b9283969fbcbaf2ee