### PR TITLE
Fix UploadedFile usage in tests

### DIFF
--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -82,8 +82,13 @@ class QrControllerTest extends TestCase
 
         $logoFile = tempnam(sys_get_temp_dir(), 'logo');
         imagepng(imagecreatetruecolor(10, 10), $logoFile);
-        $stream = fopen($logoFile, 'rb');
-        $uploaded = new UploadedFile($stream, filesize($logoFile), UPLOAD_ERR_OK, 'logo.png', 'image/png');
+        $uploaded = new UploadedFile(
+            $logoFile,
+            'logo.png',
+            'image/png',
+            filesize($logoFile),
+            UPLOAD_ERR_OK
+        );
         $upReq = $this->createRequest('POST', '/logo.png')->withUploadedFiles(['file' => $uploaded]);
         $logo->post($upReq, new Response());
 
@@ -249,7 +254,8 @@ class QrControllerTest extends TestCase
         $cfg = new \App\Service\ConfigService($pdo);
         $teams = new \App\Service\TeamService($pdo, $cfg);
         $events = new \App\Service\EventService($pdo);
-        $qr = new \App\Controller\QrController($cfg, $teams, $events);
+        $catalogs = new \App\Service\CatalogService($pdo, $cfg);
+        $qr = new \App\Controller\QrController($cfg, $teams, $events, $catalogs);
 
         $cfg->setActiveEventUid('1');
         $req = $this->createRequest('GET', '/qr.pdf')->withQueryParams(['t' => 'Demo']);


### PR DESCRIPTION
## Summary
- fix UploadedFile instantiation with filename
- ensure QrController is constructed with all required services
- run PHPUnit on the PdfUsesUploadedLogo test

## Testing
- `./vendor/bin/phpcs src/`
- `./vendor/bin/phpstan analyse src/ --no-progress --memory-limit=256M`
- `./vendor/bin/phpunit --filter testPdfUsesUploadedLogo tests/Controller/QrControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_687dcfa3b970832ba27d957833d40916