### PR TITLE
Fix adminer 502 error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,8 @@ services:
       - LETSENCRYPT_HOST=adminer.${DOMAIN}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
       - ADMINER_DEFAULT_SERVER=postgres
+    ports:
+      - "8081:8080"
     depends_on:
       - postgres
     networks:


### PR DESCRIPTION
## Summary
- expose Adminer port so nginx-proxy can resolve it

## Testing
- `vendor/bin/phpunit` *(fails: no such column errors)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6878e1275b48832baff6f2d7b27e6fed