### PR TITLE
Fix new catalog question saving

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1117,6 +1117,10 @@ document.addEventListener('DOMContentLoaded', function () {
           opt.textContent = c.name || c.sort_order || c.slug;
           catSelect.appendChild(opt);
         });
+        if (!catalogFile && catalogs.length > 0) {
+          catSelect.value = catalogs[0].uid || catalogs[0].slug || catalogs[0].sort_order;
+          loadCatalog(catSelect.value);
+        }
         notify('Katalogliste gespeichert', 'success');
       })
       .catch(err => {


### PR DESCRIPTION
## Summary
- update admin JS to initialize new catalog after saving

## Testing
- `vendor/bin/phpunit` *(fails: PDO errors)*
- `pytest tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6875685dbac8832ba0828036fa487e02