### PR TITLE
Add domain access tests

### DIFF
--- a/tests/Controller/DomainAccessTest.php
+++ b/tests/Controller/DomainAccessTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class DomainAccessTest extends TestCase
+{
+    public function testMarketingRoutesOnMainDomain(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/landing');
+        $request = $request->withUri($request->getUri()->withHost('main.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+
+    public function testTenantApiRejectedOnSubdomain(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $request = $this->createRequest('POST', '/tenants');
+        $request = $request->withUri($request->getUri()->withHost('tenant.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(403, $response->getStatusCode());
+        session_destroy();
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add DomainAccessTest to verify marketing pages only open on `MAIN_DOMAIN`
- assert tenant API returns 403 on tenant subdomains

## Testing
- `vendor/bin/phpunit --filter DomainAccessTest --stop-on-error --stop-on-failure`
- `vendor/bin/phpunit --stop-on-error --stop-on-failure` *(fails: CatalogControllerTest::testGetNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_687d6efa8468832b86d93c228eeb45b2