### PR TITLE
Fix line length warnings

### DIFF
--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -44,8 +44,12 @@ class EventService
         $existingStmt = $this->pdo->query('SELECT uid FROM events');
         $existing = $existingStmt->fetchAll(PDO::FETCH_COLUMN);
 
-        $updateStmt = $this->pdo->prepare('UPDATE events SET name = ?, start_date = ?, end_date = ?, description = ? WHERE uid = ?');
-        $insertStmt = $this->pdo->prepare('INSERT INTO events(uid,name,start_date,end_date,description) VALUES(?,?,?,?,?)');
+        $updateStmt = $this->pdo->prepare(
+            'UPDATE events SET name = ?, start_date = ?, end_date = ?, description = ? WHERE uid = ?'
+        );
+        $insertStmt = $this->pdo->prepare(
+            'INSERT INTO events(uid,name,start_date,end_date,description) VALUES(?,?,?,?,?)'
+        );
         $uids = [];
         foreach ($events as $event) {
             $uid = $event['uid'] ?? bin2hex(random_bytes(16));

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -342,8 +342,9 @@ class ResultService
             $del = $this->pdo->prepare('DELETE FROM question_results WHERE event_uid=?');
             $del->execute([$uid]);
             $stmt = $this->pdo->prepare(
-                'INSERT INTO question_results(name,catalog,question_id,attempt,correct,answer_text,photo,consent,event_uid) '
-                . 'VALUES(?,?,?,?,?,?,?,?,?)'
+                'INSERT INTO question_results(' .
+                'name,catalog,question_id,attempt,correct,answer_text,photo,consent,event_uid) ' .
+                'VALUES(?,?,?,?,?,?,?,?,?)'
             );
         } else {
             $this->pdo->exec('DELETE FROM question_results');

--- a/src/routes.php
+++ b/src/routes.php
@@ -257,7 +257,9 @@ return function (\Slim\App $app) {
         return $request->getAttribute('importController')->post($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
     $app->post('/import/{name}', function (Request $request, Response $response, array $args) {
-        return $request->getAttribute('importController')->import($request->withAttribute('name', $args['name']), $response);
+        return $request
+            ->getAttribute('importController')
+            ->import($request->withAttribute('name', $args['name']), $response);
     })->add(new RoleAuthMiddleware('admin'));
     $app->post('/export', function (Request $request, Response $response) {
         return $request->getAttribute('exportController')->post($request, $response);
@@ -266,10 +268,14 @@ return function (\Slim\App $app) {
         return $request->getAttribute('backupController')->list($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
     $app->get('/backups/{name}/download', function (Request $request, Response $response, array $args) {
-        return $request->getAttribute('backupController')->download($request->withAttribute('name', $args['name']), $response);
+        return $request
+            ->getAttribute('backupController')
+            ->download($request->withAttribute('name', $args['name']), $response);
     })->add(new RoleAuthMiddleware('admin'));
     $app->delete('/backups/{name}', function (Request $request, Response $response, array $args) {
-        return $request->getAttribute('backupController')->delete($request->withAttribute('name', $args['name']), $response);
+        return $request
+            ->getAttribute('backupController')
+            ->delete($request->withAttribute('name', $args['name']), $response);
     })->add(new RoleAuthMiddleware('admin'));
     $app->get('/qr.png', function (Request $request, Response $response) {
         return $request->getAttribute('qrController')->image($request, $response);

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -21,7 +21,11 @@ class ExportControllerTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $pdo->exec("INSERT INTO events(uid,name) VALUES('ev1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -21,7 +21,11 @@ class ImportControllerTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $pdo->exec("INSERT INTO events(uid,name) VALUES('ev1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -63,7 +63,11 @@ class QrControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','Event','Sub')");
         $cfg = new \App\Service\ConfigService($pdo);
         $cfg->setActiveEventUid('1');
@@ -168,10 +172,20 @@ class QrControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
         $pdo->exec("INSERT INTO events(uid,name) VALUES('1','Event')");
-        $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY, event_uid TEXT);');
-        $pdo->exec("INSERT INTO teams(sort_order,name,uid,event_uid) VALUES(1,'A','1','1'),(2,'B','2','1')");
+        $pdo->exec(
+            'CREATE TABLE teams(' .
+            'sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY, event_uid TEXT' .
+            ');'
+        );
+        $pdo->exec(
+            "INSERT INTO teams(sort_order,name,uid,event_uid) VALUES(1,'A','1','1'),(2,'B','2','1')"
+        );
 
         $cfg = new \App\Service\ConfigService($pdo);
         $cfg->setActiveEventUid('1');
@@ -218,7 +232,11 @@ class QrControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','First','A'),('2','Second','B')");
 
         $cfg = new \App\Service\ConfigService($pdo);

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -44,7 +44,11 @@ class ResultControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','Event','Sub')");
         $pdo->exec(
             <<<'SQL'
@@ -82,7 +86,11 @@ class ResultControllerTest extends TestCase
             "name,catalog,question_id,attempt,correct,photo) " .
             "VALUES('Team1','cat',1,1,1,'/path/foo.jpg')"
         );
-        $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY, event_uid TEXT);');
+        $pdo->exec(
+            'CREATE TABLE teams(' .
+            'sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY, event_uid TEXT' .
+            ');'
+        );
         $pdo->exec("INSERT INTO teams(sort_order,name,uid,event_uid) VALUES(1,'Team1','1','1')");
 
         $cfg = new \App\Service\ConfigService($pdo);
@@ -114,13 +122,61 @@ class ResultControllerTest extends TestCase
     {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(displayErrorDetails INTEGER, QRUser INTEGER, QRRemember INTEGER, logoPath TEXT, pageTitle TEXT, backgroundColor TEXT, buttonColor TEXT, CheckAnswerButton TEXT, adminUser TEXT, adminPass TEXT, QRRestrict INTEGER, competitionMode INTEGER, teamResults INTEGER, photoUpload INTEGER, puzzleWordEnabled INTEGER, puzzleWord TEXT, puzzleFeedback TEXT, inviteText TEXT, event_uid TEXT);');
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT);');
-        $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','First','A'),('2','Second','B')");
-        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT);');
-        $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time) VALUES('Team1','cat',1,1,1,0)");
-        $pdo->exec('CREATE TABLE question_results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, question_id INTEGER NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, answer_text TEXT, photo TEXT, consent BOOLEAN);');
-        $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY, event_uid TEXT);');
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE config(
+                displayErrorDetails INTEGER,
+                QRUser INTEGER,
+                QRRemember INTEGER,
+                logoPath TEXT,
+                pageTitle TEXT,
+                backgroundColor TEXT,
+                buttonColor TEXT,
+                CheckAnswerButton TEXT,
+                adminUser TEXT,
+                adminPass TEXT,
+                QRRestrict INTEGER,
+                competitionMode INTEGER,
+                teamResults INTEGER,
+                photoUpload INTEGER,
+                puzzleWordEnabled INTEGER,
+                puzzleWord TEXT,
+                puzzleFeedback TEXT,
+                inviteText TEXT,
+                event_uid TEXT
+            );
+            SQL
+        );
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
+        $pdo->exec(
+            "INSERT INTO events(uid,name,description) VALUES('1','First','A'),('2','Second','B')"
+        );
+        $pdo->exec(
+            'CREATE TABLE results(' .
+            'id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, ' .
+            'attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, ' .
+            'time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT' .
+            ');'
+        );
+        $pdo->exec(
+            "INSERT INTO results(name,catalog,attempt,correct,total,time) VALUES('Team1','cat',1,1,1,0)"
+        );
+        $pdo->exec(
+            'CREATE TABLE question_results(' .
+            'id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, ' .
+            'question_id INTEGER NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, ' .
+            'answer_text TEXT, photo TEXT, consent BOOLEAN' .
+            ');'
+        );
+        $pdo->exec(
+            'CREATE TABLE teams(' .
+            'sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY, event_uid TEXT' .
+            ');'
+        );
         $pdo->exec("INSERT INTO teams(sort_order,name,uid,event_uid) VALUES(1,'Team1','1','1')");
 
         $cfg = new \App\Service\ConfigService($pdo);

--- a/tests/Service/EventServiceTest.php
+++ b/tests/Service/EventServiceTest.php
@@ -14,7 +14,11 @@ class EventServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT NOT NULL, start_date TEXT, end_date TEXT, description TEXT);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT NOT NULL, start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(id INTEGER PRIMARY KEY AUTOINCREMENT, event_uid TEXT);');
         return $pdo;
     }
@@ -24,7 +28,12 @@ class EventServiceTest extends TestCase
         $pdo = $this->createPdo();
         $service = new EventService($pdo);
         $data = [
-            ['name' => 'Test Event', 'start_date' => '2025-07-04T18:00', 'end_date' => '2025-07-04T23:00', 'description' => 'Demo'],
+            [
+                'name' => 'Test Event',
+                'start_date' => '2025-07-04T18:00',
+                'end_date' => '2025-07-04T23:00',
+                'description' => 'Demo',
+            ],
         ];
         $service->saveAll($data);
         $count = (int) $pdo->query('SELECT COUNT(*) FROM config')->fetchColumn();


### PR DESCRIPTION
## Summary
- split long SQL query strings in EventService and ResultService
- wrap long lines in routes.php
- format test SQL statements to comply with 120-character rule

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpstan --memory-limit=256M`
- `vendor/bin/phpunit` *(fails: PDOException: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_6876b6a0adb0832b9d7099999d2c8bae