### PR TITLE
Add shared role constants

### DIFF
--- a/migrations/20240714_limit_user_roles.sql
+++ b/migrations/20240714_limit_user_roles.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users ALTER COLUMN role SET DEFAULT 'catalog-editor';
+UPDATE users SET role='catalog-editor' WHERE role NOT IN ('admin','catalog-editor','event-manager','analyst','team-manager');
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_role_check;
+ALTER TABLE users ADD CONSTRAINT users_role_check CHECK (role IN ('admin','catalog-editor','event-manager','analyst','team-manager'));

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1461,11 +1461,12 @@ document.addEventListener('DOMContentLoaded', function () {
     const roleCell = document.createElement('td');
     const roleSelect = document.createElement('select');
     roleSelect.className = 'uk-select user-role';
-    ['user', 'admin'].forEach(r => {
+    const roles = window.roles || [];
+    roles.forEach(r => {
       const opt = document.createElement('option');
       opt.value = r;
       opt.textContent = r;
-      if ((u.role || 'user') === r) opt.selected = true;
+      if ((u.role || roles[0]) === r) opt.selected = true;
       roleSelect.appendChild(opt);
     });
     roleCell.appendChild(roleSelect);

--- a/scripts/seed_roles.php
+++ b/scripts/seed_roles.php
@@ -21,7 +21,7 @@ $pdo = new PDO($dsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
 $pdo->beginTransaction();
 $insert = $pdo->prepare('INSERT INTO users(username,password,role) VALUES(?,?,?) ON CONFLICT (username) DO NOTHING');
 $insert->execute(['admin', password_hash('admin', PASSWORD_DEFAULT), 'admin']);
-$insert->execute(['staff', password_hash('staff', PASSWORD_DEFAULT), 'user']);
+$insert->execute(['staff', password_hash('staff', PASSWORD_DEFAULT), 'catalog-editor']);
 $pdo->commit();
 
 echo "Seeded example users\n";

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -13,6 +13,7 @@ use App\Service\CatalogService;
 use App\Service\TeamService;
 use App\Service\EventService;
 use App\Service\UserService;
+use App\Domain\Roles;
 use App\Infrastructure\Database;
 
 /**
@@ -94,6 +95,7 @@ class AdminController
             'catalogs' => $catalogs,
             'teams' => $teams,
             'users' => $users,
+            'roles' => Roles::ALL,
             'baseUrl' => $baseUrl,
             'event' => $event,
             'role' => $role,

--- a/src/Domain/Roles.php
+++ b/src/Domain/Roles.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain;
+
+final class Roles
+{
+    public const ADMIN = 'admin';
+    public const CATALOG_EDITOR = 'catalog-editor';
+    public const EVENT_MANAGER = 'event-manager';
+    public const ANALYST = 'analyst';
+    public const TEAM_MANAGER = 'team-manager';
+
+    public const ALL = [
+        self::ADMIN,
+        self::CATALOG_EDITOR,
+        self::EVENT_MANAGER,
+        self::ANALYST,
+        self::TEAM_MANAGER,
+    ];
+}

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use PDO;
+use App\Domain\Roles;
 
 /**
  * Service for user and role management.
@@ -34,8 +35,11 @@ class UserService
     /**
      * Create a new user with the given role.
      */
-    public function create(string $username, string $password, string $role = 'user'): void
+    public function create(string $username, string $password, string $role = Roles::CATALOG_EDITOR): void
     {
+        if (!in_array($role, Roles::ALL, true)) {
+            $role = Roles::CATALOG_EDITOR;
+        }
         $stmt = $this->pdo->prepare('INSERT INTO users(username,password,role) VALUES(?,?,?)');
         $stmt->execute([
             strtolower($username),
@@ -87,8 +91,11 @@ class UserService
 
         foreach ($users as $u) {
             $id = isset($u['id']) ? (int) $u['id'] : 0;
-            $username = strtolower((string) ($u['username'] ?? ''));
-            $role = (string) ($u['role'] ?? 'user');
+            $username = strtolower((string) $u['username']);
+            $role = (string) $u['role'];
+            if (!in_array($role, Roles::ALL, true)) {
+                $role = Roles::CATALOG_EDITOR;
+            }
             $pass = $u['password'] ?? '';
 
             if ($id === 0 || !isset($existing[$id])) {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -636,6 +636,7 @@
   <script src="/js/custom-icons.js"></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
+    window.roles = {{ roles|json_encode|raw }};
   </script>
   <script src="/js/admin.js"></script>
   <script src="/js/app.js"></script>


### PR DESCRIPTION
## Summary
- centralize allowed roles in `src/Domain/Roles.php`
- expose roles to admin dashboard and dropdown
- validate roles in `UserService`
- seed script and new migration for role constraint
- build role dropdown from provided list

## Testing
- `vendor/bin/phpcs` *(fails: requires xmlwriter and SimpleXML)*
- `vendor/bin/phpstan` *(fails: 2 errors)*
- `vendor/bin/phpunit` *(fails: 54 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e62320a5c832bbbf1d9c7fea94cc6