### PR TITLE
Enable dynamic virtual host for Slim service

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ scripts/delete_tenant.sh foo
 Beide Skripte lesen die Variable `DOMAIN` aus `sample.env` und nutzen sie
 für die vhost-Konfiguration.
 
+Für den eigentlichen Quiz-Container lässt sich der Hostname über die
+Umgebungsvariable `SLIM_VIRTUAL_HOST` steuern. Starte mehrere Instanzen
+mit unterschiedlichen Werten, werden die Subdomains automatisch als
+eigene Mandanten behandelt. Der eingesetzte Proxy erzeugt dank
+`nginxproxy/acme-companion` für jede konfigurierte Domain ein
+Let's-Encrypt-Zertifikat, sobald der Container gestartet wird.
+
 ## Anpassung
 
 Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition besitzt weiterhin ein `slug` für die URL. Fragen verknüpfen den Katalog nun über `catalog_uid`. Das bisherige `id` dient ausschließlich der Sortierung und wird automatisch vergeben.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,15 +64,14 @@ services:
 
   slim:
     build: .
-    container_name: slim
     working_dir: /var/www
     volumes:
       - ./:/var/www
       - ./config/php.ini:/usr/local/etc/php/conf.d/uploads.ini
       - quizdata:/var/www/data
     environment:
-      - VIRTUAL_HOST=${DOMAIN}
-      - LETSENCRYPT_HOST=${DOMAIN}
+      - VIRTUAL_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}
+      - LETSENCRYPT_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
       - POSTGRES_DSN=${POSTGRES_DSN}
       - POSTGRES_USER=${POSTGRES_USER}

--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,5 @@
 DOMAIN=example.com
+SLIM_VIRTUAL_HOST=example.com
 LETSENCRYPT_EMAIL=admin@example.com
 POSTGRES_DSN=pgsql:host=postgres;dbname=quiz
 POSTGRES_USER=quiz


### PR DESCRIPTION
## Summary
- remove static container name for `slim`
- allow overriding host via `SLIM_VIRTUAL_HOST`
- document tenant subdomains and automatic certificate generation

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-gd --ignore-platform-req=ext-dom --ignore-platform-req=ext-simplexml`
- `vendor/bin/phpunit` *(fails: PDO exceptions)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_686ef4d5370c832bbee41f94f6f55677