### PR TITLE
Fix per-event config switching

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1306,7 +1306,7 @@ document.addEventListener('DOMContentLoaded', function () {
     fetch('/config.json', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(cfgInitial)
+      body: JSON.stringify({ event_uid: uid })
     }).then(() => {
       window.location.reload();
     }).catch(() => {});


### PR DESCRIPTION
## Summary
- when activating a different event only send the event UID to the server
- avoid overwriting the configuration of the selected event

## Testing
- `vendor/bin/phpunit tests/Controller/LogoControllerTest.php` *(passes: warnings remain)*
- `vendor/bin/phpunit` *(fails: multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_68775032fc84832b92d9665b0dbc784c