### PR TITLE
Add MAIN_DOMAIN variable and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Bauen des Docker-Images nach
 `/usr/local/etc/php/conf.d/custom.ini` kopiert und automatisch geladen.
 Das `docker-compose.yml` bindet dieselbe Datei als Volume ein, sodass
 Änderungen ohne erneutes Bauen wirksam werden.
-Die verwendete Domain wird aus der Datei `.env` gelesen (Variable `DOMAIN`).
+Die verwendete Domain wird aus der Datei `.env` gelesen (Variablen `DOMAIN` oder `MAIN_DOMAIN`).
 Beim Start des Containers installiert ein Entrypoint-Skript automatisch alle
 Composer-Abhängigkeiten, sofern das Verzeichnis `vendor/` noch nicht existiert.
 Ein vorheriges `composer install` ist somit nicht mehr erforderlich,
@@ -202,8 +202,9 @@ php -m | grep exif
 ```
 
 Die Anwendung lädt beim Start eine vorhandene `.env`-Datei ein, auch wenn sie
-ohne Docker betrieben wird. Ist `DOMAIN` dort gesetzt, wird für QR-Codes und
-Exportlinks diese Adresse verwendet. Enthält die Variable kein Schema, wird
+ohne Docker betrieben wird. Ist `DOMAIN` oder `MAIN_DOMAIN` dort gesetzt,
+werden für QR-Codes und Exportlinks diese Adressen verwendet. Enthält die
+Variable kein Schema, wird
 standardmäßig `https://` vorangestellt.
 
 ## Multi-Tenant Setup
@@ -236,6 +237,7 @@ Let's-Encrypt-Zertifikat, sobald der Container gestartet wird.
 Weitere nützliche Variablen in `.env` sind:
 
 - `LETSENCRYPT_EMAIL` – Kontaktadresse für die automatische Zertifikatserstellung.
+- `MAIN_DOMAIN` – zentrale Domain des Quiz-Containers (z.B. `quizrace.app`).
 - `BASE_PATH` – optionaler Basis-Pfad, falls die Anwendung nicht im Root der Domain liegt.
 
 ## Anpassung

--- a/config/settings.php
+++ b/config/settings.php
@@ -30,4 +30,6 @@ $settings['postgres_pass'] = getenv('POSTGRES_PASSWORD')
     ?: getenv('POSTGRES_PASS')
     ?: ($settings['postgres_pass'] ?? null);
 
+$settings['main_domain'] = getenv('MAIN_DOMAIN') ?: ($settings['main_domain'] ?? null);
+
 return $settings;

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -38,7 +38,7 @@ toc: true
    php scripts/import_to_pgsql.php
    ```
 
- Das mitgelieferte `docker-compose.yml` startet die Anwendung samt Reverse Proxy. Daten werden dauerhaft in einem Volume gesichert, Beweisfotos bleiben als JPEG im Ordner `data/photos` erhalten. Dabei richtet die Anwendung Fotos, sofern möglich, anhand ihrer EXIF-Daten aus. Die Domain und weitere Parameter lassen sich über die Datei `.env` anpassen.
+ Das mitgelieferte `docker-compose.yml` startet die Anwendung samt Reverse Proxy. Daten werden dauerhaft in einem Volume gesichert, Beweisfotos bleiben als JPEG im Ordner `data/photos` erhalten. Dabei richtet die Anwendung Fotos, sofern möglich, anhand ihrer EXIF-Daten aus. Die Domain (`MAIN_DOMAIN`) und weitere Parameter lassen sich über die Datei `.env` anpassen.
 **Wichtig:** Damit Fotos automatisch gedreht werden können, muss die PHP-Erweiterung `exif` installiert und aktiviert sein. Prüfen lässt sich das mit:
 ```bash
 php -m | grep exif

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ curl -X DELETE http://$DOMAIN/tenants \
 Die Mandanten-Logik nutzt folgende Variablen aus `.env` oder `.env.template`:
 
 - `DOMAIN` legt die Basis-Domain für alle Mandanten fest.
+- `MAIN_DOMAIN` definiert die Hauptdomain des Quiz-Containers.
 - `POSTGRES_DSN`, `POSTGRES_USER` und `POSTGRES_PASSWORD` bestimmen den Datenbankzugang.
 
 ## Service-Accounts

--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,5 @@
 DOMAIN=example.com
+MAIN_DOMAIN=quizrace.app
 SLIM_VIRTUAL_HOST=example.com
 LETSENCRYPT_EMAIL=admin@example.com
 POSTGRES_DSN=pgsql:host=postgres;dbname=quiz


### PR DESCRIPTION
## Summary
- add `MAIN_DOMAIN` to sample.env
- load `MAIN_DOMAIN` in configuration
- document `MAIN_DOMAIN` in README and docs

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Tests: 89, Assertions: 130, Errors: 19)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687d5b451488832b9159cd374ce5f2dc