### PR TITLE
Fix nginx proxy configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,10 @@ services:
       - ./certs:/etc/nginx/certs:ro
       - ./vhost.d:/etc/nginx/vhost.d
       - ./html:/usr/share/nginx/html
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./conf.d:/etc/nginx/conf.d
       - /etc/nginx/dhparam:/etc/nginx/dhparam
+    labels:
+      com.github.nginx-proxy.nginx: "true"
     networks:
       - webproxy
 
@@ -44,6 +46,7 @@ services:
     restart: unless-stopped
     environment:
       - NGINX_CONTAINER=nginx
+      - NGINX_PROXY_CONTAINER=nginx
       - DEFAULT_EMAIL=${LETSENCRYPT_EMAIL}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
## Summary
- fix volume mapping for nginx container
- mark nginx container with docker-gen label
- point acme-companion at the nginx container
- add an empty `conf.d` directory

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit` *(fails: no such column `event_uid`)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_68782035550c832bbe40dae9a25574d0