### PR TITLE
Fix sort order uniqueness per event

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS catalogs (
 );
 ALTER TABLE catalogs
     ADD CONSTRAINT catalogs_unique_sort_order
-    UNIQUE(sort_order) DEFERRABLE INITIALLY DEFERRED;
+    UNIQUE(event_uid, sort_order) DEFERRABLE INITIALLY DEFERRED;
 
 -- Questions belonging to catalogs
 CREATE TABLE IF NOT EXISTS questions (

--- a/migrations/20240907_catalog_sort_order_per_event.sql
+++ b/migrations/20240907_catalog_sort_order_per_event.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.catalogs DROP CONSTRAINT IF EXISTS catalogs_unique_sort_order;
+ALTER TABLE public.catalogs ADD CONSTRAINT catalogs_unique_sort_order UNIQUE(event_uid, sort_order) DEFERRABLE INITIALLY DEFERRED;

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -20,7 +20,7 @@ class CatalogServiceTest extends TestCase
             <<<'SQL'
             CREATE TABLE catalogs(
                 uid TEXT PRIMARY KEY,
-                sort_order INTEGER UNIQUE NOT NULL,
+                sort_order INTEGER NOT NULL,
                 slug TEXT UNIQUE NOT NULL,
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
@@ -28,8 +28,10 @@ class CatalogServiceTest extends TestCase
                 qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
                 comment TEXT,
-                design_path TEXT
+                design_path TEXT,
+                event_uid TEXT
             );
+            CREATE UNIQUE INDEX catalogs_unique_sort_order ON catalogs(event_uid, sort_order);
             SQL
         );
         $pdo->exec(
@@ -60,15 +62,17 @@ class CatalogServiceTest extends TestCase
             <<<'SQL'
             CREATE TABLE catalogs(
                 uid TEXT PRIMARY KEY,
-                sort_order INTEGER UNIQUE NOT NULL,
+                sort_order INTEGER NOT NULL,
                 slug TEXT UNIQUE NOT NULL,
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
                 description TEXT,
                 qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
-                design_path TEXT
+                design_path TEXT,
+                event_uid TEXT
             );
+            CREATE UNIQUE INDEX catalogs_unique_sort_order ON catalogs(event_uid, sort_order);
             SQL
         );
         $pdo->exec(


### PR DESCRIPTION
## Summary
- enforce catalog sort order uniqueness per event
- document constraint change
- update tests to reflect new constraint
- add DB migration for new unique constraint

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml --dont-report-useless-tests` *(fails: 40 errors, 12 failures)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js` *(fails: Functions not found)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6876c4779be4832baf5ccc677c600b71