### PR TITLE
Fix nginx reload and share vhost.d path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - certs:/etc/nginx/certs:rw
-      - vhostd:/etc/nginx/vhost.d
+      - ./vhost.d:/etc/nginx/vhost.d
       - htmldata:/usr/share/nginx/html
       - confd:/etc/nginx/conf.d
       - nginx_template:/etc/docker-gen/templates
@@ -53,7 +53,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - certs:/etc/nginx/certs:rw
       - acme:/etc/acme.sh
-      - vhostd:/etc/nginx/vhost.d
+      - ./vhost.d:/etc/nginx/vhost.d
       - htmldata:/usr/share/nginx/html
     networks:
       - webproxy
@@ -119,7 +119,6 @@ networks:
 
 volumes:
   certs:
-  vhostd:
   htmldata:
   confd:
   acme:

--- a/scripts/create_tenant.sh
+++ b/scripts/create_tenant.sh
@@ -28,4 +28,4 @@ curl -s -X POST \
 mkdir -p "$BASE_DIR/vhost.d"
 echo "client_max_body_size $CLIENT_MAX_BODY_SIZE;" > "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"
 
-docker compose exec nginx-proxy nginx -s reload
+docker compose exec nginx nginx -s reload

--- a/scripts/delete_tenant.sh
+++ b/scripts/delete_tenant.sh
@@ -24,4 +24,4 @@ curl -s -X DELETE \
 
 rm -f "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"
 
-docker compose exec nginx-proxy nginx -s reload
+docker compose exec nginx nginx -s reload


### PR DESCRIPTION
## Summary
- map `vhost.d` directory from repo for all proxy containers
- remove unused named volume
- reload nginx container correctly from tenant scripts

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit` *(fails: General error: 1 no such column: event_uid)*

------
https://chatgpt.com/codex/tasks/task_e_687964f2fe9c832b81f608f2afcf4ed6