### PR TITLE
Fix admin backup API calls

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2,7 +2,12 @@
 document.addEventListener('DOMContentLoaded', function () {
   const basePath = window.basePath || '';
   const withBase = path => basePath + path;
-  const apiFetch = (path, options) => fetch(withBase(path), options);
+  const apiFetch = (path, options = {}) => {
+    return fetch(withBase(path), {
+      credentials: 'same-origin',
+      ...options
+    });
+  };
   function notify(msg, status = 'primary') {
     if (typeof UIkit !== 'undefined' && UIkit.notification) {
       UIkit.notification({ message: msg, status, pos: 'top-center', timeout: 2000 });


### PR DESCRIPTION
## Summary
- ensure admin uses session cookies for API requests

## Testing
- `vendor/bin/phpunit` *(fails: no such column errors)*

------
https://chatgpt.com/codex/tasks/task_e_687990c05268832b8e773fe063404d8e