### PR TITLE
Fix mobile event header

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -91,6 +91,10 @@ body.dark-mode .topbar {
   background-color: #1e1e1e;
   border-color: #444;
 }
+body.dark-mode .event-header-bar {
+  background-color: #1e1e1e;
+  border-color: #444;
+}
 
 body.dark-mode .modern-info-card {
   border-color: #444;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -129,6 +129,13 @@ body.uk-padding {
   height: 56px;
 }
 
+.event-header-bar {
+  background: #fff;
+  border-bottom: 1px solid #e5e5e5;
+  padding: 0.25rem 0.5rem;
+  line-height: 1.2;
+}
+
 .bottombar {
   position: fixed;
   bottom: 0;
@@ -426,5 +433,26 @@ body.dark-mode .sticky-actions {
 .flip-card.flipped .flip-card-inner { transform: rotateY(180deg); }
 .flip-card-front, .flip-card-back { position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; padding: 1rem; border-radius: 8px; background: #fff; backface-visibility: hidden; box-shadow: 0 2px 6px rgba(0,0,0,0.2); }
 .flip-card-back { transform: rotateY(180deg); }
+
+@media (max-width: 639px) {
+  .topbar {
+    flex-wrap: wrap;
+  }
+  .topbar .uk-navbar-left,
+  .topbar .uk-navbar-right {
+    width: 50%;
+  }
+  .topbar .uk-navbar-center {
+    order: 1;
+    width: 100%;
+  }
+  body.uk-padding,
+  .index-page {
+    padding-top: 112px;
+  }
+  .nav-placeholder {
+    height: 112px;
+  }
+}
 
 

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -26,6 +26,11 @@
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
     {% endblock %}
+    {% block headerbar %}
+      {% if event.description %}
+        <div class="event-header-bar uk-text-center">{{ event.description }}</div>
+      {% endif %}
+    {% endblock %}
   {% endembed %}
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin">

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -15,4 +15,5 @@
     </div>
   </div>
 </nav>
+{% block headerbar %}{% endblock %}
 <div class="nav-placeholder"></div>


### PR DESCRIPTION
## Summary
- add a new block in `topbar.twig` for an event header
- show event description in the new bar on the index page
- style `.event-header-bar` for light and dark modes

## Testing
- `vendor/bin/phpunit` *(fails: no such table errors)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_68769153b504832ba56a75ed88e3594d