### PR TITLE
Implement batch summary photo import

### DIFF
--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -129,10 +129,7 @@ class ImportController
         if (is_readable($summaryFile)) {
             $photos = json_decode((string)file_get_contents($summaryFile), true) ?? [];
             if (is_array($photos)) {
-                $svc = $this->summaryPhotos;
-                foreach ($photos as $p) {
-                    $svc->add((string)($p['name'] ?? ''), (string)($p['path'] ?? ''), (int)($p['time'] ?? 0));
-                }
+                $this->summaryPhotos->saveAll($photos);
             }
         }
 


### PR DESCRIPTION
## Summary
- add a `saveAll()` method for summary photos to replace data
- switch import controller to use the batch method
- test that repeated imports don't duplicate photos

## Testing
- `./vendor/bin/phpunit -c phpunit.xml tests/Controller/ImportControllerTest.php --filter testImportTwiceDoesNotDuplicateSummaryPhotos`
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: no such table errors)*
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795a1b9f00832bb7f762fe37ecc578