### PR TITLE
Ensure custom php.ini is loaded in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,11 @@ Soll ein höheres Limit dauerhaft gelten, lege im Verzeichnis `vhost.d/` eine Da
 Nach dem Anpassen genügt ein Neustart des Containers `docker-gen` (z.B. `docker compose restart docker-gen`), damit nginx die Einstellung übernimmt.
 
 Werte `upload_max_filesize` und `post_max_size` angepasst werden. Dafür
-liegt im Verzeichnis `config/` bereits eine kleine `php.ini` bei. Diese
-wird beim Bauen des Docker-Images nach
+liegt im Verzeichnis `config/` eine kleine `php.ini` bereit. Sie wird beim
+Bauen des Docker-Images nach
 `/usr/local/etc/php/conf.d/custom.ini` kopiert und automatisch geladen.
+Das `docker-compose.yml` bindet dieselbe Datei als Volume ein, sodass
+Änderungen ohne erneutes Bauen wirksam werden.
 Die verwendete Domain wird aus der Datei `.env` gelesen (Variable `DOMAIN`).
 Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
 Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,8 @@ services:
     working_dir: /var/www
     volumes:
       - ./:/var/www
-      - ./config/php.ini:/usr/local/etc/php/conf.d/99-upload.ini:ro
+      # Mount custom PHP settings (overrides copy in Dockerfile)
+      - ./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:ro
     environment:
       - VIRTUAL_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}
       - LETSENCRYPT_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}


### PR DESCRIPTION
## Summary
- mount `config/php.ini` directly to `/usr/local/etc/php/conf.d/custom.ini`
- document in README that docker-compose mounts this php.ini for custom settings

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit -c phpunit.xml --stop-on-failure` *(fails: no such column event_uid)*

------
https://chatgpt.com/codex/tasks/task_e_6878f74568d0832ba99a207561c25684