### PR TITLE
Fix duplicate table setup in ResultService tests

### DIFF
--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -235,18 +235,6 @@ class ResultServiceTest extends TestCase
         );
         $pdo->exec(
             <<<'SQL'
-            CREATE TABLE catalogs(
-                uid TEXT PRIMARY KEY,
-                sort_order INTEGER,
-                slug TEXT,
-                file TEXT,
-                name TEXT,
-                event_uid TEXT
-            );
-            SQL
-        );
-        $pdo->exec(
-            <<<'SQL'
             CREATE TABLE questions(
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 catalog_uid TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- remove a duplicated `CREATE TABLE catalogs` block from `ResultServiceTest`

## Testing
- `vendor/bin/phpunit` *(fails: Errors: 3, Failures: 14)*

------
https://chatgpt.com/codex/tasks/task_e_687dcfa7a9a8832ba6cb03374bfc9966