### PR TITLE
Create catalog automatically on POST

### DIFF
--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -89,6 +89,9 @@ class CatalogController
             return $response->withStatus(400);
         }
 
+        if ($this->service->slugByFile($file) === null) {
+            $this->service->createCatalog($file);
+        }
         $this->service->write($file, $data);
 
         return $response->withStatus(204);


### PR DESCRIPTION
## Summary
- create catalog entry if POSTed file doesn't exist
- update `CatalogController` to use the new helper
- simplify `CatalogControllerTest` and rely solely on POST for creation

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: ConfigServiceTest, ResultServiceTest)*

------
https://chatgpt.com/codex/tasks/task_e_687de2c25ea0832b870e4afaa155eacf