### PR TITLE
Add service account role

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,18 @@ Die Mandanten-Logik nutzt folgende Variablen aus `.env` oder `sample.env`:
 - `DOMAIN` legt die Basis-Domain für alle Mandanten fest.
 - `POSTGRES_DSN`, `POSTGRES_USER` und `POSTGRES_PASSWORD` bestimmen den Datenbankzugang.
 
+## Service-Accounts
+
+Service-Accounts eignen sich für automatisierte Abläufe. Sie lassen sich wie normale Benutzer über `/users.json` anlegen. Dabei wird als Rolle `service-account` gesetzt.
+
+Authentifiziert wird ein Service-Account über die JSON-Variante von `/login`. Die Sitzungskücke aus der Antwort muss bei weiteren API-Aufrufen mitgesendet werden.
+
+```bash
+curl -c cookies.txt -X POST http://$DOMAIN/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"robot","password":"secret"}'
+```
+
 ## Weitere Seiten
 
 * [Wie läuft das Spiel?](spielablauf.md)

--- a/migrations/20240902_add_service_account_role.sql
+++ b/migrations/20240902_add_service_account_role.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.users DROP CONSTRAINT IF EXISTS users_role_check;
+ALTER TABLE public.users ADD CONSTRAINT users_role_check CHECK (role IN ('admin','catalog-editor','event-manager','analyst','team-manager','service-account'));
+

--- a/src/Domain/Roles.php
+++ b/src/Domain/Roles.php
@@ -11,6 +11,7 @@ final class Roles
     public const EVENT_MANAGER = 'event-manager';
     public const ANALYST = 'analyst';
     public const TEAM_MANAGER = 'team-manager';
+    public const SERVICE_ACCOUNT = 'service-account';
 
     public const ALL = [
         self::ADMIN,
@@ -18,5 +19,6 @@ final class Roles
         self::EVENT_MANAGER,
         self::ANALYST,
         self::TEAM_MANAGER,
+        self::SERVICE_ACCOUNT,
     ];
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -231,10 +231,10 @@ return function (\Slim\App $app) {
 
     $app->post('/tenants', function (Request $request, Response $response) {
         return $request->getAttribute('tenantController')->create($request, $response);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
     $app->delete('/tenants', function (Request $request, Response $response) {
         return $request->getAttribute('tenantController')->delete($request, $response);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
 
     $app->get('/teams.json', function (Request $request, Response $response) {
         return $request->getAttribute('teamController')->get($request, $response);
@@ -244,10 +244,10 @@ return function (\Slim\App $app) {
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::TEAM_MANAGER));
     $app->get('/users.json', function (Request $request, Response $response) {
         return $request->getAttribute('userController')->get($request, $response);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
     $app->post('/users.json', function (Request $request, Response $response) {
         return $request->getAttribute('userController')->post($request, $response);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
     $app->post('/password', function (Request $request, Response $response) {
         return $request->getAttribute('passwordController')->post($request, $response);
     })->add(new RoleAuthMiddleware(...Roles::ALL));


### PR DESCRIPTION
## Summary
- extend user roles with new `service-account` role
- update access control to accept service accounts for tenant and user APIs
- allow database constraint to accept new role via migration
- document service account usage in docs

## Testing
- `vendor/bin/phpunit` *(fails: PDO::__construct(): Argument #1 ($dsn) must be a valid data source name)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpstan analyse --memory-limit=256M -l 1`

------
https://chatgpt.com/codex/tasks/task_e_687169802fa8832bb86b80f9a2bbeae8