### PR TITLE
Handle event id in quiz links

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -18,6 +18,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
 };
 // Lädt die verfügbaren Fragenkataloge und startet nach Auswahl das Quiz
 (function(){
+  const eventUid = (window.quizConfig || {}).event_uid || '';
   function setStored(key, value){
     try{
       sessionStorage.setItem(key, value);
@@ -290,7 +291,9 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
           showCatalogSolvedModal(cat.name || cat.slug || cat.sort_order, remaining);
           return;
         }
-        history.replaceState(null, '', '?katalog=' + (cat.slug || cat.sort_order));
+        let qs = '?katalog=' + (cat.slug || cat.sort_order);
+        if(eventUid) qs += '&event=' + encodeURIComponent(eventUid);
+        history.replaceState(null, '', qs);
         loadQuestions(cat.slug || cat.sort_order, cat.file, cat.raetsel_buchstabe, cat.uid, cat.name || cat.slug || cat.sort_order, cat.description || '', cat.comment || '');
       });
       const title = document.createElement('h3');

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -13,6 +13,7 @@ function insertSoftHyphens(text){
   return text ? text.replace(/\/-/g, '\u00AD') : '';
 }
 document.addEventListener('DOMContentLoaded', () => {
+  const eventUid = (window.quizConfig || {}).event_uid || '';
   const resultsBtn = document.getElementById('show-results-btn');
   const puzzleBtn = document.getElementById('check-puzzle-btn');
   const photoBtn = document.getElementById('upload-photo-btn');
@@ -202,7 +203,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const td1 = document.createElement('td');
             const a = document.createElement('a');
             if (info.slug) {
-              a.href = '/?katalog=' + encodeURIComponent(info.slug);
+              let href = '/?katalog=' + encodeURIComponent(info.slug);
+              if(eventUid) href += '&event=' + encodeURIComponent(eventUid);
+              a.href = href;
               a.target = '_blank';
             } else {
               a.href = '#';

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -339,6 +339,9 @@
           <div class="uk-width-1-1 uk-width-1-2@s">
             <div class="export-card uk-card uk-card-default uk-card-body">
               {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ c.slug : '?katalog=' ~ c.slug %}
+              {% if event.uid %}
+                {% set link = link ~ '&event=' ~ event.uid %}
+              {% endif %}
               <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
               <p>{{ c.description }}</p>
               <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000&label=0" alt="QR" width="96" height="96">


### PR DESCRIPTION
## Summary
- propagate `event_uid` from `window.quizConfig` when building links
- include the event id on summary page links
- append event id to admin catalog links

## Testing
- `node tests/test_results_rankings.js`
- `node tests/test_competition_mode.js`
- `pytest -q tests/test_html_validity.py tests/test_json_validity.py`
- `vendor/bin/phpunit --do-not-cache-result` *(fails: 14 errors, 14 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6877f0e429f4832bade7a2b080fa844f