### PR TITLE
Update Dockerfile to include php.ini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ WORKDIR /var/www
 COPY . /var/www
 RUN composer install --no-interaction --prefer-dist --no-progress
 
+# include custom PHP configuration
+COPY config/php.ini /usr/local/etc/php/conf.d/custom.ini
+
 # run static analysis during image build
 # increase memory limit for phpstan to avoid out-of-memory errors
 RUN if [ -f vendor/bin/phpstan ]; then vendor/bin/phpstan --no-progress --memory-limit=512M; fi

--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ Soll ein höheres Limit dauerhaft gelten, lege im Verzeichnis `vhost.d/` eine Da
 Nach dem Anpassen genügt ein Neustart des Containers `docker-gen` (z.B. `docker compose restart docker-gen`), damit nginx die Einstellung übernimmt.
 
 Werte `upload_max_filesize` und `post_max_size` angepasst werden. Dafür
-liegt im Verzeichnis `config/` bereits eine kleine `php.ini` bei, die in
-`docker-compose.yml` eingebunden wird.
+liegt im Verzeichnis `config/` bereits eine kleine `php.ini` bei. Diese
+wird beim Bauen des Docker-Images nach
+`/usr/local/etc/php/conf.d/custom.ini` kopiert und automatisch geladen.
 Die verwendete Domain wird aus der Datei `.env` gelesen (Variable `DOMAIN`).
 Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
 Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.


### PR DESCRIPTION
## Summary
- copy custom php.ini during container build
- update README for new php.ini handling

## Testing
- `composer install --no-interaction --prefer-dist --no-progress`
- `vendor/bin/phpunit --no-coverage` *(fails: General error: 1 no such column: event_uid)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f31c7bf8832ba87c98fa527d4ff5