### PR TITLE
Fix docs for Alpine container

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 
    Alternativ lassen sich Schema- und Datenimport direkt im Docker-Container ausführen:
    ```bash
-   docker compose exec slim bash -c \
+   docker compose exec slim sh -c \
      'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && \
       php scripts/import_to_pgsql.php'
    ```

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -30,7 +30,7 @@ toc: true
    ```
    Alternativ lassen sich Schema- und Datenimport auch im Docker-Container ausführen:
    ```bash
-   docker compose exec slim bash -c \
+   docker compose exec slim sh -c \
      'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && php scripts/import_to_pgsql.php'
    ```
 

--- a/scripts/run_psql_in_docker.sh
+++ b/scripts/run_psql_in_docker.sh
@@ -3,5 +3,5 @@
 # Requires docker compose and the environment variables from .env.
 set -e
 
-docker compose exec slim bash -c 'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && php scripts/import_to_pgsql.php'
+docker compose exec slim sh -c 'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && php scripts/import_to_pgsql.php'
 


### PR DESCRIPTION
## Summary
- update documentation to use `sh` when running docker compose commands
- align script with Alpine-based container

## Testing
- `vendor/bin/phpunit` *(fails: PDOException)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687580b73b00832bb023ed3c2a15db4d