### PR TITLE
Fix tests DB setup

### DIFF
--- a/tests/Controller/ExportImportControllerTest.php
+++ b/tests/Controller/ExportImportControllerTest.php
@@ -23,7 +23,12 @@ class ExportImportControllerTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, name TEXT);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT NOT NULL,' .
+            ' start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $pdo->exec("INSERT INTO events(uid,name) VALUES('ev1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");


### PR DESCRIPTION
## Summary
- ensure POSTGRES_DSN defaults to sqlite for tests and clean up
- update ExportImport controller test schema for new event columns

## Testing
- `composer install -n`
- `./vendor/bin/phpunit --display-warnings=0` *(fails: no such table: question_results, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6876d09b3d4c832ba1f7ce6713f4ae4e