### PR TITLE
Fix frontend logo path

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -97,7 +97,7 @@
                 <label class="uk-form-label" for="cfgLogoPreview">Logo Vorschau</label>
                 <div class="uk-form-controls">
                   <div class="logo-frame uk-margin-small-top">
-                    <img id="cfgLogoPreview" src="{{ config.logoPath|default('') }}" alt="Logo Vorschau" class="logo-placeholder">
+                    <img id="cfgLogoPreview" src="{{ basePath ~ config.logoPath|default('') }}" alt="Logo Vorschau" class="logo-placeholder">
                   </div>
                 </div>
               </div>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -35,7 +35,7 @@
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin">
       <div id="quiz-header" class="uk-text-center uk-margin">
-        <img id="quiz-logo" class="logo-placeholder" src="{{ config.logoPath|default('') }}" alt="Logo">
+        <img id="quiz-logo" class="logo-placeholder" src="{{ basePath ~ config.logoPath|default('') }}" alt="Logo">
       </div>
       <progress id="progress" class="uk-progress" value="0" max="1" aria-label="Fortschritt des Quiz" aria-valuenow="0"></progress>
       <span id="question-announcer" class="uk-hidden-visually" aria-live="polite"></span>


### PR DESCRIPTION
## Summary
- ensure base path prefix for logo image in templates

## Testing
- `composer install`
- `./vendor/bin/phpunit --testdox` *(fails: no such table events)*

------
https://chatgpt.com/codex/tasks/task_e_687901e12fa8832b990eac2021c81150