### PR TITLE
Fix admin menu toggle

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1739,6 +1739,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const adminTabs = document.getElementById('adminTabs');
   const adminMenu = document.getElementById('adminMenu');
   const adminNav = document.getElementById('adminNav');
+  const adminMenuToggle = document.getElementById('adminMenuToggle');
 
   function activeHelpText() {
     if (!adminTabs) return '';
@@ -1750,6 +1751,11 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!helpSidebar || !helpContent) return;
     helpContent.textContent = activeHelpText();
     UIkit.offcanvas(helpSidebar).show();
+  });
+
+  adminMenuToggle?.addEventListener('click', e => {
+    e.preventDefault();
+    if (adminNav) UIkit.offcanvas(adminNav).show();
   });
 
   if (adminMenu && adminTabs) {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -13,7 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a class="uk-icon-button" uk-icon="icon: menu; ratio: 2" aria-label="Menü" uk-toggle="target: #adminNav"></a>
+      <a id="adminMenuToggle" class="uk-icon-button" uk-icon="icon: menu; ratio: 2" aria-label="Menü" uk-toggle="target: #adminNav"></a>
     {% endblock %}
     {% block center %}
       <h3 id="activeEventHeader" class="uk-margin-remove">{{ event.name }}</h3>


### PR DESCRIPTION
## Summary
- make the admin menu toggle button addressable with an ID
- open the offcanvas explicitly via JS when clicking the toggle

## Testing
- `python3 tests/test_html_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `composer install`
- `vendor/bin/phpunit --testdox` *(fails: 404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_6877a736348c832bbe3d0246188f1c31