### PR TITLE
Configure slim container for proxy

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 # Domain-Routing (z. B. für VIRTUAL_HOST)
 DOMAIN=quizrace.app
-SLIM_VIRTUAL_HOST=app.quizrace.app
+SLIM_VIRTUAL_HOST=quizrace.app
 
 # Let's Encrypt
 LETSENCRYPT_EMAIL=admin@quizrace.app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
 
   slim:
     build: .
+    container_name: slim-1
     working_dir: /var/www
     volumes:
       - ./:/var/www


### PR DESCRIPTION
## Summary
- enable `slim` container to be recognized by docker-gen
- update example `.env` for quizrace.app domain

## Testing
- `./vendor/bin/phpcs src/`
- `./vendor/bin/phpstan analyse src/ --memory-limit=1G`
- `./vendor/bin/phpunit --colors=never` *(fails: PDOException etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6878a6afff20832b916ae4e9b96bbe22