### PR TITLE
Fix docs build missing theme

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-rtd-theme'
+gem 'csv'
+gem 'bigdecimal'


### PR DESCRIPTION
## Summary
- add Gemfile so GitHub Pages installs the `jekyll-rtd-theme`

## Testing
- `bundle exec jekyll build` *(fails: undefined method `tainted?`)*
- `vendor/bin/phpunit --coverage-clover clover.xml` *(fails: Tests: 66, Errors: 62)*

------
https://chatgpt.com/codex/tasks/task_e_686e77949a4c832b942e93ebb2a14f0c