### PR TITLE
Fix photo previews in results grid

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -322,7 +322,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function fetchCatalogMap() {
     if (catalogMap) return Promise.resolve(catalogMap);
-    return fetch('/kataloge/catalogs.json', { headers: { 'Accept': 'application/json' } })
+    return fetch(withBase('/kataloge/catalogs.json'), {
+      headers: { 'Accept': 'application/json' }
+    })
       .then(r => r.json())
       .then(list => {
         const map = {};
@@ -349,8 +351,8 @@ document.addEventListener('DOMContentLoaded', () => {
   function load() {
     Promise.all([
       fetchCatalogMap(),
-      fetch('/results.json').then(r => r.json()),
-      fetch('/question-results.json').then(r => r.json())
+      fetch(withBase('/results.json')).then(r => r.json()),
+      fetch(withBase('/question-results.json')).then(r => r.json())
     ])
       .then(([catMap, rows, qrows]) => {
         rows.forEach(r => {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -425,8 +425,8 @@
               <td>
                 {% if r.photo is defined and r.photo %}
                 <span class="photo-wrapper">
-                  <a class="uk-inline rotate-link" href="{{ r.photo }}" data-caption='<button class="uk-icon-button lightbox-rotate-btn" type="button" uk-icon="history" data-path="{{ r.photo }}" aria-label="Drehen"></button>' data-attrs="class: uk-inverse-light">
-                    <img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb">
+                  <a class="uk-inline rotate-link" href="{{ basePath ~ r.photo }}" data-caption='<button class="uk-icon-button lightbox-rotate-btn" type="button" uk-icon="history" data-path="{{ basePath ~ r.photo }}" aria-label="Drehen"></button>' data-attrs="class: uk-inverse-light">
+                    <img src="{{ basePath ~ r.photo }}" alt="Beweisfoto" class="proof-thumb">
                   </a>
                 </span>
                 {% endif %}

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -36,8 +36,8 @@
           <td>
             {% if r.photo is defined and r.photo %}
             <span class="photo-wrapper">
-              <a class="uk-inline rotate-link" href="{{ r.photo }}" data-caption='<button class="uk-icon-button lightbox-rotate-btn" type="button" uk-icon="history" data-path="{{ r.photo }}" aria-label="Drehen"></button>' data-attrs="class: uk-inverse-light">
-                <img src="{{ r.photo }}" alt="Beweisfoto" class="proof-thumb">
+              <a class="uk-inline rotate-link" href="{{ basePath ~ r.photo }}" data-caption='<button class="uk-icon-button lightbox-rotate-btn" type="button" uk-icon="history" data-path="{{ basePath ~ r.photo }}" aria-label="Drehen"></button>' data-attrs="class: uk-inverse-light">
+                <img src="{{ basePath ~ r.photo }}" alt="Beweisfoto" class="proof-thumb">
               </a>
             </span>
             {% endif %}


### PR DESCRIPTION
## Summary
- fix fetch URLs in results.js to honor basePath
- prefix basePath for result photos in results and admin templates

## Testing
- `./vendor/bin/phpcs -n --standard=PSR12 src`
- `./vendor/bin/phpstan analyse --no-interaction --memory-limit=512M`
- `./vendor/bin/phpunit` *(fails: General error, tests expect database tables)*

------
https://chatgpt.com/codex/tasks/task_e_6877ff35ed98832b975e0f78673ef005