### PR TITLE
Set active event automatically when single event

### DIFF
--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -105,6 +105,12 @@ if ($configData || $activeUid !== null) {
     );
 }
 
+if ($activeUid !== null) {
+    $pdo->exec('DELETE FROM active_event');
+    $stmt = $pdo->prepare('INSERT INTO active_event(event_uid) VALUES(?)');
+    $stmt->execute([$activeUid]);
+}
+
 
 // Import teams
 $teamsFile = "$base/data/teams.json";

--- a/src/Infrastructure/Migrations/Migrator.php
+++ b/src/Infrastructure/Migrations/Migrator.php
@@ -83,5 +83,13 @@ SQL
                 );
             }
         }
+
+        $eventStmt = $pdo->query('SELECT uid FROM events LIMIT 2');
+        $events = $eventStmt->fetchAll(PDO::FETCH_COLUMN);
+        if (count($events) === 1) {
+            $pdo->exec('DELETE FROM active_event');
+            $ins = $pdo->prepare('INSERT INTO active_event(event_uid) VALUES(?)');
+            $ins->execute([$events[0]]);
+        }
     }
 }

--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -82,6 +82,12 @@ class EventService
         }
 
         $this->pdo->commit();
+
+        $countStmt = $this->pdo->query('SELECT uid FROM events LIMIT 2');
+        $eventUids = $countStmt->fetchAll(PDO::FETCH_COLUMN);
+        if (count($eventUids) === 1) {
+            $this->config->setActiveEventUid((string) $eventUids[0]);
+        }
     }
 
     /**

--- a/tests/Service/EventServiceTest.php
+++ b/tests/Service/EventServiceTest.php
@@ -55,4 +55,25 @@ class EventServiceTest extends TestCase
         $this->assertNotNull($row);
         $this->assertSame('Eins', $row['name']);
     }
+
+    public function testActiveEventIsSetWhenSingleEvent(): void
+    {
+        $pdo = $this->createPdo();
+        $svc = new EventService($pdo);
+        $svc->saveAll([[ 'uid' => 'e1', 'name' => 'Single' ]]);
+        $uid = $pdo->query('SELECT event_uid FROM active_event')->fetchColumn();
+        $this->assertSame('e1', $uid);
+    }
+
+    public function testActiveEventNotTouchedWithMultipleEvents(): void
+    {
+        $pdo = $this->createPdo();
+        $svc = new EventService($pdo);
+        $svc->saveAll([
+            ['uid' => 'e1', 'name' => 'One'],
+            ['uid' => 'e2', 'name' => 'Two'],
+        ]);
+        $count = (int) $pdo->query('SELECT COUNT(*) FROM active_event')->fetchColumn();
+        $this->assertSame(0, $count);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure exactly-one event becomes active in EventService
- persist active event after migrations and SQL imports
- test new EventService behaviour

## Testing
- `vendor/bin/phpunit` *(fails: Tests: 83, Assertions: 107, Errors: 17, Failures: 14)*
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=512M`
- `pytest -q tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6877f0ea1ae8832bb4c03af854aed50e