### PR TITLE
Fix event date display

### DIFF
--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -29,7 +29,12 @@ class EventService
     public function getAll(): array
     {
         $stmt = $this->pdo->query('SELECT uid,name,start_date,end_date,description FROM events ORDER BY name');
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return array_map(function (array $row) {
+            $row['start_date'] = $this->formatDate($row['start_date']);
+            $row['end_date'] = $this->formatDate($row['end_date']);
+            return $row;
+        }, $rows);
     }
 
     /**
@@ -99,7 +104,12 @@ class EventService
     {
         $stmt = $this->pdo->query('SELECT uid,name,start_date,end_date,description FROM events ORDER BY name LIMIT 1');
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $row !== false ? $row : null;
+        if ($row === false) {
+            return null;
+        }
+        $row['start_date'] = $this->formatDate($row['start_date']);
+        $row['end_date'] = $this->formatDate($row['end_date']);
+        return $row;
     }
 
     /**
@@ -111,6 +121,8 @@ class EventService
         $stmt->execute([$uid]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($row !== false) {
+            $row['start_date'] = $this->formatDate($row['start_date']);
+            $row['end_date'] = $this->formatDate($row['end_date']);
             return $row;
         }
 
@@ -133,5 +145,18 @@ class EventService
         }
 
         return null;
+    }
+
+    private function formatDate(?string $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+        try {
+            $dt = new \DateTime($value);
+            return $dt->format('Y-m-d\TH:i');
+        } catch (\Exception $e) {
+            return $value;
+        }
     }
 }

--- a/tests/Service/EventServiceTest.php
+++ b/tests/Service/EventServiceTest.php
@@ -45,6 +45,16 @@ class EventServiceTest extends TestCase
         $this->assertSame('2025-07-04T23:00', $rows[0]['end_date']);
     }
 
+    public function testGetAllFormatsDates(): void
+    {
+        $pdo = $this->createPdo();
+        $pdo->exec("INSERT INTO events(uid,name,start_date,end_date) VALUES('a1','Evt','2025-07-04 18:00:00+00','2025-07-04 20:00:00+00')");
+        $service = new EventService($pdo);
+        $rows = $service->getAll();
+        $this->assertSame('2025-07-04T18:00', $rows[0]['start_date']);
+        $this->assertSame('2025-07-04T20:00', $rows[0]['end_date']);
+    }
+
     public function testGetByUid(): void
     {
         $pdo = $this->createPdo();


### PR DESCRIPTION
## Summary
- ensure event timestamps are formatted for `<input type="datetime-local">`
- test returned event date format

## Testing
- `vendor/bin/phpunit tests/Service/EventServiceTest.php --stop-on-failure`
- `vendor/bin/phpunit` *(fails: General error: 1 no such column: event_uid)*

------
https://chatgpt.com/codex/tasks/task_e_6878fde7f0fc832b9a6c5a647cda4a1e