### PR TITLE
Handle event param in catalog redirect

### DIFF
--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -46,8 +46,16 @@ class CatalogController
 
         if ($accept === '' || strpos($accept, 'application/json') === false) {
             $slug = $this->service->slugByFile($file) ?? pathinfo($file, PATHINFO_FILENAME);
+            $params = $request->getQueryParams();
+            $event = (string)($params['event'] ?? '');
+            $location = '/?';
+            if ($event !== '') {
+                $location .= 'event=' . urlencode($event) . '&';
+            }
+            $location .= 'katalog=' . urlencode($slug);
+
             return $response
-                ->withHeader('Location', '/?katalog=' . urlencode($slug))
+                ->withHeader('Location', $location)
                 ->withStatus(302);
         }
 


### PR DESCRIPTION
## Summary
- forward `event` query parameter in CatalogController redirects
- cover event param in catalog controller tests

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml -q`
- `vendor/bin/phpunit --stop-on-failure tests/Controller/CatalogControllerTest.php --filter testRedirectIncludesEvent`
- `vendor/bin/phpunit --stop-on-failure` *(fails: Tests\Controller\CatalogControllerTest::testPostAndGet)*

------
https://chatgpt.com/codex/tasks/task_e_6877f0def040832ba2c8c6e1a831ec43