### PR TITLE
Add tenant management endpoints

### DIFF
--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\TenantService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * API endpoints for managing tenants.
+ */
+class TenantController
+{
+    private TenantService $service;
+
+    public function __construct(TenantService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function create(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $this->service->create($data);
+        return $response->withStatus(201);
+    }
+
+    public function delete(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data) || !isset($data['uid'])) {
+            return $response->withStatus(400);
+        }
+        $this->service->delete((string) $data['uid']);
+        return $response->withStatus(204);
+    }
+}

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Simple in-memory service for managing tenants.
+ */
+class TenantService
+{
+    /**
+     * @var array<int,array<string,mixed>>
+     */
+    private array $tenants = [];
+
+    /**
+     * Create a new tenant record.
+     *
+     * @param array<string,mixed> $data
+     */
+    public function create(array $data): void
+    {
+        $this->tenants[] = $data;
+    }
+
+    /**
+     * Delete a tenant by UID if present.
+     */
+    public function delete(string $uid): void
+    {
+        foreach ($this->tenants as $i => $row) {
+            if (($row['uid'] ?? null) === $uid) {
+                unset($this->tenants[$i]);
+            }
+        }
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -22,6 +22,7 @@ use App\Service\TeamService;
 use App\Service\PhotoConsentService;
 use App\Service\EventService;
 use App\Service\UserService;
+use App\Service\TenantService;
 use App\Controller\ResultController;
 use App\Controller\TeamController;
 use App\Controller\PasswordController;
@@ -33,6 +34,7 @@ use App\Controller\LogoController;
 use App\Controller\SummaryController;
 use App\Controller\EvidenceController;
 use App\Controller\EventController;
+use App\Controller\TenantController;
 use Psr\Log\NullLogger;
 use App\Controller\BackupController;
 use App\Domain\Roles;
@@ -60,6 +62,7 @@ require_once __DIR__ . '/Controller/ExportController.php';
 require_once __DIR__ . '/Controller/EventController.php';
 require_once __DIR__ . '/Controller/BackupController.php';
 require_once __DIR__ . '/Controller/UserController.php';
+require_once __DIR__ . '/Controller/TenantController.php';
 
 use App\Infrastructure\Database;
 use App\Infrastructure\Migrations\Migrator;
@@ -73,6 +76,7 @@ return function (\Slim\App $app) {
     $teamService = new TeamService($pdo, $configService);
     $consentService = new PhotoConsentService($pdo, $configService);
     $eventService = new EventService($pdo);
+    $tenantService = new TenantService();
     $userService = new \App\Service\UserService($pdo);
 
     $configController = new ConfigController($configService);
@@ -87,6 +91,7 @@ return function (\Slim\App $app) {
     );
     $teamController = new TeamController($teamService);
     $eventController = new EventController($eventService);
+    $tenantController = new TenantController($tenantService);
     $passwordController = new PasswordController($userService);
     $userController = new UserController($userService);
     $qrController = new QrController($configService, $teamService, $eventService);
@@ -162,6 +167,11 @@ return function (\Slim\App $app) {
         ->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
     $app->post('/events.json', [$eventController, 'post'])
         ->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
+
+    $app->post('/tenants', [$tenantController, 'create'])
+        ->add(new RoleAuthMiddleware(Roles::ADMIN));
+    $app->delete('/tenants', [$tenantController, 'delete'])
+        ->add(new RoleAuthMiddleware(Roles::ADMIN));
 
     $app->get('/teams.json', [$teamController, 'get']);
     $app->post('/teams.json', [$teamController, 'post'])

--- a/tests/Controller/TenantControllerTest.php
+++ b/tests/Controller/TenantControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Controller\TenantController;
+use App\Service\TenantService;
+use Tests\TestCase;
+use Slim\Psr7\Response;
+use Slim\Psr7\Factory\StreamFactory;
+
+class TenantControllerTest extends TestCase
+{
+    private function setupDb(): string
+    {
+        $db = tempnam(sys_get_temp_dir(), 'db');
+        putenv('POSTGRES_DSN=sqlite:' . $db);
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        $_ENV['POSTGRES_DSN'] = 'sqlite:' . $db;
+        $_ENV['POSTGRES_USER'] = '';
+        $_ENV['POSTGRES_PASSWORD'] = '';
+        return $db;
+    }
+
+    public function testCreateReturns201(): void
+    {
+        $service = new TenantService();
+        $controller = new TenantController($service);
+        $request = $this->createRequest('POST', '/tenants', ['HTTP_CONTENT_TYPE' => 'application/json']);
+        $stream = (new StreamFactory())->createStream(json_encode(['uid' => 't1']));
+        $request = $request->withBody($stream);
+        $response = $controller->create($request, new Response());
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+
+    public function testDeleteReturns204(): void
+    {
+        $service = new TenantService();
+        $service->create(['uid' => 't1']);
+        $controller = new TenantController($service);
+        $request = $this->createRequest('DELETE', '/tenants', ['HTTP_CONTENT_TYPE' => 'application/json']);
+        $stream = (new StreamFactory())->createStream(json_encode(['uid' => 't1']));
+        $request = $request->withBody($stream);
+        $response = $controller->delete($request, new Response());
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testCreateDeniedForNonAdmin(): void
+    {
+        $db = $this->setupDb();
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'user'];
+        $req = $this->createRequest('POST', '/tenants');
+        $res = $app->handle($req);
+        $this->assertEquals(302, $res->getStatusCode());
+        $this->assertEquals('/login', $res->getHeaderLine('Location'));
+        session_destroy();
+        unlink($db);
+    }
+
+    public function testDeleteDeniedForNonAdmin(): void
+    {
+        $db = $this->setupDb();
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'user'];
+        $req = $this->createRequest('DELETE', '/tenants');
+        $res = $app->handle($req);
+        $this->assertEquals(302, $res->getStatusCode());
+        $this->assertEquals('/login', $res->getHeaderLine('Location'));
+        session_destroy();
+        unlink($db);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TenantController` with create and delete actions
- provide a simple in-memory `TenantService`
- register tenant routes and service in `routes.php`
- test new controller behaviours and access control

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `vendor/bin/phpcs` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ee928fda8832ba4acb0786c8e388e