### PR TITLE
Fix logo path routing

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -304,13 +304,13 @@ return function (\Slim\App $app) {
     $app->get('/invites.pdf', function (Request $request, Response $response) {
         return $request->getAttribute('qrController')->pdfAll($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
-    $app->get('/logo.png', function (Request $request, Response $response) {
+    $app->get('/{file:logo(?:-[\w-]+)?\.png}', function (Request $request, Response $response) {
         return $request->getAttribute('logoController')->get($request->withAttribute('ext', 'png'), $response);
     });
     $app->post('/logo.png', function (Request $request, Response $response) {
         return $request->getAttribute('logoController')->post($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
-    $app->get('/logo.webp', function (Request $request, Response $response) {
+    $app->get('/{file:logo(?:-[\w-]+)?\.webp}', function (Request $request, Response $response) {
         return $request->getAttribute('logoController')->get($request->withAttribute('ext', 'webp'), $response);
     });
     $app->post('/logo.webp', function (Request $request, Response $response) {


### PR DESCRIPTION
## Summary
- support event-specific logo filenames in routing
- test retrieving logos via dynamic filenames

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox` *(fails: no such table: events)*

------
https://chatgpt.com/codex/tasks/task_e_687a59518890832b80e36ccb9e363df7