### PR TITLE
Fix long line in LogoControllerTest

### DIFF
--- a/tests/Controller/LogoControllerTest.php
+++ b/tests/Controller/LogoControllerTest.php
@@ -139,7 +139,13 @@ class LogoControllerTest extends TestCase
         $logoFile = tempnam(sys_get_temp_dir(), 'logo');
         imagewebp(imagecreatetruecolor(10, 10), $logoFile);
         $stream = fopen($logoFile, 'rb');
-        $uploaded = new UploadedFile(new Stream($stream), 'logo.webp', 'image/webp', filesize($logoFile), UPLOAD_ERR_OK);
+        $uploaded = new UploadedFile(
+            new Stream($stream),
+            'logo.webp',
+            'image/webp',
+            filesize($logoFile),
+            UPLOAD_ERR_OK
+        );
         $request = $this->createRequest('POST', '/logo.png');
         $request = $request->withUploadedFiles(['file' => $uploaded]);
 


### PR DESCRIPTION
## Summary
- resolve coding standards warning in LogoControllerTest

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpstan --memory-limit=1G`
- `vendor/bin/phpunit` *(fails: Slim HTTPNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_687793d4e478832b95863b07d9a5ecc9