### PR TITLE
Update catalog links with event uid

### DIFF
--- a/src/Controller/AdminCatalogController.php
+++ b/src/Controller/AdminCatalogController.php
@@ -8,6 +8,9 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
 use App\Service\CatalogService;
+use App\Service\ConfigService;
+use App\Service\EventService;
+use App\Infrastructure\Database;
 
 /**
  * Displays the catalog administration overview page.
@@ -30,6 +33,26 @@ class AdminCatalogController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
+        $pdo = Database::connectFromEnv();
+        $cfgSvc = new ConfigService($pdo);
+        $eventSvc = new EventService($pdo);
+
+        $params = $request->getQueryParams();
+        $uid = (string)($params['event'] ?? '');
+        if ($uid !== '') {
+            $cfgSvc->getConfigForEvent($uid);
+            $event = $eventSvc->getByUid($uid) ?? $eventSvc->getFirst();
+        } else {
+            $cfg = $cfgSvc->getConfig();
+            $event = null;
+            $evUid = (string)($cfg['event_uid'] ?? '');
+            if ($evUid !== '') {
+                $event = $eventSvc->getByUid($evUid);
+            }
+            if ($event === null) {
+                $event = $eventSvc->getFirst();
+            }
+        }
         $catalogsJson = $this->service->read('catalogs.json');
         $catalogs = [];
         if ($catalogsJson !== null) {
@@ -54,6 +77,7 @@ class AdminCatalogController
         return $view->render($response, 'kataloge.twig', [
             'kataloge' => $catalogs,
             'baseUrl' => $baseUrl,
+            'event' => $event,
         ]);
     }
 }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -338,7 +338,7 @@
           {% for c in catalogs %}
           <div class="uk-width-1-1 uk-width-1-2@s">
             <div class="export-card uk-card uk-card-default uk-card-body">
-              {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ c.slug : '?katalog=' ~ c.slug %}
+              {% set link = baseUrl ? baseUrl ~ '/?event=' ~ event.uid ~ '&katalog=' ~ c.slug : '?event=' ~ event.uid ~ '&katalog=' ~ c.slug %}
               <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
               <p>{{ c.description }}</p>
               <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000&label=0" alt="QR" width="96" height="96">

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -21,7 +21,7 @@
                             <div class="uk-text-small uk-margin-small-top">{{ katalog.beschreibung }}</div>
                         </div>
                         <div class="uk-width-auto@s uk-width-1-1">
-                            {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ katalog.slug : '?katalog=' ~ katalog.slug %}
+                            {% set link = baseUrl ? baseUrl ~ '/?event=' ~ event.uid ~ '&katalog=' ~ katalog.slug : '?event=' ~ event.uid ~ '&katalog=' ~ katalog.slug %}
                             <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
                             <button class="uk-button uk-button-danger uk-button-small uk-width-1-1">Löschen</button>
                         </div>


### PR DESCRIPTION
## Summary
- pass event data to catalog admin controller
- include `event.uid` when building catalog links and QR codes

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: Slim\Exception\HttpNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6877f0c857d0832baa6ae24298971e01