### PR TITLE
Update catalog header links

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -338,9 +338,9 @@
           {% for c in catalogs %}
           <div class="uk-width-1-1 uk-width-1-2@s">
             <div class="export-card uk-card uk-card-default uk-card-body">
-              <h4 class="uk-card-title">{{ c.name }}</h4>
-              <p>{{ c.description }}</p>
               {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ c.slug : '?katalog=' ~ c.slug %}
+              <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
+              <p>{{ c.description }}</p>
               <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000&label=0" alt="QR" width="96" height="96">
             </div>
           </div>


### PR DESCRIPTION
## Summary
- link catalog headers in admin summary tab

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Slim\Exception\HttpNotFoundException)*
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e40a9e5c832b9b0cfad80f7574e6