### PR TITLE
Fix newline at end of DomainAccessTest

### DIFF
--- a/tests/Controller/DomainAccessTest.php
+++ b/tests/Controller/DomainAccessTest.php
@@ -43,4 +43,3 @@ class DomainAccessTest extends TestCase
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- remove the superfluous blank line at the end of `DomainAccessTest.php`

## Testing
- `vendor/bin/phpcs tests/Controller/DomainAccessTest.php`

------
https://chatgpt.com/codex/tasks/task_e_687d7a064dd4832bb81239341f272530