### PR TITLE
Fix PDF header missing file issue

### DIFF
--- a/src/Service/Pdf.php
+++ b/src/Service/Pdf.php
@@ -36,7 +36,7 @@ class Pdf extends Fpdi
         $qrSize = 20.0; // keep same dimensions as original header code
         $headerHeight = max(25.0, $qrSize + 5.0);
 
-        if (is_readable($logoFile)) {
+        if (is_file($logoFile) && is_readable($logoFile)) {
             if (str_ends_with(strtolower($logoFile), '.webp')) {
                 $img = Image::make($logoFile);
                 $logoTemp = tempnam(sys_get_temp_dir(), 'logo') . '.png';


### PR DESCRIPTION
## Summary
- avoid FPDF errors when logoPath is empty

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: 84 tests, 16 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877fa75b0e4832bbb335a3dd95d16b8