### PR TITLE
Add marketing controllers

### DIFF
--- a/src/Controller/Marketing/LandingController.php
+++ b/src/Controller/Marketing/LandingController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Marketing;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
+
+/**
+ * Displays the landing page for the marketing site.
+ */
+class LandingController
+{
+    /**
+     * Render the landing page.
+     */
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'marketing/landing.twig');
+    }
+}

--- a/src/Controller/Marketing/PricingController.php
+++ b/src/Controller/Marketing/PricingController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Marketing;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
+
+/**
+ * Displays the pricing page for the marketing site.
+ */
+class PricingController
+{
+    /**
+     * Render the pricing page.
+     */
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'marketing/pricing.twig');
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -37,6 +37,8 @@ use App\Controller\SummaryController;
 use App\Controller\EvidenceController;
 use App\Controller\EventController;
 use App\Controller\TenantController;
+use App\Controller\Marketing\LandingController;
+use App\Controller\Marketing\PricingController;
 use Psr\Log\NullLogger;
 use App\Controller\BackupController;
 use App\Domain\Roles;
@@ -66,6 +68,8 @@ require_once __DIR__ . '/Controller/EventController.php';
 require_once __DIR__ . '/Controller/BackupController.php';
 require_once __DIR__ . '/Controller/UserController.php';
 require_once __DIR__ . '/Controller/TenantController.php';
+require_once __DIR__ . '/Controller/Marketing/LandingController.php';
+require_once __DIR__ . '/Controller/Marketing/PricingController.php';
 
 use App\Infrastructure\Database;
 use App\Infrastructure\Migrations\Migrator;
@@ -170,6 +174,20 @@ return function (\Slim\App $app) {
     $app->get('/datenschutz', DatenschutzController::class);
     $app->get('/impressum', ImpressumController::class);
     $app->get('/lizenz', LizenzController::class);
+    $app->get('/landing', function (Request $request, Response $response) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(404);
+        }
+        $controller = new LandingController();
+        return $controller($request, $response);
+    });
+    $app->get('/pricing', function (Request $request, Response $response) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(404);
+        }
+        $controller = new PricingController();
+        return $controller($request, $response);
+    });
     $app->get('/login', [LoginController::class, 'show']);
     $app->post('/login', [LoginController::class, 'login']);
     $app->get('/logout', LogoutController::class);

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -1,0 +1,27 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Landing{% endblock %}
+
+{% block head %}
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+{% endblock %}
+
+{% block body_class %}uk-background-muted uk-padding{% endblock %}
+
+{% block body %}
+  {% embed 'topbar.twig' %}
+    {% block center %}
+      <span class="uk-navbar-title">Landing</span>
+    {% endblock %}
+  {% endembed %}
+  <div class="uk-container uk-container-small">
+    <h1 class="uk-heading-divider uk-hidden">Landing</h1>
+    <p class="uk-text-lead">Willkommen auf unserer Quiz-Plattform.</p>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ basePath }}/js/app.js"></script>
+{% endblock %}

--- a/templates/marketing/pricing.twig
+++ b/templates/marketing/pricing.twig
@@ -1,0 +1,27 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Pricing{% endblock %}
+
+{% block head %}
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+{% endblock %}
+
+{% block body_class %}uk-background-muted uk-padding{% endblock %}
+
+{% block body %}
+  {% embed 'topbar.twig' %}
+    {% block center %}
+      <span class="uk-navbar-title">Pricing</span>
+    {% endblock %}
+  {% endembed %}
+  <div class="uk-container uk-container-small">
+    <h1 class="uk-heading-divider uk-hidden">Pricing</h1>
+    <p class="uk-text-lead">Informationen zu unseren Preisen.</p>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ basePath }}/js/app.js"></script>
+{% endblock %}

--- a/tests/Controller/LandingControllerTest.php
+++ b/tests/Controller/LandingControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class LandingControllerTest extends TestCase
+{
+    public function testLandingPage(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/landing');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testLandingPageTenant(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/landing');
+        $request = $request->withUri($request->getUri()->withHost('tenant.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(404, $response->getStatusCode());
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+}

--- a/tests/Controller/PricingControllerTest.php
+++ b/tests/Controller/PricingControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class PricingControllerTest extends TestCase
+{
+    public function testPricingPage(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/pricing');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testPricingPageTenant(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/pricing');
+        $request = $request->withUri($request->getUri()->withHost('tenant.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(404, $response->getStatusCode());
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `LandingController` and `PricingController`
- add simple Twig views under `templates/marketing`
- wire up routes guarded by `domainType` in `src/routes.php`
- test that marketing pages are unavailable for tenants

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpcs`
- `vendor/bin/phpstan --memory-limit=256M`
- `vendor/bin/phpunit` *(fails: Errors: 19, Failures: 10)*

------
https://chatgpt.com/codex/tasks/task_e_687d5d2525b4832bb73c80c0e36388f2