### PR TITLE
Fix rotate button activation after pagination

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -358,6 +358,8 @@ document.addEventListener('DOMContentLoaded', () => {
         resultsData = rows;
         currentPage = 1;
         renderPage(currentPage);
+        initRotateButtons();
+        refreshLightboxes();
         updatePagination();
 
         const rankings = computeRankings(rows);
@@ -385,6 +387,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const page = parseInt(target.dataset.page, 10);
       if (!Number.isNaN(page)) {
         renderPage(page);
+        initRotateButtons();
+        refreshLightboxes();
         updatePagination();
       }
     }


### PR DESCRIPTION
## Summary
- ensure rotate buttons work after page changes in results table

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: Errors: 45, Failures: 10)*

------
https://chatgpt.com/codex/tasks/task_e_6876b6b74a6c832b8b18f7eeadc0b2cd