### PR TITLE
Fix insecure workflow dependencies

### DIFF
--- a/.github/workflows/composer-install.yml
+++ b/.github/workflows/composer-install.yml
@@ -13,7 +13,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@355155f9fb51da580099149361dcbdad69cfab9c
         with:
           php-version: '8.2'
 

--- a/.github/workflows/composer-require-phpcs.yml
+++ b/.github/workflows/composer-require-phpcs.yml
@@ -13,7 +13,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@355155f9fb51da580099149361dcbdad69cfab9c
         with:
           php-version: '8.2'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Execute remote deploy commands
-        uses: appleboy/ssh-action@v0.1.7
+        uses: appleboy/ssh-action@d91a1af6f57cd4478ceee14d7705601dafabaa19
         with:
           host: ${{ secrets.DOMAIN }}
           username: ${{ secrets.USER }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Set up PHP ${{ matrix.php }}
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@355155f9fb51da580099149361dcbdad69cfab9c
               with:
                   php-version: ${{ matrix.php }}
                   coverage: xdebug
@@ -30,7 +30,7 @@ jobs:
               run: composer config allow-plugins.phpstan/extension-installer true
 
             - name: Install dependencies with Composer
-              uses: ramsey/composer-install@v2
+              uses: ramsey/composer-install@1919f6c305aea6ab10e6181a8ddf72317ad77e0e
 
             - name: Debug Composer
               run: composer show --all


### PR DESCRIPTION
## Summary
- pin third-party GitHub Actions to full commit SHAs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eed8c8184832bbdf47cccf674cab1