### PR TITLE
Fix catalog migrations for sort_order

### DIFF
--- a/migrations/20240625_use_sort_order.sql
+++ b/migrations/20240625_use_sort_order.sql
@@ -19,7 +19,16 @@ BEGIN
         SELECT 1 FROM information_schema.table_constraints
         WHERE constraint_name = 'catalogs_sort_order_unique'
     ) THEN
-        ALTER TABLE public.catalogs ADD CONSTRAINT catalogs_sort_order_unique UNIQUE(sort_order);
+        IF EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'catalogs'
+              AND indexname = 'catalogs_sort_order_unique'
+        ) THEN
+            DROP INDEX IF EXISTS catalogs_sort_order_unique;
+        END IF;
+        ALTER TABLE public.catalogs
+            ADD CONSTRAINT catalogs_sort_order_unique UNIQUE(sort_order);
     END IF;
 END$$;
 

--- a/migrations/20240627_make_catalog_sort_order_deferrable.sql
+++ b/migrations/20240627_make_catalog_sort_order_deferrable.sql
@@ -6,6 +6,14 @@ BEGIN
             AND constraint_name = 'catalogs_sort_order_unique'
     ) THEN
         ALTER TABLE public.catalogs DROP CONSTRAINT catalogs_sort_order_unique;
+        IF EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'catalogs'
+              AND indexname = 'catalogs_sort_order_unique'
+        ) THEN
+            DROP INDEX IF EXISTS catalogs_sort_order_unique;
+        END IF;
     END IF;
     IF EXISTS (
         SELECT 1 FROM information_schema.table_constraints


### PR DESCRIPTION
## Summary
- handle existing index when adding `catalogs_sort_order_unique`
- clean up leftover index before re-adding deferrable constraint

## Testing
- `phpcs --standard=phpcs.xml`
- `phpstan analyse --no-progress --memory-limit=256M`
- `phpunit -c phpunit.xml --colors=never` *(fails: no such table, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6877d11eea80832bab373cd03fe8ac26