### PR TITLE
Fix line length warnings

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -43,8 +43,12 @@ class QrController
     /**
      * Inject configuration service dependency.
      */
-    public function __construct(ConfigService $config, TeamService $teams, EventService $events, CatalogService $catalogs)
-    {
+    public function __construct(
+        ConfigService $config,
+        TeamService $teams,
+        EventService $events,
+        CatalogService $catalogs
+    ) {
         $this->config = $config;
         $this->teams = $teams;
         $this->events = $events;

--- a/src/routes.php
+++ b/src/routes.php
@@ -110,7 +110,12 @@ return function (\Slim\App $app) {
             ->withAttribute('tenantController', new TenantController($tenantService))
             ->withAttribute('passwordController', new PasswordController($userService))
             ->withAttribute('userController', new UserController($userService))
-            ->withAttribute('qrController', new QrController($configService, $teamService, $eventService, $catalogService))
+            ->withAttribute('qrController', new QrController(
+                $configService,
+                $teamService,
+                $eventService,
+                $catalogService
+            ))
             ->withAttribute('catalogDesignController', new CatalogDesignController($catalogService))
             ->withAttribute('logoController', new LogoController($configService))
             ->withAttribute('summaryController', new SummaryController($configService))


### PR DESCRIPTION
## Summary
- break long constructor lines to fit PSR-12
- split route middleware line for QR controller

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: no such table errors and other failures)*
- `./vendor/bin/phpcs src/Controller/QrController.php src/routes.php`
- `./vendor/bin/phpstan analyse --error-format=raw --memory-limit=256M`

------
https://chatgpt.com/codex/tasks/task_e_6876bc2874fc832ba9abc57bbb542a54