### PR TITLE
Fix schema ordering

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -1,6 +1,15 @@
 -- Combined base schema for Sommerfest Quiz
 -- Generated to replace individual migrations
 
+-- Event definitions
+CREATE TABLE IF NOT EXISTS events (
+    uid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    description TEXT
+);
+
 -- Configuration settings
 CREATE TABLE IF NOT EXISTS config (
     id SERIAL PRIMARY KEY,
@@ -21,15 +30,6 @@ CREATE TABLE IF NOT EXISTS config (
     inviteText TEXT,
     qrremember BOOLEAN DEFAULT FALSE,
     event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
-);
-
--- Event definitions
-CREATE TABLE IF NOT EXISTS events (
-    uid TEXT PRIMARY KEY,
-    name TEXT NOT NULL,
-    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
-    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
-    description TEXT
 );
 
 -- Teams list

--- a/migrations/20240910_base_schema.sql
+++ b/migrations/20240910_base_schema.sql
@@ -1,6 +1,15 @@
 -- Combined base schema for Sommerfest Quiz
 -- Generated to replace individual migrations
 
+-- Event definitions
+CREATE TABLE IF NOT EXISTS events (
+    uid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    description TEXT
+);
+
 -- Configuration settings
 CREATE TABLE IF NOT EXISTS config (
     id SERIAL PRIMARY KEY,
@@ -21,15 +30,6 @@ CREATE TABLE IF NOT EXISTS config (
     inviteText TEXT,
     qrremember BOOLEAN DEFAULT FALSE,
     event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
-);
-
--- Event definitions
-CREATE TABLE IF NOT EXISTS events (
-    uid TEXT PRIMARY KEY,
-    name TEXT NOT NULL,
-    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
-    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
-    description TEXT
 );
 
 -- Teams list


### PR DESCRIPTION
## Summary
- place `events` table before `config` so foreign keys resolve

## Testing
- `vendor/bin/phpunit` *(fails: Errors 14, Failures 15)*
- `pytest tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6877da17be90832b96d2128162003579