### PR TITLE
Fix docker socket path in nginx-proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./certs:/etc/nginx/certs:rw
       - ./vhost.d:/etc/nginx/vhost.d
       - ./html:/usr/share/nginx/html


### PR DESCRIPTION
## Summary
- correct the docker socket mount in docker-compose

## Testing
- `./vendor/bin/phpcs src/`
- `./vendor/bin/phpstan analyse src/ --memory-limit=1G`
- `./vendor/bin/phpunit` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6877b687c1b8832bacdd8120297ca9e9