### PR TITLE
Implement validation for backup deletion

### DIFF
--- a/src/Controller/BackupController.php
+++ b/src/Controller/BackupController.php
@@ -80,6 +80,9 @@ class BackupController
     public function delete(Request $request, Response $response, array $args): Response
     {
         $name = basename((string)($args['name'] ?? ''));
+        if (!preg_match('/^[A-Za-z0-9._-]+$/', $name) || $name === '.' || $name === '..') {
+            return $response->withStatus(400);
+        }
         $path = $this->dir . '/' . $name;
         if (!is_dir($path)) {
             return $response->withStatus(404);

--- a/tests/Controller/BackupControllerTest.php
+++ b/tests/Controller/BackupControllerTest.php
@@ -77,5 +77,22 @@ namespace Tests\Controller {
             \rmdir($base . '/fail');
             \rmdir($base);
         }
+
+        public function testDeleteInvalidName(): void
+        {
+            $base = sys_get_temp_dir() . '/bct_' . uniqid();
+            mkdir($base, 0777, true);
+
+            $controller = new BackupController($base);
+            $res = $controller->delete(
+                $this->createRequest('DELETE', '/backups/..'),
+                new Response(),
+                ['name' => '..']
+            );
+
+            $this->assertEquals(400, $res->getStatusCode());
+
+            \rmdir($base);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate backup name prior to deletion
- add test ensuring invalid names return 400

## Testing
- `vendor/bin/phpunit --filter=testDeleteInvalidName --testdox` *(fails: PHPUnit deprecation notice)*

------
https://chatgpt.com/codex/tasks/task_e_687dd98cc5b4832ba1d7d967af16b73e