### PR TITLE
Seed users for all roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,14 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
   ```bash
   php scripts/seed_roles.php
   ```
-  ausgeführt werden.
+  ausgeführt werden. Das Skript legt einen Benutzer pro Rolle an. Benutzername
+  und Passwort entsprechen dabei jeweils dem Rollennamen:
+
+  - `admin` – Administrator
+  - `catalog-editor` – Fragenkataloge bearbeiten
+  - `event-manager` – Veranstaltungen verwalten
+  - `analyst` – Ergebnisse analysieren
+  - `team-manager` – Teams verwalten
 
    Wird `POSTGRES_DSN` gesetzt und enthält das Verzeichnis `data/` bereits JSON-Dateien,
    legt das Entrypoint-Skript des Containers die Tabellen automatisch an und importiert

--- a/scripts/seed_roles.php
+++ b/scripts/seed_roles.php
@@ -1,6 +1,10 @@
 <?php
 declare(strict_types=1);
 
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Domain\Roles;
+
 $base = dirname(__DIR__);
 $configFile = "$base/data/config.json";
 $config = [];
@@ -17,11 +21,19 @@ if (!$dsn || !$user || !$db) {
     exit(1);
 }
 
+
 $pdo = new PDO($dsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 $pdo->beginTransaction();
 $insert = $pdo->prepare('INSERT INTO users(username,password,role) VALUES(?,?,?) ON CONFLICT (username) DO NOTHING');
-$insert->execute(['admin', password_hash('admin', PASSWORD_DEFAULT), 'admin']);
-$insert->execute(['staff', password_hash('staff', PASSWORD_DEFAULT), 'catalog-editor']);
+
+foreach (Roles::ALL as $role) {
+    $insert->execute([
+        $role,
+        password_hash($role, PASSWORD_DEFAULT),
+        $role,
+    ]);
+}
+
 $pdo->commit();
 
 echo "Seeded example users\n";


### PR DESCRIPTION
## Summary
- add autoload usage and loop over `Roles::ALL`
- seed one account per role
- document default role accounts in README

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_686e65b10bdc832b8ace29b4bb6ef176