### PR TITLE
Fix migration when header columns absent

### DIFF
--- a/migrations/20240709_move_header_to_events.sql
+++ b/migrations/20240709_move_header_to_events.sql
@@ -1,5 +1,17 @@
 
-INSERT INTO public.events(uid,name,description)
-SELECT '1', header, subheader FROM public.config LIMIT 1;
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'config'
+          AND column_name = 'header'
+    ) THEN
+        INSERT INTO public.events(uid,name,description)
+        SELECT '1', header, subheader FROM public.config LIMIT 1;
+    END IF;
+END;
+$$;
+
 ALTER TABLE public.config DROP COLUMN IF EXISTS header;
 ALTER TABLE public.config DROP COLUMN IF EXISTS subheader;


### PR DESCRIPTION
## Summary
- avoid failing migration when `header` columns are missing

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml --stop-on-failure` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877d33351a0832bb1653e3d12a1fe49