### PR TITLE
Fix schema index duplicates and sequence reset

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS teams (
     uid UUID DEFAULT gen_random_uuid() PRIMARY KEY NOT NULL,
     event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
 );
-CREATE UNIQUE INDEX idx_team_name ON teams(name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_name ON teams(name);
 
 -- Quiz results
 CREATE TABLE IF NOT EXISTS results (
@@ -58,8 +58,8 @@ CREATE TABLE IF NOT EXISTS results (
     photo TEXT,
     event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
 );
-CREATE INDEX idx_results_catalog ON results(catalog);
-CREATE INDEX idx_results_name ON results(name);
+CREATE INDEX IF NOT EXISTS idx_results_catalog ON results(catalog);
+CREATE INDEX IF NOT EXISTS idx_results_name ON results(name);
 
 -- Per-question answer log
 CREATE TABLE IF NOT EXISTS question_results (
@@ -74,9 +74,9 @@ CREATE TABLE IF NOT EXISTS question_results (
     consent BOOLEAN,
     event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
 );
-CREATE INDEX idx_qresults_catalog ON question_results(catalog);
-CREATE INDEX idx_qresults_name ON question_results(name);
-CREATE INDEX idx_qresults_question ON question_results(question_id);
+CREATE INDEX IF NOT EXISTS idx_qresults_catalog ON question_results(catalog);
+CREATE INDEX IF NOT EXISTS idx_qresults_name ON question_results(name);
+CREATE INDEX IF NOT EXISTS idx_qresults_question ON question_results(question_id);
 
 -- Catalog definitions
 CREATE TABLE IF NOT EXISTS catalogs (
@@ -109,7 +109,7 @@ CREATE TABLE IF NOT EXISTS questions (
     FOREIGN KEY (catalog_uid) REFERENCES catalogs(uid) ON DELETE CASCADE,
     UNIQUE (catalog_uid, sort_order)
 );
-CREATE INDEX idx_questions_catalog ON questions(catalog_uid);
+CREATE INDEX IF NOT EXISTS idx_questions_catalog ON questions(catalog_uid);
 
 -- Photo consents for uploaded evidence
 CREATE TABLE IF NOT EXISTS photo_consents (
@@ -118,4 +118,4 @@ CREATE TABLE IF NOT EXISTS photo_consents (
     time INTEGER NOT NULL,
     event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
 );
-CREATE INDEX idx_photo_consents_team ON photo_consents(team);
+CREATE INDEX IF NOT EXISTS idx_photo_consents_team ON photo_consents(team);

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -98,7 +98,11 @@ if ($configData || $activeUid !== null) {
         }
     }
     $stmt->execute();
-    $pdo->exec("SELECT setval(pg_get_serial_sequence('config','id'), (SELECT COALESCE(MAX(id),0) FROM config))");
+    $pdo->exec(
+        "SELECT setval(" .
+        "pg_get_serial_sequence('config','id'), " .
+        "GREATEST(1, (SELECT COALESCE(MAX(id),0) FROM config)))"
+    );
 }
 
 $eventsFile = "$base/data/events.json";
@@ -176,7 +180,7 @@ if (is_readable($resultsFile)) {
     }
     $pdo->exec(
         "SELECT setval(pg_get_serial_sequence('results','id'), " .
-        "(SELECT COALESCE(MAX(id),0) FROM results))"
+        "GREATEST(1, (SELECT COALESCE(MAX(id),0) FROM results)))"
     );
 }
 
@@ -225,7 +229,7 @@ if (is_readable($catalogsFile)) {
     }
     $pdo->exec(
         "SELECT setval(pg_get_serial_sequence('questions','id'), " .
-        "(SELECT COALESCE(MAX(id),0) FROM questions))"
+        "GREATEST(1, (SELECT COALESCE(MAX(id),0) FROM questions)))"
     );
 }
 
@@ -243,7 +247,7 @@ if (is_readable($consentFile)) {
     }
     $pdo->exec(
         "SELECT setval(pg_get_serial_sequence('photo_consents','id'), " .
-        "(SELECT COALESCE(MAX(id),0) FROM photo_consents))"
+        "GREATEST(1, (SELECT COALESCE(MAX(id),0) FROM photo_consents)))"
     );
 }
 


### PR DESCRIPTION
## Summary
- avoid duplicate index errors by checking `IF NOT EXISTS` in `schema.sql`
- prevent sequence value 0 in `import_to_pgsql.php`

## Testing
- `vendor/bin/phpunit --dont-report-useless-tests` *(fails: PDOException)*
- `pytest -q`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_687578ac2b5c832bb2e9dbbc555bb57d