### PR TITLE
Fix flip question answer display

### DIFF
--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -145,6 +145,12 @@ class CatalogService
                     unset($row[$k]);
                 }
             }
+            if ($row['type'] === 'flip' && isset($row['answers'])) {
+                $row['answer'] = is_array($row['answers'])
+                    ? reset($row['answers'])
+                    : $row['answers'];
+                unset($row['answers']);
+            }
             $questions[] = $row;
         }
         return json_encode($questions, JSON_PRETTY_PRINT);
@@ -233,12 +239,19 @@ class CatalogService
             ' VALUES(?,?,?,?,?,?,?,?)'
         );
         foreach ($data as $i => $q) {
+            $answers = null;
+            if (isset($q['answer'])) {
+                $answers = json_encode($q['answer']);
+            } elseif (isset($q['answers'])) {
+                $answers = json_encode($q['answers']);
+            }
+
             $qStmt->execute([
                 $cat['uid'],
                 $q['type'] ?? '',
                 $q['prompt'] ?? '',
                 isset($q['options']) ? json_encode($q['options']) : null,
-                isset($q['answers']) ? json_encode($q['answers']) : null,
+                $answers,
                 isset($q['terms']) ? json_encode($q['terms']) : null,
                 isset($q['items']) ? json_encode($q['items']) : null,
                 $i + 1,


### PR DESCRIPTION
## Summary
- read 'answer' for flip questions from DB
- persist 'answer' when writing questions so flip cards show their back side

## Testing
- `vendor/bin/phpcs src/Service/CatalogService.php`
- `vendor/bin/phpstan analyse src/Service/CatalogService.php`
- `vendor/bin/phpunit` *(fails: event_uid column missing)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_687576ac264c832baed6c1569c17e3ef