### PR TITLE
Update restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   nginx-proxy:
     image: jwilder/nginx-proxy:alpine
     container_name: nginx-proxy
-    restart: always
+    restart: unless-stopped
     environment:
       - CLIENT_MAX_BODY_SIZE=10m
     ports:


### PR DESCRIPTION
## Summary
- adjust docker-compose to not restart `nginx-proxy` automatically

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: PDO configuration errors)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f47ef1c8832bbb81ecee2eb977da