### PR TITLE
Add logger dependency to EvidenceController

### DIFF
--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use App\Service\ResultService;
 use App\Service\PhotoConsentService;
+use Psr\Log\LoggerInterface;
 use Intervention\Image\ImageManagerStatic as Image;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -17,15 +18,17 @@ class EvidenceController
 {
     private ResultService $results;
     private PhotoConsentService $consent;
+    private LoggerInterface $logger;
     private string $dir;
 
     /**
      * Set up controller dependencies and target directory.
      */
-    public function __construct(ResultService $results, PhotoConsentService $consent, string $dir)
+    public function __construct(ResultService $results, PhotoConsentService $consent, LoggerInterface $logger, string $dir)
     {
         $this->results = $results;
         $this->consent = $consent;
+        $this->logger = $logger;
         $this->dir = rtrim($dir, '/');
     }
 
@@ -82,6 +85,7 @@ class EvidenceController
             try {
                 $img->orientate();
             } catch (\Throwable $e) {
+                $this->logger->warning('Photo rotation failed: ' . $e->getMessage());
                 // orientation failed; continue without rotating
             }
         }

--- a/src/routes.php
+++ b/src/routes.php
@@ -29,6 +29,7 @@ use App\Controller\QrController;
 use App\Controller\LogoController;
 use App\Controller\SummaryController;
 use App\Controller\EvidenceController;
+use Psr\Log\NullLogger;
 use App\Controller\BackupController;
 
 require_once __DIR__ . '/Controller/HomeController.php';
@@ -101,6 +102,7 @@ return function (\Slim\App $app) {
     $evidenceController = new EvidenceController(
         $resultService,
         $consentService,
+        new NullLogger(),
         __DIR__ . '/../data/photos'
     );
 


### PR DESCRIPTION
## Summary
- inject `Psr\Log\LoggerInterface` into `EvidenceController`
- log warning when photo rotation fails
- use `NullLogger` in routes when constructing `EvidenceController`

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml tests/TestCase.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686589d252dc832bbe86fed01ddf365b