### PR TITLE
Fix missing admin icons

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -18,7 +18,15 @@
     {% block center %}
       <h3 id="activeEventHeader" class="uk-margin-remove">{{ event.name }}</h3>
     {% endblock %}
-    {% block right %}{% endblock %}
+    {% block right %}
+      <div class="theme-switch">
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
+      </div>
+      <button id="helpBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" aria-label="Hilfe"></button>
+    {% endblock %}
   {% endembed %}
   <ul id="adminTabs" uk-tab>
     <li class="uk-active" data-help="Veranstaltungen anlegen oder bearbeiten. Jede Zeile enthält Name, Beginn, Ende und Beschreibung. 'Hinzufügen' erstellt einen neuen Eintrag. Speichern übernimmt die Änderungen."><a href="#">Veranstaltungen</a></li>


### PR DESCRIPTION
## Summary
- restore dark mode, high contrast and help icons in admin topbar

## Testing
- `pytest -q`
- `python3 tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6878e96a1674832baa9a8a2c10c6313c