### PR TITLE
Fix catalog tests session handling

### DIFF
--- a/ROBOTS.md
+++ b/ROBOTS.md
@@ -173,6 +173,13 @@ class CatalogService
 * **Für alle von der Coding-Guideline abweichenden Vorschläge:
   Immer mit Hinweis und Link auf offizielle PHP-Standards (PSR, RFC, etc.)**
 
+## 15. **Fehlervermeidung bei Tests**
+
+* In Tests, die Rollen erfordern, muss stets `session_start()` aufgerufen und
+  `$_SESSION['user']` mit der passenden Rolle belegt werden.
+* Doppelte `session_start()`-Aufrufe innerhalb eines Tests sind zu vermeiden.
+* Vor jedem Commit sind alle PHPUnit-Tests mit `./vendor/bin/phpunit` auszuführen.
+
 # Ende robots.md
 
 **→ Diese Datei muss jedem Pull Request beigelegt und beachtet werden!**

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -53,12 +53,6 @@ class CatalogControllerTest extends TestCase
         $controller = new CatalogController($service);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
-        session_start();
-        $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
-        session_start();
-        $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
-        session_start();
-        $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
         $request = $this->createRequest('GET', '/kataloge/missing.json', ['HTTP_ACCEPT' => 'application/json']);
         $response = $controller->get($request, new Response(), ['file' => 'missing.json']);
         $this->assertEquals(404, $response->getStatusCode());
@@ -104,6 +98,8 @@ class CatalogControllerTest extends TestCase
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
         $controller = new CatalogController($service);
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 
         $request = $this->createRequest('POST', '/kataloge/test.json');
         $request = $request->withParsedBody(['a' => 1]);
@@ -162,6 +158,8 @@ class CatalogControllerTest extends TestCase
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
         $controller = new CatalogController($service);
+        session_start();
+        $_SESSION["user"] = ["id" => 1, "role" => "catalog-editor"];
 
         $createReq = $this->createRequest('PUT', '/kataloge/new.json');
         $createRes = $controller->create($createReq, new Response(), ['file' => 'new.json']);
@@ -219,6 +217,8 @@ class CatalogControllerTest extends TestCase
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
         $controller = new CatalogController($service);
+        session_start();
+        $_SESSION["user"] = ["id" => 1, "role" => "catalog-editor"];
 
         $service->write('cat.json', [['a' => 1], ['b' => 2]]);
 


### PR DESCRIPTION
## Summary
- fix missing/duplicate session setup in catalog controller tests
- document test session handling in ROBOTS.md

## Testing
- `./vendor/bin/phpunit | head -n 40`

------
https://chatgpt.com/codex/tasks/task_e_6877964514b0832ba1978d323087db8a