### PR TITLE
Implement confirmation before deleting events

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1234,7 +1234,11 @@ document.addEventListener('DOMContentLoaded', function () {
     del.className = 'uk-button uk-button-danger';
     del.textContent = '×';
     del.setAttribute('aria-label', 'Löschen');
-    del.addEventListener('click', () => row.remove());
+    del.addEventListener('click', () => {
+      if (confirm('Veranstaltung wirklich löschen? Dabei werden auch alle angelegten Kataloge, Fragen und Teams entfernt.')) {
+        row.remove();
+      }
+    });
     delCell.appendChild(del);
 
     row.appendChild(handleCell);


### PR DESCRIPTION
## Summary
- warn that deleting an event also removes catalogs and teams

## Testing
- `composer install --no-interaction --ignore-platform-reqs`
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: PDO driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e51c65d50832b84970a8924980939