### PR TITLE
Replace file checks with DB assertions in Catalog tests

### DIFF
--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -219,7 +219,9 @@ class CatalogControllerTest extends TestCase
         $createReq = $this->createRequest('PUT', '/kataloge/new.json');
         $createRes = $controller->create($createReq, new Response(), ['file' => 'new.json']);
         $this->assertEquals(204, $createRes->getStatusCode());
-        $this->assertFileExists($dir . '/new.json');
+        $stmt = $pdo->prepare('SELECT COUNT(*) FROM catalogs WHERE file=? OR slug=?');
+        $stmt->execute(['new.json', 'new']);
+        $this->assertSame('1', $stmt->fetchColumn());
 
         $deleteRes = $controller->delete(
             $this->createRequest('DELETE', '/kataloge/new.json'),
@@ -227,7 +229,9 @@ class CatalogControllerTest extends TestCase
             ['file' => 'new.json']
         );
         $this->assertEquals(204, $deleteRes->getStatusCode());
-        $this->assertFileDoesNotExist($dir . '/new.json');
+        $stmt = $pdo->prepare('SELECT COUNT(*) FROM catalogs WHERE file=? OR slug=?');
+        $stmt->execute(['new.json', 'new']);
+        $this->assertSame('0', $stmt->fetchColumn());
 
         rmdir($dir);
         session_destroy();


### PR DESCRIPTION
## Summary
- update `CatalogControllerTest` to verify creation and deletion via database

## Testing
- `composer install`
- `vendor/bin/phpunit --filter CatalogControllerTest tests/Controller/CatalogControllerTest.php` *(fails: Failed asserting that 0 is identical to '1')*

------
https://chatgpt.com/codex/tasks/task_e_687de2dbe468832b8bdd9280a7221595