### PR TITLE
Move password column after role in user table

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1493,8 +1493,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     row.appendChild(handleCell);
     row.appendChild(nameCell);
-    row.appendChild(passCell);
     row.appendChild(roleCell);
+    row.appendChild(passCell);
     row.appendChild(delCell);
     return row;
   }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -591,8 +591,8 @@
               <tr>
                 <th><span uk-icon="icon: question" uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></span></th>
                 <th>Benutzername</th>
-                <th><span uk-icon="icon: key" uk-tooltip="title: Passwort setzen; pos: top"></span></th>
                 <th>Rolle</th>
+                <th><span uk-icon="icon: key" uk-tooltip="title: Passwort setzen; pos: top"></span></th>
                 <th><span uk-icon="icon: question" uk-tooltip="title: Benutzer entfernen; pos: top"></span></th>
               </tr>
             </thead>


### PR DESCRIPTION
## Summary
- reorder user table headers so the password-set column comes after the role column
- update row builder in admin.js accordingly

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`
- ❌ `composer install --no-interaction --no-progress` *(fails: composer not found)*
- ❌ `vendor/bin/phpunit --version` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6f3d94a0832bb9b7a1ffcc077410