### PR TITLE
Handle null event UID in catalog service

### DIFF
--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -196,7 +196,7 @@ class CatalogService
                     $cat['description'] ?? null,
                     $cat['qrcode_url'] ?? null,
                     $cat['raetsel_buchstabe'] ?? null,
-                    $uid,
+                    $uid !== '' ? $uid : null,
                 ];
                 if ($this->hasCommentColumn()) {
                     $row[] = $cat['comment'] ?? null;

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -226,4 +226,23 @@ class CatalogServiceTest extends TestCase
         $rows = json_decode($service->read('catalogs.json'), true);
         $this->assertSame(['Two', 'One', 'Three'], array_column($rows, 'name'));
     }
+
+    public function testWriteWithoutActiveEventUid(): void
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec("INSERT INTO config(event_uid) VALUES(NULL)");
+        $cfg = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfg);
+        $catalog = [[
+            'uid' => 'uid5',
+            'sort_order' => 1,
+            'slug' => 'ne',
+            'file' => 'ne.json',
+            'name' => 'NoEvent',
+            'comment' => ''
+        ]];
+        $service->write('catalogs.json', $catalog);
+        $stmt = $pdo->query('SELECT event_uid FROM catalogs');
+        $this->assertNull($stmt->fetchColumn());
+    }
 }


### PR DESCRIPTION
## Summary
- insert `null` when event UID is empty in CatalogService
- ensure catalogs save correctly with no active event uid

## Testing
- `vendor/bin/phpunit` *(fails: General error: 1 no such column: event_uid)*

------
https://chatgpt.com/codex/tasks/task_e_68750695dbc8832bad063cfe344f3bfa