### PR TITLE
Update event UID usage in PDF generation

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -174,7 +174,7 @@ class QrController
         }
 
         $cfg = $this->config->getConfig();
-        $uid = (string)($cfg['event_uid'] ?? '');
+        $uid = $this->config->getActiveEventUid();
         $ev = null;
         if ($uid !== '') {
             $ev = $this->events->getByUid($uid);
@@ -243,7 +243,7 @@ class QrController
         $teams = $this->teams->getAll();
 
         $cfg = $this->config->getConfig();
-        $uid = (string)($cfg['event_uid'] ?? '');
+        $uid = $this->config->getActiveEventUid();
         $ev = null;
         if ($uid !== '') {
             $ev = $this->events->getByUid($uid);

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -245,7 +245,7 @@ class ResultController
         $rankings = $awardService->computeRankings($results, $catalogCount);
 
         $cfg = $this->config->getConfig();
-        $uid = (string)($cfg['event_uid'] ?? '');
+        $uid = $this->config->getActiveEventUid();
         $event = null;
         if ($uid !== '') {
             $event = $this->events->getByUid($uid);


### PR DESCRIPTION
## Summary
- use ConfigService::getActiveEventUid in QR and result PDF controllers
- adapt QR controller test setup to specify active event and include new test for switching the active event
- adapt result controller test setup similarly with a new test

## Testing
- `composer install`
- `vendor/bin/phpunit --filter QrControllerTest` *(fails: PDO connection and missing columns)*
- `vendor/bin/phpunit --filter ResultControllerTest` *(fails: PDO connection and missing tables)*

------
https://chatgpt.com/codex/tasks/task_e_6876b0c64d08832ba9282b7b4e2f41bb