### PR TITLE
Add event import/export to controllers

### DIFF
--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -9,6 +9,7 @@ use App\Service\ConfigService;
 use App\Service\ResultService;
 use App\Service\TeamService;
 use App\Service\PhotoConsentService;
+use App\Service\EventService;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 
@@ -22,6 +23,7 @@ class ExportController
     private ResultService $results;
     private TeamService $teams;
     private PhotoConsentService $consents;
+    private EventService $events;
     private string $dataDir;
     private string $backupDir;
 
@@ -34,6 +36,7 @@ class ExportController
         ResultService $results,
         TeamService $teams,
         PhotoConsentService $consents,
+        EventService $events,
         string $dataDir,
         string $backupDir
     ) {
@@ -42,6 +45,7 @@ class ExportController
         $this->results = $results;
         $this->teams = $teams;
         $this->consents = $consents;
+        $this->events = $events;
         $this->dataDir = rtrim($dataDir, '/');
         $this->backupDir = rtrim($backupDir, '/');
     }
@@ -72,6 +76,12 @@ class ExportController
         if ($cfg !== null) {
             file_put_contents($dir . '/config.json', $cfg . "\n");
         }
+
+        $events = $this->events->getAll();
+        file_put_contents(
+            $dir . '/events.json',
+            json_encode($events, JSON_PRETTY_PRINT) . "\n"
+        );
 
         $teams = $this->teams->getAll();
         file_put_contents(

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -9,6 +9,7 @@ use App\Service\ConfigService;
 use App\Service\ResultService;
 use App\Service\TeamService;
 use App\Service\PhotoConsentService;
+use App\Service\EventService;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 
@@ -22,6 +23,7 @@ class ImportController
     private ResultService $results;
     private TeamService $teams;
     private PhotoConsentService $consents;
+    private EventService $events;
     private string $dataDir;
     private string $backupDir;
 
@@ -34,6 +36,7 @@ class ImportController
         ResultService $results,
         TeamService $teams,
         PhotoConsentService $consents,
+        EventService $events,
         string $dataDir,
         string $backupDir
     ) {
@@ -42,6 +45,7 @@ class ImportController
         $this->results = $results;
         $this->teams = $teams;
         $this->consents = $consents;
+        $this->events = $events;
         $this->dataDir = rtrim($dataDir, '/');
         $this->backupDir = rtrim($backupDir, '/');
     }
@@ -76,6 +80,14 @@ class ImportController
         if (!is_readable($catalogsFile)) {
             return $response->withStatus(404);
         }
+        $eventsFile = $dir . '/events.json';
+        if (is_readable($eventsFile)) {
+            $events = json_decode((string)file_get_contents($eventsFile), true) ?? [];
+            if (is_array($events)) {
+                $this->events->saveAll($events);
+            }
+        }
+
         $cfgFile = $dir . '/config.json';
         if (is_readable($cfgFile)) {
             $cfg = json_decode((string)file_get_contents($cfgFile), true) ?? [];

--- a/src/routes.php
+++ b/src/routes.php
@@ -117,6 +117,7 @@ return function (\Slim\App $app) {
                 $resultService,
                 $teamService,
                 $consentService,
+                $eventService,
                 __DIR__ . '/../data',
                 __DIR__ . '/../backup'
             ))
@@ -126,6 +127,7 @@ return function (\Slim\App $app) {
                 $resultService,
                 $teamService,
                 $consentService,
+                $eventService,
                 __DIR__ . '/../data',
                 __DIR__ . '/../backup'
             ))


### PR DESCRIPTION
## Summary
- include EventService in ExportController and export events
- import events before config in ImportController
- pass EventService to controllers via routes.php
- adjust import_to_pgsql script to load events prior to config
- add tests for exporting and importing events

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml src/Controller/ExportController.php tests/Controller/ImportControllerTest.php tests/Controller/ExportControllerTest.php scripts/import_to_pgsql.php`
- `POSTGRES_DSN="sqlite:$tmpfile" POSTGRES_USER='' POSTGRES_PASSWORD='' vendor/bin/phpunit tests/Controller/ImportControllerTest.php tests/Controller/ExportControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_687562f99b2c832ba5e8a205f548d24d