### PR TITLE
Update restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   nginx-proxy:
     image: jwilder/nginx-proxy:alpine
     container_name: nginx-proxy
-    restart: always
+    restart: unless-stopped
     environment:
       - CLIENT_MAX_BODY_SIZE=10m
     ports:
@@ -20,7 +20,7 @@ services:
 
   postgres:
     image: postgres:15
-    restart: always
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -32,7 +32,7 @@ services:
 
   adminer:
     image: adminer
-    restart: always
+    restart: unless-stopped
     environment:
       - VIRTUAL_HOST=adminer.${DOMAIN}
       - LETSENCRYPT_HOST=adminer.${DOMAIN}
@@ -46,7 +46,7 @@ services:
   letsencrypt:
     image: nginxproxy/acme-companion
     container_name: nginx-proxy-letsencrypt
-    restart: always
+    restart: unless-stopped
     depends_on:
       - nginx-proxy
     environment:


### PR DESCRIPTION
## Summary
- adjust docker-compose to not restart containers automatically

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: PDO configuration errors)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6873f47ef1c8832bbb81ecee2eb977da