### PR TITLE
Add PDF template background support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "twig/twig": "^3.8",
         "slim/twig-view": "^3.3",
         "setasign/fpdf": "^1.8",
+        "setasign/fpdi": "^2.6",
         "endroid/qr-code": "^5.0",
         "intervention/image": "^2.7",
         "ext-exif": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d96cd143988f6918398e0a2bd35470ff",
+    "content-hash": "06d577b2f8624cadc59200b8807dca35",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -901,6 +901,78 @@
                 "source": "https://github.com/Setasign/FPDF/tree/1.8.6"
             },
             "time": "2023-06-26T14:44:25+00:00"
+        },
+        {
+            "name": "setasign/fpdi",
+            "version": "v2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDI.git",
+                "reference": "67c31f5e50c93c20579ca9e23035d8c540b51941"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDI/zipball/67c31f5e50c93c20579ca9e23035d8c540b51941",
+                "reference": "67c31f5e50c93c20579ca9e23035d8c540b51941",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zlib": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "setasign/tfpdf": "<1.31"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7",
+                "setasign/fpdf": "~1.8.6",
+                "setasign/tfpdf": "~1.33",
+                "squizlabs/php_codesniffer": "^3.5",
+                "tecnickcom/tcpdf": "^6.2"
+            },
+            "suggest": {
+                "setasign/fpdf": "FPDI will extend this class but as it is also possible to use TCPDF or tFPDF as an alternative. There's no fixed dependency configured."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "setasign\\Fpdi\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Slabon",
+                    "email": "jan.slabon@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                },
+                {
+                    "name": "Maximilian Kresse",
+                    "email": "maximilian.kresse@setasign.com",
+                    "homepage": "https://www.setasign.com"
+                }
+            ],
+            "description": "FPDI is a collection of PHP classes facilitating developers to read pages from existing PDF documents and use them as templates in FPDF. Because it is also possible to use FPDI with TCPDF, there are no fixed dependencies defined. Please see suggestions for packages which evaluates the dependencies automatically.",
+            "homepage": "https://www.setasign.com/fpdi",
+            "keywords": [
+                "fpdf",
+                "fpdi",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/Setasign/FPDI/issues",
+                "source": "https://github.com/Setasign/FPDI/tree/v2.6.3"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/setasign/fpdi",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-02-05T13:22:35+00:00"
         },
         {
             "name": "slim/psr7",
@@ -3410,7 +3482,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "ext-exif": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -187,7 +187,13 @@ class QrController
         $logoFile = __DIR__ . '/../../data/' . ltrim((string)($cfg['logoPath'] ?? ''), '/');
 
         $pdf = new Pdf($title, $subtitle, $logoFile);
+        $templatePath = __DIR__ . '/../../data/template.pdf';
         $pdf->AddPage();
+        if (is_readable($templatePath)) {
+            $pdf->setSourceFile($templatePath);
+            $tpl = $pdf->importPage(1);
+            $pdf->useTemplate($tpl, 0, 0, $pdf->GetPageWidth(), $pdf->GetPageHeight());
+        }
 
         $qrSize = 20.0; // mm
 
@@ -250,6 +256,7 @@ class QrController
         $logoPath = __DIR__ . '/../../data/' . ltrim((string)($cfg['logoPath'] ?? ''), '/');
 
         $pdf = new Pdf($title, $subtitle, $logoPath);
+        $templatePath = __DIR__ . '/../../data/template.pdf';
 
         foreach ($teams as $team) {
             $builder = Builder::create()
@@ -272,6 +279,11 @@ class QrController
             }
 
             $pdf->AddPage();
+            if (is_readable($templatePath)) {
+                $pdf->setSourceFile($templatePath);
+                $tpl = $pdf->importPage(1);
+                $pdf->useTemplate($tpl, 0, 0, $pdf->GetPageWidth(), $pdf->GetPageHeight());
+            }
 
             $qrSize = 20.0;
 

--- a/src/Service/Pdf.php
+++ b/src/Service/Pdf.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Service;
 
-use FPDF;
+use setasign\Fpdi\Fpdi;
 use Intervention\Image\ImageManagerStatic as Image;
 
 /**
  * Custom FPDF subclass that renders the event header.
  */
-class Pdf extends FPDF
+class Pdf extends Fpdi
 {
     private string $title;
     private string $subtitle;


### PR DESCRIPTION
## Summary
- add `setasign/fpdi` dependency
- switch `Pdf` service to extend FPDI
- support optional `data/template.pdf` background in QR PDFs

## Testing
- `vendor/bin/phpunit` *(fails: General error: no such table)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_687516ba6410832bb8d0a8752f997199