### PR TITLE
Add event UID to photo consents

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -117,6 +117,7 @@ CREATE INDEX idx_questions_catalog ON questions(catalog_uid);
 CREATE TABLE IF NOT EXISTS photo_consents (
     id SERIAL PRIMARY KEY,
     team TEXT NOT NULL,
-    time INTEGER NOT NULL
+    time INTEGER NOT NULL,
+    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX idx_photo_consents_team ON photo_consents(team);

--- a/migrations/20240715_add_event_uid_to_photo_consents.sql
+++ b/migrations/20240715_add_event_uid_to_photo_consents.sql
@@ -1,0 +1,5 @@
+ALTER TABLE photo_consents ADD COLUMN IF NOT EXISTS event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE;
+-- Set the active event UID for existing rows if not already assigned
+UPDATE photo_consents
+SET event_uid = (SELECT event_uid FROM config LIMIT 1)
+WHERE event_uid IS NULL;

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -169,9 +169,13 @@ if (is_readable($catalogsFile)) {
 $consentFile = "$base/data/photo_consents.json";
 if (is_readable($consentFile)) {
     $consents = json_decode(file_get_contents($consentFile), true) ?? [];
-    $stmt = $pdo->prepare('INSERT INTO photo_consents(team,time) VALUES(?,?)');
+    $stmt = $pdo->prepare('INSERT INTO photo_consents(team,time,event_uid) VALUES(?,?,?)');
     foreach ($consents as $c) {
-        $stmt->execute([ $c['team'] ?? '', $c['time'] ?? 0 ]);
+        $stmt->execute([
+            $c['team'] ?? '',
+            $c['time'] ?? 0,
+            $c['event_uid'] ?? $activeUid,
+        ]);
     }
     $pdo->exec("SELECT setval(pg_get_serial_sequence('photo_consents','id'), (SELECT COALESCE(MAX(id),0) FROM photo_consents))");
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -70,7 +70,7 @@ return function (\Slim\App $app) {
     $catalogService = new CatalogService($pdo, $configService);
     $resultService = new ResultService($pdo, $configService);
     $teamService = new TeamService($pdo, $configService);
-    $consentService = new PhotoConsentService($pdo);
+    $consentService = new PhotoConsentService($pdo, $configService);
     $eventService = new EventService($pdo);
     $userService = new \App\Service\UserService($pdo);
 

--- a/tests/Service/PhotoConsentServiceTest.php
+++ b/tests/Service/PhotoConsentServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Service;
 
 use App\Service\PhotoConsentService;
+use App\Service\ConfigService;
 use PDO;
 use Tests\TestCase;
 
@@ -14,8 +15,11 @@ class PhotoConsentServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL);');
-        $svc = new PhotoConsentService($pdo);
+        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL, event_uid TEXT);');
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $cfg->saveConfig(['event_uid' => 'e1']);
+        $svc = new PhotoConsentService($pdo, $cfg);
         $svc->add('TeamA', 123);
         $svc->add('TeamB', 456);
         $stmt = $pdo->query('SELECT team,time FROM photo_consents ORDER BY id');
@@ -29,8 +33,11 @@ class PhotoConsentServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL);');
-        $svc = new PhotoConsentService($pdo);
+        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL, event_uid TEXT);');
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $cfg->saveConfig(['event_uid' => 'e1']);
+        $svc = new PhotoConsentService($pdo, $cfg);
         $svc->add('TeamA', 1);
         $svc->add('TeamB', 2);
 
@@ -38,5 +45,54 @@ class PhotoConsentServiceTest extends TestCase
         $this->assertCount(2, $data);
         $this->assertSame('TeamA', $data[0]['team']);
         $this->assertSame(2, (int)$data[1]['time']);
+    }
+
+    public function testAddStoresEventUid(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL, event_uid TEXT);');
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $cfg->saveConfig(['event_uid' => 'ev1']);
+        $svc = new PhotoConsentService($pdo, $cfg);
+        $svc->add('TeamA', 1);
+        $uid = $pdo->query('SELECT event_uid FROM photo_consents')->fetchColumn();
+        $this->assertSame('ev1', $uid);
+    }
+
+    public function testGetAllFiltersByEventUid(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL, event_uid TEXT);');
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $cfg->saveConfig(['event_uid' => 'ev1']);
+        $svc = new PhotoConsentService($pdo, $cfg);
+        $pdo->exec("INSERT INTO photo_consents(team,time,event_uid) VALUES('A',1,'ev1')");
+        $pdo->exec("INSERT INTO photo_consents(team,time,event_uid) VALUES('B',2,'ev2')");
+        $rows = $svc->getAll();
+        $this->assertCount(1, $rows);
+        $this->assertSame('A', $rows[0]['team']);
+    }
+
+    public function testSaveAllReplacesOnlyCurrentEvent(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE photo_consents(id INTEGER PRIMARY KEY AUTOINCREMENT, team TEXT NOT NULL, time INTEGER NOT NULL, event_uid TEXT);');
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $cfg->saveConfig(['event_uid' => 'ev1']);
+        $svc = new PhotoConsentService($pdo, $cfg);
+        $pdo->exec("INSERT INTO photo_consents(team,time,event_uid) VALUES('A',1,'ev1')");
+        $pdo->exec("INSERT INTO photo_consents(team,time,event_uid) VALUES('B',2,'ev2')");
+        $svc->saveAll([[ 'team' => 'C', 'time' => 3 ]]);
+        $countEv2 = (int)$pdo->query("SELECT COUNT(*) FROM photo_consents WHERE event_uid='ev2'")->fetchColumn();
+        $this->assertSame(1, $countEv2);
+        $rows = $pdo->query("SELECT team FROM photo_consents WHERE event_uid='ev1'")->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertCount(1, $rows);
+        $this->assertSame('C', $rows[0]);
     }
 }


### PR DESCRIPTION
## Summary
- add migration for `event_uid` in `photo_consents`
- document new column in schema docs
- store and filter consents by active event
- update import script and routes
- extend tests for event-specific behaviour

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `python3 tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`
- `./vendor/bin/phpunit --display-warnings=0 -c phpunit.xml` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6933c160832ba40aeeb0652f483b