### PR TITLE
Add tenant management scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,26 @@ ohne Docker betrieben wird. Ist `DOMAIN` dort gesetzt, wird für QR-Codes und
 Exportlinks diese Adresse verwendet. Enthält die Variable kein Schema, wird
 standardmäßig `https://` vorangestellt.
 
+## Multi-Tenant Setup
+
+Mehrere Subdomains lassen sich als eigene Mandanten betreiben. Ein neuer
+Mandant wird mit `scripts/create_tenant.sh` angelegt:
+
+```bash
+scripts/create_tenant.sh foo
+```
+
+Das Skript sendet einen API-Aufruf an `/tenant`, legt die Datei
+`vhost.d/foo.$DOMAIN` an und lädt anschließend den Proxy neu. Zum Entfernen
+eines Mandanten steht `scripts/delete_tenant.sh` bereit:
+
+```bash
+scripts/delete_tenant.sh foo
+```
+
+Beide Skripte lesen die Variable `DOMAIN` aus `sample.env` und nutzen sie
+für die vhost-Konfiguration.
+
 ## Anpassung
 
 Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition besitzt weiterhin ein `slug` für die URL. Fragen verknüpfen den Katalog nun über `catalog_uid`. Das bisherige `id` dient ausschließlich der Sortierung und wird automatisch vergeben.

--- a/scripts/create_tenant.sh
+++ b/scripts/create_tenant.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Create a new tenant and reload nginx proxy
+set -e
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <subdomain>" >&2
+  exit 1
+fi
+
+SUBDOMAIN="$1"
+BASE_DIR="$(dirname "$0")/.."
+ENV_FILE="$BASE_DIR/sample.env"
+DOMAIN="$(grep '^DOMAIN=' "$ENV_FILE" | cut -d '=' -f2)"
+
+if [ -z "$DOMAIN" ]; then
+  echo "DOMAIN not found in $ENV_FILE" >&2
+  exit 1
+fi
+
+curl -s -X POST \
+  -H 'Content-Type: application/json' \
+  -d "{\"subdomain\":\"$SUBDOMAIN\"}" \
+  "http://$DOMAIN/tenant"
+
+mkdir -p "$BASE_DIR/vhost.d"
+echo 'client_max_body_size 20m;' > "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"
+
+docker-compose exec nginx-proxy nginx -s reload

--- a/scripts/delete_tenant.sh
+++ b/scripts/delete_tenant.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Delete a tenant and reload nginx proxy
+set -e
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <subdomain>" >&2
+  exit 1
+fi
+
+SUBDOMAIN="$1"
+BASE_DIR="$(dirname "$0")/.."
+ENV_FILE="$BASE_DIR/sample.env"
+DOMAIN="$(grep '^DOMAIN=' "$ENV_FILE" | cut -d '=' -f2)"
+
+if [ -z "$DOMAIN" ]; then
+  echo "DOMAIN not found in $ENV_FILE" >&2
+  exit 1
+fi
+
+curl -s -X DELETE \
+  -H 'Content-Type: application/json' \
+  -d "{\"subdomain\":\"$SUBDOMAIN\"}" \
+  "http://$DOMAIN/tenant"
+
+rm -f "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"
+
+docker-compose exec nginx-proxy nginx -s reload


### PR DESCRIPTION
## Summary
- add `create_tenant.sh` and `delete_tenant.sh` scripts
- document multi-tenant setup in README

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef2f5f250832b9af326d6aadc3c8e