### PR TITLE
Remove duplicate qrremember column

### DIFF
--- a/migrations/20240905_drop_duplicate_qrremember.sql
+++ b/migrations/20240905_drop_duplicate_qrremember.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.config DROP COLUMN IF EXISTS qrremember;


### PR DESCRIPTION
## Summary
- add migration to drop unquoted `qrremember` from `config`

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpunit --no-coverage` *(fails: PDO errors and failing tests)*
- `vendor/bin/phpstan analyse --memory-limit=512M --no-progress`

------
https://chatgpt.com/codex/tasks/task_e_687597887cb4832bb2394eb28b249c83