### PR TITLE
Add catalog design upload and usage

### DIFF
--- a/migrations/20240906_add_design_path_to_catalogs.sql
+++ b/migrations/20240906_add_design_path_to_catalogs.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.catalogs ADD COLUMN IF NOT EXISTS design_path TEXT;

--- a/src/Controller/CatalogDesignController.php
+++ b/src/Controller/CatalogDesignController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\CatalogService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Manage upload and retrieval of catalog design templates.
+ */
+class CatalogDesignController
+{
+    private CatalogService $catalogs;
+
+    public function __construct(CatalogService $catalogs)
+    {
+        $this->catalogs = $catalogs;
+    }
+
+    public function get(Request $request, Response $response): Response
+    {
+        $slug = (string)$request->getAttribute('slug');
+        $path = $this->catalogs->getDesignPath($slug);
+        if ($path === null || $path === '') {
+            return $response->withStatus(404);
+        }
+        $abs = __DIR__ . '/../../data/' . ltrim($path, '/');
+        if (!is_readable($abs)) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write((string)file_get_contents($abs));
+        return $response->withHeader('Content-Type', 'application/pdf');
+    }
+
+    public function post(Request $request, Response $response): Response
+    {
+        $slug = (string)$request->getAttribute('slug');
+        $files = $request->getUploadedFiles();
+        if (!isset($files['file'])) {
+            $response->getBody()->write('missing file');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
+        }
+        $file = $files['file'];
+        if ($file->getError() !== UPLOAD_ERR_OK) {
+            $response->getBody()->write('upload error');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
+        }
+        $ext = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
+        if ($ext !== 'pdf') {
+            $response->getBody()->write('unsupported file type');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
+        }
+        $dir = __DIR__ . '/../../data/designs';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $target = $dir . '/' . $slug . '.pdf';
+        $file->moveTo($target);
+        $relPath = '/designs/' . $slug . '.pdf';
+        $this->catalogs->setDesignPath($slug, $relPath);
+        return $response->withStatus(204);
+    }
+}

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Service\ConfigService;
 use App\Service\TeamService;
 use App\Service\EventService;
+use App\Service\CatalogService;
 use Endroid\QrCode\Builder\Builder;
 use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Writer\SvgWriter;
@@ -30,6 +31,7 @@ class QrController
     private ConfigService $config;
     private TeamService $teams;
     private EventService $events;
+    private CatalogService $catalogs;
     /**
      * Stack for keeping track of currently selected PDF font.
      * Each entry is an array with [family, style, size].
@@ -41,11 +43,12 @@ class QrController
     /**
      * Inject configuration service dependency.
      */
-    public function __construct(ConfigService $config, TeamService $teams, EventService $events)
+    public function __construct(ConfigService $config, TeamService $teams, EventService $events, CatalogService $catalogs)
     {
         $this->config = $config;
         $this->teams = $teams;
         $this->events = $events;
+        $this->catalogs = $catalogs;
     }
 
     /**
@@ -188,6 +191,13 @@ class QrController
 
         $pdf = new Pdf($title, $subtitle, $logoFile);
         $templatePath = __DIR__ . '/../../data/template.pdf';
+        $catSlug = (string)($params['catalog'] ?? '');
+        if ($catSlug !== '') {
+            $design = $this->catalogs->getDesignPath($catSlug);
+            if ($design !== null && $design !== '') {
+                $templatePath = __DIR__ . '/../../data/' . ltrim($design, '/');
+            }
+        }
         $pdf->AddPage();
         if (is_readable($templatePath)) {
             $pdf->setSourceFile($templatePath);
@@ -257,6 +267,13 @@ class QrController
 
         $pdf = new Pdf($title, $subtitle, $logoPath);
         $templatePath = __DIR__ . '/../../data/template.pdf';
+        $catSlug = (string)($params['catalog'] ?? '');
+        if ($catSlug !== '') {
+            $design = $this->catalogs->getDesignPath($catSlug);
+            if ($design !== null && $design !== '') {
+                $templatePath = __DIR__ . '/../../data/' . ltrim($design, '/');
+            }
+        }
 
         foreach ($teams as $team) {
             $builder = Builder::create()

--- a/src/routes.php
+++ b/src/routes.php
@@ -31,6 +31,7 @@ use App\Controller\ImportController;
 use App\Controller\ExportController;
 use App\Controller\QrController;
 use App\Controller\LogoController;
+use App\Controller\CatalogDesignController;
 use App\Controller\SummaryController;
 use App\Controller\EvidenceController;
 use App\Controller\EventController;
@@ -56,6 +57,7 @@ require_once __DIR__ . '/Controller/PasswordController.php';
 require_once __DIR__ . '/Controller/AdminCatalogController.php';
 require_once __DIR__ . '/Controller/QrController.php';
 require_once __DIR__ . '/Controller/LogoController.php';
+require_once __DIR__ . '/Controller/CatalogDesignController.php';
 require_once __DIR__ . '/Controller/SummaryController.php';
 require_once __DIR__ . '/Controller/EvidenceController.php';
 require_once __DIR__ . '/Controller/ExportController.php';
@@ -108,7 +110,8 @@ return function (\Slim\App $app) {
             ->withAttribute('tenantController', new TenantController($tenantService))
             ->withAttribute('passwordController', new PasswordController($userService))
             ->withAttribute('userController', new UserController($userService))
-            ->withAttribute('qrController', new QrController($configService, $teamService, $eventService))
+            ->withAttribute('qrController', new QrController($configService, $teamService, $eventService, $catalogService))
+            ->withAttribute('catalogDesignController', new CatalogDesignController($catalogService))
             ->withAttribute('logoController', new LogoController($configService))
             ->withAttribute('summaryController', new SummaryController($configService))
             ->withAttribute('importController', new ImportController(
@@ -291,6 +294,15 @@ return function (\Slim\App $app) {
     });
     $app->post('/logo.webp', function (Request $request, Response $response) {
         return $request->getAttribute('logoController')->post($request, $response);
+    })->add(new RoleAuthMiddleware('admin'));
+
+    $app->get('/catalog/{slug}/design', function (Request $request, Response $response, array $args) {
+        $req = $request->withAttribute('slug', $args['slug']);
+        return $request->getAttribute('catalogDesignController')->get($req, $response);
+    })->add(new RoleAuthMiddleware('admin'));
+    $app->post('/catalog/{slug}/design', function (Request $request, Response $response, array $args) {
+        $req = $request->withAttribute('slug', $args['slug']);
+        return $request->getAttribute('catalogDesignController')->post($req, $response);
     })->add(new RoleAuthMiddleware('admin'));
     $app->post('/photos', function (Request $request, Response $response) {
         return $request->getAttribute('evidenceController')->post($request, $response);

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -68,7 +68,8 @@ class QrControllerTest extends TestCase
         $cfg = new \App\Service\ConfigService($pdo);
         $teams = new \App\Service\TeamService($pdo, $cfg);
         $events = new \App\Service\EventService($pdo);
-        $qr = new \App\Controller\QrController($cfg, $teams, $events);
+        $catalogs = new \App\Service\CatalogService($pdo, $cfg);
+        $qr = new \App\Controller\QrController($cfg, $teams, $events, $catalogs);
         $logo = new \App\Controller\LogoController($cfg);
 
         $req = $this->createRequest('GET', '/qr.pdf?t=Demo');
@@ -127,7 +128,8 @@ class QrControllerTest extends TestCase
         $cfg = new \App\Service\ConfigService($pdo);
         $teams = new \App\Service\TeamService($pdo, $cfg);
         $events = new \App\Service\EventService($pdo);
-        $qr  = new \App\Controller\QrController($cfg, $teams, $events);
+        $catalogs = new \App\Service\CatalogService($pdo, $cfg);
+        $qr  = new \App\Controller\QrController($cfg, $teams, $events, $catalogs);
 
         $req = $this->createRequest('GET', '/qr.pdf?t=Demo');
         $response = $qr->pdf($req, new Response());
@@ -174,7 +176,8 @@ class QrControllerTest extends TestCase
         $cfg = new \App\Service\ConfigService($pdo);
         $teams = new \App\Service\TeamService($pdo, $cfg);
         $events = new \App\Service\EventService($pdo);
-        $qr  = new \App\Controller\QrController($cfg, $teams, $events);
+        $catalogs = new \App\Service\CatalogService($pdo, $cfg);
+        $qr  = new \App\Controller\QrController($cfg, $teams, $events, $catalogs);
 
         $req = $this->createRequest('GET', '/invites.pdf');
         $response = $qr->pdfAll($req, new Response());

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -27,7 +27,8 @@ class CatalogServiceTest extends TestCase
                 description TEXT,
                 qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
-                comment TEXT
+                comment TEXT,
+                design_path TEXT
             );
             SQL
         );
@@ -65,7 +66,8 @@ class CatalogServiceTest extends TestCase
                 name TEXT NOT NULL,
                 description TEXT,
                 qrcode_url TEXT,
-                raetsel_buchstabe TEXT
+                raetsel_buchstabe TEXT,
+                design_path TEXT
             );
             SQL
         );


### PR DESCRIPTION
## Summary
- allow storing design_path for catalogs
- support PDF design upload per catalog
- use design templates in QR PDFs
- wire design upload routes
- adjust service and tests for design paths

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpstan --memory-limit=512M`
- `vendor/bin/phpunit` *(fails: no such table: public.catalogs)*

------
https://chatgpt.com/codex/tasks/task_e_6875067e31b8832b8276c70b610d0d2c