### PR TITLE
Fix schema definitions in tests

### DIFF
--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -28,7 +28,8 @@ class CatalogControllerTest extends TestCase
                 description TEXT,
                 qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
-                comment TEXT
+                comment TEXT,
+                event_uid TEXT
             );
             SQL
         );
@@ -75,7 +76,8 @@ class CatalogControllerTest extends TestCase
                 description TEXT,
                 qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
-                comment TEXT
+                comment TEXT,
+                event_uid TEXT
             );
             SQL
         );
@@ -126,7 +128,8 @@ class CatalogControllerTest extends TestCase
                 description TEXT,
                 qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
-                comment TEXT
+                comment TEXT,
+                event_uid TEXT
             );
             SQL
         );
@@ -186,7 +189,8 @@ class CatalogControllerTest extends TestCase
                 description TEXT,
                 qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
-                comment TEXT
+                comment TEXT,
+                event_uid TEXT
             );
             SQL
         );
@@ -245,7 +249,8 @@ class CatalogControllerTest extends TestCase
                 description TEXT,
                 qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
-                comment TEXT
+                comment TEXT,
+                event_uid TEXT
             );
             SQL
         );
@@ -304,7 +309,8 @@ class CatalogControllerTest extends TestCase
                 description TEXT,
                 qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
-                comment TEXT
+                comment TEXT,
+                event_uid TEXT
             );
             SQL
         );

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -38,7 +38,8 @@ class ResultControllerTest extends TestCase
                 puzzleWordEnabled INTEGER,
                 puzzleWord TEXT,
                 puzzleFeedback TEXT,
-                inviteText TEXT
+                inviteText TEXT,
+                event_uid TEXT
             );
             SQL
         );
@@ -48,6 +49,18 @@ class ResultControllerTest extends TestCase
             ');'
         );
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','Event','Sub')");
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, description TEXT,' .
+            ' qrcode_url TEXT, raetsel_buchstabe TEXT, event_uid TEXT' .
+            ');'
+        );
+        $pdo->exec(
+            'CREATE TABLE questions(' .
+            'id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER,' .
+            ' type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT' .
+            ');'
+        );
         $pdo->exec(
             <<<'SQL'
             CREATE TABLE results(
@@ -59,7 +72,8 @@ class ResultControllerTest extends TestCase
                 total INTEGER NOT NULL,
                 time INTEGER NOT NULL,
                 puzzleTime INTEGER,
-                photo TEXT
+                photo TEXT,
+                event_uid TEXT
             );
             SQL
         );
@@ -75,7 +89,8 @@ class ResultControllerTest extends TestCase
                 correct INTEGER NOT NULL,
                 answer_text TEXT,
                 photo TEXT,
-                consent BOOLEAN
+                consent BOOLEAN,
+                event_uid TEXT
             );
             SQL
         );
@@ -152,10 +167,22 @@ class ResultControllerTest extends TestCase
             "INSERT INTO events(uid,name,description) VALUES('1','First','A'),('2','Second','B')"
         );
         $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, description TEXT,' .
+            ' qrcode_url TEXT, raetsel_buchstabe TEXT, event_uid TEXT' .
+            ');'
+        );
+        $pdo->exec(
+            'CREATE TABLE questions(' .
+            'id INTEGER PRIMARY KEY AUTOINCREMENT, catalog_uid TEXT NOT NULL, sort_order INTEGER,' .
+            ' type TEXT NOT NULL, prompt TEXT NOT NULL, options TEXT, answers TEXT, terms TEXT, items TEXT' .
+            ');'
+        );
+        $pdo->exec(
             'CREATE TABLE results(' .
             'id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, ' .
             'attempt INTEGER NOT NULL, correct INTEGER NOT NULL, total INTEGER NOT NULL, ' .
-            'time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT' .
+            'time INTEGER NOT NULL, puzzleTime INTEGER, photo TEXT, event_uid TEXT' .
             ');'
         );
         $pdo->exec(
@@ -165,7 +192,7 @@ class ResultControllerTest extends TestCase
             'CREATE TABLE question_results(' .
             'id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, catalog TEXT NOT NULL, ' .
             'question_id INTEGER NOT NULL, attempt INTEGER NOT NULL, correct INTEGER NOT NULL, ' .
-            'answer_text TEXT, photo TEXT, consent BOOLEAN' .
+            'answer_text TEXT, photo TEXT, consent BOOLEAN, event_uid TEXT' .
             ');'
         );
         $pdo->exec(

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -31,6 +31,11 @@ class ResultServiceTest extends TestCase
             );
             SQL
         );
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
@@ -62,6 +67,11 @@ class ResultServiceTest extends TestCase
             );
             SQL
         );
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
@@ -92,6 +102,11 @@ class ResultServiceTest extends TestCase
                 event_uid TEXT
             );
             SQL
+        );
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
         );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
@@ -125,6 +140,11 @@ class ResultServiceTest extends TestCase
             );
             SQL
         );
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
@@ -156,6 +176,11 @@ class ResultServiceTest extends TestCase
             );
             SQL
         );
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
         $service = new ResultService($pdo, $cfg);
@@ -186,6 +211,11 @@ class ResultServiceTest extends TestCase
             );
             SQL
         );
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $pdo->exec(
             <<<'SQL'
@@ -198,7 +228,8 @@ class ResultServiceTest extends TestCase
                 correct INTEGER NOT NULL,
                 answer_text TEXT,
                 photo TEXT,
-                consent INTEGER
+                consent INTEGER,
+                event_uid TEXT
             );
             SQL
         );
@@ -209,7 +240,8 @@ class ResultServiceTest extends TestCase
                 sort_order INTEGER,
                 slug TEXT,
                 file TEXT,
-                name TEXT
+                name TEXT,
+                event_uid TEXT
             );
             SQL
         );
@@ -265,6 +297,11 @@ class ResultServiceTest extends TestCase
             );
             SQL
         );
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $pdo->exec(
             <<<'SQL'
@@ -277,7 +314,8 @@ class ResultServiceTest extends TestCase
                 correct INTEGER NOT NULL,
                 answer_text TEXT,
                 photo TEXT,
-                consent INTEGER
+                consent INTEGER,
+                event_uid TEXT
             );
             SQL
         );
@@ -320,7 +358,8 @@ class ResultServiceTest extends TestCase
                 sort_order INTEGER,
                 slug TEXT,
                 file TEXT,
-                name TEXT
+                name TEXT,
+                event_uid TEXT
             );
             SQL
         );

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -18,7 +18,30 @@ class TenantServiceTest extends TestCase
         if (!is_dir($dir)) {
             mkdir($dir);
         }
-        file_put_contents($dir . '/001.sql', 'CREATE TABLE sample(id INTEGER);');
+        $sql = <<<'SQL'
+CREATE TABLE events(uid TEXT PRIMARY KEY);
+CREATE TABLE catalogs(
+    uid TEXT PRIMARY KEY,
+    sort_order INTEGER,
+    slug TEXT,
+    file TEXT,
+    name TEXT,
+    event_uid TEXT
+);
+CREATE TABLE question_results(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    catalog TEXT,
+    question_id INTEGER,
+    attempt INTEGER,
+    correct INTEGER,
+    answer_text TEXT,
+    photo TEXT,
+    consent INTEGER,
+    event_uid TEXT
+);
+SQL;
+        file_put_contents($dir . '/20240910_base_schema.sql', $sql);
         return new TenantService($pdo, $dir);
     }
 


### PR DESCRIPTION
## Summary
- expand catalog table definitions in CatalogControllerTest
- include event_uid and extra fields in ResultControllerTest schemas
- add missing catalogs tables in ResultServiceTest
- create minimal base schema for TenantServiceTest migrations

## Testing
- `vendor/bin/phpunit` *(fails: 4 errors, 14 failures but no missing table errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d7bfe3054832b8500231bdb98e61d