### PR TITLE
Add vhost config for upload size

### DIFF
--- a/vhost.d/quizrace.app
+++ b/vhost.d/quizrace.app
@@ -1,0 +1,1 @@
+client_max_body_size 10M;


### PR DESCRIPTION
## Summary
- add per-host upload limit for quizrace.app
- run phpcs/phpstan/phpunit

## Testing
- `./vendor/bin/phpcs src/`
- `./vendor/bin/phpstan analyse src/ --memory-limit=512M`
- `./vendor/bin/phpunit` *(fails: no such column, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6878ee403c98832b9b28595220032056