### PR TITLE
Check domain type for tenant routes

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -263,9 +263,15 @@ return function (\Slim\App $app) {
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
 
     $app->post('/tenants', function (Request $request, Response $response) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(403);
+        }
         return $request->getAttribute('tenantController')->create($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
     $app->delete('/tenants', function (Request $request, Response $response) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(403);
+        }
         return $request->getAttribute('tenantController')->delete($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
 

--- a/tests/Controller/TenantControllerTest.php
+++ b/tests/Controller/TenantControllerTest.php
@@ -98,4 +98,42 @@ class TenantControllerTest extends TestCase
         session_destroy();
         unlink($db);
     }
+
+    public function testCreateForbiddenOnTenantDomain(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $req = $this->createRequest('POST', '/tenants');
+        $req = $req->withUri($req->getUri()->withHost('tenant.test'));
+        $res = $app->handle($req);
+        $this->assertEquals(403, $res->getStatusCode());
+        session_destroy();
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+
+    public function testDeleteForbiddenOnTenantDomain(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $req = $this->createRequest('DELETE', '/tenants');
+        $req = $req->withUri($req->getUri()->withHost('tenant.test'));
+        $res = $app->handle($req);
+        $this->assertEquals(403, $res->getStatusCode());
+        session_destroy();
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- restrict `/tenants` routes to main domain only
- test POST and DELETE `/tenants` behavior on tenant domains

## Testing
- `vendor/bin/phpunit` *(fails: Errors: 19, Failures: 10)*

------
https://chatgpt.com/codex/tasks/task_e_687d6d1666b0832b918ffc8b395a1c78