### PR TITLE
Fix team saving by adding unique uid

### DIFF
--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -54,15 +54,19 @@ class TeamService
         if ($uid !== '') {
             $del = $this->pdo->prepare('DELETE FROM teams WHERE event_uid=?');
             $del->execute([$uid]);
-            $stmt = $this->pdo->prepare('INSERT INTO teams(event_uid,sort_order,name) VALUES(?,?,?)');
+            $stmt = $this->pdo->prepare(
+                'INSERT INTO teams(uid,event_uid,sort_order,name) VALUES(?,?,?,?)'
+            );
             foreach ($teams as $i => $name) {
-                $stmt->execute([$uid, $i + 1, $name]);
+                $teamUid = bin2hex(random_bytes(16));
+                $stmt->execute([$teamUid, $uid, $i + 1, $name]);
             }
         } else {
             $this->pdo->exec('DELETE FROM teams');
-            $stmt = $this->pdo->prepare('INSERT INTO teams(sort_order,name) VALUES(?,?)');
+            $stmt = $this->pdo->prepare('INSERT INTO teams(uid,sort_order,name) VALUES(?,?,?)');
             foreach ($teams as $i => $name) {
-                $stmt->execute([$i + 1, $name]);
+                $teamUid = bin2hex(random_bytes(16));
+                $stmt->execute([$teamUid, $i + 1, $name]);
             }
         }
         $this->pdo->commit();

--- a/tests/Service/TeamServiceTest.php
+++ b/tests/Service/TeamServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\TeamService;
+use App\Service\ConfigService;
+use PDO;
+use Tests\TestCase;
+
+class TeamServiceTest extends TestCase
+{
+    public function testSaveAllStoresUid(): void
+    {
+        $pdo = $this->createDatabase();
+        $pdo->exec("INSERT INTO events(uid,name) VALUES('ev1','Event1')");
+        $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");
+        $cfg = new ConfigService($pdo);
+        $cfg->setActiveEventUid('ev1');
+        $svc = new TeamService($pdo, $cfg);
+
+        $svc->saveAll(['A', 'B']);
+        $rows = $pdo->query('SELECT uid,name,event_uid FROM teams ORDER BY sort_order')
+            ->fetchAll(PDO::FETCH_ASSOC);
+        $this->assertCount(2, $rows);
+        $this->assertSame('A', $rows[0]['name']);
+        $this->assertNotEmpty($rows[0]['uid']);
+        $this->assertSame('ev1', $rows[0]['event_uid']);
+        $this->assertNotSame($rows[0]['uid'], $rows[1]['uid']);
+    }
+
+    public function testSaveAllWithoutEvent(): void
+    {
+        $pdo = $this->createDatabase();
+        $cfg = new ConfigService($pdo);
+        $cfg->setActiveEventUid('');
+        $svc = new TeamService($pdo, $cfg);
+        $svc->saveAll(['Team']);
+        $row = $pdo->query('SELECT uid,event_uid FROM teams')->fetch(PDO::FETCH_ASSOC);
+        $this->assertNotFalse($row);
+        $this->assertNotEmpty($row['uid']);
+        $this->assertNull($row['event_uid']);
+    }
+}


### PR DESCRIPTION
## Summary
- generate unique `uid` values when saving teams
- cover `TeamService` with new unit tests

## Testing
- `./vendor/bin/phpcs src/Service/TeamService.php tests/Service/TeamServiceTest.php`
- `./vendor/bin/phpstan analyse src --no-progress --memory-limit=512M`
- `./vendor/bin/phpunit --filter TeamServiceTest`
- `./vendor/bin/phpunit` *(fails: 20 errors, 9 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6878fd332ca4832bb13ce59e81ff72a8