### PR TITLE
Fix long regex line in results ranking test

### DIFF
--- a/tests/test_results_rankings.js
+++ b/tests/test_results_rankings.js
@@ -4,7 +4,10 @@ const assert = require('assert');
 
 const code = fs.readFileSync('public/js/results.js', 'utf8');
 const fmtMatch = code.match(/function formatTime\(ts\)[\s\S]*?\n\s*\}/);
-const rankMatch = code.match(/function computeRankings\(rows\) \{[\s\S]*?return { puzzleList, catalogList, pointsList };\n\s*\}/);
+const rankPattern =
+    'function computeRankings\\(rows\\) \\{' +
+    '[\\s\\S]*?return { puzzleList, catalogList, pointsList };\\n\\s*\\}';
+const rankMatch = code.match(new RegExp(rankPattern));
 if (!fmtMatch || !rankMatch) {
     throw new Error('Functions not found');
 }


### PR DESCRIPTION
## Summary
- split ranking regex pattern in test_results_rankings.js for readability

## Testing
- `node tests/test_results_rankings.js`
- `node tests/test_competition_mode.js`
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_687de11147ec832ba292743b2dfad281