### PR TITLE
Add event placeholder buttons in invitation editor

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -122,6 +122,16 @@ document.addEventListener('DOMContentLoaded', function () {
     textarea.selectionEnd = end + before.length;
   }
 
+  function insertText(textarea, text) {
+    if (!textarea) return;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const val = textarea.value;
+    textarea.value = val.slice(0, start) + text + val.slice(end);
+    textarea.focus();
+    textarea.selectionStart = textarea.selectionEnd = start + text.length;
+  }
+
   commentToolbar?.addEventListener('click', (e) => {
     const btn = e.target.closest('button[data-format]');
     if (!btn) return;
@@ -149,8 +159,12 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   inviteToolbar?.addEventListener('click', (e) => {
-    const btn = e.target.closest('button[data-format]');
+    const btn = e.target.closest('button[data-format],button[data-insert]');
     if (!btn) return;
+    if (btn.dataset.insert) {
+      insertText(inviteTextarea, btn.dataset.insert);
+      return;
+    }
     const fmt = btn.dataset.format;
     switch (fmt) {
       case 'h2':

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -51,7 +51,14 @@ class HelpController
         }
 
         if (!empty($cfg['inviteText'])) {
-            $cfg['inviteText'] = str_ireplace('[team]', 'Team´s', (string)$cfg['inviteText']);
+            $invite = str_ireplace('[team]', 'Team´s', (string)$cfg['inviteText']);
+            if ($event !== null) {
+                $invite = str_ireplace('[event_name]', (string)($event['name'] ?? ''), $invite);
+                $invite = str_ireplace('[event_start]', (string)($event['start_date'] ?? ''), $invite);
+                $invite = str_ireplace('[event_end]', (string)($event['end_date'] ?? ''), $invite);
+                $invite = str_ireplace('[event_description]', (string)($event['description'] ?? ''), $invite);
+            }
+            $cfg['inviteText'] = $invite;
         }
 
         return $view->render($response, 'help.twig', [

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -187,7 +187,7 @@ class QrController
             $ev = $this->events->getByUid($uid);
         }
         if ($ev === null) {
-            $ev = ['name' => '', 'description' => ''];
+            $ev = ['name' => '', 'start_date' => '', 'end_date' => '', 'description' => ''];
         }
         $title = (string)$ev['name'];
         $subtitle = (string)$ev['description'];
@@ -226,6 +226,10 @@ class QrController
                 $team = 'Team';
             }
             $invite = str_ireplace('[team]', $team, $invite);
+            $invite = str_ireplace('[event_name]', (string)($ev['name'] ?? ''), $invite);
+            $invite = str_ireplace('[event_start]', (string)($ev['start_date'] ?? ''), $invite);
+            $invite = str_ireplace('[event_end]', (string)($ev['end_date'] ?? ''), $invite);
+            $invite = str_ireplace('[event_description]', (string)($ev['description'] ?? ''), $invite);
             $pdf->SetFont('Arial', '', 11);
             $this->renderHtml($pdf, $invite, 'Arial', '', 11);
         }
@@ -263,7 +267,7 @@ class QrController
             $ev = $this->events->getByUid($uid);
         }
         if ($ev === null) {
-            $ev = ['name' => '', 'description' => ''];
+            $ev = ['name' => '', 'start_date' => '', 'end_date' => '', 'description' => ''];
         }
         $title = (string)$ev['name'];
         $subtitle = (string)$ev['description'];
@@ -319,6 +323,10 @@ class QrController
             $invite = (string)($cfg['inviteText'] ?? '');
             if ($invite !== '') {
                 $invite = str_ireplace('[team]', $team ?: 'Team', $invite);
+                $invite = str_ireplace('[event_name]', (string)($ev['name'] ?? ''), $invite);
+                $invite = str_ireplace('[event_start]', (string)($ev['start_date'] ?? ''), $invite);
+                $invite = str_ireplace('[event_end]', (string)($ev['end_date'] ?? ''), $invite);
+                $invite = str_ireplace('[event_description]', (string)($ev['description'] ?? ''), $invite);
                 $pdf->SetFont('Arial', '', 11);
                 $this->renderHtml($pdf, $invite, 'Arial', '', 11);
             }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -399,6 +399,11 @@
               <button class="uk-button uk-button-default" type="button" data-format="h5">H5</button>
               <button class="uk-button uk-button-default" type="button" data-format="bold"><strong>B</strong></button>
               <button class="uk-button uk-button-default" type="button" data-format="italic"><em>I</em></button>
+              <button class="uk-button uk-button-default" type="button" data-insert="[TEAM]">[TEAM]</button>
+              <button class="uk-button uk-button-default" type="button" data-insert="[EVENT_NAME]">[EVENT_NAME]</button>
+              <button class="uk-button uk-button-default" type="button" data-insert="[EVENT_START]">[EVENT_START]</button>
+              <button class="uk-button uk-button-default" type="button" data-insert="[EVENT_END]">[EVENT_END]</button>
+              <button class="uk-button uk-button-default" type="button" data-insert="[EVENT_DESCRIPTION]">[EVENT_DESCRIPTION]</button>
             </div>
             <textarea id="inviteTextTextarea" class="uk-textarea" rows="5" placeholder="Text eingeben..."></textarea>
             <div class="uk-flex uk-flex-right uk-margin-top">

--- a/tests/Controller/HelpControllerTest.php
+++ b/tests/Controller/HelpControllerTest.php
@@ -48,7 +48,13 @@ class HelpControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec("INSERT INTO config(inviteText) VALUES('Hallo [Team]!');");
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT' .
+            ');'
+        );
+        $pdo->exec("INSERT INTO events(uid,name,start_date,end_date,description) VALUES('1','Event','2024-01-01T10:00','2024-01-01T12:00','Desc')");
+        $pdo->exec("INSERT INTO config(inviteText, event_uid) VALUES('Hallo [Team], willkommen zu [EVENT_NAME] am [EVENT_START] bis [EVENT_END] - [EVENT_DESCRIPTION]!','1')");
 
         putenv('POSTGRES_DSN=sqlite:' . $dbFile);
         putenv('POSTGRES_USER=');
@@ -61,7 +67,8 @@ class HelpControllerTest extends TestCase
         $request = $this->createRequest('GET', '/help');
         $response = $app->handle($request);
 
-        $this->assertStringContainsString('Hallo Team´s!', (string)$response->getBody());
+        $expected = 'Hallo Team´s, willkommen zu Event am 2024-01-01T10:00 bis 2024-01-01T12:00 - Desc!';
+        $this->assertStringContainsString($expected, (string)$response->getBody());
 
         unlink($dbFile);
     }

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -124,11 +124,11 @@ class QrControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, name TEXT, description TEXT' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT' .
             ');'
         );
-        $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','Event','')");
-        $pdo->exec("INSERT INTO config(inviteText, event_uid) VALUES('Hallo [Team]!','1')");
+        $pdo->exec("INSERT INTO events(uid,name,start_date,end_date,description) VALUES('1','Event','2024-01-01T10:00','2024-01-01T12:00','Desc')");
+        $pdo->exec("INSERT INTO config(inviteText, event_uid) VALUES('Hallo [TEAM], willkommen zu [EVENT_NAME] am [EVENT_START] bis [EVENT_END] - [EVENT_DESCRIPTION]!','1')");
 
         $cfg = new \App\Service\ConfigService($pdo);
         $cfg->setActiveEventUid('1');
@@ -141,7 +141,8 @@ class QrControllerTest extends TestCase
         $response = $qr->pdf($req, new Response());
         $pdf = (string)$response->getBody();
 
-        $this->assertStringContainsString('Hallo Demo!', $pdf);
+        $expected = 'Hallo Demo, willkommen zu Event am 2024-01-01T10:00 bis 2024-01-01T12:00 - Desc!';
+        $this->assertStringContainsString($expected, $pdf);
         $this->assertStringContainsString('Event', $pdf);
     }
 


### PR DESCRIPTION
## Summary
- extend invitation text editor with buttons to insert new event placeholders
- support replacing event placeholders in help and PDF controllers
- update admin JavaScript to handle placeholder insertion
- add tests for new placeholders

## Testing
- `vendor/bin/phpunit` *(fails: Tests: 87, Assertions: 127, Errors: 19, Failures: 9, Warnings: 7, Deprecations: 16, PHPUnit Deprecations: 1, Notices: 12)*

------
https://chatgpt.com/codex/tasks/task_e_68790a01ed60832b8581e38f7c4a9334