### PR TITLE
Add troubleshooting docs for failing test data

### DIFF
--- a/docs-jtd/_toc.yml
+++ b/docs-jtd/_toc.yml
@@ -19,3 +19,4 @@
     - kontakt.md
 - Entwicklung & Updates:
     - changelog.md
+    - tests-fehlerbehebung.md

--- a/docs-jtd/tests-fehlerbehebung.md
+++ b/docs-jtd/tests-fehlerbehebung.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Tests & Fehlerbehebung
+nav_order: 2
+parent: Entwicklung & Updates
+---
+
+# Tests & Fehlerbehebung
+
+## Fehler bei Datenvergleich
+
+### Beispiele
+
+- `Failed asserting that '[]' matches JSON string ...`
+- `Failed asserting that actual size 0 matches expected size 1`
+
+### Ursache
+
+- Erwartete Testdaten fehlen oder werden nicht wie erwartet erzeugt oder gelesen.
+- Die Datenbank ist nicht korrekt vorbereitet.
+
+### Lösung
+
+- Prüfe das Setup und Teardown deiner Tests.
+- Stelle sicher, dass initiale Testdaten und Migrationen ausgeführt werden.


### PR DESCRIPTION
## Summary
- document how to fix failing data comparison tests
- include document in the GitHub Pages navigation

## Testing
- `vendor/bin/phpcs src/`
- `vendor/bin/phpstan analyse src/ --memory-limit=512M`
- `vendor/bin/phpunit -c phpunit.xml` *(fails: 17 errors, 14 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6877fa7e9d34832ba17ff6ba4b93ada7