### PR TITLE
Fix summary tab refresh

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1832,6 +1832,10 @@ document.addEventListener('DOMContentLoaded', function () {
         loadSummary();
       }
     });
+    const summaryIdx = 5;
+    adminTabs.children[summaryIdx]?.addEventListener('click', () => {
+      loadSummary();
+    });
     adminMenu.querySelectorAll('[data-tab]').forEach(item => {
       item.addEventListener('click', e => {
         e.preventDefault();
@@ -1839,6 +1843,9 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!isNaN(idx)) {
           tabControl.show(idx);
           if (adminNav) UIkit.offcanvas(adminNav).hide();
+          if (idx === summaryIdx) {
+            loadSummary();
+          }
         }
       });
     });


### PR DESCRIPTION
## Summary
- ensure Zusammenfassung tab refreshes whenever selected

## Testing
- `vendor/bin/phpunit` *(fails: no such column errors)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_687950818674832b9bb20b9a466bc089