### PR TITLE
Fix docs build missing theme

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,2 @@
 title: Sommerfest Quiz Dokumentation
-theme: jekyll-rtd-theme
+theme: minima


### PR DESCRIPTION
## Summary
- use the GitHub Pages default `minima` theme
- remove unused docs Gemfile

## Testing
- `bundle exec jekyll build -s docs -d docs/_site` *(fails: Could not locate Gemfile)*
- `jekyll build -s docs -d docs/_site` *(fails: jekyll not found)*
- `vendor/bin/phpunit --coverage-clover clover.xml` *(fails: phpunit not found)*


------
https://chatgpt.com/codex/tasks/task_e_686e77949a4c832b942e93ebb2a14f0c