### PR TITLE
Fix docker docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
     working_dir: /var/www
     volumes:
       - ./:/var/www
+      - ./config/php.ini:/usr/local/etc/php/conf.d/99-upload.ini:ro
     environment:
       - VIRTUAL_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}
       - LETSENCRYPT_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}


### PR DESCRIPTION
## Summary
- document nginx upload limit via `vhost.d`
- mention optional environment variables in README
- mount `config/php.ini` in docker-compose for PHP settings

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: General error: 1 no such column: event_uid)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6878ec7b8d30832b8fa4690582721a75