### PR TITLE
Fix migration constraint duplication

### DIFF
--- a/migrations/20240910_base_schema.sql
+++ b/migrations/20240910_base_schema.sql
@@ -90,9 +90,17 @@ CREATE TABLE IF NOT EXISTS catalogs (
     design_path TEXT,
     event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
 );
-ALTER TABLE catalogs
-    ADD CONSTRAINT catalogs_unique_sort_order
-    UNIQUE(event_uid, sort_order) DEFERRABLE INITIALLY DEFERRED;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'catalogs_unique_sort_order'
+          AND table_name = 'catalogs'
+    ) THEN
+        ALTER TABLE catalogs
+            ADD CONSTRAINT catalogs_unique_sort_order UNIQUE(event_uid, sort_order) DEFERRABLE INITIALLY DEFERRED;
+    END IF;
+END$$;
 
 -- Questions belonging to catalogs
 CREATE TABLE IF NOT EXISTS questions (


### PR DESCRIPTION
## Summary
- handle missing constraint gracefully during migrations

## Testing
- `vendor/bin/phpcs src/`
- `vendor/bin/phpstan analyse src/ --no-progress --memory-limit=1G`
- `vendor/bin/phpunit` *(fails: no such table: tenants)*

------
https://chatgpt.com/codex/tasks/task_e_6877d8a2aa50832baaa7d25cefa4f41a