### PR TITLE
Add role info to admin help

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -40,7 +40,7 @@
     <li data-help="Einzelne Antworten analysieren. Tabelle filtert nach Teams/Personen."><a href="#">Statistik</a></li>
     <li data-help="QR-Codes für alle Kataloge und Teams anzeigen, um Quizlinks oder Anmeldungen weiterzugeben. 'Drucken' erstellt eine übersichtliche Liste."><a href="#">Zusammenfassung</a></li>
     {% if role == 'admin' %}
-    <li data-help="Administrationspasswort ändern und Sicherungen verwalten."><a href="#">Administration</a></li>
+    <li data-help="Benutzer verwalten, Rollen zuweisen und Sicherungen erstellen. Rollen: admin – Administrator; catalog-editor – Fragenkataloge bearbeiten; event-manager – Veranstaltungen verwalten; analyst – Ergebnisse analysieren; team-manager – Teams verwalten."><a href="#">Administration</a></li>
     {% endif %}
   </ul>
   <ul class="uk-switcher uk-margin">


### PR DESCRIPTION
## Summary
- update help text in admin tab with role descriptions

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_686e6ef265d8832bb1ee0ac365d6a697