### PR TITLE
Fix topbar button usability on small screens

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -442,9 +442,14 @@ body.dark-mode .sticky-actions {
   .topbar .uk-navbar-right {
     width: 50%;
   }
+  .topbar .uk-navbar-right {
+    justify-content: flex-end;
+  }
   .topbar .uk-navbar-center {
     order: 1;
     width: 100%;
+    position: static;
+    transform: none;
   }
   #adminTabs {
     display: none;


### PR DESCRIPTION
## Summary
- fix layout of mobile topbar so dark mode and barrier icons are right-aligned

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpunit --testdox` *(fails: 20 errors, 9 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6878ff0f6398832b9d30cdd1bb67876a