### PR TITLE
Fix nginx-proxy docker socket path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./certs:/etc/nginx/certs:rw
       - ./vhost.d:/etc/nginx/vhost.d
       - ./html:/usr/share/nginx/html


### PR DESCRIPTION
## Summary
- update the socket mount path for `nginx-proxy` to `/tmp/docker.sock`

## Testing
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit --no-coverage` *(fails: Errors: 14, Failures: 15)*

------
https://chatgpt.com/codex/tasks/task_e_6877b8f0f9f4832b9b240d89daa5a505