### PR TITLE
Fix event updates preserving config

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1259,6 +1259,8 @@ document.addEventListener('DOMContentLoaded', function () {
   function updateActiveHeader(name) {
     const el = document.getElementById('activeEventHeader');
     if (el) el.textContent = name || '';
+    const top = document.getElementById('topbar-title');
+    if (top) top.textContent = name || top.dataset.defaultTitle || '';
   }
 
   function setActiveEvent(uid, name) {


### PR DESCRIPTION
## Summary
- prevent config deletion when editing events
- update top bar title when switching active event

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml` *(fails: PDO errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e743d9714832b8e728a8cb2f3d2b2