### PR TITLE
Add domain detection middleware

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -26,6 +26,7 @@ if (is_readable($envFile)) {
 use Slim\Views\Twig;
 use Slim\Views\TwigMiddleware;
 use App\Application\Middleware\SessionMiddleware;
+use App\Application\Middleware\DomainMiddleware;
 use App\Twig\UikitExtension;
 
 $settings = require __DIR__ . '/../config/settings.php';
@@ -38,6 +39,7 @@ $twig->addExtension(new UikitExtension());
 $twig->getEnvironment()->addGlobal('basePath', rtrim($basePath, '/'));
 $app->add(TwigMiddleware::create($app, $twig));
 $app->add(new SessionMiddleware());
+$app->add(new DomainMiddleware());
 
 $app->addErrorMiddleware((bool)($settings['displayErrorDetails'] ?? false), true, true);
 (require __DIR__ . '/../src/routes.php')($app);

--- a/src/Application/Middleware/DomainMiddleware.php
+++ b/src/Application/Middleware/DomainMiddleware.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Middleware;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
+
+/**
+ * Determines domain type based on request host.
+ */
+class DomainMiddleware implements MiddlewareInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(Request $request, RequestHandler $handler): Response
+    {
+        $host = $request->getUri()->getHost();
+        $mainDomain = getenv('MAIN_DOMAIN') ?: '';
+        $domainType = $host === $mainDomain ? 'main' : 'tenant';
+        $request = $request->withAttribute('domainType', $domainType);
+
+        return $handler->handle($request);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,6 +54,7 @@ class TestCase extends PHPUnit_TestCase
         $app->setBasePath($basePath);
         $app->add(TwigMiddleware::create($app, $twig));
         $app->add(new SessionMiddleware());
+        $app->add(new \App\Application\Middleware\DomainMiddleware());
 
         // Register error middleware
         $app->addErrorMiddleware((bool)($settings['displayErrorDetails'] ?? false), true, true);


### PR DESCRIPTION
## Summary
- implement DomainMiddleware to tag request with `domainType`
- register middleware in app bootstrap
- include middleware in test harness

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml src/Application/Middleware/DomainMiddleware.php public/index.php tests/TestCase.php`
- `vendor/bin/phpstan analyse --no-progress src/Application/Middleware/DomainMiddleware.php public/index.php`
- `vendor/bin/phpunit` *(fails: Tests: 91, Errors: 19, Failures: 10)*

------
https://chatgpt.com/codex/tasks/task_e_687d5bca49ec832bb6d6eaa10bbbab48