### PR TITLE
Fix long line in SummaryPhotoServiceTest

### DIFF
--- a/tests/Service/SummaryPhotoServiceTest.php
+++ b/tests/Service/SummaryPhotoServiceTest.php
@@ -15,7 +15,11 @@ class SummaryPhotoServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec("CREATE TABLE summary_photos(id INTEGER PRIMARY KEY AUTOINCREMENT,name TEXT,path TEXT,time INTEGER,event_uid TEXT);");
+        $pdo->exec(
+            'CREATE TABLE summary_photos(' .
+            'id INTEGER PRIMARY KEY AUTOINCREMENT,' .
+            'name TEXT,path TEXT,time INTEGER,event_uid TEXT);'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
         $cfg->saveConfig(['event_uid' => 'ev1']);


### PR DESCRIPTION
## Summary
- break long SQL line into multiple lines

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpunit` *(fails: ImportController type errors and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_6876c0241348832b803af2d8dfc068b0