### PR TITLE
Update backup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,8 @@ Backups lassen sich über `/export` erstellen und per `/import` oder
 Sicherungen, einzelne Ordner können über `/backups/{name}/download`
 heruntergeladen oder via `DELETE /backups/{name}` entfernt werden.
 Damit das funktioniert, muss der Ordner `backup/` vom Serverprozess
-beschreibbar sein.
+beschreibbar sein. Beim Aufruf per `curl` oder anderen Tools müssen Namen mit
+Sonderzeichen (Leerzeichen, Doppelpunkte etc.) URL-kodiert werden.
 
 ### Logo hochladen
 Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue PNG- oder WebP-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert. Die Datei landet im Verzeichnis `data/`, damit auch PDFs das Logo einbinden können.


### PR DESCRIPTION
## Summary
- note that backup names with special characters must be URL encoded when using command-line tools

## Testing
- `vendor/bin/phpunit` *(fails: Errors: 1, Failures: 12)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687dd999aa1c832ba9b6196020978459