### PR TITLE
Fix admin config fields

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -75,8 +75,6 @@ document.addEventListener('DOMContentLoaded', function () {
     logoFile: document.getElementById('cfgLogoFile'),
     logoPreview: document.getElementById('cfgLogoPreview'),
     pageTitle: document.getElementById('cfgPageTitle'),
-    header: document.getElementById('cfgHeader'),
-    subheader: document.getElementById('cfgSubheader'),
     backgroundColor: document.getElementById('cfgBackgroundColor'),
     buttonColor: document.getElementById('cfgButtonColor'),
     checkAnswerButton: document.getElementById('cfgCheckAnswerButton'),
@@ -214,8 +212,6 @@ document.addEventListener('DOMContentLoaded', function () {
       cfgFields.logoPreview.src = data.logoPath ? data.logoPath + '?' + Date.now() : '';
     }
     cfgFields.pageTitle.value = data.pageTitle || '';
-    cfgFields.header.value = data.header || '';
-    cfgFields.subheader.value = data.subheader || '';
     cfgFields.backgroundColor.value = data.backgroundColor || '';
     cfgFields.buttonColor.value = data.buttonColor || '';
     cfgFields.checkAnswerButton.checked = data.CheckAnswerButton !== 'no';
@@ -322,9 +318,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
         return cfgInitial.logoPath;
       })(),
-      pageTitle: cfgFields.pageTitle.value.trim(),
-      header: cfgFields.header.value.trim(),
-      subheader: cfgFields.subheader.value.trim(),
+        pageTitle: cfgFields.pageTitle.value.trim(),
       backgroundColor: cfgFields.backgroundColor.value.trim(),
       buttonColor: cfgFields.buttonColor.value.trim(),
       CheckAnswerButton: cfgFields.checkAnswerButton.checked ? 'yes' : 'no',

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -8,9 +8,6 @@ window.quizConfig = {
   // Titel im Browser-Tab
   pageTitle: 'Modernes Quiz mit UIkit',
 
-  // Überschrift und Untertitel auf der Startseite
-  header: 'Sommerfest 2025',
-  subheader: 'Willkommen beim Veranstaltungsquiz',
 
   // Farbschema der Anwendung
   backgroundColor: '#ffffff',


### PR DESCRIPTION
## Summary
- remove obsolete header inputs from admin.js
- drop header defaults from sample config

## Testing
- `apt-get update`
- `apt-get install -y composer` *(installs composer but composer install fails due to missing PHP extensions)*
- `composer install` *(fails: ext-gd and ext-dom missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d84fc30c0832ba1de43e4a846633b