### PR TITLE
Add automatic changelog workflow

### DIFF
--- a/.gitcliff.toml
+++ b/.gitcliff.toml
@@ -1,0 +1,7 @@
+[changelog]
+header = "# Changelog\n\n"
+
+[git]
+filter_unconventional = false
+
+tag_pattern = ".*"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,48 @@
+name: Update Changelog
+
+on:
+  push:
+    branches: [ main ]
+  release:
+    types: [released]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Optional: Install typos, falls du es wirklich nutzen willst
+      # - name: Install typos (optional)
+      #   run: |
+      #     curl -Ls https://github.com/crate-ci/typos/releases/download/v1.16.19/typos-v1.16.19-x86_64-unknown-linux-musl.tar.gz | tar xz
+      #     sudo mv typos /usr/local/bin/typos
+
+      - name: Install git-cliff
+        run: |
+          wget https://github.com/orhun/git-cliff/releases/download/v2.7.0/git-cliff-2.7.0-x86_64-unknown-linux-gnu.tar.gz
+          tar -xzvf git-cliff-2.7.0-x86_64-unknown-linux-gnu.tar.gz
+          sudo mv git-cliff-2.7.0/git-cliff /usr/local/bin/
+      - name: Generate changelog
+        run: git-cliff --config .gitcliff.toml -o CHANGELOG.md
+
+      - name: Commit and push
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          if git diff --staged --quiet; then
+            echo "Changelog unchanged" && exit 0
+          fi
+          git commit -m "docs: update changelog [skip ci]"
+          git push https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git HEAD:main


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to generate CHANGELOG.md using git-cliff
- configure git-cliff with minimal settings

## Testing
- `composer install --no-interaction --no-progress` *(fails: ext-gd, ext-dom, ext-simplexml missing)*

------
https://chatgpt.com/codex/tasks/task_e_68658cb6722c832ba21f5d5082af3617