### PR TITLE
Add migration for event date columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@
 - Sanitize migrations
 - Avoid using first event if active one missing
 - Address style warnings
+- *(db)* Add migration to split event date into start/end columns
 
 ### Refactor
 

--- a/docs-jtd/verwaltung.md
+++ b/docs-jtd/verwaltung.md
@@ -15,7 +15,7 @@ Der Zugang zum Administrationsbereich erfolgt über `/login`. Nach einem erfolgr
 ## Administrationsoberfläche
 
 Unter `/admin` stehen folgende Tabs zur Verfügung:
-1. **Veranstaltungen** – Veranstaltungen anlegen, bearbeiten oder entfernen.
+1. **Veranstaltungen** – Veranstaltungen anlegen, bearbeiten oder entfernen. Jede Zeile enthält Name, Beginn, Ende und Beschreibung.
 2. **Veranstaltung konfigurieren** – Einstellungen wie Logo, Farben und Texte.
 3. **Kataloge** – Fragenkataloge erstellen und verwalten.
 4. **Fragen anpassen** – Fragen eines Katalogs hinzufügen, bearbeiten oder löschen.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -2,7 +2,7 @@
 
 Die Administrationsoberfl\u00e4che erreichen Sie \u00fcber `/admin` nach einem erfolgreichen Login. Folgende Bereiche stehen zur Verf\u00fcgung:
 
-1. **Veranstaltungen** – Veranstaltungen anlegen, bearbeiten oder entfernen.
+1. **Veranstaltungen** – Veranstaltungen anlegen, bearbeiten oder entfernen. Jede Zeile enthält Name, Beginn, Ende und Beschreibung.
 2. **Veranstaltung konfigurieren** – Farben, Logos und Texte anpassen.
 3. **Kataloge** – Fragenkataloge anlegen und verwalten.
 4. **Fragen anpassen** – Bestehende Fragen ändern oder neue hinzufügen.

--- a/migrations/20240903_add_event_dates.sql
+++ b/migrations/20240903_add_event_dates.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS start_date TEXT DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS end_date TEXT DEFAULT CURRENT_TIMESTAMP;
+UPDATE public.events SET start_date = COALESCE(start_date, date), end_date = COALESCE(end_date, date) WHERE date IS NOT NULL;
+ALTER TABLE public.events DROP COLUMN IF EXISTS date;


### PR DESCRIPTION
## Summary
- add migration `20240903_add_event_dates.sql`
- log entry for splitting event date column
- clarify docs on event table columns

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `./vendor/bin/phpunit` *(fails: requires Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_6875338764a4832bb52a19776c2e6e8d