### PR TITLE
Fix spacing in admin upload prompt

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -82,7 +82,7 @@
                 <div class="uk-form-controls">
                   <div class="js-upload uk-placeholder uk-text-center">
                     <span uk-icon="icon: cloud-upload"></span>
-                    <span class="uk-text-middle">Datei hierher ziehen oder </span>
+                    <span class="uk-text-middle">Datei hierher ziehen oder&nbsp;</span>
                     <div uk-form-custom>
                       <input type="file" id="cfgLogoFile" accept="image/png,image/webp">
                       <span class="uk-link">auswählen</span>


### PR DESCRIPTION
## Summary
- ensure a non-breaking space after "Datei hierher ziehen oder" in admin upload prompt

## Testing
- `vendor/bin/phpunit` *(fails: Tests: 87, Errors: 19)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687969e05ef0832bb1ccbd6b47a89d3d