### PR TITLE
Fix Config and Home controller tests

### DIFF
--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -52,6 +52,9 @@ class ConfigControllerTest extends TestCase
         $service = new ConfigService($pdo);
         $controller = new ConfigController($service);
 
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'event-manager'];
+
         $request = $this->createRequest('POST', '/config.json', ['HTTP_CONTENT_TYPE' => 'application/json']);
         $stream = fopen('php://temp', 'r+');
         fwrite($stream, '{invalid');


### PR DESCRIPTION
## Summary
- start a session in ConfigControllerTest so invalid JSON returns the correct status
- prepare database and seed a catalog entry in HomeControllerTest

## Testing
- `./vendor/bin/phpunit tests/Controller/ConfigControllerTest.php tests/Controller/HomeControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_687dcf8e6614832b8883bca7019ab926