### PR TITLE
Refactor Docker stack for safer volume-based setup

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,12 @@
+# Domain-Routing (z. B. für VIRTUAL_HOST)
+DOMAIN=quizrace.app
+SLIM_VIRTUAL_HOST=app.quizrace.app
+
+# Let's Encrypt
+LETSENCRYPT_EMAIL=admin@quizrace.app
+
+# PostgreSQL
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=supersecret
+POSTGRES_DB=quizdb
+POSTGRES_DSN=pgsql:host=postgres;port=5432;dbname=quizdb

--- a/README.md
+++ b/README.md
@@ -140,19 +140,27 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 ## Docker Compose
 
 Das mitgelieferte `docker-compose.yml` startet das Quiz samt Reverse Proxy.
-Die Dateien im Ordner `data/` werden dabei in einem benannten Volume
-`quizdata` gespeichert. So bleiben eingetragene Teams und Ergebnisse auch nach
-`docker compose down` erhalten. Hochgeladene Beweisfotos landen im Verzeichnis
-`data/photos` und werden dort immer als JPEG abgelegt. Durch das Volume bleiben
-die Bilder ebenfalls dauerhaft erhalten. Die
-ACME-Konfiguration des Let's-Encrypt-Begleiters landet im Ordner `acme/` und
-wird dadurch ebenfalls persistiert. Zusätzlich läuft ein Adminer-Container,
+Zertifikate und Konfigurationen werden komplett in benannten Volumes
+gespeichert. Dadurch bleiben alle Daten auch nach `docker compose down`
+erhalten und es sind keine manuellen Ordner erforderlich. Zusätzlich läuft ein
+Adminer-Container,
 der die PostgreSQL-Datenbank über die Subdomain `https://adminer.${DOMAIN}` bereitstellt. Er
 nutzt intern den Hostnamen `postgres` und erfordert keine weiteren Einstellungen.
 Um größere Uploads zu erlauben, kann die maximale
 Request-Größe des Reverse Proxys über die Umgebungsvariable
 `CLIENT_MAX_BODY_SIZE` angepasst werden. In der mitgelieferten
 `docker-compose.yml` ist dieser Wert auf `20m` gesetzt.
+
+Zum Start genügt:
+```bash
+cp .env.template .env
+docker compose up --build -d
+```
+Beenden lässt sich der Stack mit:
+```bash
+docker compose down
+```
+Die Volumes bleiben dabei erhalten.
 Beim Einsatz des integrierten Proxy-Stacks (nginx, docker-gen und acme-companion) greift der Wert nur, solange keine eigene Vhost-Konfiguration vorliegt.
 Soll ein höheres Limit dauerhaft gelten, lege im Verzeichnis `vhost.d/` eine Datei an.
 Nach dem Anpassen genügt ein Neustart des Containers `docker-gen` (z.B. `docker compose restart docker-gen`), damit nginx die Einstellung übernimmt.
@@ -209,7 +217,7 @@ eines Mandanten steht `scripts/delete_tenant.sh` bereit:
 scripts/delete_tenant.sh foo
 ```
 
-Beide Skripte lesen die Variable `DOMAIN` aus `sample.env` und nutzen sie
+Beide Skripte lesen die Variable `DOMAIN` aus `.env` und nutzen sie
 für die vhost-Konfiguration.
 
 Für den eigentlichen Quiz-Container lässt sich der Hostname über die
@@ -274,9 +282,9 @@ Das Projekt *Sommerfest-Quiz* ist eine Web-Applikation zur Erstellung und Verwal
    composer install
    ```
    Beim ersten Aufruf wird eine `composer.lock` erzeugt und alle benötigten Bibliotheken geladen.
-2. Die Beispieldatei `sample.env` in `.env` kopieren und bei Bedarf anpassen:
+2. Die Beispieldatei `.env.template` in `.env` kopieren und bei Bedarf anpassen:
    ```bash
-   cp sample.env .env
+   cp .env.template .env
    ```
 3. Lokalen Server starten:
    ```bash
@@ -286,7 +294,7 @@ Das Projekt *Sommerfest-Quiz* ist eine Web-Applikation zur Erstellung und Verwal
 
 4. Optional: Tabellen in einer PostgreSQL-Datenbank anlegen und JSON-Daten importieren (siehe Abschnitt "Schnellstart" für ausführliche Befehle).
 
-Für Docker-Betrieb steht ein `docker-compose.yml` bereit. Sämtliche Daten im Ordner `data/` werden in einem Volume namens `quizdata` gesichert, damit Ergebnisse erhalten bleiben.
+Für Docker-Betrieb steht ein `docker-compose.yml` bereit. Zertifikate und weitere Konfigurationen werden in Volumes gesichert, sodass keine lokalen Ordner benötigt werden.
 
 ### Konfigurationsdatei
 Alle wesentlichen Einstellungen stehen in `data/config.json` und werden beim ersten Import in die Datenbank übernommen. Über die Administration können sie später angepasst werden:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3'
+
 services:
   nginx:
     image: nginx:1.25-alpine
@@ -7,11 +9,11 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./certs:/etc/nginx/certs:ro
-      - ./vhost.d:/etc/nginx/vhost.d
-      - ./html:/usr/share/nginx/html
-      - ./conf.d:/etc/nginx/conf.d
-      - /etc/nginx/dhparam:/etc/nginx/dhparam
+      - certs:/etc/nginx/certs:ro
+      - vhostd:/etc/nginx/vhost.d
+      - htmldata:/usr/share/nginx/html
+      - confd:/etc/nginx/conf.d
+      - dhparam:/etc/nginx/dhparam
     labels:
       com.github.nginx-proxy.nginx: "true"
     networks:
@@ -23,19 +25,19 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ./certs:/etc/nginx/certs:rw
-      - ./vhost.d:/etc/nginx/vhost.d
-      - ./html:/usr/share/nginx/html
-      - ./conf.d:/etc/nginx/conf.d
-      - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro
+      - certs:/etc/nginx/certs:rw
+      - vhostd:/etc/nginx/vhost.d
+      - htmldata:/usr/share/nginx/html
+      - confd:/etc/nginx/conf.d
+      - nginx_template:/etc/docker-gen/templates
     command: >
       -notify-sighup nginx
       -watch
       -only-exposed
       /etc/docker-gen/templates/nginx.tmpl
       /etc/nginx/conf.d/default.conf
-    depends_on:
-      - nginx
+    labels:
+      com.github.nginx-proxy.docker-gen: "true"
     networks:
       - webproxy
 
@@ -44,18 +46,15 @@ services:
     container_name: acme-companion
     restart: unless-stopped
     environment:
-      - NGINX_CONTAINER=nginx
       - NGINX_PROXY_CONTAINER=nginx
       - NGINX_DOCKER_GEN_CONTAINER=docker-gen
       - DEFAULT_EMAIL=${LETSENCRYPT_EMAIL}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./certs:/etc/nginx/certs:rw
-      - ./acme:/etc/acme.sh
-      - ./vhost.d:/etc/nginx/vhost.d
-      - ./html:/usr/share/nginx/html
-    depends_on:
-      - nginx
+      - certs:/etc/nginx/certs:rw
+      - acme:/etc/acme.sh
+      - vhostd:/etc/nginx/vhost.d
+      - htmldata:/usr/share/nginx/html
     networks:
       - webproxy
 
@@ -89,8 +88,6 @@ services:
     working_dir: /var/www
     volumes:
       - ./:/var/www
-      - ./config/php.ini:/usr/local/etc/php/conf.d/uploads.ini
-      - quizdata:/var/www/data
     environment:
       - VIRTUAL_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}
       - LETSENCRYPT_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}
@@ -111,5 +108,11 @@ networks:
   webproxy:
 
 volumes:
+  certs:
+  vhostd:
+  htmldata:
+  confd:
+  acme:
+  dhparam:
+  nginx_template:
   pgdata:
-  quizdata:

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ curl -X DELETE http://$DOMAIN/tenants \
 
 ### Hinweise zu Umgebungsvariablen
 
-Die Mandanten-Logik nutzt folgende Variablen aus `.env` oder `sample.env`:
+Die Mandanten-Logik nutzt folgende Variablen aus `.env` oder `.env.template`:
 
 - `DOMAIN` legt die Basis-Domain für alle Mandanten fest.
 - `POSTGRES_DSN`, `POSTGRES_USER` und `POSTGRES_PASSWORD` bestimmen den Datenbankzugang.

--- a/scripts/create_tenant.sh
+++ b/scripts/create_tenant.sh
@@ -9,7 +9,7 @@ fi
 
 SUBDOMAIN="$1"
 BASE_DIR="$(dirname "$0")/.."
-ENV_FILE="$BASE_DIR/sample.env"
+ENV_FILE="$BASE_DIR/.env"
 DOMAIN="$(grep '^DOMAIN=' "$ENV_FILE" | cut -d '=' -f2)"
 
 if [ -z "$DOMAIN" ]; then

--- a/scripts/delete_tenant.sh
+++ b/scripts/delete_tenant.sh
@@ -9,7 +9,7 @@ fi
 
 SUBDOMAIN="$1"
 BASE_DIR="$(dirname "$0")/.."
-ENV_FILE="$BASE_DIR/sample.env"
+ENV_FILE="$BASE_DIR/.env"
 DOMAIN="$(grep '^DOMAIN=' "$ENV_FILE" | cut -d '=' -f2)"
 
 if [ -z "$DOMAIN" ]; then


### PR DESCRIPTION
## Summary
- overhaul docker compose to use volumes for nginx, acme and postgres
- add `.env.template` with default configuration
- update helper scripts to read `.env`
- document new start commands and volume-based setup

## Testing
- `vendor/bin/phpunit` *(fails: no such column errors)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68789abdd770832ba00c0cd75d59f151