### PR TITLE
Fix ConfigController test key mismatch

### DIFF
--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -88,13 +88,13 @@ class ConfigControllerTest extends TestCase
         $_SESSION['user'] = ['id' => 1, 'role' => 'event-manager'];
 
         $request = $this->createRequest('POST', '/config.json');
-        $request = $request->withParsedBody(['foo' => 'bar']);
+        $request = $request->withParsedBody(['pageTitle' => 'Demo']);
         $postResponse = $controller->post($request, new Response());
         $this->assertEquals(204, $postResponse->getStatusCode());
 
         $getResponse = $controller->get($this->createRequest('GET', '/config.json'), new Response());
         $this->assertEquals(200, $getResponse->getStatusCode());
-        $this->assertStringContainsString('foo', (string) $getResponse->getBody());
+        $this->assertStringContainsString('Demo', (string) $getResponse->getBody());
         session_destroy();
     }
 
@@ -148,7 +148,7 @@ class ConfigControllerTest extends TestCase
         session_start();
         $_SESSION['user'] = ['id' => 2, 'role' => 'user'];
         $request = $this->createRequest('POST', '/config.json');
-        $request = $request->withParsedBody(['foo' => 'bar']);
+        $request = $request->withParsedBody(['pageTitle' => 'Demo']);
         $response = $app->handle($request);
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('/login', $response->getHeaderLine('Location'));


### PR DESCRIPTION
## Summary
- update `ConfigControllerTest` to use a valid config key instead of `foo`

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `pytest -q tests/test_html_validity.py tests/test_json_validity.py`
- `vendor/bin/phpunit -c phpunit.xml` *(fails: 17 errors, 14 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6877fa860d8c832bb87cfe3e5f978a76