### PR TITLE
Remove redundant password change form

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Unter `/admin` stehen folgende Tabs zur Verfügung:
 4. **Teams/Personen** – Teilnehmerlisten pflegen, optional als Login-Beschränkung.
 5. **Ergebnisse** – Spielstände einsehen und herunterladen.
 6. **Statistik** – Einzelne Antworten analysieren und nach Teams filtern.
-7. **Administration** – Passwort ändern und Backups verwalten.
+7. **Administration** – Benutzer und Backups verwalten.
 
 ### Fragenkataloge
 `data/kataloge/catalogs.json` listet verfügbare Kataloge mit `slug`, Name und optionaler QR-Code-Adresse. Die Reihenfolge wird durch das Feld `sort_order` bestimmt. Jede Frage speichert die zugehörige `catalog_uid`. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:
@@ -387,7 +387,6 @@ Teams oder Personen beschränken.
 
 
 ### Administration
-Ein POST auf `/password` speichert ein neues Admin-Passwort in `config.json`.
 Backups lassen sich über `/export` erstellen und per `/import` wiederherstellen.
 `GET /backups` listet alle Sicherungen, einzelne Ordner können über
 `/backups/{name}/download` heruntergeladen oder via `DELETE /backups/{name}`

--- a/docs-jtd/verwaltung.md
+++ b/docs-jtd/verwaltung.md
@@ -22,13 +22,13 @@ Unter `/admin` stehen folgende Tabs zur Verfügung:
 5. **Teams/Personen** – Teilnehmerlisten pflegen, optional als Login-Beschränkung.
 6. **Ergebnisse** – Spielstände einsehen und herunterladen.
 7. **Statistik** – Einzelne Antworten analysieren und nach Teams filtern.
-8. **Administration** – Passwort ändern und Backups verwalten.
+8. **Administration** – Benutzer und Backups verwalten.
 Der Statistik-Tab listet jede Antwort mit Name, Versuch, Katalog, Frage, Antwort, Richtig-Status und optionalem Beweisfoto. Über ein Auswahlfeld lassen sich die Daten nach Teams oder Personen filtern.
 
 
 ## Weitere Funktionen
 
-- **Administration:** Ein POST auf `/password` speichert ein neues Admin-Passwort in `config.json`. Über `/export` kann ein JSON-Backup erstellt und per `/import` wieder eingespielt werden. 
+- **Administration:** Über `/export` kann ein JSON-Backup erstellt und per `/import` wieder eingespielt werden.
   Die Route `/backups` listet vorhandene Sicherungen.
 - **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue Datei hochladen. Das Bild wird dabei im Ordner `data/` gespeichert, sodass PDFs es einbinden können.
 - **Ergebnisse exportieren:** Alle Resultate können als CSV-Datei heruntergeladen werden.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -9,7 +9,7 @@ Die Administrationsoberfl\u00e4che erreichen Sie \u00fcber `/admin` nach einem e
 5. **Teams/Personen** – Teilnehmerlisten pflegen und optional den Zugang einschränken.
 6. **Ergebnisse** – Spielstände einsehen und als CSV herunterladen.
 7. **Statistik** – Einzelne Antworten analysieren und nach Teams filtern.
-8. **Administration** – Passwort ändern und Backups verwalten.
+8. **Administration** – Benutzer und Backups verwalten.
 Im Tab "Administration" lassen sich JSON-Sicherungen exportieren und bei Bedarf wiederherstellen.
 Der Statistik-Tab listet jede Antwort mit Name, Versuch, Katalog, Frage, Antwort, Richtig-Status und optionalem Beweisfoto. Über ein Auswahlfeld lassen sich die Daten nach Teams oder Personen filtern.
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1593,12 +1593,8 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 
-  // --------- Passwort ändern ---------
-  const passSaveBtn = document.getElementById('passSaveBtn');
   const importJsonBtn = document.getElementById('importJsonBtn');
   const exportJsonBtn = document.getElementById('exportJsonBtn');
-  const newPass = document.getElementById('newPass');
-  const newPassRepeat = document.getElementById('newPassRepeat');
   const backupTableBody = document.getElementById('backupTableBody');
 
   function loadBackups() {
@@ -1670,35 +1666,6 @@ document.addEventListener('DOMContentLoaded', function () {
       .catch(() => {});
   }
 
-  passSaveBtn?.addEventListener('click', e => {
-    e.preventDefault();
-    if (!newPass || !newPassRepeat) return;
-    const p1 = newPass.value;
-    const p2 = newPassRepeat.value;
-    if (p1 === '' || p2 === '') {
-      notify('Passwort darf nicht leer sein', 'danger');
-      return;
-    }
-    if (p1 !== p2) {
-      notify('Passwörter stimmen nicht überein', 'danger');
-      return;
-    }
-    fetch('/password', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password: p1 })
-    })
-      .then(r => {
-        if (!r.ok) throw new Error(r.statusText);
-        notify('Passwort geändert', 'success');
-        newPass.value = '';
-        newPassRepeat.value = '';
-      })
-      .catch(err => {
-        console.error(err);
-      notify('Fehler beim Speichern', 'danger');
-    });
-  });
 
   importJsonBtn?.addEventListener('click', e => {
     e.preventDefault();

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -492,30 +492,7 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Administration</h2>
 
-        <h3 class="uk-heading-bullet">Passwort ändern</h3>
-        <form id="passForm" class="uk-form-stacked">
-          <div class="uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small" uk-grid>
-            <div>
-              <div class="uk-margin">
-                <label class="uk-form-label" for="newPass">Neues Passwort
-                  <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Neues Administrationspasswort festlegen.; pos: right"></span>
-                </label>
-                <div class="uk-form-controls"><input class="uk-input" type="password" id="newPass"></div>
-              </div>
-            </div>
-            <div>
-              <div class="uk-margin">
-                <label class="uk-form-label" for="newPassRepeat">Passwort wiederholen
-                  <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Passwort zur Bestätigung erneut eingeben.; pos: right"></span>
-                </label>
-                <div class="uk-form-controls"><input class="uk-input" type="password" id="newPassRepeat"></div>
-              </div>
-            </div>
-          </div>
-          <div class="uk-margin uk-flex uk-flex-right">
-            <button id="passSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Neues Passwort speichern; pos: right">Speichern</button>
-          </div>
-        </form>
+
 
         <h3 class="uk-heading-bullet">Benutzer</h3>
         <div class="uk-overflow-auto">


### PR DESCRIPTION
## Summary
- drop admin password change form in admin template and JS
- update documentation to reflect removal of password change UI

## Testing
- `vendor/bin/phpunit` *(fails: General error)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68790bead6c0832b8653c94b3dba3c63