### PR TITLE
Fix public photo upload endpoint

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -39,7 +39,7 @@ class ResultController
         TeamService $teams,
         CatalogService $catalogs,
         string $photoDir,
-        EventService $events = null
+        ?EventService $events = null
     ) {
         $this->service = $service;
         $this->config = $config;

--- a/src/Infrastructure/Persistence/User/InMemoryUserRepository.php
+++ b/src/Infrastructure/Persistence/User/InMemoryUserRepository.php
@@ -18,7 +18,7 @@ class InMemoryUserRepository implements UserRepository
     /**
      * @param User[]|null $users
      */
-    public function __construct(array $users = null)
+    public function __construct(?array $users = null)
     {
         $this->users = $users ?? [
             1 => new User(1, 'bill.gates', 'Bill', 'Gates'),

--- a/src/routes.php
+++ b/src/routes.php
@@ -294,14 +294,14 @@ return function (\Slim\App $app) {
     })->add(new RoleAuthMiddleware('admin'));
     $app->post('/photos', function (Request $request, Response $response) {
         return $request->getAttribute('evidenceController')->post($request, $response);
-    })->add(new RoleAuthMiddleware('admin'));
+    });
     $app->post('/photos/rotate', function (Request $request, Response $response) {
         return $request->getAttribute('evidenceController')->rotate($request, $response);
-    })->add(new RoleAuthMiddleware('admin'));
+    });
     $app->get('/photo/{team}/{file}', function (Request $request, Response $response, array $args) {
         $req = $request->withAttribute('team', $args['team'])->withAttribute('file', $args['file']);
         return $request->getAttribute('evidenceController')->get($req, $response);
-    })->add(new RoleAuthMiddleware('admin'));
+    });
     $app->get('/summary', function (Request $request, Response $response) {
         return $request->getAttribute('summaryController')($request, $response);
     });

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -8,17 +8,31 @@ use Tests\TestCase;
 
 class AdminControllerTest extends TestCase
 {
+    private function setupDb(): string
+    {
+        $db = tempnam(sys_get_temp_dir(), 'db');
+        putenv('POSTGRES_DSN=sqlite:' . $db);
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        $_ENV['POSTGRES_DSN'] = 'sqlite:' . $db;
+        $_ENV['POSTGRES_USER'] = '';
+        $_ENV['POSTGRES_PASSWORD'] = '';
+        return $db;
+    }
     public function testRedirectWhenNotLoggedIn(): void
     {
+        $db = $this->setupDb();
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/admin');
         $response = $app->handle($request);
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('/login', $response->getHeaderLine('Location'));
+        unlink($db);
     }
 
     public function testAdminPageAfterLogin(): void
     {
+        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
@@ -27,10 +41,12 @@ class AdminControllerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringContainsString('export-card', (string) $response->getBody());
         session_destroy();
+        unlink($db);
     }
 
     public function testRedirectForWrongRole(): void
     {
+        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'user'];
@@ -39,5 +55,6 @@ class AdminControllerTest extends TestCase
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('/login', $response->getHeaderLine('Location'));
         session_destroy();
+        unlink($db);
     }
 }


### PR DESCRIPTION
## Summary
- allow photo upload endpoints without authentication
- fix nullable type hints
- configure DB for admin controller tests

## Testing
- `vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=512M`
- `vendor/bin/phpunit -c phpunit.xml --stop-on-failure` *(fails: no such table: public.catalogs)*

------
https://chatgpt.com/codex/tasks/task_e_6875f52a9c94832b8debbdc10e0c3e49