### PR TITLE
Fix rotate buttons after table render

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -358,6 +358,8 @@ document.addEventListener('DOMContentLoaded', () => {
         resultsData = rows;
         currentPage = 1;
         renderPage(currentPage);
+        initRotateButtons();
+        refreshLightboxes();
         updatePagination();
 
         const rankings = computeRankings(rows);
@@ -385,6 +387,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const page = parseInt(target.dataset.page, 10);
       if (!Number.isNaN(page)) {
         renderPage(page);
+        initRotateButtons();
+        refreshLightboxes();
         updatePagination();
       }
     }


### PR DESCRIPTION
## Summary
- refresh lightboxes and rotation buttons after loading results and switching pages

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: no database)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_6876b6533d44832ba4c95f993a6c1126