### PR TITLE
Fix backup restore actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,10 +387,10 @@ Teams oder Personen beschränken.
 
 
 ### Administration
-Backups lassen sich über `/export` erstellen und per `/import` wiederherstellen.
-`GET /backups` listet alle Sicherungen, einzelne Ordner können über
-`/backups/{name}/download` heruntergeladen oder via `DELETE /backups/{name}`
-entfernt werden.
+Backups lassen sich über `/export` erstellen und per `/import` oder
+`/backups/{name}/restore` wiederherstellen. `GET /backups` listet alle
+Sicherungen, einzelne Ordner können über `/backups/{name}/download`
+heruntergeladen oder via `DELETE /backups/{name}` entfernt werden.
 
 ### Logo hochladen
 Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue PNG- oder WebP-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert. Die Datei landet im Verzeichnis `data/`, damit auch PDFs das Logo einbinden können.

--- a/docs-jtd/verwaltung.md
+++ b/docs-jtd/verwaltung.md
@@ -28,7 +28,7 @@ Der Statistik-Tab listet jede Antwort mit Name, Versuch, Katalog, Frage, Antwort
 
 ## Weitere Funktionen
 
-- **Administration:** Über `/export` kann ein JSON-Backup erstellt und per `/import` wieder eingespielt werden.
+- **Administration:** Über `/export` kann ein JSON-Backup erstellt werden. Eine Wiederherstellung ist per `/import` oder `/backups/{name}/restore` möglich.
   Die Route `/backups` listet vorhandene Sicherungen.
 - **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue Datei hochladen. Das Bild wird dabei im Ordner `data/` gespeichert, sodass PDFs es einbinden können.
 - **Ergebnisse exportieren:** Alle Resultate können als CSV-Datei heruntergeladen werden.

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1644,7 +1644,7 @@ document.addEventListener('DOMContentLoaded', function () {
           imp.className = 'uk-button uk-button-primary uk-margin-small-right';
           imp.textContent = 'Wiederherstellen';
           imp.addEventListener('click', () => {
-            apiFetch('/import/' + encodeURIComponent(name), { method: 'POST' })
+            apiFetch('/backups/' + encodeURIComponent(name) + '/restore', { method: 'POST' })
               .then(r => {
                 if (!r.ok) throw new Error(r.statusText);
                 notify('Import abgeschlossen', 'success');

--- a/src/routes.php
+++ b/src/routes.php
@@ -285,6 +285,11 @@ return function (\Slim\App $app) {
             ->getAttribute('backupController')
             ->download($request->withAttribute('name', $args['name']), $response);
     })->add(new RoleAuthMiddleware('admin'));
+    $app->post('/backups/{name}/restore', function (Request $request, Response $response, array $args) {
+        return $request
+            ->getAttribute('importController')
+            ->import($request->withAttribute('name', $args['name']), $response);
+    })->add(new RoleAuthMiddleware('admin'));
     $app->delete('/backups/{name}', function (Request $request, Response $response, array $args) {
         return $request
             ->getAttribute('backupController')


### PR DESCRIPTION
## Summary
- add API route for restoring backups
- wire restore button to new endpoint
- document new route in README and docs

## Testing
- `./vendor/bin/phpcs src/routes.php`
- `./vendor/bin/phpstan analyse src/routes.php --level=max` *(fails: Found 46 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879efeebae0832baa46cf7f330f52e7