### PR TITLE
Add flip-card question type

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Mit dieser App zeigen wir, was heute schon möglich ist, wenn Menschen und versc
 ## Überblick
 
 - **Flexibel einsetzbar**: Fragenkataloge im JSON-Format lassen sich bequem austauschen oder erweitern.
-- **Fünf Fragetypen**: Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe bieten Abwechslung für jede Zielgruppe.
+- **Sechs Fragetypen**: Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten bieten Abwechslung f\u00fcr jede Zielgruppe.
 - **QR-Code-Login & Dunkelmodus**: Optionaler QR-Code-Login für schnelles Anmelden und ein zuschaltbares dunkles Design steigern den Komfort.
 - **Persistente Speicherung**: Konfigurationen, Kataloge und Ergebnisse liegen in einer PostgreSQL-Datenbank.
 

--- a/data-default/kataloge/station_1.json
+++ b/data-default/kataloge/station_1.json
@@ -18,5 +18,10 @@
     "type": "sort",
     "prompt": "Sortiere die Dateigrößen (klein zu groß):",
     "items": ["KB", "MB", "GB"]
+  },
+  {
+    "type": "flip",
+    "prompt": "Wie viele Bits ergeben ein Byte?",
+    "answer": "8"
   }
 ]

--- a/data/kataloge/station_1.json
+++ b/data/kataloge/station_1.json
@@ -18,5 +18,10 @@
     "type": "sort",
     "prompt": "Sortiere die Dateigrößen (klein zu groß):",
     "items": ["KB", "MB", "GB"]
+  },
+  {
+    "type": "flip",
+    "prompt": "Wie viele Bits ergeben ein Byte?",
+    "answer": "8"
   }
 ]

--- a/docs-jtd/faq.md
+++ b/docs-jtd/faq.md
@@ -15,7 +15,7 @@ Scanne an der ersten Station den QR-Code oder öffne den bereitgestellten Link. 
 Ja, die Oberfläche passt sich jedem Gerät an – ob Handy, Tablet oder PC.
 
 ### Welche Fragetypen gibt es?
-Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe.
+Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten.
 
 ### Wie bediene ich Drag & Drop?
 Halte ein Element gedrückt und ziehe es an die gewünschte Stelle.

--- a/docs-jtd/fragenkataloge.md
+++ b/docs-jtd/fragenkataloge.md
@@ -20,5 +20,5 @@ Ein Eintrag kann zudem ein Feld `raetsel_buchstabe` enthalten, das den Buchstabe
 - `DELETE /kataloge/{file}` entfernt die Datei.
 - `DELETE /kataloge/{file}/{index}` löscht eine Frage anhand des Index.
 
-Die Fragetypen umfassen Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe. Dank des Puzzlewort-Features kann nach jeder Runde ein Buchstabe angezeigt werden, bis sich das Lösungswort ergibt.
+Die Fragetypen umfassen Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten. Dank des Puzzlewort-Features kann nach jeder Runde ein Buchstabe angezeigt werden, bis sich das L\u00f6sungswort ergibt.
 

--- a/docs-jtd/index.md
+++ b/docs-jtd/index.md
@@ -15,7 +15,7 @@ Die Anwendung entstand als Machbarkeitsstudie, um das Potenzial moderner Code-As
 Weitere Highlights sind unter anderem:
 
 - **Flexibel einsetzbar:** Kataloge im JSON-Format lassen sich einfach austauschen oder erweitern.
-- **Fünf Fragetypen:** Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe bieten Abwechslung für alle Teilnehmer.
+- **Sechs Fragetypen:** Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten bieten Abwechslung f\u00fcr alle Teilnehmer.
 - **QR-Code-Login & Dunkelmodus:** Komfortables Spielen auf allen Geräten.
 - **Persistente Speicherung:** Alle Daten liegen zentral in PostgreSQL.
 

--- a/docs-jtd/marketing.md
+++ b/docs-jtd/marketing.md
@@ -11,7 +11,7 @@ toc: true
 ## Überblick
 
 - **Flexibel einsetzbar:** Fragenkataloge im JSON-Format lassen sich bequem austauschen oder erweitern.
-- **Fünf Fragetypen:** Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe bieten Abwechslung für jede Zielgruppe.
+- **Sechs Fragetypen:** Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten bieten Abwechslung f\u00fcr jede Zielgruppe.
 - **QR-Code-Login & Dunkelmodus:** Optionaler QR-Code-Login für schnelles Anmelden und ein zuschaltbares dunkles Design steigern den Komfort.
 - **Persistente Speicherung:** Konfigurationen, Kataloge und Ergebnisse liegen in einer PostgreSQL-Datenbank.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,7 @@ Scanne an der ersten Station den QR-Code oder öffne den bereitgestellten Link. 
 Ja, die Oberfläche passt sich jedem Gerät an – ob Handy, Tablet oder PC.
 
 ### Welche Fragetypen gibt es?
-Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe.
+Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten.
 
 ### Wie bediene ich Drag & Drop?
 Halte ein Element gedrückt und ziehe es an die gewünschte Stelle.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hohe Performance standen dabei im Mittelpunkt.
 Weitere Highlights sind:
 
 - **Flexibel einsetzbar**: Kataloge im JSON-Format lassen sich einfach austauschen.
-- **Fünf Fragetypen**: Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe.
+- **Sechs Fragetypen**: Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten.
 - **QR-Code-Login & Dunkelmodus** für komfortables Spielen auf allen Geräten.
 - **Persistente Speicherung** in PostgreSQL.
 

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -140,7 +140,14 @@ body.dark-mode .uk-card-hover:hover {
   body.dark-mode .mc-option {
     font-size: 1.5rem;
   }
-  body.dark-mode .mc-option input {
-    transform: scale(1.3);
-  }
+body.dark-mode .mc-option input {
+  transform: scale(1.3);
+}
+}
+
+body.dark-mode .flip-card-front,
+body.dark-mode .flip-card-back {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+  border: 1px solid #444;
 }

--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -127,3 +127,17 @@ body.dark-mode.high-contrast .uk-alert-primary {
   background-color: #00008b;
   color: #ffffff;
 }
+
+body.high-contrast .flip-card-front,
+body.high-contrast .flip-card-back {
+  background-color: #ffffff;
+  color: #000000;
+  border: 2px solid #000000;
+}
+
+body.dark-mode.high-contrast .flip-card-front,
+body.dark-mode.high-contrast .flip-card-back {
+  background-color: #000000;
+  color: #ffffff;
+  border: 2px solid #ffffff;
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -420,4 +420,11 @@ body.dark-mode .sticky-actions {
   color: #fff;
 }
 
+/* Flip card for "Hätten Sie es gewusst?" */
+.flip-card { perspective: 800px; position: relative; }
+.flip-card-inner { position: relative; width: 100%; min-height: 150px; transition: transform 0.6s; transform-style: preserve-3d; }
+.flip-card.flipped .flip-card-inner { transform: rotateY(180deg); }
+.flip-card-front, .flip-card-back { position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; padding: 1rem; border-radius: 8px; background: #fff; backface-visibility: hidden; box-shadow: 0 2px 6px rgba(0,0,0,0.2); }
+.flip-card-back { transform: rotateY(180deg); }
+
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -628,9 +628,10 @@ document.addEventListener('DOMContentLoaded', function () {
       assign: 'Zuordnen',
       sort: 'Sortieren',
       swipe: 'Swipe-Karten',
-      photoText: 'Foto + Text'
+      photoText: 'Foto + Text',
+      flip: 'Hätten Sie es gewusst?'
     };
-    ['sort', 'assign', 'mc', 'swipe', 'photoText'].forEach(t => {
+    ['sort', 'assign', 'mc', 'swipe', 'photoText', 'flip'].forEach(t => {
       const opt = document.createElement('option');
       opt.value = t;
       opt.textContent = labelMap[t] || t;
@@ -646,7 +647,8 @@ document.addEventListener('DOMContentLoaded', function () {
         assign: 'Begriffe den passenden Definitionen zuordnen.',
         mc: 'Mehrfachauswahl (Multiple Choice, mehrere Antworten möglich).',
         swipe: 'Karten nach links oder rechts wischen.',
-        photoText: 'Foto aufnehmen und passende Antwort eingeben.'
+        photoText: 'Foto aufnehmen und passende Antwort eingeben.',
+        flip: 'Frage mit umdrehbarer Antwortkarte.'
       };
       const base = map[typeSelect.value] || '';
       typeInfo.textContent = base + ' Für kleine Displays kannst du "\/-" als verstecktes Worttrennzeichen nutzen.';
@@ -848,6 +850,13 @@ document.addEventListener('DOMContentLoaded', function () {
         add.onclick = e => { e.preventDefault(); list.appendChild(addCard('', false)); };
         fields.appendChild(list);
         fields.appendChild(add);
+      } else if (typeSelect.value === 'flip') {
+        const ans = document.createElement('textarea');
+        ans.className = 'uk-textarea uk-margin-small-bottom flip-answer';
+        ans.placeholder = 'Antwort';
+        ans.value = q.answer || '';
+        ans.setAttribute('aria-label', 'Antwort');
+        fields.appendChild(ans);
       } else if (typeSelect.value === 'photoText') {
         const consent = document.createElement('label');
         consent.className = 'uk-margin-small-bottom';
@@ -929,6 +938,11 @@ document.addEventListener('DOMContentLoaded', function () {
           ul.appendChild(li);
         });
         preview.appendChild(ul);
+      } else if (typeSelect.value === 'flip') {
+        const p = document.createElement('p');
+        const ans = fields.querySelector('.flip-answer');
+        p.textContent = insertSoftHyphens(ans ? ans.value : 'Antwort');
+        preview.appendChild(p);
       } else if (typeSelect.value === 'photoText') {
         const p = document.createElement('p');
         p.textContent = 'Foto-Upload und Textfeld';
@@ -983,6 +997,9 @@ document.addEventListener('DOMContentLoaded', function () {
         if (rightLabel) obj.rightLabel = rightLabel;
         if (leftLabel) obj.leftLabel = leftLabel;
         return obj;
+      } else if (type === 'flip') {
+        const answer = card.querySelector('.flip-answer').value.trim();
+        return { type, prompt, answer };
       } else if (type === 'photoText') {
         const consent = card.querySelector('.consent-box').checked;
         return { type, prompt, consent };

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -345,6 +345,7 @@ function runQuiz(questions, skipIntro){
     if(q.type === 'mc') return createMcQuestion(q, idx);
     if(q.type === 'swipe') return createSwipeQuestion(q, idx);
     if(q.type === 'photoText') return createPhotoTextQuestion(q, idx);
+    if(q.type === 'flip') return createFlipQuestion(q, idx);
     return document.createElement('div');
   }
 
@@ -952,6 +953,37 @@ function runQuiz(questions, skipIntro){
     div.appendChild(uploadBtn);
     div.appendChild(text);
     div.appendChild(feedback);
+    div.appendChild(nextBtn);
+    return div;
+  }
+
+  function createFlipQuestion(q, idx){
+    const div = document.createElement('div');
+    div.className = 'question uk-text-center';
+    div.setAttribute('uk-scrollspy', 'cls: uk-animation-slide-bottom-small; target: > *; delay: 100');
+    const card = document.createElement('div');
+    card.className = 'flip-card uk-margin';
+    card.tabIndex = 0;
+    const inner = document.createElement('div');
+    inner.className = 'flip-card-inner';
+    const front = document.createElement('div');
+    front.className = 'flip-card-front';
+    front.textContent = insertSoftHyphens(q.prompt);
+    const back = document.createElement('div');
+    back.className = 'flip-card-back';
+    back.textContent = insertSoftHyphens(q.answer || '');
+    inner.appendChild(front);
+    inner.appendChild(back);
+    card.appendChild(inner);
+    const toggle = () => card.classList.toggle('flipped');
+    card.addEventListener('click', toggle);
+    card.addEventListener('keydown', e => { if(e.key==='Enter' || e.key===' ') { e.preventDefault(); toggle(); } });
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'uk-button uk-button-primary';
+    nextBtn.textContent = 'Weiter';
+    styleButton(nextBtn);
+    nextBtn.addEventListener('click', () => { results[idx] = true; next(); });
+    div.appendChild(card);
     div.appendChild(nextBtn);
     return div;
   }

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -48,7 +48,7 @@
       <li>
         <a class="uk-accordion-title" href="#">Welche Fragetypen gibt es?</a>
         <div class="uk-accordion-content">
-          <p>Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten und Foto mit Texteingabe.</p>
+          <p>Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten.</p>
         </div>
       </li>
       <li>


### PR DESCRIPTION
## Summary
- add new flip card question type with front/back animation
- support editing flip card questions in admin UI
- update styles for light, dark and high contrast modes
- document new question type across docs and FAQ
- include sample flip question in station_1 catalog
- fix encoding of the phrase "Hätten Sie es gewusst?" in all docs and UI strings

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: PDO connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875335f5828832bbbb91fa6438d8cf6