### PR TITLE
Fix docker-gen paths for nginx-proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - ./certs:/etc/nginx/certs:rw
       - ./vhost.d:/etc/nginx/vhost.d
       - ./html:/usr/share/nginx/html
+      - ./conf.d:/etc/nginx/conf.d
       - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro
     command: >
       -notify-sighup nginx
@@ -45,6 +46,7 @@ services:
     environment:
       - NGINX_CONTAINER=nginx
       - NGINX_PROXY_CONTAINER=nginx
+      - NGINX_DOCKER_GEN_CONTAINER=docker-gen
       - DEFAULT_EMAIL=${LETSENCRYPT_EMAIL}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
## Summary
- mount `conf.d` for docker-gen to generate Nginx config
- expose `NGINX_DOCKER_GEN_CONTAINER` to acme-companion

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: no such column: event_uid)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_687897ff1d64832b81e6ad6967954dd8