### PR TITLE
Fix logo path persistence

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -218,8 +218,9 @@ document.addEventListener('DOMContentLoaded', function () {
           bar.setAttribute('hidden', 'hidden');
         }, 1000);
         const file = cfgFields.logoFile.files && cfgFields.logoFile.files[0];
-                const ext = file && file.name.toLowerCase().endsWith('.webp') ? 'webp' : 'png';
-                cfgFields.logoPreview.src = withBase('/logo.' + ext) + '?' + Date.now();
+        const ext = file && file.name.toLowerCase().endsWith('.webp') ? 'webp' : 'png';
+        cfgInitial.logoPath = '/logo-' + activeEventUid + '.' + ext;
+        cfgFields.logoPreview.src = withBase(cfgInitial.logoPath) + '?' + Date.now();
         notify('Logo hochgeladen', 'success');
       }
     });
@@ -334,8 +335,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const data = Object.assign({}, cfgInitial, {
       logoPath: (function () {
         if (cfgFields.logoPreview && cfgFields.logoPreview.src) {
-          const m = cfgFields.logoPreview.src.match(/\/logo\.(png|webp)/);
-          if (m) return '/logo.' + m[1];
+          const m = cfgFields.logoPreview.src.match(/\/logo(?:-[\w-]+)?\.(png|webp)/);
+          if (m) return m[0];
         }
         return cfgInitial.logoPath;
       })(),


### PR DESCRIPTION
## Summary
- ensure uploaded logos are stored with active event UID on the client
- parse event-specific logo filenames when saving the config

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: no such column error)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6879796d22e4832bb71786ea6d4dc536