### PR TITLE
Fix migration for duplicate column

### DIFF
--- a/migrations/20240625_use_sort_order.sql
+++ b/migrations/20240625_use_sort_order.sql
@@ -3,6 +3,9 @@ BEGIN
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
         WHERE table_name = 'catalogs' AND column_name = 'id'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'catalogs' AND column_name = 'sort_order'
     ) THEN
         ALTER TABLE public.catalogs RENAME COLUMN id TO sort_order;
     END IF;


### PR DESCRIPTION
## Summary
- add a guard in the sort order migration that skips renaming when the column already exists

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml --dont-report-useless-tests` *(fails: "Errors! Tests: 81, Assertions: 109, Errors: 14, Failures: 15")*

------
https://chatgpt.com/codex/tasks/task_e_6877cf1703fc832b8ddadbaefa8c3f5c