### PR TITLE
Fix lightbox refresh after rotate

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -40,9 +40,23 @@ document.addEventListener('DOMContentLoaded', () => {
               .replace(/data-path='[^']*'/, `data-path='${newPath}'`);
           }
         }
+        refreshLightboxes();
         return newPath;
       })
       .catch(() => {});
+  }
+
+  function refreshLightboxes() {
+    if (typeof UIkit === 'undefined') return;
+    ['#resultsTableBody', '#statsTableBody'].forEach(sel => {
+      const el = document.querySelector(sel);
+      if (!el) return;
+      const lightbox = UIkit.getComponent(el, 'lightbox');
+      if (lightbox) {
+        lightbox.$emit();
+        lightbox.items = UIkit.lightbox(el).items;
+      }
+    });
   }
 
   const rotatePhoto = window.rotatePhoto || rotatePhotoImpl;

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -26,9 +26,23 @@ document.addEventListener('DOMContentLoaded', () => {
               .replace(/data-path='[^']*'/, `data-path='${newPath}'`);
           }
         }
+        refreshLightboxes();
         return newPath;
       })
       .catch(() => {});
+  }
+
+  function refreshLightboxes() {
+    if (typeof UIkit === 'undefined') return;
+    ['#resultsTableBody', '#statsTableBody'].forEach(sel => {
+      const el = document.querySelector(sel);
+      if (!el) return;
+      const lightbox = UIkit.getComponent(el, 'lightbox');
+      if (lightbox) {
+        lightbox.$emit();
+        lightbox.items = UIkit.lightbox(el).items;
+      }
+    });
   }
 
   const rotatePhoto = window.rotatePhoto || rotatePhotoImpl;


### PR DESCRIPTION
## Summary
- refresh UIkit lightbox items after rotating photos

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `pytest -q`
- `./vendor/bin/phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b6a9bbe8832bbbb219fbaaf3cf2c