### PR TITLE
Add basic Event management service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Skip schema init when db ready
 - Support soft hyphen placeholders
 - Add dynamic congratulations for team PDFs
+- Add events table and API endpoints
 
 ### Fix
 

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -29,12 +29,20 @@ CREATE TABLE IF NOT EXISTS config (
     puzzleFeedback TEXT,
     inviteText TEXT
 );
+-- Event definitions
+CREATE TABLE IF NOT EXISTS events (
+    uid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    date TEXT,
+    description TEXT
+);
 
 -- Teams list (names only)
 CREATE TABLE IF NOT EXISTS teams (
     sort_order INTEGER UNIQUE NOT NULL,
     name TEXT NOT NULL,
-    uid UUID DEFAULT gen_random_uuid() PRIMARY KEY NOT NULL
+    uid UUID DEFAULT gen_random_uuid() PRIMARY KEY NOT NULL,
+    event_uid TEXT REFERENCES events(uid)
 );
 CREATE UNIQUE INDEX idx_team_name ON teams(name);
 
@@ -46,12 +54,12 @@ CREATE TABLE IF NOT EXISTS results (
     attempt INTEGER NOT NULL,
     correct INTEGER NOT NULL,
     answer_text TEXT,
-    photo TEXT,
     consent BOOLEAN,
     total INTEGER NOT NULL,
     time INTEGER NOT NULL,
     puzzleTime INTEGER,
-    photo TEXT
+    photo TEXT,
+    event_uid TEXT REFERENCES events(uid)
 );
 CREATE INDEX idx_results_catalog ON results(catalog);
 CREATE INDEX idx_results_name ON results(name);
@@ -66,7 +74,8 @@ CREATE TABLE IF NOT EXISTS question_results (
     correct INTEGER NOT NULL,
     answer_text TEXT,
     photo TEXT,
-    consent BOOLEAN
+    consent BOOLEAN,
+    event_uid TEXT REFERENCES events(uid)
 );
 CREATE INDEX idx_qresults_catalog ON question_results(catalog);
 CREATE INDEX idx_qresults_name ON question_results(name);
@@ -82,7 +91,8 @@ CREATE TABLE IF NOT EXISTS catalogs (
     description TEXT,
     qrcode_url TEXT,
     raetsel_buchstabe TEXT,
-    comment TEXT
+    comment TEXT,
+    event_uid TEXT REFERENCES events(uid)
 );
 ALTER TABLE catalogs
     ADD CONSTRAINT catalogs_unique_sort_order

--- a/migrations/20240630_create_events_table.sql
+++ b/migrations/20240630_create_events_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS events (
+    uid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    date TEXT,
+    description TEXT
+);

--- a/migrations/20240708_add_event_uid_columns.sql
+++ b/migrations/20240708_add_event_uid_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE catalogs ADD COLUMN IF NOT EXISTS event_uid TEXT REFERENCES events(uid);
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS event_uid TEXT REFERENCES events(uid);
+ALTER TABLE results ADD COLUMN IF NOT EXISTS event_uid TEXT REFERENCES events(uid);
+ALTER TABLE question_results ADD COLUMN IF NOT EXISTS event_uid TEXT REFERENCES events(uid);

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\EventService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * API endpoints for managing events.
+ */
+class EventController
+{
+    private EventService $service;
+
+    public function __construct(EventService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function get(Request $request, Response $response): Response
+    {
+        $data = $this->service->getAll();
+        $response->getBody()->write(json_encode($data));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    public function post(Request $request, Response $response): Response
+    {
+        $data = json_decode((string)$request->getBody(), true);
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $this->service->saveAll($data);
+        return $response->withStatus(204);
+    }
+}

--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use PDO;
+
+/**
+ * Service for managing quiz events.
+ */
+class EventService
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * Retrieve all events ordered by name.
+     *
+     * @return list<array{uid:string,name:string,date:?string,description:?string}>
+     */
+    public function getAll(): array
+    {
+        $stmt = $this->pdo->query('SELECT uid,name,date,description FROM events ORDER BY name');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Replace all events with the provided list.
+     *
+     * @param list<array{uid?:string,name:string,date?:string,description?:string}> $events
+     */
+    public function saveAll(array $events): void
+    {
+        $this->pdo->beginTransaction();
+        $this->pdo->exec('DELETE FROM events');
+        $stmt = $this->pdo->prepare('INSERT INTO events(uid,name,date,description) VALUES(?,?,?,?)');
+        foreach ($events as $event) {
+            $uid = $event['uid'] ?? bin2hex(random_bytes(16));
+            $stmt->execute([
+                $uid,
+                (string)$event['name'],
+                $event['date'] ?? null,
+                $event['description'] ?? null,
+            ]);
+        }
+        $this->pdo->commit();
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -20,6 +20,7 @@ use App\Service\CatalogService;
 use App\Service\ResultService;
 use App\Service\TeamService;
 use App\Service\PhotoConsentService;
+use App\Service\EventService;
 use App\Controller\ResultController;
 use App\Controller\TeamController;
 use App\Controller\PasswordController;
@@ -29,6 +30,7 @@ use App\Controller\QrController;
 use App\Controller\LogoController;
 use App\Controller\SummaryController;
 use App\Controller\EvidenceController;
+use App\Controller\EventController;
 use Psr\Log\NullLogger;
 use App\Controller\BackupController;
 
@@ -52,6 +54,7 @@ require_once __DIR__ . '/Controller/LogoController.php';
 require_once __DIR__ . '/Controller/SummaryController.php';
 require_once __DIR__ . '/Controller/EvidenceController.php';
 require_once __DIR__ . '/Controller/ExportController.php';
+require_once __DIR__ . '/Controller/EventController.php';
 require_once __DIR__ . '/Controller/BackupController.php';
 
 use App\Infrastructure\Database;
@@ -65,6 +68,7 @@ return function (\Slim\App $app) {
     $resultService = new ResultService($pdo);
     $teamService = new TeamService($pdo);
     $consentService = new PhotoConsentService($pdo);
+    $eventService = new EventService($pdo);
 
     $configController = new ConfigController($configService);
     $catalogController = new CatalogController($catalogService);
@@ -76,6 +80,7 @@ return function (\Slim\App $app) {
         __DIR__ . '/../data/photos'
     );
     $teamController = new TeamController($teamService);
+    $eventController = new EventController($eventService);
     $passwordController = new PasswordController($configService);
     $qrController = new QrController($configService, $teamService);
     $logoController = new LogoController($configService);
@@ -139,6 +144,9 @@ return function (\Slim\App $app) {
     $app->delete('/kataloge/{file}/{index}', [$catalogController, 'deleteQuestion']);
     $app->put('/kataloge/{file}', [$catalogController, 'create']);
     $app->delete('/kataloge/{file}', [$catalogController, 'delete']);
+
+    $app->get('/events.json', [$eventController, 'get']);
+    $app->post('/events.json', [$eventController, 'post']);
 
     $app->get('/teams.json', [$teamController, 'get']);
     $app->post('/teams.json', [$teamController, 'post']);

--- a/tests/Service/EventServiceTest.php
+++ b/tests/Service/EventServiceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\EventService;
+use PDO;
+use Tests\TestCase;
+
+class EventServiceTest extends TestCase
+{
+    private function createPdo(): PDO
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT NOT NULL, date TEXT, description TEXT);');
+        return $pdo;
+    }
+
+    public function testSaveAndGet(): void
+    {
+        $pdo = $this->createPdo();
+        $service = new EventService($pdo);
+        $data = [
+            ['name' => 'Test Event', 'date' => '2025-07-04', 'description' => 'Demo'],
+        ];
+        $service->saveAll($data);
+        $rows = $service->getAll();
+        $this->assertCount(1, $rows);
+        $this->assertSame('Test Event', $rows[0]['name']);
+        $this->assertSame('2025-07-04', $rows[0]['date']);
+    }
+}


### PR DESCRIPTION
## Summary
- support new events table via migration
- document events table in schema
- add EventService for managing events
- add migration for event columns
- expose event management API

## Testing
- `php -v`
- `phpunit --stop-on-failure --colors=never` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6cf27a1c832b9263ced6f595f0f2