### PR TITLE
Run migrations automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 
    Wird `POSTGRES_DSN` gesetzt und enthält das Verzeichnis `data/` bereits JSON-Dateien,
    legt das Entrypoint-Skript des Containers die Tabellen automatisch an und importiert
-   die Daten beim Start.
+   die Daten beim Start. Direkt danach werden alle Migrationen ausgeführt,
+   sodass neue Spalten sofort verfügbar sind.
 
 ## Docker Compose
 
@@ -177,7 +178,8 @@ solange die App innerhalb des Docker-Setups gestartet wird.
 
 Ist in der `.env` die Variable `POSTGRES_DSN` gesetzt, legt das Entrypoint-
 Skript beim Start automatisch die Datenbank anhand von `docs/schema.sql` an und
-importiert die vorhandenen JSON-Daten. Neben `POSTGRES_DSN` werden dafür auch
+importiert die vorhandenen JSON-Daten. Danach werden die Migrationen einmalig
+ausgeführt. Neben `POSTGRES_DSN` werden dafür auch
 `POSTGRES_USER`, `POSTGRES_PASSWORD` und `POSTGRES_DB` ausgewertet (zur
 Kompatibilität wird auch `POSTGRES_PASS` noch unterstützt).
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -55,6 +55,10 @@ if [ -n "$POSTGRES_DSN" ] && [ -f docs/schema.sql ]; then
             echo "Data import complete"
         fi
     fi
+    if [ -f scripts/run_migrations.php ]; then
+        echo "Running migrations"
+        php scripts/run_migrations.php
+    fi
     unset PGPASSWORD
 fi
 

--- a/scripts/run_migrations.php
+++ b/scripts/run_migrations.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Infrastructure\Database;
+use App\Infrastructure\Migrations\Migrator;
+
+$base = Database::connectFromEnv();
+Migrator::migrate($base, __DIR__ . '/../migrations');
+
+$host = getenv('SLIM_VIRTUAL_HOST') ?: getenv('DOMAIN');
+$schema = 'public';
+if ($host) {
+    $sub = explode('.', $host)[0];
+    if ($sub && $sub !== $host) {
+        $stmt = $base->prepare('SELECT subdomain FROM tenants WHERE subdomain = ?');
+        $stmt->execute([$sub]);
+        $found = $stmt->fetchColumn();
+        if ($found !== false) {
+            $schema = (string) $found;
+        }
+    }
+}
+
+$tenant = Database::connectWithSchema($schema);
+Migrator::migrate($tenant, __DIR__ . '/../migrations');


### PR DESCRIPTION
## Summary
- add a run_migrations script
- execute migrations on startup
- document auto migrations on container start

## Testing
- `vendor/bin/phpunit` *(fails: 13 errors, 16 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6877765d5658832bbb827525869e905f