### PR TITLE
Add tenant service with database schema support

### DIFF
--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -23,10 +23,10 @@ class TenantController
     public function create(Request $request, Response $response): Response
     {
         $data = json_decode((string) $request->getBody(), true);
-        if (!is_array($data)) {
+        if (!is_array($data) || !isset($data['uid'], $data['schema'])) {
             return $response->withStatus(400);
         }
-        $this->service->create($data);
+        $this->service->createTenant((string) $data['uid'], (string) $data['schema']);
         return $response->withStatus(201);
     }
 
@@ -36,7 +36,7 @@ class TenantController
         if (!is_array($data) || !isset($data['uid'])) {
             return $response->withStatus(400);
         }
-        $this->service->delete((string) $data['uid']);
+        $this->service->deleteTenant((string) $data['uid']);
         return $response->withStatus(204);
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -76,7 +76,7 @@ return function (\Slim\App $app) {
     $teamService = new TeamService($pdo, $configService);
     $consentService = new PhotoConsentService($pdo, $configService);
     $eventService = new EventService($pdo);
-    $tenantService = new TenantService();
+    $tenantService = new TenantService($pdo);
     $userService = new \App\Service\UserService($pdo);
 
     $configController = new ConfigController($configService);

--- a/tests/Controller/TenantControllerTest.php
+++ b/tests/Controller/TenantControllerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Controller;
 
 use App\Controller\TenantController;
 use App\Service\TenantService;
+use PDO;
 use Tests\TestCase;
 use Slim\Psr7\Response;
 use Slim\Psr7\Factory\StreamFactory;
@@ -26,10 +27,14 @@ class TenantControllerTest extends TestCase
 
     public function testCreateReturns201(): void
     {
-        $service = new TenantService();
+        $service = new class extends TenantService {
+            public function __construct() {}
+            public function createTenant(string $uid, string $schema): void {}
+            public function deleteTenant(string $uid): void {}
+        };
         $controller = new TenantController($service);
         $request = $this->createRequest('POST', '/tenants', ['HTTP_CONTENT_TYPE' => 'application/json']);
-        $stream = (new StreamFactory())->createStream(json_encode(['uid' => 't1']));
+        $stream = (new StreamFactory())->createStream(json_encode(['uid' => 't1', 'schema' => 's1']));
         $request = $request->withBody($stream);
         $response = $controller->create($request, new Response());
         $this->assertEquals(201, $response->getStatusCode());
@@ -37,8 +42,11 @@ class TenantControllerTest extends TestCase
 
     public function testDeleteReturns204(): void
     {
-        $service = new TenantService();
-        $service->create(['uid' => 't1']);
+        $service = new class extends TenantService {
+            public function __construct() {}
+            public function createTenant(string $uid, string $schema): void {}
+            public function deleteTenant(string $uid): void {}
+        };
         $controller = new TenantController($service);
         $request = $this->createRequest('DELETE', '/tenants', ['HTTP_CONTENT_TYPE' => 'application/json']);
         $stream = (new StreamFactory())->createStream(json_encode(['uid' => 't1']));

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\TenantService;
+use Tests\TestCase;
+use PDO;
+
+class TenantServiceTest extends TestCase
+{
+    private function createService(string $dir, PDO &$pdo): TenantService
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT);');
+        if (!is_dir($dir)) {
+            mkdir($dir);
+        }
+        file_put_contents($dir . '/001.sql', 'CREATE TABLE sample(id INTEGER);');
+        return new TenantService($pdo, $dir);
+    }
+
+    public function testCreateTenantInsertsRow(): void
+    {
+        $dir = sys_get_temp_dir() . '/mig' . uniqid();
+        $service = $this->createService($dir, $pdo);
+        $service->createTenant('u1', 's1');
+        $count = (int) $pdo->query('SELECT COUNT(*) FROM tenants')->fetchColumn();
+        $this->assertSame(1, $count);
+    }
+
+    public function testDeleteTenantRemovesRow(): void
+    {
+        $dir = sys_get_temp_dir() . '/mig' . uniqid();
+        $service = $this->createService($dir, $pdo);
+        $service->createTenant('u2', 's2');
+        $service->deleteTenant('u2');
+        $count = (int) $pdo->query('SELECT COUNT(*) FROM tenants')->fetchColumn();
+        $this->assertSame(0, $count);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TenantService` for schema-based tenants
- wire new service into controller and routes
- update controller tests for new API
- add tests for `TenantService`

## Testing
- `composer --version` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eed2fcea8832b92b567a40fc56c6b