### PR TITLE
Adjust base schema and remove extra migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,12 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
    ```bash
   php scripts/import_to_pgsql.php
   ```
-  Ab Version 20240911 werden Beispielbenutzer über eine Migration automatisch
-  angelegt. Das optionale Skript
+  Beispielbenutzer lassen sich mithilfe des Skripts
   ```bash
   php scripts/seed_roles.php
   ```
-  existiert weiterhin, wird aber in der Regel nicht mehr benötigt. Es legt
-  einen Benutzer pro Rolle an. Benutzername und Passwort entsprechen dabei
-  jeweils dem Rollennamen:
+  anlegen. Es erstellt einen Benutzer pro Rolle, wobei Benutzername und Passwort
+  jeweils dem Rollennamen entsprechen:
 
   - `admin` – Administrator
   - `catalog-editor` – Fragenkataloge bearbeiten

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -1,18 +1,27 @@
--- Combined base schema for Sommerfest Quiz
--- Generated to replace individual migrations
+-- Combined base schema for Sommerfest Quiz (optimiert, robust und idempotent)
 
--- Event definitions
+-- ENUM f\xC3\xBCr Rollen
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_role') THEN
+    CREATE TYPE user_role AS ENUM (
+      'admin','catalog-editor','event-manager','analyst','team-manager','service-account'
+    );
+  END IF;
+END$$;
+
+-- Events
 CREATE TABLE IF NOT EXISTS events (
     uid TEXT PRIMARY KEY,
     name TEXT NOT NULL,
-    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
-    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    start_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    end_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     description TEXT
 );
 
--- Configuration settings
+-- Config
 CREATE TABLE IF NOT EXISTS config (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     displayErrorDetails BOOLEAN,
     QRUser BOOLEAN,
     logoPath TEXT,
@@ -29,21 +38,24 @@ CREATE TABLE IF NOT EXISTS config (
     puzzleFeedback TEXT,
     inviteText TEXT,
     qrremember BOOLEAN DEFAULT FALSE,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_config_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 
--- Teams list
+-- Teams
 CREATE TABLE IF NOT EXISTS teams (
-    sort_order INTEGER UNIQUE NOT NULL,
+    sort_order INTEGER NOT NULL,
     name TEXT NOT NULL,
     uid TEXT PRIMARY KEY,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_teams_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE,
+    CONSTRAINT uq_teams_sort_order UNIQUE (event_uid, sort_order)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_team_name ON teams(name);
 
--- Quiz results
+-- Results
 CREATE TABLE IF NOT EXISTS results (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name TEXT NOT NULL,
     catalog TEXT NOT NULL,
     attempt INTEGER NOT NULL,
@@ -54,14 +66,15 @@ CREATE TABLE IF NOT EXISTS results (
     time INTEGER NOT NULL,
     puzzleTime INTEGER,
     photo TEXT,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_results_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_results_catalog ON results(catalog);
 CREATE INDEX IF NOT EXISTS idx_results_name ON results(name);
 
--- Per-question answer log
+-- Per-question results
 CREATE TABLE IF NOT EXISTS question_results (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name TEXT NOT NULL,
     catalog TEXT NOT NULL,
     question_id INTEGER NOT NULL,
@@ -70,13 +83,14 @@ CREATE TABLE IF NOT EXISTS question_results (
     answer_text TEXT,
     photo TEXT,
     consent BOOLEAN,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_qresults_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_qresults_catalog ON question_results(catalog);
 CREATE INDEX IF NOT EXISTS idx_qresults_name ON question_results(name);
 CREATE INDEX IF NOT EXISTS idx_qresults_question ON question_results(question_id);
 
--- Catalog definitions
+-- Catalogs
 CREATE TABLE IF NOT EXISTS catalogs (
     uid TEXT PRIMARY KEY,
     sort_order INTEGER NOT NULL,
@@ -88,64 +102,77 @@ CREATE TABLE IF NOT EXISTS catalogs (
     raetsel_buchstabe TEXT,
     comment TEXT,
     design_path TEXT,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_catalogs_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
-ALTER TABLE catalogs
-    ADD CONSTRAINT catalogs_unique_sort_order
-    UNIQUE(event_uid, sort_order) DEFERRABLE INITIALLY DEFERRED;
 
--- Questions belonging to catalogs
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'catalogs_unique_sort_order'
+      AND table_name = 'catalogs'
+  ) THEN
+    ALTER TABLE catalogs
+      ADD CONSTRAINT catalogs_unique_sort_order
+      UNIQUE(event_uid, sort_order) DEFERRABLE INITIALLY DEFERRED;
+  END IF;
+END$$;
+
+-- Questions
 CREATE TABLE IF NOT EXISTS questions (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     catalog_uid TEXT NOT NULL,
     sort_order INTEGER,
     type TEXT NOT NULL,
     prompt TEXT NOT NULL,
-    options JSONB,
-    answers JSONB,
-    terms JSONB,
-    items JSONB,
+    options JSONB DEFAULT '{}'::JSONB,
+    answers JSONB DEFAULT '[]'::JSONB,
+    terms JSONB DEFAULT '{}'::JSONB,
+    items JSONB DEFAULT '{}'::JSONB,
     FOREIGN KEY (catalog_uid) REFERENCES catalogs(uid) ON DELETE CASCADE,
-    UNIQUE (catalog_uid, sort_order)
+    CONSTRAINT uq_questions_catalog_sort UNIQUE (catalog_uid, sort_order)
 );
 CREATE INDEX IF NOT EXISTS idx_questions_catalog ON questions(catalog_uid);
 
 -- Photo consents
 CREATE TABLE IF NOT EXISTS photo_consents (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     team TEXT NOT NULL,
     time INTEGER NOT NULL,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_photo_consents_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_photo_consents_team ON photo_consents(team);
 
--- Summary photos uploaded after quiz completion
+-- Summary photos
 CREATE TABLE IF NOT EXISTS summary_photos (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name TEXT NOT NULL,
     path TEXT NOT NULL,
     time INTEGER NOT NULL,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_summary_photos_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_summary_photos_name ON summary_photos(name);
 
 -- User accounts
 CREATE TABLE IF NOT EXISTS users (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     username TEXT UNIQUE NOT NULL,
     password TEXT NOT NULL,
-    role TEXT NOT NULL DEFAULT 'catalog-editor',
-    CONSTRAINT users_role_check CHECK (role IN ('admin','catalog-editor','event-manager','analyst','team-manager','service-account'))
+    role user_role NOT NULL DEFAULT 'catalog-editor'
 );
 
 -- Tenant definitions
 CREATE TABLE IF NOT EXISTS tenants (
     uid TEXT PRIMARY KEY,
     subdomain TEXT UNIQUE NOT NULL,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Currently active event
 CREATE TABLE IF NOT EXISTS active_event (
-    event_uid TEXT PRIMARY KEY REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT PRIMARY KEY,
+    CONSTRAINT fk_active_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );

--- a/migrations/20240910_base_schema.sql
+++ b/migrations/20240910_base_schema.sql
@@ -1,18 +1,27 @@
--- Combined base schema for Sommerfest Quiz
--- Generated to replace individual migrations
+-- Combined base schema for Sommerfest Quiz (optimiert, robust und idempotent)
 
--- Event definitions
+-- ENUM f\xC3\xBCr Rollen
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_role') THEN
+    CREATE TYPE user_role AS ENUM (
+      'admin','catalog-editor','event-manager','analyst','team-manager','service-account'
+    );
+  END IF;
+END$$;
+
+-- Events
 CREATE TABLE IF NOT EXISTS events (
     uid TEXT PRIMARY KEY,
     name TEXT NOT NULL,
-    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
-    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    start_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    end_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     description TEXT
 );
 
--- Configuration settings
+-- Config
 CREATE TABLE IF NOT EXISTS config (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     displayErrorDetails BOOLEAN,
     QRUser BOOLEAN,
     logoPath TEXT,
@@ -29,21 +38,24 @@ CREATE TABLE IF NOT EXISTS config (
     puzzleFeedback TEXT,
     inviteText TEXT,
     qrremember BOOLEAN DEFAULT FALSE,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_config_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 
--- Teams list
+-- Teams
 CREATE TABLE IF NOT EXISTS teams (
-    sort_order INTEGER UNIQUE NOT NULL,
+    sort_order INTEGER NOT NULL,
     name TEXT NOT NULL,
     uid TEXT PRIMARY KEY,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_teams_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE,
+    CONSTRAINT uq_teams_sort_order UNIQUE (event_uid, sort_order)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_team_name ON teams(name);
 
--- Quiz results
+-- Results
 CREATE TABLE IF NOT EXISTS results (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name TEXT NOT NULL,
     catalog TEXT NOT NULL,
     attempt INTEGER NOT NULL,
@@ -54,14 +66,15 @@ CREATE TABLE IF NOT EXISTS results (
     time INTEGER NOT NULL,
     puzzleTime INTEGER,
     photo TEXT,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_results_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_results_catalog ON results(catalog);
 CREATE INDEX IF NOT EXISTS idx_results_name ON results(name);
 
--- Per-question answer log
+-- Per-question results
 CREATE TABLE IF NOT EXISTS question_results (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name TEXT NOT NULL,
     catalog TEXT NOT NULL,
     question_id INTEGER NOT NULL,
@@ -70,13 +83,14 @@ CREATE TABLE IF NOT EXISTS question_results (
     answer_text TEXT,
     photo TEXT,
     consent BOOLEAN,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_qresults_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_qresults_catalog ON question_results(catalog);
 CREATE INDEX IF NOT EXISTS idx_qresults_name ON question_results(name);
 CREATE INDEX IF NOT EXISTS idx_qresults_question ON question_results(question_id);
 
--- Catalog definitions
+-- Catalogs
 CREATE TABLE IF NOT EXISTS catalogs (
     uid TEXT PRIMARY KEY,
     sort_order INTEGER NOT NULL,
@@ -88,73 +102,77 @@ CREATE TABLE IF NOT EXISTS catalogs (
     raetsel_buchstabe TEXT,
     comment TEXT,
     design_path TEXT,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_catalogs_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
+
 DO $$
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM information_schema.table_constraints
-        WHERE constraint_name = 'catalogs_unique_sort_order'
-          AND table_name = 'catalogs'
-    ) THEN
-        ALTER TABLE catalogs
-            ADD CONSTRAINT catalogs_unique_sort_order UNIQUE(event_uid, sort_order) DEFERRABLE INITIALLY DEFERRED;
-    END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'catalogs_unique_sort_order'
+      AND table_name = 'catalogs'
+  ) THEN
+    ALTER TABLE catalogs
+      ADD CONSTRAINT catalogs_unique_sort_order
+      UNIQUE(event_uid, sort_order) DEFERRABLE INITIALLY DEFERRED;
+  END IF;
 END$$;
 
-
--- Questions belonging to catalogs
+-- Questions
 CREATE TABLE IF NOT EXISTS questions (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     catalog_uid TEXT NOT NULL,
     sort_order INTEGER,
     type TEXT NOT NULL,
     prompt TEXT NOT NULL,
-    options JSONB,
-    answers JSONB,
-    terms JSONB,
-    items JSONB,
+    options JSONB DEFAULT '{}'::JSONB,
+    answers JSONB DEFAULT '[]'::JSONB,
+    terms JSONB DEFAULT '{}'::JSONB,
+    items JSONB DEFAULT '{}'::JSONB,
     FOREIGN KEY (catalog_uid) REFERENCES catalogs(uid) ON DELETE CASCADE,
-    UNIQUE (catalog_uid, sort_order)
+    CONSTRAINT uq_questions_catalog_sort UNIQUE (catalog_uid, sort_order)
 );
 CREATE INDEX IF NOT EXISTS idx_questions_catalog ON questions(catalog_uid);
 
 -- Photo consents
 CREATE TABLE IF NOT EXISTS photo_consents (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     team TEXT NOT NULL,
     time INTEGER NOT NULL,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_photo_consents_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_photo_consents_team ON photo_consents(team);
 
--- Summary photos uploaded after quiz completion
+-- Summary photos
 CREATE TABLE IF NOT EXISTS summary_photos (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name TEXT NOT NULL,
     path TEXT NOT NULL,
     time INTEGER NOT NULL,
-    event_uid TEXT REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT,
+    CONSTRAINT fk_summary_photos_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_summary_photos_name ON summary_photos(name);
 
 -- User accounts
 CREATE TABLE IF NOT EXISTS users (
-    id SERIAL PRIMARY KEY,
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     username TEXT UNIQUE NOT NULL,
     password TEXT NOT NULL,
-    role TEXT NOT NULL DEFAULT 'catalog-editor',
-    CONSTRAINT users_role_check CHECK (role IN ('admin','catalog-editor','event-manager','analyst','team-manager','service-account'))
+    role user_role NOT NULL DEFAULT 'catalog-editor'
 );
 
 -- Tenant definitions
 CREATE TABLE IF NOT EXISTS tenants (
     uid TEXT PRIMARY KEY,
     subdomain TEXT UNIQUE NOT NULL,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Currently active event
 CREATE TABLE IF NOT EXISTS active_event (
-    event_uid TEXT PRIMARY KEY REFERENCES events(uid) ON DELETE CASCADE
+    event_uid TEXT PRIMARY KEY,
+    CONSTRAINT fk_active_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
 );

--- a/migrations/20240911_seed_users.sql
+++ b/migrations/20240911_seed_users.sql
@@ -1,9 +1,0 @@
--- Seed default users for all roles
-INSERT INTO users (username, password, role) VALUES
-    ('admin', '$2y$12$B8GYqPQQK3F80qJeu.vRXeskUmaET17P91MmApvIahLX8qWqdC/JW', 'admin'),
-    ('catalog-editor', '$2y$12$cqeheVnVT8rp7bR3dU6VxuB21tOg4mqWnYJV4HnSkraiQQWpug/fi', 'catalog-editor'),
-    ('event-manager', '$2y$12$CXo0lxynUmIL7YvhkcS39uh7tqzgzzlXELGj0sTO1q3TOMPQXGwsy', 'event-manager'),
-    ('analyst', '$2y$12$gsSk0qYxpQStGmhK4WQB6OHS82taT778avI3ge7K2xoro1uvGH.gO', 'analyst'),
-    ('team-manager', '$2y$12$oi.gl3hmXZnbiMIQTzcPy.RqurPkl.I0LSJWsfHp.8yWfglp.1z3y', 'team-manager'),
-    ('service-account', '$2y$12$MoevWkEJWoWym8ZFtvNWU.p37EX5DqxlOXEdeeU1SFscnRZZLEC6G', 'service-account')
-ON CONFLICT (username) DO NOTHING;

--- a/src/Infrastructure/Migrations/Migrator.php
+++ b/src/Infrastructure/Migrations/Migrator.php
@@ -39,6 +39,13 @@ class Migrator
                 $sql = preg_replace('/DO \$\$.*?\$\$/s', '', $sql);
                 $sql = preg_replace('/ALTER TABLE \w+ DROP CONSTRAINT IF EXISTS .*?;/', '', $sql);
                 $sql = preg_replace('/\bSERIAL\s+PRIMARY\s+KEY\b/', 'INTEGER PRIMARY KEY AUTOINCREMENT', $sql);
+                $sql = preg_replace(
+                    '/INTEGER\s+GENERATED\s+ALWAYS\s+AS\s+IDENTITY\s+PRIMARY\s+KEY/',
+                    'INTEGER PRIMARY KEY AUTOINCREMENT',
+                    $sql
+                );
+                $sql = preg_replace('/TIMESTAMP WITH TIME ZONE/', 'TEXT', $sql);
+                $sql = preg_replace('/::JSONB/', '', $sql);
             }
 
             $pdo->exec($sql);


### PR DESCRIPTION
## Summary
- update base migration with optimized schema
- remove outdated seed user migration
- sync docs/schema.sql with new schema
- adjust readme on seeding users
- enhance Migrator for identity columns and SQLite

## Testing
- `./vendor/bin/phpcs src/`
- `./vendor/bin/phpstan analyse src/ --memory-limit=256M`
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: 404 Not Found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877e77a7ce0832bbd916f2375082161