### PR TITLE
Fix mobile admin menu icons

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -585,7 +585,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/custom-icons.js"></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -67,7 +67,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/custom-icons.js"></script>
   <script>

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -92,7 +92,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/custom-icons.js"></script>
 {% endblock %}

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -37,7 +37,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/custom-icons.js"></script>
   <script>

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -57,7 +57,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/custom-icons.js"></script>
   <script>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -45,7 +45,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/custom-icons.js"></script>
   <script src="https://unpkg.com/html5-qrcode@2.3.7/html5-qrcode.min.js"></script>
   <script>

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -26,6 +26,7 @@
     </div>
   </nav>
   <script src="/js/uikit.min.js"></script>
+  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/i18n/de-de.js"></script>
   {% block scripts %}{% endblock %}
 </body>

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -94,7 +94,6 @@ SOFTWARE.
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/custom-icons.js"></script>
   <script>

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -56,7 +56,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/custom-icons.js"></script>
 {% endblock %}

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -60,7 +60,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/app.js"></script>
   <script src="/js/results.js"></script>
 {% endblock %}

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -43,7 +43,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/js/uikit-icons.min.js"></script>
   <script src="/js/custom-icons.js"></script>
   <script src="/js/app.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- load UIkit icon script globally in `layout.twig`
- remove duplicate icon script includes from templates

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Argument #6 $summaryPhotos must be of type App\Service\SummaryPhotoService)*

------
https://chatgpt.com/codex/tasks/task_e_6876c13717d4832ba4838071fe425721