### PR TITLE
Fix events duplication during DB import

### DIFF
--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -105,32 +105,6 @@ if ($configData || $activeUid !== null) {
     );
 }
 
-$eventsFile = "$base/data/events.json";
-$activeUid = (string)($config['event_uid'] ?? '');
-if (is_readable($eventsFile)) {
-    $events = json_decode(file_get_contents($eventsFile), true) ?? [];
-    $firstUid = null;
-    $stmt = $pdo->prepare('INSERT INTO events(uid,name,start_date,end_date,description) VALUES(?,?,?,?,?)');
-    foreach ($events as $e) {
-        $uid = $e['uid'] ?? bin2hex(random_bytes(16));
-        if ($firstUid === null) {
-            $firstUid = $uid;
-        }
-        $stmt->execute([
-            $uid,
-            $e['name'] ?? '',
-            $e['start_date'] ?? date('Y-m-d\TH:i'),
-            $e['end_date'] ?? date('Y-m-d\TH:i'),
-            $e['description'] ?? null,
-        ]);
-    }
-    if ($activeUid === '' && $firstUid !== null) {
-        $activeUid = $firstUid;
-    }
-}
-if ($activeUid === '') {
-    $activeUid = null;
-}
 
 // Import teams
 $teamsFile = "$base/data/teams.json";


### PR DESCRIPTION
## Summary
- prevent events from being imported twice by removing the second import block

## Testing
- `vendor/bin/phpunit --do-not-cache-result` *(fails: Slim\Exception\HttpNotFoundException)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6877df8e382c832b809e883a2b66bd41