### PR TITLE
Fix public access to results

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -169,11 +169,11 @@ return function (\Slim\App $app) {
 
     $app->get('/results.json', function (Request $request, Response $response) {
         return $request->getAttribute('resultController')->get($request, $response);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::ANALYST));
+    });
 
     $app->get('/question-results.json', function (Request $request, Response $response) {
         return $request->getAttribute('resultController')->getQuestions($request, $response);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::ANALYST));
+    });
 
     $app->get('/results/download', function (Request $request, Response $response) {
         return $request->getAttribute('resultController')->download($request, $response);


### PR DESCRIPTION
## Summary
- allow quiz participants to retrieve results without being logged in

## Testing
- `vendor/bin/phpunit` *(fails: 50 errors)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_68757c16cc08832b9097703265d6749b