### PR TITLE
Handle non-JSON photo upload responses

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1356,6 +1356,10 @@ function runQuiz(questions, skipIntro){
           if (!r.ok) {
             throw new Error(await r.text());
           }
+          const ct = r.headers.get('Content-Type') || '';
+          if (!ct.includes('application/json')) {
+            throw new Error(await r.text());
+          }
           return r.json();
         })
         .then(data => {

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -369,6 +369,10 @@ document.addEventListener('DOMContentLoaded', () => {
           if (!r.ok) {
             throw new Error(await r.text());
           }
+          const ct = r.headers.get('Content-Type') || '';
+          if (!ct.includes('application/json')) {
+            throw new Error(await r.text());
+          }
           return r.json();
         })
         .then(data => {


### PR DESCRIPTION
## Summary
- handle unexpected HTML response when uploading photos

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpstan --memory-limit=512M` *(fails: arguments.count)*
- `vendor/bin/phpunit` *(fails: 47 errors, 9 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6876c0c0001c832baca4375fbc7cbd88