### PR TITLE
Enable rotation for uploaded photos

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -399,4 +399,16 @@ body.dark-mode .sticky-actions {
   }
 }
 
+/* Wrapper for thumbnails with rotate button */
+.photo-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.photo-rotate-btn {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+}
+
 

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -21,6 +21,21 @@ document.addEventListener('DOMContentLoaded', () => {
     return text ? text.replace(/\/-/g, '\u00AD') : '';
   }
 
+  function rotatePhoto(path, img, link) {
+    fetch('/photos/rotate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path })
+    })
+      .then(r => { if (!r.ok) throw new Error('rotate'); })
+      .then(() => {
+        const t = Date.now();
+        img.src = path + '?t=' + t;
+        if (link) link.href = path + '?t=' + t;
+      })
+      .catch(() => {});
+  }
+
   function renderTable(rows) {
     if (!tbody) return;
     tbody.innerHTML = '';
@@ -50,6 +65,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const td = document.createElement('td');
         if (idx === cells.length - 1) {
           if (r.photo) {
+            const wrap = document.createElement('span');
+            wrap.className = 'photo-wrapper';
+
             const a = document.createElement('a');
             a.className = 'uk-inline';
             a.href = r.photo;
@@ -61,8 +79,19 @@ document.addEventListener('DOMContentLoaded', () => {
             img.alt = 'Beweisfoto';
             img.className = 'proof-thumb';
 
+            const btn = document.createElement('button');
+            btn.className = 'uk-icon-button photo-rotate-btn';
+            btn.type = 'button';
+            btn.setAttribute('uk-icon', 'history');
+            btn.addEventListener('click', (e) => {
+              e.preventDefault();
+              rotatePhoto(r.photo, img, a);
+            });
+
             a.appendChild(img);
-            td.appendChild(a);
+            wrap.appendChild(a);
+            wrap.appendChild(btn);
+            td.appendChild(wrap);
           }
         } else {
           td.textContent = c;
@@ -337,9 +366,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  function initRotateButtons() {
+    document.querySelectorAll('.photo-rotate-btn').forEach(btn => {
+      const wrap = btn.closest('.photo-wrapper');
+      const img = wrap ? wrap.querySelector('img') : null;
+      const link = wrap ? wrap.querySelector('a') : null;
+      const path = btn.dataset.path || (link ? link.getAttribute('href') : '');
+      if (!img || !path) return;
+      btn.addEventListener('click', e => {
+        e.preventDefault();
+        rotatePhoto(path, img, link);
+      });
+    });
+  }
+
   if (refreshBtn && typeof UIkit !== 'undefined') {
     UIkit.icon(refreshBtn);
   }
 
+  initRotateButtons();
   load();
 });

--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -124,4 +124,27 @@ class EvidenceController
         $response->getBody()->write((string)file_get_contents($path));
         return $response->withHeader('Content-Type', $type);
     }
+
+    /**
+     * Rotate an existing photo clockwise by 90 degrees.
+     */
+    public function rotate(Request $request, Response $response): Response
+    {
+        $data = $request->getParsedBody() ?? [];
+        $path = isset($data['path']) ? (string)$data['path'] : '';
+        if (!preg_match('#^/photo/([^/]+)/([^/]+)$#', $path, $m)) {
+            return $response->withStatus(400);
+        }
+        $team = preg_replace('/[^A-Za-z0-9_-]/', '_', $m[1]);
+        $file = basename($m[2]);
+        $filePath = $this->dir . '/' . $team . '/' . $file;
+        if (!is_file($filePath)) {
+            return $response->withStatus(404);
+        }
+        $img = Image::make($filePath);
+        $img->rotate(-90)->save($filePath, 70);
+
+        $response->getBody()->write(json_encode(['status' => 'ok']));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -155,6 +155,7 @@ return function (\Slim\App $app) {
     $app->get('/logo.webp', [$logoController, 'get'])->setArgument('ext', 'webp');
     $app->post('/logo.webp', [$logoController, 'post']);
     $app->post('/photos', [$evidenceController, 'post']);
+    $app->post('/photos/rotate', [$evidenceController, 'rotate']);
     $app->get('/photo/{team}/{file}', [$evidenceController, 'get']);
     $app->get('/summary', $summaryController);
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -324,7 +324,16 @@
               <td>{{ r.correct }}/{{ r.total }}</td>
               <td>{{ r.time | date('Y-m-d H:i') }}</td>
               <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>
-              <td>{% if r.photo is defined and r.photo %}<a class="uk-inline" href="{{ r.photo }}" data-caption="Beweisfoto" data-attrs="class: uk-inverse-light"><img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb"></a>{% endif %}</td>
+              <td>
+                {% if r.photo is defined and r.photo %}
+                <span class="photo-wrapper">
+                  <a class="uk-inline" href="{{ r.photo }}" data-caption="Beweisfoto" data-attrs="class: uk-inverse-light">
+                    <img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb">
+                  </a>
+                  <button class="uk-icon-button photo-rotate-btn" type="button" uk-icon="history" data-path="{{ r.photo }}" aria-label="Drehen"></button>
+                </span>
+                {% endif %}
+              </td>
             </tr>
             {% else %}
             <tr><td colspan="7">Keine Daten</td></tr>

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -33,7 +33,16 @@
           <td>{{ r.correct }}/{{ r.total }}</td>
           <td>{{ r.time | date('Y-m-d H:i') }}</td>
           <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>
-          <td>{% if r.photo is defined and r.photo %}<a class="uk-inline" href="{{ r.photo }}" data-caption="Beweisfoto" data-attrs="class: uk-inverse-light"><img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb"></a>{% endif %}</td>
+          <td>
+            {% if r.photo is defined and r.photo %}
+            <span class="photo-wrapper">
+              <a class="uk-inline" href="{{ r.photo }}" data-caption="Beweisfoto" data-attrs="class: uk-inverse-light">
+                <img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb">
+              </a>
+              <button class="uk-icon-button photo-rotate-btn" type="button" uk-icon="history" data-path="{{ r.photo }}" aria-label="Drehen"></button>
+            </span>
+            {% endif %}
+          </td>
         </tr>
         {% else %}
         <tr><td colspan="7">Keine Daten</td></tr>


### PR DESCRIPTION
## Summary
- allow rotating uploaded photos in 90° steps
- expose new API route `/photos/rotate`
- add rotate buttons to photo previews
- update JS to call new rotation endpoint
- tweak styles for rotate button overlay

## Testing
- `pytest tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686588b423bc832b810993c4c56d9288