### PR TITLE
Fix SQL WHERE clause spacing

### DIFF
--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -40,6 +40,7 @@ class ResultService
             LEFT JOIN catalogs c ON c.uid = r.catalog
                 OR CAST(c.sort_order AS TEXT) = r.catalog
                 OR c.slug = r.catalog
+
         SQL;
         $params = [];
         if ($event !== '') {
@@ -78,6 +79,7 @@ class ResultService
             LEFT JOIN catalogs c ON c.uid = q.catalog_uid
                 OR CAST(c.sort_order AS TEXT) = qr.catalog
                 OR c.slug = qr.catalog
+
         SQL;
         $params = [];
         if ($event !== '') {


### PR DESCRIPTION
## Summary
- add newline before WHERE clauses in ResultService SQL

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: PDO and SQL errors)*

------
https://chatgpt.com/codex/tasks/task_e_687405759e20832bb9e7eb7594a79819