### PR TITLE
Fix team photo scaling in PDF

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -351,8 +351,24 @@ class ResultController
                     }
                     $imgY = $pdf->GetY() + 25;
                     $imgX = ($pdf->GetPageWidth() - $imgWidth) / 2;
-                    $pdf->Image($file, $imgX, $imgY, $imgWidth, 100);
-                    $pdf->SetY($imgY + 100);
+
+                    $imgSize = @getimagesize($file);
+                    $imgHeight = 100.0;
+                    if ($imgSize !== false && $imgSize[0] > 0) {
+                        $imgHeight = $imgWidth * ($imgSize[1] / $imgSize[0]);
+                    }
+
+                    $footerY = $pdf->GetPageHeight() - 10;
+                    $availableHeight = $footerY - $imgY;
+                    if ($imgHeight > $availableHeight) {
+                        $scale = $availableHeight / $imgHeight;
+                        $imgHeight = $availableHeight;
+                        $imgWidth = $imgWidth * $scale;
+                        $imgX = ($pdf->GetPageWidth() - $imgWidth) / 2;
+                    }
+
+                    $pdf->Image($file, $imgX, $imgY, $imgWidth, $imgHeight);
+                    $pdf->SetY($imgY + $imgHeight);
                     if ($tmp !== null) {
                         unlink($tmp);
                     }


### PR DESCRIPTION
## Summary
- ensure team photos keep aspect ratio in PDF export
- reduce photo size if it exceeds available page height

## Testing
- `node tests/test_results_rankings.js`
- `node tests/test_competition_mode.js`
- `pytest -q tests/test_html_validity.py tests/test_json_validity.py`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ba7d01f8832bb819793f56be43da