### PR TITLE
Seed admin account via migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
   - `analyst` – Ergebnisse analysieren
   - `team-manager` – Teams verwalten
 
+  Ab der nachfolgenden Migration 20240912 wird zudem ein Admin-Account
+  importiert, sodass direkt eine Anmeldung mit `admin` möglich ist.
+
    Wird `POSTGRES_DSN` gesetzt und enthält das Verzeichnis `data/` bereits JSON-Dateien,
    legt das Entrypoint-Skript des Containers die Tabellen automatisch an und importiert
    die Daten beim Start. Direkt danach werden alle Migrationen ausgeführt,

--- a/migrations/20240912_seed_admin_account.sql
+++ b/migrations/20240912_seed_admin_account.sql
@@ -1,0 +1,4 @@
+-- Seed admin login after roles
+INSERT INTO users (username, password, role) VALUES
+    ('admin', '$2y$12$B8GYqPQQK3F80qJeu.vRXeskUmaET17P91MmApvIahLX8qWqdC/JW', 'admin')
+ON CONFLICT (username) DO NOTHING;


### PR DESCRIPTION
## Summary
- add migration to seed an admin account after the role seeding
- document admin account import in README

## Testing
- `./vendor/bin/phpcs`
- `./vendor/bin/phpstan analyse --error-format=raw --memory-limit=1G`
- `./vendor/bin/phpunit` *(fails: Slim\Exception\HttpNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6877e57d41dc832b806451a02f3248b4