### PR TITLE
Remove role check on catalog GET

### DIFF
--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -51,9 +51,6 @@ class CatalogController
                 ->withStatus(302);
         }
 
-        if (!$this->hasRole(Roles::ADMIN, Roles::CATALOG_EDITOR)) {
-            return $response->withStatus(403);
-        }
 
         $content = $this->service->read($file);
         if ($content === null) {

--- a/src/routes.php
+++ b/src/routes.php
@@ -202,7 +202,7 @@ return function (\Slim\App $app) {
     $app->get('/kataloge/{file}', function (Request $request, Response $response, array $args) {
         $req = $request->withAttribute('file', $args['file']);
         return $request->getAttribute('catalogController')->get($req, $response, $args);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
+    });
 
     $app->post('/kataloge/{file}', function (Request $request, Response $response, array $args) {
         $req = $request->withAttribute('file', $args['file']);


### PR DESCRIPTION
## Summary
- let anyone GET catalog JSON without RoleAuthMiddleware
- simplify `CatalogController::get()` to drop manual role check

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpcs`
- `php -d memory_limit=1G vendor/bin/phpstan` *(fails: Found 2 errors)*
- `vendor/bin/phpunit --coverage-clover clover.xml` *(fails: 50 errors)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `pytest tests/test_html_validity.py tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687574647c98832b93dc153ddc3fc576