### PR TITLE
Ignore PHPStan warnings

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,3 +4,6 @@ parameters:
     - src
   stubFiles:
     - stubs/endroid_qr.stub
+  ignoreErrors:
+    - '#Call to function is_callable.+will always evaluate to true#'
+    - '#Method App\\Service\\AwardService::join\(\) is unused#'


### PR DESCRIPTION
## Summary
- ignore warnings in phpstan.neon.dist

## Testing
- `vendor/bin/phpunit` *(fails: DSN errors)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6873fcd67aa8832b9a970cb356172580