### PR TITLE
Fix QRRemember duplicate column

### DIFF
--- a/migrations/20240909_fix_qrremember.sql
+++ b/migrations/20240909_fix_qrremember.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.config ADD COLUMN IF NOT EXISTS "QRRemember" BOOLEAN DEFAULT FALSE;
+UPDATE public.config SET "QRRemember" = COALESCE("QRRemember", qrremember);
+ALTER TABLE public.config DROP COLUMN IF EXISTS qrremember;


### PR DESCRIPTION
## Summary
- add migration to consolidate QRRemember column

## Testing
- `vendor/bin/phpunit --no-coverage` *(fails: 13 errors, 16 failures)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68778ed31478832bbab2460c4cb6a734