### PR TITLE
Inject ConfigService into catalog, result and team services

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -36,8 +36,9 @@ class AdminController
         if ($event === null) {
             $event = $eventSvc->getFirst();
         }
-        $results = (new ResultService($pdo))->getAll();
-        $catalogSvc = new CatalogService($pdo);
+        $configSvc = new ConfigService($pdo);
+        $results = (new ResultService($pdo, $configSvc))->getAll();
+        $catalogSvc = new CatalogService($pdo, $configSvc);
         $catalogsJson = $catalogSvc->read('catalogs.json');
         $catalogs = [];
         $catMap = [];
@@ -80,7 +81,7 @@ class AdminController
             }
         }
 
-        $teams = (new TeamService($pdo))->getAll();
+        $teams = (new TeamService($pdo, $configSvc))->getAll();
         return $view->render($response, 'admin.twig', [
             'config' => $cfg,
             'results' => $results,

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -41,7 +41,7 @@ class HomeController
             $cfg = ConfigService::removePuzzleInfo($cfg);
         }
 
-        $catalogService = new CatalogService($pdo);
+        $catalogService = new CatalogService($pdo, new ConfigService($pdo));
 
         $catalogsJson = $catalogService->read('catalogs.json');
         $catalogs = [];

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -145,7 +145,8 @@ class ResultController
         $results = $this->service->getAll();
 
         $pdo = Database::connectFromEnv();
-        $catalogSvc = new CatalogService($pdo);
+        $configSvc = new ConfigService($pdo);
+        $catalogSvc = new CatalogService($pdo, $configSvc);
         $json = $catalogSvc->read('catalogs.json');
         $map = [];
         if ($json !== null) {

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -14,35 +14,24 @@ use App\Service\ConfigService;
 class TeamService
 {
     private PDO $pdo;
+    private ConfigService $config;
 
     /**
      * Inject database connection.
      */
-    public function __construct(PDO $pdo)
+    public function __construct(PDO $pdo, ConfigService $config)
     {
         $this->pdo = $pdo;
+        $this->config = $config;
     }
 
-    /**
-     * Retrieve the active event UID.
-     */
-    private function activeEventUid(): string
-    {
-        try {
-            $stmt = $this->pdo->query('SELECT event_uid FROM config LIMIT 1');
-            $uid = $stmt->fetchColumn();
-            return $uid === false ? '' : (string)$uid;
-        } catch (PDOException $e) {
-            return '';
-        }
-    }
 
     /**
      * Retrieve the ordered list of teams.
      */
     public function getAll(): array
     {
-        $uid = $this->activeEventUid();
+        $uid = $this->config->getActiveEventUid();
         $sql = 'SELECT name FROM teams';
         $params = [];
         if ($uid !== '') {
@@ -60,7 +49,7 @@ class TeamService
      */
     public function saveAll(array $teams): void
     {
-        $uid = $this->activeEventUid();
+        $uid = $this->config->getActiveEventUid();
         $this->pdo->beginTransaction();
         if ($uid !== '') {
             $del = $this->pdo->prepare('DELETE FROM teams WHERE event_uid=?');

--- a/src/routes.php
+++ b/src/routes.php
@@ -64,9 +64,9 @@ return function (\Slim\App $app) {
     $pdo = Database::connectFromEnv();
     Migrator::migrate($pdo, __DIR__ . '/../migrations');
     $configService = new ConfigService($pdo);
-    $catalogService = new CatalogService($pdo);
-    $resultService = new ResultService($pdo);
-    $teamService = new TeamService($pdo);
+    $catalogService = new CatalogService($pdo, $configService);
+    $resultService = new ResultService($pdo, $configService);
+    $teamService = new TeamService($pdo, $configService);
     $consentService = new PhotoConsentService($pdo);
     $eventService = new EventService($pdo);
 

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Controller;
 
 use App\Controller\CatalogController;
 use App\Service\CatalogService;
+use App\Service\ConfigService;
 use Tests\TestCase;
 use Slim\Psr7\Response;
 
@@ -13,9 +14,14 @@ class CatalogControllerTest extends TestCase
 {
     public function testGetNotFound(): void
     {
-        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
-        mkdir($dir);
-        $controller = new CatalogController(new CatalogService());
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT, UNIQUE(catalog_uid, sort_order));');
+        $cfg = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfg);
+        $controller = new CatalogController($service);
         $request = $this->createRequest('GET', '/kataloge/missing.json', ['HTTP_ACCEPT' => 'application/json']);
         $response = $controller->get($request, new Response(), ['file' => 'missing.json']);
         $this->assertEquals(404, $response->getStatusCode());
@@ -24,9 +30,13 @@ class CatalogControllerTest extends TestCase
 
     public function testPostAndGet(): void
     {
-        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
-        mkdir($dir);
-        $service = new CatalogService();
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT, UNIQUE(catalog_uid, sort_order));');
+        $cfg = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfg);
         $controller = new CatalogController($service);
 
         $request = $this->createRequest('POST', '/kataloge/test.json');
@@ -48,9 +58,13 @@ class CatalogControllerTest extends TestCase
 
     public function testCreateAndDelete(): void
     {
-        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
-        mkdir($dir);
-        $service = new CatalogService();
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT, UNIQUE(catalog_uid, sort_order));');
+        $cfg = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfg);
         $controller = new CatalogController($service);
 
         $createReq = $this->createRequest('PUT', '/kataloge/new.json');
@@ -71,9 +85,13 @@ class CatalogControllerTest extends TestCase
 
     public function testDeleteQuestion(): void
     {
-        $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
-        mkdir($dir);
-        $service = new CatalogService();
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT, UNIQUE(catalog_uid, sort_order));');
+        $cfg = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfg);
         $controller = new CatalogController($service);
 
         $service->write('cat.json', [['a' => 1], ['b' => 2]]);
@@ -94,7 +112,13 @@ class CatalogControllerTest extends TestCase
     {
         $dir = sys_get_temp_dir() . '/catalog_' . uniqid();
         mkdir($dir);
-        $controller = new CatalogController(new CatalogService());
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER UNIQUE NOT NULL, slug TEXT UNIQUE NOT NULL, file TEXT NOT NULL, name TEXT NOT NULL, description TEXT, qrcode_url TEXT, raetsel_buchstabe TEXT, comment TEXT);');
+        $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT, UNIQUE(catalog_uid, sort_order));');
+        $cfg = new ConfigService($pdo);
+        $controller = new CatalogController(new CatalogService($pdo, $cfg));
 
         $request = $this->createRequest('POST', '/kataloge/test.json', ['HTTP_CONTENT_TYPE' => 'application/json']);
         $stream = fopen('php://temp', 'r+');

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -26,11 +26,12 @@ class ImportControllerTest extends TestCase
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
         $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL);');
 
+        $cfg = new ConfigService($pdo);
         return [
-            new CatalogService($pdo),
-            new ConfigService($pdo),
-            new ResultService($pdo),
-            new TeamService($pdo),
+            new CatalogService($pdo, $cfg),
+            $cfg,
+            new ResultService($pdo, $cfg),
+            new TeamService($pdo, $cfg),
             new PhotoConsentService($pdo),
             $pdo,
         ];

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -42,7 +42,7 @@ class QrControllerTest extends TestCase
         $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, date TEXT, description TEXT);');
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','Event','Sub')");
         $cfg = new \App\Service\ConfigService($pdo);
-        $teams = new \App\Service\TeamService($pdo);
+        $teams = new \App\Service\TeamService($pdo, $cfg);
         $events = new \App\Service\EventService($pdo);
         $qr = new \App\Controller\QrController($cfg, $teams, $events);
         $logo = new \App\Controller\LogoController($cfg);
@@ -75,7 +75,7 @@ class QrControllerTest extends TestCase
         $pdo->exec("INSERT INTO config(inviteText, header) VALUES('Hallo [Team]!','Event');");
 
         $cfg = new \App\Service\ConfigService($pdo);
-        $teams = new \App\Service\TeamService($pdo);
+        $teams = new \App\Service\TeamService($pdo, $cfg);
         $events = new \App\Service\EventService($pdo);
         $qr  = new \App\Controller\QrController($cfg, $teams, $events);
 
@@ -98,7 +98,7 @@ class QrControllerTest extends TestCase
         $pdo->exec("INSERT INTO teams(sort_order,name,uid) VALUES(1,'A','1'),(2,'B','2')");
 
         $cfg = new \App\Service\ConfigService($pdo);
-        $teams = new \App\Service\TeamService($pdo);
+        $teams = new \App\Service\TeamService($pdo, $cfg);
         $events = new \App\Service\EventService($pdo);
         $qr  = new \App\Controller\QrController($cfg, $teams, $events);
 

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -31,9 +31,9 @@ class ResultControllerTest extends TestCase
         $pdo->exec("INSERT INTO teams(sort_order,name,uid) VALUES(1,'Team1','1')");
 
         $cfg = new \App\Service\ConfigService($pdo);
-        $svc = new \App\Service\ResultService($pdo);
-        $teams = new \App\Service\TeamService($pdo);
-        $catalogs = new \App\Service\CatalogService($pdo);
+        $svc = new \App\Service\ResultService($pdo, $cfg);
+        $teams = new \App\Service\TeamService($pdo, $cfg);
+        $catalogs = new \App\Service\CatalogService($pdo, $cfg);
         $events = new \App\Service\EventService($pdo);
         $ctrl = new \App\Controller\ResultController($svc, $cfg, $teams, $catalogs, sys_get_temp_dir(), $events);
 

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Service;
 
 use App\Service\ResultService;
+use App\Service\ConfigService;
 use PDO;
 use Tests\TestCase;
 
@@ -15,7 +16,9 @@ class ResultServiceTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
-        $service = new ResultService($pdo);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $service = new ResultService($pdo, $cfg);
 
         $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $this->assertSame(1, $first['attempt']);
@@ -29,7 +32,9 @@ class ResultServiceTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
-        $service = new ResultService($pdo);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $service = new ResultService($pdo, $cfg);
 
         $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $this->assertSame(1, $first['attempt']);
@@ -43,7 +48,9 @@ class ResultServiceTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
-        $service = new ResultService($pdo);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $service = new ResultService($pdo, $cfg);
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $ts = time();
@@ -58,7 +65,9 @@ class ResultServiceTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
-        $service = new ResultService($pdo);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $service = new ResultService($pdo, $cfg);
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1', 'puzzleTime' => 123]);
         $res = $service->markPuzzle('TeamA', 'cat1', 456);
@@ -72,7 +81,9 @@ class ResultServiceTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
-        $service = new ResultService($pdo);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $service = new ResultService($pdo, $cfg);
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $service->setPhoto('TeamA', 'cat1', '/photo/test.jpg');
@@ -85,6 +96,7 @@ class ResultServiceTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $pdo->exec('CREATE TABLE question_results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, question_id INTEGER NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, answer_text TEXT, photo TEXT, consent INTEGER);');
         $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT);');
         $pdo->exec('CREATE TABLE questions(id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER, type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT);');
@@ -92,7 +104,8 @@ class ResultServiceTest extends TestCase
         $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u1',1,'text','Q1')");
         $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u1',2,'text','Q2')");
 
-        $service = new ResultService($pdo);
+        $cfg = new ConfigService($pdo);
+        $service = new ResultService($pdo, $cfg);
         $service->add(['name' => 'Team', 'catalog' => 'cat1', 'correct' => 1, 'total' => 2, 'wrong' => [2]]);
 
         $stmt = $pdo->query('SELECT question_id, correct FROM question_results ORDER BY id');
@@ -109,8 +122,10 @@ class ResultServiceTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $pdo->exec('CREATE TABLE question_results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, question_id INTEGER NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, answer_text TEXT, photo TEXT, consent INTEGER);');
-        $service = new ResultService($pdo);
+        $cfg = new ConfigService($pdo);
+        $service = new ResultService($pdo, $cfg);
         $service->add([ 'name' => 'Team', 'catalog' => 'cat1', 'correct' => 1, 'total' => 1 ]);
         $service->clear();
         $resCount = (int) $pdo->query('SELECT COUNT(*) FROM results')->fetchColumn();


### PR DESCRIPTION
## Summary
- inject `ConfigService` into `CatalogService`, `ResultService` and `TeamService`
- replace local `activeEventUid()` calls with `ConfigService::getActiveEventUid()`
- wire new dependencies in controllers, routes and tests

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686da5efc508832bb95c6265436374ec