### PR TITLE
Update docs for vhost.d setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ Kopiere das Beispiel `vhost.d/example.com` und passe den Wert
 Die optionale Variable `CLIENT_MAX_BODY_SIZE` in `.env` liefert dabei nur
 einen Standardwert für Skripte wie `scripts/create_tenant.sh`.
 
+**Wichtig:** Beim ersten Start ist das Verzeichnis `vhost.d/` noch leer.
+Lege daher unbedingt die Datei `vhost.d/\${DOMAIN}` mit folgendem Inhalt an,
+damit Uploads bis zu 50&nbsp;MB funktionieren:
+
+```nginx
+client_max_body_size 50m;
+```
+
 Zum Start genügt:
 ```bash
 cp .env.template .env


### PR DESCRIPTION
## Summary
- document that `vhost.d/$DOMAIN` must contain `client_max_body_size 50m;` on first start

## Testing
- `composer install --no-interaction --prefer-dist`
- `vendor/bin/phpcs -q --standard=PSR12 src/`
- `vendor/bin/phpstan analyse src/ --no-progress --memory-limit=512M`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: General error: 1 no such column: event_uid)*


------
https://chatgpt.com/codex/tasks/task_e_687958582d0c832b8339815b6b17bea4