### PR TITLE
Fix migration failure when old column missing

### DIFF
--- a/migrations/20240909_fix_qrremember.sql
+++ b/migrations/20240909_fix_qrremember.sql
@@ -1,3 +1,13 @@
 ALTER TABLE public.config ADD COLUMN IF NOT EXISTS "QRRemember" BOOLEAN DEFAULT FALSE;
-UPDATE public.config SET "QRRemember" = COALESCE("QRRemember", qrremember);
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'config' AND column_name = 'qrremember'
+    ) THEN
+        EXECUTE 'UPDATE public.config SET "QRRemember" = COALESCE("QRRemember", qrremember)';
+    END IF;
+END$$;
+
 ALTER TABLE public.config DROP COLUMN IF EXISTS qrremember;


### PR DESCRIPTION
## Summary
- ensure migration checks for `qrremember` column before updating

## Testing
- `vendor/bin/phpunit` *(fails: 13 errors, 16 failures)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687798376b7c832b81b2ce19c2b1f88b