### PR TITLE
Bind config to events

### DIFF
--- a/data-default/config.json
+++ b/data-default/config.json
@@ -19,5 +19,5 @@
   "postgres_dsn": "pgsql:host=postgres;dbname=quiz",
   "postgres_user": "quiz",
   "postgres_pass": "quiz",
-  "activeEventUid": "1"
+  "event_uid": "1"
 }

--- a/data/config.json
+++ b/data/config.json
@@ -19,5 +19,5 @@
   "postgres_dsn": "pgsql:host=postgres;dbname=quiz",
   "postgres_user": "quiz",
   "postgres_pass": "quiz",
-  "activeEventUid": "1"
+  "event_uid": "1"
 }

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS config (
     puzzleWordEnabled BOOLEAN,
     puzzleWord TEXT,
     puzzleFeedback TEXT,
-    inviteText TEXT
+    inviteText TEXT,
+    event_uid TEXT REFERENCES events(uid)
 );
 -- Event definitions
 CREATE TABLE IF NOT EXISTS events (

--- a/migrations/20240711_add_event_uid_to_config.sql
+++ b/migrations/20240711_add_event_uid_to_config.sql
@@ -1,0 +1,3 @@
+ALTER TABLE config ADD COLUMN IF NOT EXISTS event_uid TEXT REFERENCES events(uid);
+UPDATE config SET event_uid = activeEventUid WHERE event_uid IS NULL;
+ALTER TABLE config DROP COLUMN IF EXISTS activeEventUid;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1163,7 +1163,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const eventsListEl = document.getElementById('eventsList');
   const eventAddBtn = document.getElementById('eventAddBtn');
   const eventsSaveBtn = document.getElementById('eventsSaveBtn');
-  let activeEventUid = cfgInitial.activeEventUid || '';
+  let activeEventUid = cfgInitial.event_uid || '';
 
   function collectEvents() {
     return Array.from(eventsListEl.querySelectorAll('.event-row')).map(row => ({
@@ -1259,7 +1259,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function setActiveEvent(uid, name) {
     activeEventUid = uid;
-    cfgInitial.activeEventUid = uid;
+    cfgInitial.event_uid = uid;
     updateActiveHeader(name);
     fetch('/config.json', {
       method: 'POST',

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -33,7 +33,7 @@ $pdo->exec('TRUNCATE config, teams, results, catalogs, questions, photo_consents
 
 // Import config
 $configData = array_intersect_key($config, array_flip([
-    'displayErrorDetails','QRUser','logoPath','pageTitle','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback','inviteText','activeEventUid'
+    'displayErrorDetails','QRUser','logoPath','pageTitle','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback','inviteText','event_uid'
 ]));
 if (isset($configData['adminPass'])) {
     $info = password_get_info($configData['adminPass']);
@@ -59,7 +59,7 @@ if ($configData) {
 
 // Import events
 $eventsFile = "$base/data/events.json";
-$activeUid = (string)($config['activeEventUid'] ?? '');
+$activeUid = (string)($config['event_uid'] ?? '');
 if (is_readable($eventsFile)) {
     $events = json_decode(file_get_contents($eventsFile), true) ?? [];
     $firstUid = null;

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -29,7 +29,7 @@ class AdminController
         $cfg = (new ConfigService($pdo))->getConfig();
         $eventSvc = new EventService($pdo);
         $event = null;
-        $uid = (string)($cfg['activeEventUid'] ?? '');
+        $uid = (string)($cfg['event_uid'] ?? '');
         if ($uid !== '') {
             $event = $eventSvc->getByUid($uid);
         }

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -26,7 +26,7 @@ class HelpController
         $cfg = (new ConfigService($pdo))->getConfig();
         $eventSvc = new EventService($pdo);
         $event = null;
-        $uid = (string)($cfg['activeEventUid'] ?? '');
+        $uid = (string)($cfg['event_uid'] ?? '');
         if ($uid !== '') {
             $event = $eventSvc->getByUid($uid);
         }

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -27,7 +27,7 @@ class HomeController
         $cfg = (new ConfigService($pdo))->getConfig();
         $eventSvc = new EventService($pdo);
         $event = null;
-        $uid = (string)($cfg['activeEventUid'] ?? '');
+        $uid = (string)($cfg['event_uid'] ?? '');
         if ($uid !== '') {
             $event = $eventSvc->getByUid($uid);
         }

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -175,7 +175,7 @@ class QrController
         }
 
         $cfg = $this->config->getConfig();
-        $uid = (string)($cfg['activeEventUid'] ?? '');
+        $uid = (string)($cfg['event_uid'] ?? '');
         $ev = null;
         if ($uid !== '') {
             $ev = $this->events->getByUid($uid);
@@ -238,7 +238,7 @@ class QrController
         $teams = $this->teams->getAll();
 
         $cfg = $this->config->getConfig();
-        $uid = (string)($cfg['activeEventUid'] ?? '');
+        $uid = (string)($cfg['event_uid'] ?? '');
         $ev = null;
         if ($uid !== '') {
             $ev = $this->events->getByUid($uid);

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -245,7 +245,7 @@ class ResultController
         $rankings = $awardService->computeRankings($results, $catalogCount);
 
         $cfg = $this->config->getConfig();
-        $uid = (string)($cfg['activeEventUid'] ?? '');
+        $uid = (string)($cfg['event_uid'] ?? '');
         $event = null;
         if ($uid !== '') {
             $event = $this->events->getByUid($uid);

--- a/src/Controller/SummaryController.php
+++ b/src/Controller/SummaryController.php
@@ -34,7 +34,7 @@ class SummaryController
     {
         $view = Twig::fromRequest($request);
         $cfg = $this->config->getConfig();
-        $uid = (string)($cfg['activeEventUid'] ?? '');
+        $uid = (string)($cfg['event_uid'] ?? '');
         $event = null;
         if ($uid !== '') {
             $event = $this->events->getByUid($uid);

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -32,7 +32,7 @@ class CatalogService
     private function activeEventUid(): string
     {
         try {
-            $stmt = $this->pdo->query('SELECT activeEventUid FROM config LIMIT 1');
+            $stmt = $this->pdo->query('SELECT event_uid FROM config LIMIT 1');
             $uid = $stmt->fetchColumn();
             return $uid === false ? '' : (string)$uid;
         } catch (PDOException $e) {

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -75,7 +75,7 @@ class ConfigService
      */
     public function saveConfig(array $data): void
     {
-        $keys = ['displayErrorDetails','QRUser','logoPath','pageTitle','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback','inviteText','activeEventUid'];
+        $keys = ['displayErrorDetails','QRUser','logoPath','pageTitle','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback','inviteText','event_uid'];
         $filtered = array_intersect_key($data, array_flip($keys));
         $this->pdo->beginTransaction();
         $this->pdo->exec('DELETE FROM config');
@@ -102,7 +102,7 @@ class ConfigService
     public function setActiveEventUid(string $uid): void
     {
         $cfg = $this->getConfig();
-        $cfg['activeEventUid'] = $uid;
+        $cfg['event_uid'] = $uid;
         $this->saveConfig($cfg);
     }
 
@@ -112,7 +112,7 @@ class ConfigService
     public function getActiveEventUid(): string
     {
         $cfg = $this->getConfig();
-        return (string)($cfg['activeEventUid'] ?? '');
+        return (string)($cfg['event_uid'] ?? '');
     }
 
     /**
@@ -123,7 +123,7 @@ class ConfigService
      */
     private function normalizeKeys(array $row): array
     {
-        $keys = ['displayErrorDetails','QRUser','logoPath','pageTitle','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback','inviteText','activeEventUid'];
+        $keys = ['displayErrorDetails','QRUser','logoPath','pageTitle','backgroundColor','buttonColor','CheckAnswerButton','adminUser','adminPass','QRRestrict','competitionMode','teamResults','photoUpload','puzzleWordEnabled','puzzleWord','puzzleFeedback','inviteText','event_uid'];
         $map = [];
         foreach ($keys as $k) {
             $map[strtolower($k)] = $k;

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -29,7 +29,7 @@ class ResultService
     private function activeEventUid(): string
     {
         try {
-            $stmt = $this->pdo->query('SELECT activeEventUid FROM config LIMIT 1');
+            $stmt = $this->pdo->query('SELECT event_uid FROM config LIMIT 1');
             $uid = $stmt->fetchColumn();
             return $uid === false ? '' : (string)$uid;
         } catch (PDOException $e) {

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -29,7 +29,7 @@ class TeamService
     private function activeEventUid(): string
     {
         try {
-            $stmt = $this->pdo->query('SELECT activeEventUid FROM config LIMIT 1');
+            $stmt = $this->pdo->query('SELECT event_uid FROM config LIMIT 1');
             $uid = $stmt->fetchColumn();
             return $uid === false ? '' : (string)$uid;
         } catch (PDOException $e) {

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -18,7 +18,7 @@ class ConfigControllerTest extends TestCase
         rename($path, $backup);
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, activeEventUid TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $controller = new ConfigController(new ConfigService($pdo));
         $request = $this->createRequest('GET', '/config.json');
         $response = $controller->get($request, new Response());
@@ -31,7 +31,7 @@ class ConfigControllerTest extends TestCase
     {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, activeEventUid TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $service = new ConfigService($pdo);
         $controller = new ConfigController($service);
 
@@ -50,7 +50,7 @@ class ConfigControllerTest extends TestCase
     {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, activeEventUid TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $service = new ConfigService($pdo);
         $controller = new ConfigController($service);
 

--- a/tests/Controller/HelpControllerTest.php
+++ b/tests/Controller/HelpControllerTest.php
@@ -21,7 +21,7 @@ class HelpControllerTest extends TestCase
         $dbFile = tempnam(sys_get_temp_dir(), 'db');
         $pdo = new \PDO('sqlite:' . $dbFile);
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $pdo->exec("INSERT INTO config(inviteText) VALUES('Hallo [Team]!');");
 
         putenv('POSTGRES_DSN=sqlite:' . $dbFile);

--- a/tests/Controller/LogoControllerTest.php
+++ b/tests/Controller/LogoControllerTest.php
@@ -16,7 +16,7 @@ class LogoControllerTest extends TestCase
     {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $cfg = new ConfigService($pdo);
         $controller = new LogoController($cfg);
         $request = $this->createRequest('GET', '/logo.png');
@@ -30,7 +30,7 @@ class LogoControllerTest extends TestCase
         $tmpConfig = tempnam(sys_get_temp_dir(), 'cfg');
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $cfg = new ConfigService($pdo);
         $controller = new LogoController($cfg);
         $logoFile = tempnam(sys_get_temp_dir(), 'logo');
@@ -56,7 +56,7 @@ class LogoControllerTest extends TestCase
         $tmpConfig = tempnam(sys_get_temp_dir(), 'cfg');
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $cfg = new ConfigService($pdo);
         $controller = new LogoController($cfg);
         $logoFile = tempnam(sys_get_temp_dir(), 'logo');

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -38,7 +38,7 @@ class QrControllerTest extends TestCase
     {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, date TEXT, description TEXT);');
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','Event','Sub')");
         $cfg = new \App\Service\ConfigService($pdo);
@@ -71,7 +71,7 @@ class QrControllerTest extends TestCase
     {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, header TEXT, subheader TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $pdo->exec("INSERT INTO config(inviteText, header) VALUES('Hallo [Team]!','Event');");
 
         $cfg = new \App\Service\ConfigService($pdo);
@@ -91,7 +91,7 @@ class QrControllerTest extends TestCase
     {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, date TEXT, description TEXT);');
         $pdo->exec("INSERT INTO events(uid,name) VALUES('1','Event')");
         $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY);');

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -14,7 +14,7 @@ class ConfigServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, activeEventUid TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $service = new ConfigService($pdo);
         $data = ['pageTitle' => 'Demo'];
 
@@ -28,7 +28,7 @@ class ConfigServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, activeEventUid TEXT);');
+        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
         $service = new ConfigService($pdo);
 
         $this->assertNull($service->getJson());


### PR DESCRIPTION
## Summary
- migrate to an `event_uid` column on `config`
- update schema and import script
- adjust controllers, services, and JS to use the new column
- update unit tests accordingly

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686d9a7d7690832bbc55d7849b7fac12