### PR TITLE
Fix lightbox refresh after photo rotation

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -48,12 +48,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function refreshLightboxes() {
     if (typeof UIkit === 'undefined') return;
-    ['#resultsTableBody', '#statsTableBody'].forEach(sel => {
-      const el = document.querySelector(sel);
-      if (!el) return;
+    document.querySelectorAll('[uk-lightbox]').forEach(el => {
       const lightbox = UIkit.getComponent(el, 'lightbox');
       if (lightbox) {
-        lightbox.$emit();
         lightbox.items = UIkit.lightbox(el).items;
       }
     });

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -34,12 +34,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function refreshLightboxes() {
     if (typeof UIkit === 'undefined') return;
-    ['#resultsTableBody', '#statsTableBody'].forEach(sel => {
-      const el = document.querySelector(sel);
-      if (!el) return;
+    document.querySelectorAll('[uk-lightbox]').forEach(el => {
       const lightbox = UIkit.getComponent(el, 'lightbox');
       if (lightbox) {
-        lightbox.$emit();
         lightbox.items = UIkit.lightbox(el).items;
       }
     });


### PR DESCRIPTION
## Summary
- refresh the UIkit lightbox component after rotating photos

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6865ba968380832b81dd8ccc41e7344c