### PR TITLE
Replace docker-compose command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,4 +18,4 @@ jobs:
           script: |
             cd /var/sommerfest-quiz
             git pull
-            docker-compose up -d
+            docker compose up -d

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 
    Alternativ lassen sich Schema- und Datenimport direkt im Docker-Container ausführen:
    ```bash
-   docker-compose exec slim bash -c \
+   docker compose exec slim bash -c \
      'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && \
       php scripts/import_to_pgsql.php'
    ```
@@ -140,7 +140,7 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 Das mitgelieferte `docker-compose.yml` startet das Quiz samt Reverse Proxy.
 Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
 `quizdata` gespeichert. So bleiben eingetragene Teams und Ergebnisse auch nach
-`docker-compose down` erhalten. Hochgeladene Beweisfotos landen im Verzeichnis
+`docker compose down` erhalten. Hochgeladene Beweisfotos landen im Verzeichnis
 `data/photos` und werden dort immer als JPEG abgelegt. Durch das Volume bleiben
 die Bilder ebenfalls dauerhaft erhalten. Die
 ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
@@ -164,7 +164,7 @@ client_max_body_size 20m;
 ```
 
 Nach dem Anlegen oder Anpassen der Datei sollte der Proxy neu gestartet
-werden, damit die Einstellung aktiv wird (z.B. mit `docker-compose
+werden, damit die Einstellung aktiv wird (z.B. mit `docker compose
 restart nginx-proxy`). Innerhalb des App-Containers können zudem die
 Werte `upload_max_filesize` und `post_max_size` angepasst werden. Dafür
 liegt im Verzeichnis `config/` bereits eine kleine `php.ini` bei, die in

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -30,7 +30,7 @@ toc: true
    ```
    Alternativ lassen sich Schema- und Datenimport auch im Docker-Container ausführen:
    ```bash
-   docker-compose exec slim bash -c \
+   docker compose exec slim bash -c \
      'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && php scripts/import_to_pgsql.php'
    ```
 

--- a/scripts/create_tenant.sh
+++ b/scripts/create_tenant.sh
@@ -25,4 +25,4 @@ curl -s -X POST \
 mkdir -p "$BASE_DIR/vhost.d"
 echo 'client_max_body_size 20m;' > "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"
 
-docker-compose exec nginx-proxy nginx -s reload
+docker compose exec nginx-proxy nginx -s reload

--- a/scripts/delete_tenant.sh
+++ b/scripts/delete_tenant.sh
@@ -24,4 +24,4 @@ curl -s -X DELETE \
 
 rm -f "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"
 
-docker-compose exec nginx-proxy nginx -s reload
+docker compose exec nginx-proxy nginx -s reload

--- a/scripts/run_psql_in_docker.sh
+++ b/scripts/run_psql_in_docker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Apply PostgreSQL schema and import default data using the Docker container.
-# Requires docker-compose and the environment variables from .env.
+# Requires docker compose and the environment variables from .env.
 set -e
 
-docker-compose exec slim bash -c 'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && php scripts/import_to_pgsql.php'
+docker compose exec slim bash -c 'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && php scripts/import_to_pgsql.php'
 


### PR DESCRIPTION
## Summary
- switch to the modern `docker compose` command everywhere

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: PDO and other errors)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6874073e18f4832ba2ac7099ae75d0ab