### PR TITLE
Handle backup deletion errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ Backups lassen sich über `/export` erstellen und per `/import` oder
 `/backups/{name}/restore` wiederherstellen. `GET /backups` listet alle
 Sicherungen, einzelne Ordner können über `/backups/{name}/download`
 heruntergeladen oder via `DELETE /backups/{name}` entfernt werden.
+Damit das funktioniert, muss der Ordner `backup/` vom Serverprozess
+beschreibbar sein.
 
 ### Logo hochladen
 Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue PNG- oder WebP-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert. Die Datei landet im Verzeichnis `data/`, damit auch PDFs das Logo einbinden können.

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1673,10 +1673,15 @@ document.addEventListener('DOMContentLoaded', function () {
           del.addEventListener('click', () => {
             apiFetch('/backups/' + encodeURIComponent(name), { method: 'DELETE' })
               .then(r => {
-                if (!r.ok) throw new Error(r.statusText);
-                loadBackups();
+                if (r.ok) {
+                  loadBackups();
+                  return;
+                }
+                return r.json().then(data => {
+                  throw new Error(data.error || r.statusText);
+                });
               })
-              .catch(() => notify('Fehler beim Löschen', 'danger'));
+              .catch(err => notify(err.message || 'Fehler beim Löschen', 'danger'));
           });
           actionTd.appendChild(imp);
           actionTd.appendChild(dl);

--- a/src/Controller/BackupController.php
+++ b/src/Controller/BackupController.php
@@ -95,7 +95,19 @@ class BackupController
                 @unlink($file->getPathname());
             }
         }
-        @rmdir($path);
+
+        $ok = rmdir($path);
+        if (!$ok && is_dir($path)) {
+            $status = is_writable($path) && is_writable(dirname($path)) ? 500 : 403;
+            $message = $status === 403
+                ? 'Permission denied deleting backup directory'
+                : 'Failed to delete backup directory';
+            $response->getBody()->write(json_encode(['error' => $message]));
+            return $response
+                ->withStatus($status)
+                ->withHeader('Content-Type', 'application/json');
+        }
+
         return $response->withStatus(204);
     }
 }

--- a/tests/Controller/BackupControllerTest.php
+++ b/tests/Controller/BackupControllerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller {
+    function rmdir(string $dir): bool
+    {
+        return \Tests\Controller\BackupControllerTest::callRmdir($dir);
+    }
+}
+
+namespace Tests\Controller {
+
+    use App\Controller\BackupController;
+    use Slim\Psr7\Response;
+    use Tests\TestCase;
+
+    class BackupControllerTest extends TestCase
+    {
+        /** @var callable|null */
+        public static $rmdirCallback = null;
+
+        public static function callRmdir(string $dir): bool
+        {
+            if (self::$rmdirCallback !== null) {
+                return (self::$rmdirCallback)($dir);
+            }
+            return \rmdir($dir);
+        }
+
+        protected function tearDown(): void
+        {
+            self::$rmdirCallback = null;
+            parent::tearDown();
+        }
+
+        public function testDeleteSuccess(): void
+        {
+            $base = sys_get_temp_dir() . '/bct_' . uniqid();
+            mkdir($base . '/ok', 0777, true);
+            file_put_contents($base . '/ok/test.txt', 'a');
+
+            $controller = new BackupController($base);
+            $res = $controller->delete(
+                $this->createRequest('DELETE', '/backups/ok'),
+                new Response(),
+                ['name' => 'ok']
+            );
+
+            $this->assertEquals(204, $res->getStatusCode());
+            $this->assertDirectoryDoesNotExist($base . '/ok');
+            \rmdir($base);
+        }
+
+        public function testDeleteFailure(): void
+        {
+            $base = sys_get_temp_dir() . '/bct_' . uniqid();
+            mkdir($base . '/fail', 0777, true);
+            file_put_contents($base . '/fail/test.txt', 'a');
+
+            self::$rmdirCallback = fn(string $dir) => false;
+
+            $controller = new BackupController($base);
+            $res = $controller->delete(
+                $this->createRequest('DELETE', '/backups/fail'),
+                new Response(),
+                ['name' => 'fail']
+            );
+
+            $this->assertEquals(500, $res->getStatusCode());
+            $body = (string) $res->getBody();
+            $this->assertStringContainsString('delete backup directory', $body);
+
+            // cleanup
+            self::$rmdirCallback = null;
+            unlink($base . '/fail/test.txt');
+            \rmdir($base . '/fail');
+            \rmdir($base);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- handle removal errors in `BackupController`
- surface error message in admin UI
- mention writable `backup/` directory in README
- add `BackupControllerTest`

## Testing
- `composer exec -- phpunit` *(fails: Errors: 19, Failures: 10)*

------
https://chatgpt.com/codex/tasks/task_e_687d47f6d344832b8d628fea14b06c3a