### PR TITLE
Fix rotate endpoint JSON parsing

### DIFF
--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -153,6 +153,14 @@ class EvidenceController
     public function rotate(Request $request, Response $response): Response
     {
         $data = $request->getParsedBody() ?? [];
+        $ct = $request->getHeaderLine('Content-Type');
+        if (str_starts_with($ct, 'application/json')) {
+            $json = json_decode((string) $request->getBody(), true);
+            if (is_array($json)) {
+                $data = $json;
+            }
+        }
+
         $path = isset($data['path']) ? (string)$data['path'] : '';
         if (!preg_match('#^/photo/([^/]+)/([^/]+)$#', $path, $m)) {
             return $response->withStatus(400);


### PR DESCRIPTION
## Summary
- handle JSON requests correctly in `EvidenceController::rotate`

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpstan`
- `vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_6865a88f1f28832bba635d85b507bb41