### PR TITLE
Implement admin user management

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -12,6 +12,7 @@ use App\Service\ResultService;
 use App\Service\CatalogService;
 use App\Service\TeamService;
 use App\Service\EventService;
+use App\Service\UserService;
 use App\Infrastructure\Database;
 
 /**
@@ -81,12 +82,14 @@ class AdminController
             }
         }
 
-        $teams = (new TeamService($pdo, $configSvc))->getAll();
+        $teams  = (new TeamService($pdo, $configSvc))->getAll();
+        $users  = (new UserService($pdo))->getAll();
         return $view->render($response, 'admin.twig', [
             'config' => $cfg,
             'results' => $results,
             'catalogs' => $catalogs,
             'teams' => $teams,
+            'users' => $users,
             'baseUrl' => $baseUrl,
             'event' => $event,
         ]);

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\UserService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * CRUD operations for user accounts.
+ */
+class UserController
+{
+    private UserService $service;
+
+    public function __construct(UserService $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * Return all users as JSON.
+     */
+    public function get(Request $request, Response $response): Response
+    {
+        $list = $this->service->getAll();
+        $response->getBody()->write(json_encode($list));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    /**
+     * Replace the user list with the provided data.
+     */
+    public function post(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $this->service->saveAll($data);
+        return $response->withStatus(204);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -25,6 +25,7 @@ use App\Service\UserService;
 use App\Controller\ResultController;
 use App\Controller\TeamController;
 use App\Controller\PasswordController;
+use App\Controller\UserController;
 use App\Controller\ImportController;
 use App\Controller\ExportController;
 use App\Controller\QrController;
@@ -57,6 +58,7 @@ require_once __DIR__ . '/Controller/EvidenceController.php';
 require_once __DIR__ . '/Controller/ExportController.php';
 require_once __DIR__ . '/Controller/EventController.php';
 require_once __DIR__ . '/Controller/BackupController.php';
+require_once __DIR__ . '/Controller/UserController.php';
 
 use App\Infrastructure\Database;
 use App\Infrastructure\Migrations\Migrator;
@@ -85,6 +87,7 @@ return function (\Slim\App $app) {
     $teamController = new TeamController($teamService);
     $eventController = new EventController($eventService);
     $passwordController = new PasswordController($userService);
+    $userController = new UserController($userService);
     $qrController = new QrController($configService, $teamService, $eventService);
     $logoController = new LogoController($configService);
     $summaryController = new SummaryController($configService);
@@ -153,6 +156,8 @@ return function (\Slim\App $app) {
 
     $app->get('/teams.json', [$teamController, 'get']);
     $app->post('/teams.json', [$teamController, 'post']);
+    $app->get('/users.json', [$userController, 'get']);
+    $app->post('/users.json', [$userController, 'post']);
     $app->post('/password', [$passwordController, 'post']);
     $app->post('/import', [$importController, 'post']);
     $app->post('/import/{name}', [$importController, 'import']);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -501,6 +501,28 @@
           </div>
         </form>
 
+        <h3 class="uk-heading-bullet">Benutzer</h3>
+        <div class="uk-overflow-auto">
+          <table class="uk-table uk-table-divider uk-table-small">
+            <thead>
+              <tr>
+                <th><span uk-icon="icon: question" uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></span></th>
+                <th>Benutzername</th>
+                <th>Passwort</th>
+                <th>Rolle</th>
+                <th><span uk-icon="icon: question" uk-tooltip="title: Benutzer entfernen; pos: top"></span></th>
+              </tr>
+            </thead>
+            <tbody id="usersList" uk-sortable="group: sortable-group"></tbody>
+          </table>
+        </div>
+        <div class="uk-margin">
+          <button id="userAddBtn" class="uk-button uk-button-default" uk-tooltip="title: Neuen Benutzer anlegen; pos: right">Hinzufügen</button>
+        </div>
+        <div class="uk-margin uk-flex uk-flex-right">
+          <button id="usersSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Änderungen speichern; pos: right">Speichern</button>
+        </div>
+
         <h3 class="uk-heading-bullet">Sicherungen</h3>
         <div class="uk-margin uk-flex uk-flex-right">
           <button id="exportJsonBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Datenbank als JSON exportieren; pos: right">Backup erstellen</button>


### PR DESCRIPTION
## Summary
- add `UserController` for CRUD operations
- extend `UserService` with `getAll()` and `saveAll()`
- fetch users in `AdminController` and expose new `/users.json` routes
- create a user management table on the administration tab
- implement frontend logic for editing users

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686e4fa3ea08832b8a8b7dc28cc34d0e