### PR TITLE
Auto-config for new events

### DIFF
--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -107,6 +107,19 @@ class ConfigService
     }
 
     /**
+     * Ensure a configuration row exists for the given event UID.
+     */
+    public function ensureConfigForEvent(string $uid): void
+    {
+        $stmt = $this->pdo->prepare('SELECT 1 FROM config WHERE event_uid = ? LIMIT 1');
+        $stmt->execute([$uid]);
+        if ($stmt->fetchColumn() === false) {
+            $insert = $this->pdo->prepare('INSERT INTO config(event_uid) VALUES(?)');
+            $insert->execute([$uid]);
+        }
+    }
+
+    /**
      * Return the UID of the currently active event or an empty string.
      */
     public function getActiveEventUid(): string

--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use PDO;
+use App\Service\ConfigService;
 
 /**
  * Service for managing quiz events.
@@ -12,10 +13,12 @@ use PDO;
 class EventService
 {
     private PDO $pdo;
+    private ConfigService $config;
 
-    public function __construct(PDO $pdo)
+    public function __construct(PDO $pdo, ?ConfigService $config = null)
     {
         $this->pdo = $pdo;
+        $this->config = $config ?? new ConfigService($pdo);
     }
 
     /**
@@ -43,10 +46,11 @@ class EventService
             $uid = $event['uid'] ?? bin2hex(random_bytes(16));
             $stmt->execute([
                 $uid,
-                (string)$event['name'],
+                (string) $event['name'],
                 $event['date'] ?? null,
                 $event['description'] ?? null,
             ]);
+            $this->config->ensureConfigForEvent($uid);
         }
         $this->pdo->commit();
     }

--- a/tests/Service/EventServiceTest.php
+++ b/tests/Service/EventServiceTest.php
@@ -15,6 +15,7 @@ class EventServiceTest extends TestCase
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT NOT NULL, date TEXT, description TEXT);');
+        $pdo->exec('CREATE TABLE config(id INTEGER PRIMARY KEY AUTOINCREMENT, event_uid TEXT);');
         return $pdo;
     }
 
@@ -26,6 +27,8 @@ class EventServiceTest extends TestCase
             ['name' => 'Test Event', 'date' => '2025-07-04', 'description' => 'Demo'],
         ];
         $service->saveAll($data);
+        $count = (int) $pdo->query('SELECT COUNT(*) FROM config')->fetchColumn();
+        $this->assertSame(1, $count);
         $rows = $service->getAll();
         $this->assertCount(1, $rows);
         $this->assertSame('Test Event', $rows[0]['name']);


### PR DESCRIPTION
## Summary
- add helper in `ConfigService` to ensure config rows exist for events
- create config entries for events when saving all events
- test new behaviour in `EventServiceTest`

## Testing
- `vendor/bin/phpunit -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e33ca7284832b97971969ac3384c2