### PR TITLE
Run migrations in unit tests

### DIFF
--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -13,44 +13,7 @@ class CatalogServiceTest extends TestCase
 {
     private function createPdo(): PDO
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE catalogs(
-                uid TEXT PRIMARY KEY,
-                sort_order INTEGER NOT NULL,
-                slug TEXT UNIQUE NOT NULL,
-                file TEXT NOT NULL,
-                name TEXT NOT NULL,
-                description TEXT,
-                qrcode_url TEXT,
-                raetsel_buchstabe TEXT,
-                comment TEXT,
-                design_path TEXT,
-                event_uid TEXT
-            );
-            CREATE UNIQUE INDEX catalogs_unique_sort_order ON catalogs(event_uid, sort_order);
-            SQL
-        );
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE questions(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                catalog_uid TEXT NOT NULL,
-                sort_order INTEGER,
-                type TEXT NOT NULL,
-                prompt TEXT NOT NULL,
-                options TEXT,
-                answers TEXT,
-                terms TEXT,
-                items TEXT,
-                UNIQUE(catalog_uid, sort_order)
-            );
-            SQL
-        );
-        return $pdo;
+        return $this->createMigratedPdo();
     }
 
     private function createPdoNoComment(): PDO

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -12,33 +12,7 @@ class ConfigServiceTest extends TestCase
 {
     public function testReadWriteConfig(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE config(
-                displayErrorDetails INTEGER,
-                QRUser INTEGER,
-                QRRemember INTEGER,
-                logoPath TEXT,
-                pageTitle TEXT,
-                backgroundColor TEXT,
-                buttonColor TEXT,
-                CheckAnswerButton TEXT,
-                adminUser TEXT,
-                adminPass TEXT,
-                QRRestrict INTEGER,
-                competitionMode INTEGER,
-                teamResults INTEGER,
-                photoUpload INTEGER,
-                puzzleWordEnabled INTEGER,
-                puzzleWord TEXT,
-                puzzleFeedback TEXT,
-                inviteText TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
+        $pdo = $this->createMigratedPdo();
         $service = new ConfigService($pdo);
         $data = ['pageTitle' => 'Demo'];
 
@@ -50,33 +24,7 @@ class ConfigServiceTest extends TestCase
 
     public function testGetJsonReturnsNullIfFileMissing(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE config(
-                displayErrorDetails INTEGER,
-                QRUser INTEGER,
-                QRRemember INTEGER,
-                logoPath TEXT,
-                pageTitle TEXT,
-                backgroundColor TEXT,
-                buttonColor TEXT,
-                CheckAnswerButton TEXT,
-                adminUser TEXT,
-                adminPass TEXT,
-                QRRestrict INTEGER,
-                competitionMode INTEGER,
-                teamResults INTEGER,
-                photoUpload INTEGER,
-                puzzleWordEnabled INTEGER,
-                puzzleWord TEXT,
-                puzzleFeedback TEXT,
-                inviteText TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
+        $pdo = $this->createMigratedPdo();
         $service = new ConfigService($pdo);
 
         $this->assertNull($service->getJson());

--- a/tests/Service/EventServiceTest.php
+++ b/tests/Service/EventServiceTest.php
@@ -12,15 +12,7 @@ class EventServiceTest extends TestCase
 {
     private function createPdo(): PDO
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, name TEXT NOT NULL, start_date TEXT, end_date TEXT, description TEXT' .
-            ');'
-        );
-        $pdo->exec('CREATE TABLE config(id INTEGER PRIMARY KEY AUTOINCREMENT, event_uid TEXT);');
-        return $pdo;
+        return $this->createMigratedPdo();
     }
 
     public function testSaveAndGet(): void

--- a/tests/Service/PhotoConsentServiceTest.php
+++ b/tests/Service/PhotoConsentServiceTest.php
@@ -13,19 +13,7 @@ class PhotoConsentServiceTest extends TestCase
 {
     public function testAddConsentAppendsEntry(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE photo_consents(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                team TEXT NOT NULL,
-                time INTEGER NOT NULL,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $cfg->saveConfig(['event_uid' => 'e1']);
         $svc = new PhotoConsentService($pdo, $cfg);
@@ -40,19 +28,7 @@ class PhotoConsentServiceTest extends TestCase
 
     public function testGetAllReturnsStoredConsents(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE photo_consents(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                team TEXT NOT NULL,
-                time INTEGER NOT NULL,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $cfg->saveConfig(['event_uid' => 'e1']);
         $svc = new PhotoConsentService($pdo, $cfg);
@@ -67,19 +43,7 @@ class PhotoConsentServiceTest extends TestCase
 
     public function testAddStoresEventUid(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE photo_consents(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                team TEXT NOT NULL,
-                time INTEGER NOT NULL,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $cfg->saveConfig(['event_uid' => 'ev1']);
         $svc = new PhotoConsentService($pdo, $cfg);
@@ -90,19 +54,7 @@ class PhotoConsentServiceTest extends TestCase
 
     public function testGetAllFiltersByEventUid(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE photo_consents(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                team TEXT NOT NULL,
-                time INTEGER NOT NULL,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $cfg->saveConfig(['event_uid' => 'ev1']);
         $svc = new PhotoConsentService($pdo, $cfg);
@@ -115,19 +67,7 @@ class PhotoConsentServiceTest extends TestCase
 
     public function testSaveAllReplacesOnlyCurrentEvent(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE photo_consents(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                team TEXT NOT NULL,
-                time INTEGER NOT NULL,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $cfg->saveConfig(['event_uid' => 'ev1']);
         $svc = new PhotoConsentService($pdo, $cfg);

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -13,25 +13,7 @@ class ResultServiceTest extends TestCase
 {
     public function testAddIncrementsAttemptForSameCatalog(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                total INTEGER NOT NULL,
-                time INTEGER NOT NULL,
-                puzzleTime INTEGER,
-                photo TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
 
@@ -44,25 +26,7 @@ class ResultServiceTest extends TestCase
 
     public function testAddDoesNotIncrementAcrossCatalogs(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                total INTEGER NOT NULL,
-                time INTEGER NOT NULL,
-                puzzleTime INTEGER,
-                photo TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
 
@@ -75,25 +39,7 @@ class ResultServiceTest extends TestCase
 
     public function testMarkPuzzleUpdatesEntry(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                total INTEGER NOT NULL,
-                time INTEGER NOT NULL,
-                puzzleTime INTEGER,
-                photo TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
 
@@ -107,25 +53,7 @@ class ResultServiceTest extends TestCase
 
     public function testMarkPuzzleReturnsTrueIfAlreadySolved(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                total INTEGER NOT NULL,
-                time INTEGER NOT NULL,
-                puzzleTime INTEGER,
-                photo TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
 
@@ -138,25 +66,7 @@ class ResultServiceTest extends TestCase
 
     public function testSetPhotoUpdatesEntry(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                total INTEGER NOT NULL,
-                time INTEGER NOT NULL,
-                puzzleTime INTEGER,
-                photo TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
 
@@ -168,66 +78,7 @@ class ResultServiceTest extends TestCase
 
     public function testAddStoresQuestionResults(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                total INTEGER NOT NULL,
-                time INTEGER NOT NULL,
-                puzzleTime INTEGER,
-                photo TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE question_results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                question_id INTEGER NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                answer_text TEXT,
-                photo TEXT,
-                consent INTEGER
-            );
-            SQL
-        );
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE catalogs(
-                uid TEXT PRIMARY KEY,
-                sort_order INTEGER,
-                slug TEXT,
-                file TEXT,
-                name TEXT
-            );
-            SQL
-        );
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE questions(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                catalog_uid TEXT NOT NULL,
-                sort_order INTEGER,
-                type TEXT NOT NULL,
-                prompt TEXT NOT NULL,
-                options TEXT,
-                answers TEXT,
-                terms TEXT,
-                items TEXT
-            );
-            SQL
-        );
+        $pdo = $this->createMigratedPdo();
         $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES('u1',1,'cat1','c.json','C')");
         $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u1',1,'text','Q1')");
         $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u1',2,'text','Q2')");
@@ -247,40 +98,7 @@ class ResultServiceTest extends TestCase
 
     public function testClearRemovesResultsAndQuestionResults(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                total INTEGER NOT NULL,
-                time INTEGER NOT NULL,
-                puzzleTime INTEGER,
-                photo TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE question_results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                question_id INTEGER NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                answer_text TEXT,
-                photo TEXT,
-                consent INTEGER
-            );
-            SQL
-        );
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
         $service->add([ 'name' => 'Team', 'catalog' => 'cat1', 'correct' => 1, 'total' => 1 ]);
@@ -293,70 +111,11 @@ class ResultServiceTest extends TestCase
 
     public function testPhotoAttachedAfterEventUidChange(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                total INTEGER NOT NULL,
-                time INTEGER NOT NULL,
-                puzzleTime INTEGER,
-                photo TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE catalogs(
-                uid TEXT PRIMARY KEY,
-                sort_order INTEGER,
-                slug TEXT,
-                file TEXT,
-                name TEXT
-            );
-            SQL
-        );
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE questions(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                catalog_uid TEXT NOT NULL,
-                sort_order INTEGER,
-                type TEXT NOT NULL,
-                prompt TEXT NOT NULL,
-                options TEXT,
-                answers TEXT,
-                terms TEXT,
-                items TEXT
-            );
-            SQL
-        );
         $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES('u',1,'cat1','c.json','C')");
         $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u',1,'text','Q1')");
-        $pdo->exec(
-            <<<'SQL'
-            CREATE TABLE question_results(
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                catalog TEXT NOT NULL,
-                question_id INTEGER NOT NULL,
-                attempt INTEGER NOT NULL,
-                correct INTEGER NOT NULL,
-                answer_text TEXT,
-                photo TEXT,
-                consent INTEGER,
-                event_uid TEXT
-            );
-            SQL
-        );
+        // table question_results already created by migration
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
 

--- a/tests/Service/SummaryPhotoServiceTest.php
+++ b/tests/Service/SummaryPhotoServiceTest.php
@@ -13,14 +13,7 @@ class SummaryPhotoServiceTest extends TestCase
 {
     public function testAddAndGetAll(): void
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec(
-            'CREATE TABLE summary_photos(' .
-            'id INTEGER PRIMARY KEY AUTOINCREMENT,' .
-            'name TEXT,path TEXT,time INTEGER,event_uid TEXT);'
-        );
-        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo = $this->createMigratedPdo();
         $cfg = new ConfigService($pdo);
         $cfg->saveConfig(['event_uid' => 'ev1']);
         $svc = new SummaryPhotoService($pdo, $cfg);

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -12,9 +12,7 @@ class TenantServiceTest extends TestCase
 {
     private function createService(string $dir, PDO &$pdo): TenantService
     {
-        $pdo = new PDO('sqlite::memory:');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT);');
+        $pdo = $this->createMigratedPdo();
         if (!is_dir($dir)) {
             mkdir($dir);
         }
@@ -25,7 +23,6 @@ class TenantServiceTest extends TestCase
     public function testCreateTenantInsertsRow(): void
     {
         $dir = sys_get_temp_dir() . '/mig' . uniqid();
-        $pdo = new PDO('sqlite::memory:');
         $service = $this->createService($dir, $pdo);
         $service->createTenant('u1', 's1');
         $count = (int) $pdo->query('SELECT COUNT(*) FROM tenants')->fetchColumn();
@@ -35,7 +32,6 @@ class TenantServiceTest extends TestCase
     public function testDeleteTenantRemovesRow(): void
     {
         $dir = sys_get_temp_dir() . '/mig' . uniqid();
-        $pdo = new PDO('sqlite::memory:');
         $service = $this->createService($dir, $pdo);
         $service->createTenant('u2', 's2');
         $service->deleteTenant('u2');
@@ -46,7 +42,6 @@ class TenantServiceTest extends TestCase
     public function testCreateAndDeleteSequence(): void
     {
         $dir = sys_get_temp_dir() . '/mig' . uniqid();
-        $pdo = new PDO('sqlite::memory:');
         $service = $this->createService($dir, $pdo);
         $service->createTenant('u3', 's3');
         $this->assertSame(1, (int) $pdo->query('SELECT COUNT(*) FROM tenants')->fetchColumn());


### PR DESCRIPTION
## Summary
- ensure temporary SQLite databases are migrated in tests
- provide helper to create migrated connections
- simplify service tests to use migrated databases

## Testing
- `composer install`
- `vendor/bin/phpunit --testsuite "Test Suite" --no-coverage` *(fails: HttpNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6877fa61aba4832b8be9ab8ef3cb6167