### PR TITLE
Fix active event fallback to config

### DIFF
--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -218,6 +218,10 @@ class ConfigService
         }
         $stmt = $this->pdo->query('SELECT event_uid FROM active_event LIMIT 1');
         $uid = $stmt->fetchColumn();
+        if ($uid === false || $uid === null || $uid === '') {
+            $stmt = $this->pdo->query('SELECT event_uid FROM config LIMIT 1');
+            $uid = $stmt->fetchColumn();
+        }
         $this->activeEvent = $uid !== false && $uid !== null ? (string)$uid : '';
         return $this->activeEvent;
     }


### PR DESCRIPTION
## Summary
- ensure `ConfigService::getActiveEventUid()` falls back to the config table when no active event is set

## Testing
- `./vendor/bin/phpcs src/`
- `./vendor/bin/phpstan analyse src/ --memory-limit=1G`
- `./vendor/bin/phpunit --filter testPhotoAttachedAfterEventUidChange tests/Service/ResultServiceTest.php`
- `./vendor/bin/phpunit` *(fails: no such table errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877dcd8b4e4832ba3c7ddf5978db471