### PR TITLE
Extend events with start/end defaults

### DIFF
--- a/data-default/events.json
+++ b/data-default/events.json
@@ -2,7 +2,8 @@
   {
     "uid": "1",
     "name": "Sommerfest 2025",
-    "date": "",
+    "start_date": "2025-07-04T18:00",
+    "end_date": "2025-07-04T23:00",
     "description": "Willkommen beim Veranstaltungsquiz"
   }
 ]

--- a/data/events.json
+++ b/data/events.json
@@ -2,7 +2,8 @@
   {
     "uid": "1",
     "name": "Sommerfest 2025",
-    "date": "",
+    "start_date": "2025-07-04T18:00",
+    "end_date": "2025-07-04T23:00",
     "description": "Willkommen beim Veranstaltungsquiz"
   }
 ]

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS config (
 CREATE TABLE IF NOT EXISTS events (
     uid TEXT PRIMARY KEY,
     name TEXT NOT NULL,
-    date TEXT,
+    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
     description TEXT
 );
 

--- a/migrations/20240630_create_events_table.sql
+++ b/migrations/20240630_create_events_table.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS events (
     uid TEXT PRIMARY KEY,
     name TEXT NOT NULL,
-    date TEXT,
+    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
     description TEXT
 );

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1169,7 +1169,8 @@ document.addEventListener('DOMContentLoaded', function () {
     return Array.from(eventsListEl.querySelectorAll('.event-row')).map(row => ({
       uid: row.dataset.uid || crypto.randomUUID(),
       name: row.querySelector('.event-name').value.trim(),
-      date: row.querySelector('.event-date').value.trim(),
+      start_date: row.querySelector('.event-start').value.trim() || new Date().toISOString().slice(0, 16),
+      end_date: row.querySelector('.event-end').value.trim() || new Date().toISOString().slice(0, 16),
       description: row.querySelector('.event-desc').value.trim()
     })).filter(e => e.name);
   }
@@ -1202,12 +1203,20 @@ document.addEventListener('DOMContentLoaded', function () {
     nameInput.value = ev.name || '';
     nameCell.appendChild(nameInput);
 
-    const dateCell = document.createElement('td');
-    const dateInput = document.createElement('input');
-    dateInput.type = 'date';
-    dateInput.className = 'uk-input event-date';
-    dateInput.value = ev.date || '';
-    dateCell.appendChild(dateInput);
+    const startCell = document.createElement('td');
+    const startInput = document.createElement('input');
+    startInput.type = 'datetime-local';
+    startInput.className = 'uk-input event-start';
+    const now = new Date().toISOString().slice(0, 16);
+    startInput.value = ev.start_date || now;
+    startCell.appendChild(startInput);
+
+    const endCell = document.createElement('td');
+    const endInput = document.createElement('input');
+    endInput.type = 'datetime-local';
+    endInput.className = 'uk-input event-end';
+    endInput.value = ev.end_date || now;
+    endCell.appendChild(endInput);
 
     const descCell = document.createElement('td');
     const descInput = document.createElement('input');
@@ -1243,7 +1252,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     row.appendChild(handleCell);
     row.appendChild(nameCell);
-    row.appendChild(dateCell);
+    row.appendChild(startCell);
+    row.appendChild(endCell);
     row.appendChild(descCell);
     row.appendChild(activateCell);
     row.appendChild(delCell);

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -76,7 +76,7 @@ $activeUid = (string)($config['event_uid'] ?? '');
 if (is_readable($eventsFile)) {
     $events = json_decode(file_get_contents($eventsFile), true) ?? [];
     $firstUid = null;
-    $stmt = $pdo->prepare('INSERT INTO events(uid,name,date,description) VALUES(?,?,?,?)');
+    $stmt = $pdo->prepare('INSERT INTO events(uid,name,start_date,end_date,description) VALUES(?,?,?,?,?)');
     foreach ($events as $e) {
         $uid = $e['uid'] ?? bin2hex(random_bytes(16));
         if ($firstUid === null) {
@@ -85,7 +85,8 @@ if (is_readable($eventsFile)) {
         $stmt->execute([
             $uid,
             $e['name'] ?? '',
-            $e['date'] ?? null,
+            $e['start_date'] ?? date('Y-m-d\TH:i'),
+            $e['end_date'] ?? date('Y-m-d\TH:i'),
             $e['description'] ?? null,
         ]);
     }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -30,7 +30,7 @@
     {% endblock %}
   {% endembed %}
   <ul id="adminTabs" uk-tab>
-    <li class="uk-active" data-help="Veranstaltungen anlegen oder bearbeiten. Jede Zeile enthält Name, Datum und Beschreibung. 'Hinzufügen' erstellt einen neuen Eintrag. Speichern übernimmt die Änderungen."><a href="#">Veranstaltungen</a></li>
+    <li class="uk-active" data-help="Veranstaltungen anlegen oder bearbeiten. Jede Zeile enthält Name, Beginn, Ende und Beschreibung. 'Hinzufügen' erstellt einen neuen Eintrag. Speichern übernimmt die Änderungen."><a href="#">Veranstaltungen</a></li>
     <li data-help="Logo hochladen und Vorschau ansehen. Seitentitel, Überschrift und Untertitel festlegen. Hintergrund- und Buttonfarbe wählen. Optional den Button 'Antwort prüfen' und den QR-Code-Login aktivieren. 'Zurücksetzen' lädt gespeicherte Werte, 'Speichern' übernimmt Änderungen."><a href="#">Veranstaltung konfigurieren</a></li>
     <li data-help="Fragenkataloge anlegen oder bearbeiten. Jede Zeile enthält einen Slug, Name, Beschreibung und optional einen Buchstaben für das Rätselwort. Der Slug kann angepasst werden. 'Hinzufügen' erstellt einen neuen Katalog, das rote × entfernt einen Eintrag. Speichern übernimmt die Änderungen."><a href="#">Kataloge</a></li>
     <li data-help="Nach Auswahl eines Katalogs einzelne Fragen bearbeiten oder neue anlegen. 'Neue Frage' fügt eine weitere hinzu, 'Zurücksetzen' verwirft Änderungen, 'Speichern' sichert den gesamten Katalog."><a href="#">Fragen anpassen</a></li>
@@ -53,7 +53,8 @@
               <tr>
                 <th><span uk-icon="icon: question" uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></span></th>
                 <th>Name</th>
-                <th>Datum</th>
+                <th>Beginn</th>
+                <th>Ende</th>
                 <th>Beschreibung</th>
                 <th>Aktiv</th>
                 <th><span uk-icon="icon: question" uk-tooltip="title: Veranstaltung entfernen; pos: top"></span></th>

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -20,7 +20,7 @@ class ImportControllerTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, date TEXT, description TEXT);');
+        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $pdo->exec("INSERT INTO events(uid,name) VALUES('ev1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -62,7 +62,7 @@ class QrControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, date TEXT, description TEXT);');
+        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','Event','Sub')");
         $cfg = new \App\Service\ConfigService($pdo);
         $teams = new \App\Service\TeamService($pdo, $cfg);
@@ -163,7 +163,7 @@ class QrControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, date TEXT, description TEXT);');
+        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
         $pdo->exec("INSERT INTO events(uid,name) VALUES('1','Event')");
         $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY);');
         $pdo->exec("INSERT INTO teams(sort_order,name,uid) VALUES(1,'A','1'),(2,'B','2')");

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -43,7 +43,7 @@ class ResultControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, date TEXT, description TEXT);');
+        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','Event','Sub')");
         $pdo->exec(
             <<<'SQL'

--- a/tests/Service/EventServiceTest.php
+++ b/tests/Service/EventServiceTest.php
@@ -14,7 +14,7 @@ class EventServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT NOT NULL, date TEXT, description TEXT);');
+        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT NOT NULL, start_date TEXT, end_date TEXT, description TEXT);');
         $pdo->exec('CREATE TABLE config(id INTEGER PRIMARY KEY AUTOINCREMENT, event_uid TEXT);');
         return $pdo;
     }
@@ -24,7 +24,7 @@ class EventServiceTest extends TestCase
         $pdo = $this->createPdo();
         $service = new EventService($pdo);
         $data = [
-            ['name' => 'Test Event', 'date' => '2025-07-04', 'description' => 'Demo'],
+            ['name' => 'Test Event', 'start_date' => '2025-07-04T18:00', 'end_date' => '2025-07-04T23:00', 'description' => 'Demo'],
         ];
         $service->saveAll($data);
         $count = (int) $pdo->query('SELECT COUNT(*) FROM config')->fetchColumn();
@@ -32,7 +32,8 @@ class EventServiceTest extends TestCase
         $rows = $service->getAll();
         $this->assertCount(1, $rows);
         $this->assertSame('Test Event', $rows[0]['name']);
-        $this->assertSame('2025-07-04', $rows[0]['date']);
+        $this->assertSame('2025-07-04T18:00', $rows[0]['start_date']);
+        $this->assertSame('2025-07-04T23:00', $rows[0]['end_date']);
     }
 
     public function testGetByUid(): void


### PR DESCRIPTION
## Summary
- default event rows to current datetime
- use current timestamp in PHP when missing
- document defaults in schema and migration

## Testing
- `vendor/bin/phpunit` *(fails: database connection errors)*
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: 2 errors)*
- `vendor/bin/phpcs`

------
https://chatgpt.com/codex/tasks/task_e_687501d02958832b93fe54fc2faf62df