### PR TITLE
Fix logo path persistence

### DIFF
--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -177,6 +177,12 @@ class ConfigService
         $this->pdo->commit();
 
         $this->setActiveEventUid($uid);
+
+        $json = $this->getJson();
+        if ($json !== null) {
+            $path = dirname(__DIR__, 2) . '/data/config.json';
+            file_put_contents($path, $json . "\n");
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure that saving configuration also writes config.json

## Testing
- `vendor/bin/phpunit` *(fails: SQL errors)*

------
https://chatgpt.com/codex/tasks/task_e_68796d105d28832bb576a4e523b575f3