### PR TITLE
Fix event listener capture for lightbox rotate

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -396,7 +396,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (newPath) btn.dataset.path = newPath;
       });
     }
-  });
+  }, { capture: true });
 
   load();
 });

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -167,7 +167,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (newPath) btn.dataset.path = newPath;
       });
     }
-  });
+  }, { capture: true });
 
   load();
 });


### PR DESCRIPTION
## Summary
- trigger rotate buttons in capture phase

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`
- ❌ `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686597c2df98832b96b32eb7fd155e28