### PR TITLE
Add summary photo storage feature

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -119,3 +119,13 @@ CREATE TABLE IF NOT EXISTS photo_consents (
     event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_photo_consents_team ON photo_consents(team);
+
+-- Summary photos uploaded after quiz completion
+CREATE TABLE IF NOT EXISTS summary_photos (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    path TEXT NOT NULL,
+    time INTEGER NOT NULL,
+    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_summary_photos_name ON summary_photos(name);

--- a/migrations/20240906_create_summary_photos.sql
+++ b/migrations/20240906_create_summary_photos.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS summary_photos (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    path TEXT NOT NULL,
+    time INTEGER NOT NULL,
+    event_uid TEXT REFERENCES public.events(uid) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_summary_photos_name ON public.summary_photos(name);

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -179,7 +179,7 @@ document.addEventListener('DOMContentLoaded', () => {
     pagination.innerHTML = html;
   }
 
-  function computeRankings(rows) {
+  function computeRankings(rows, photos) {
     const catalogs = new Set();
     const puzzleTimes = new Map();
     const catTimes = new Map();
@@ -239,7 +239,9 @@ document.addEventListener('DOMContentLoaded', () => {
     totalScores.sort((a, b) => b.raw - a.raw);
     const pointsList = totalScores.slice(0, 3);
 
-    return { puzzleList, catalogList, pointsList };
+    const photoList = Array.isArray(photos) ? photos.slice(0, 3) : [];
+
+    return { puzzleList, catalogList, pointsList, photoList };
   }
 
   function renderRankings(rankings) {
@@ -260,7 +262,13 @@ document.addEventListener('DOMContentLoaded', () => {
         title: 'Highscore-Champions',
         list: rankings.pointsList,
         tooltip: 'Top 3 Teams/Spieler mit den meisten Punkten'
-      }
+      },
+      {
+        title: "Gruppenfotos",
+        list: rankings.photoList,
+        photos: true,
+        tooltip: ""
+      },
     ];
     const MAX_ITEMS = 3;
     cards.forEach(card => {
@@ -288,22 +296,30 @@ document.addEventListener('DOMContentLoaded', () => {
         const li = document.createElement('li');
         const item = card.list[i];
         if (item) {
-          const gridItem = document.createElement('div');
-          gridItem.className = 'uk-grid-small';
-          gridItem.setAttribute('uk-grid', '');
+          if (card.photos) {
+            const img = document.createElement('img');
+            img.src = item.path || item.value;
+            img.alt = 'Foto';
+            img.className = 'proof-thumb';
+            li.appendChild(img);
+          } else {
+            const gridItem = document.createElement('div');
+            gridItem.className = 'uk-grid-small';
+            gridItem.setAttribute('uk-grid', '');
 
-          const teamDiv = document.createElement('div');
-          teamDiv.className = 'uk-width-expand';
-          teamDiv.setAttribute('uk-leader', '');
-          teamDiv.style.setProperty('--uk-leader-fill-content', ' ');
-          teamDiv.textContent = `${i + 1}. ${item.name}`;
+            const teamDiv = document.createElement('div');
+            teamDiv.className = 'uk-width-expand';
+            teamDiv.setAttribute('uk-leader', '');
+            teamDiv.style.setProperty('--uk-leader-fill-content', ' ');
+            teamDiv.textContent = `${i + 1}. ${item.name}`;
 
-          const timeDiv = document.createElement('div');
-          timeDiv.textContent = item.value;
+            const timeDiv = document.createElement('div');
+            timeDiv.textContent = item.value;
 
-          gridItem.appendChild(teamDiv);
-          gridItem.appendChild(timeDiv);
-          li.appendChild(gridItem);
+            gridItem.appendChild(teamDiv);
+            gridItem.appendChild(timeDiv);
+            li.appendChild(gridItem);
+          }
         } else {
           li.textContent = '-';
         }
@@ -347,9 +363,10 @@ document.addEventListener('DOMContentLoaded', () => {
     Promise.all([
       fetchCatalogMap(),
       fetch('/results.json').then(r => r.json()),
-      fetch('/question-results.json').then(r => r.json())
+      fetch('/question-results.json').then(r => r.json()),
+      fetch('/summary-photos.json').then(r => r.json())
     ])
-      .then(([catMap, rows, qrows]) => {
+      .then(([catMap, rows, qrows, photos]) => {
         rows.forEach(r => {
           if (!r.catalogName && catMap[r.catalog]) r.catalogName = catMap[r.catalog];
           if (catMap[r.catalog]) r.catalog = catMap[r.catalog];
@@ -360,7 +377,7 @@ document.addEventListener('DOMContentLoaded', () => {
         renderPage(currentPage);
         updatePagination();
 
-        const rankings = computeRankings(rows);
+        const rankings = computeRankings(rows, photos);
         renderRankings(rankings);
 
         qrows.forEach(r => {

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -9,6 +9,7 @@ use App\Service\ConfigService;
 use App\Service\ResultService;
 use App\Service\TeamService;
 use App\Service\PhotoConsentService;
+use App\Service\SummaryPhotoService;
 use App\Service\EventService;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -23,6 +24,7 @@ class ExportController
     private ResultService $results;
     private TeamService $teams;
     private PhotoConsentService $consents;
+    private SummaryPhotoService $summaryPhotos;
     private EventService $events;
     private string $dataDir;
     private string $backupDir;
@@ -36,6 +38,7 @@ class ExportController
         ResultService $results,
         TeamService $teams,
         PhotoConsentService $consents,
+        SummaryPhotoService $summaryPhotos,
         EventService $events,
         string $dataDir,
         string $backupDir
@@ -45,6 +48,7 @@ class ExportController
         $this->results = $results;
         $this->teams = $teams;
         $this->consents = $consents;
+        $this->summaryPhotos = $summaryPhotos;
         $this->events = $events;
         $this->dataDir = rtrim($dataDir, '/');
         $this->backupDir = rtrim($backupDir, '/');
@@ -105,6 +109,12 @@ class ExportController
         file_put_contents(
             $dir . '/photo_consents.json',
             json_encode($consents, JSON_PRETTY_PRINT) . "\n"
+        );
+
+        $photos = $this->summaryPhotos->getAll();
+        file_put_contents(
+            $dir . '/summary_photos.json',
+            json_encode($photos, JSON_PRETTY_PRINT) . "\n"
         );
 
         $catalogDir = $dir . '/kataloge';

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -9,6 +9,7 @@ use App\Service\ConfigService;
 use App\Service\ResultService;
 use App\Service\TeamService;
 use App\Service\PhotoConsentService;
+use App\Service\SummaryPhotoService;
 use App\Service\EventService;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -23,6 +24,7 @@ class ImportController
     private ResultService $results;
     private TeamService $teams;
     private PhotoConsentService $consents;
+    private SummaryPhotoService $summaryPhotos;
     private EventService $events;
     private string $dataDir;
     private string $backupDir;
@@ -36,6 +38,7 @@ class ImportController
         ResultService $results,
         TeamService $teams,
         PhotoConsentService $consents,
+        SummaryPhotoService $summaryPhotos,
         EventService $events,
         string $dataDir,
         string $backupDir
@@ -45,6 +48,7 @@ class ImportController
         $this->results = $results;
         $this->teams = $teams;
         $this->consents = $consents;
+        $this->summaryPhotos = $summaryPhotos;
         $this->events = $events;
         $this->dataDir = rtrim($dataDir, '/');
         $this->backupDir = rtrim($backupDir, '/');
@@ -119,6 +123,16 @@ class ImportController
             $consents = json_decode((string)file_get_contents($consentsFile), true) ?? [];
             if (is_array($consents)) {
                 $this->consents->saveAll($consents);
+            }
+        }
+        $summaryFile = $dir . '/summary_photos.json';
+        if (is_readable($summaryFile)) {
+            $photos = json_decode((string)file_get_contents($summaryFile), true) ?? [];
+            if (is_array($photos)) {
+                $svc = $this->summaryPhotos;
+                foreach ($photos as $p) {
+                    $svc->add((string)($p['name'] ?? ''), (string)($p['path'] ?? ''), (int)($p['time'] ?? 0));
+                }
             }
         }
 

--- a/src/Service/SummaryPhotoService.php
+++ b/src/Service/SummaryPhotoService.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use PDO;
+use App\Service\ConfigService;
+
+/**
+ * Manage summary photos uploaded at quiz completion.
+ */
+class SummaryPhotoService
+{
+    private PDO $pdo;
+    private ConfigService $config;
+
+    public function __construct(PDO $pdo, ConfigService $config)
+    {
+        $this->pdo = $pdo;
+        $this->config = $config;
+    }
+
+    /**
+     * Store a new summary photo path.
+     */
+    public function add(string $name, string $path, int $time): void
+    {
+        $uid = $this->config->getActiveEventUid();
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO summary_photos(name,path,time,event_uid) VALUES(?,?,?,?)'
+        );
+        $stmt->execute([$name, $path, $time, $uid]);
+    }
+
+    /**
+     * Retrieve stored summary photos.
+     *
+     * @return list<array{name:string,path:string,time:int}>
+     */
+    public function getAll(): array
+    {
+        $uid = $this->config->getActiveEventUid();
+        $sql = 'SELECT name,path,time FROM summary_photos';
+        $params = [];
+        if ($uid !== '') {
+            $sql .= ' WHERE event_uid=?';
+            $params[] = $uid;
+        }
+        $sql .= ' ORDER BY id';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -298,6 +298,9 @@ return function (\Slim\App $app) {
     $app->post('/photos/rotate', function (Request $request, Response $response) {
         return $request->getAttribute('evidenceController')->rotate($request, $response);
     });
+    $app->get('/summary-photos.json', function (Request $request, Response $response) {
+        return $request->getAttribute('evidenceController')->listSummary($request, $response);
+    });
     $app->get('/photo/{team}/{file}', function (Request $request, Response $response, array $args) {
         $req = $request->withAttribute('team', $args['team'])->withAttribute('file', $args['file']);
         return $request->getAttribute('evidenceController')->get($req, $response);

--- a/tests/Service/SummaryPhotoServiceTest.php
+++ b/tests/Service/SummaryPhotoServiceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\SummaryPhotoService;
+use App\Service\ConfigService;
+use PDO;
+use Tests\TestCase;
+
+class SummaryPhotoServiceTest extends TestCase
+{
+    public function testAddAndGetAll(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec("CREATE TABLE summary_photos(id INTEGER PRIMARY KEY AUTOINCREMENT,name TEXT,path TEXT,time INTEGER,event_uid TEXT);");
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $cfg = new ConfigService($pdo);
+        $cfg->saveConfig(['event_uid' => 'ev1']);
+        $svc = new SummaryPhotoService($pdo, $cfg);
+        $svc->add('Team', '/photo/img.jpg', 1);
+        $rows = $svc->getAll();
+        $this->assertCount(1, $rows);
+        $this->assertSame('Team', $rows[0]['name']);
+    }
+}


### PR DESCRIPTION
## Summary
- store uploaded summary photos in new `summary_photos` table
- persist summary photos via `SummaryPhotoService`
- expose `/summary-photos.json` route
- show summary photos on results page
- include summary photos in exports and imports
- add unit test for new service

## Testing
- `vendor/bin/phpunit tests/Service/SummaryPhotoServiceTest.php`
- `vendor/bin/phpunit` *(fails: no such table errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876b6bb2424832bb150fcc4bce96c8f