### PR TITLE
Improve mobile layout for events

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -463,4 +463,93 @@ body.dark-mode .sticky-actions {
   }
 }
 
+/* Floating action buttons */
+.fab {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 1100;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+.fab-save {
+  bottom: 4.5rem;
+}
+
+/* Hide button text on small screens */
+.button-text {
+  margin-left: 6px;
+}
+@media (max-width: 639px) {
+  .button-text {
+    display: none;
+  }
+}
+
+/* Toggle switch */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.4s;
+  border-radius: 22px;
+}
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+.switch input:checked + .slider {
+  background-color: #39f;
+}
+.switch input:checked + .slider:before {
+  transform: translateX(18px);
+}
+
+/* Responsive event list */
+@media (max-width: 639px) {
+  #eventsList,
+  #eventsList tr,
+  #eventsList td {
+    display: block;
+  }
+  #eventsList tr {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+  #eventsList td {
+    padding: 4px 0;
+  }
+  #eventsList td:first-child {
+    display: none;
+  }
+  #eventsList input[type="text"],
+  #eventsList input[type="datetime-local"] {
+    width: 100%;
+  }
+}
+
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1277,21 +1277,26 @@ document.addEventListener('DOMContentLoaded', function () {
     descCell.appendChild(descInput);
 
     const activateCell = document.createElement('td');
-    const activateBtn = document.createElement('button');
-    activateBtn.className = 'uk-button uk-button-default';
-    activateBtn.textContent = ev.uid === activeEventUid ? 'Aktiv' : 'Aktivieren';
-    if (ev.uid === activeEventUid) {
-      activateBtn.disabled = true;
-    }
-    activateBtn.addEventListener('click', () => {
-      setActiveEvent(row.dataset.uid, nameInput.value.trim());
+    const activateLabel = document.createElement('label');
+    activateLabel.className = 'switch';
+    const activateInput = document.createElement('input');
+    activateInput.type = 'checkbox';
+    activateInput.checked = ev.uid === activeEventUid;
+    const activateSlider = document.createElement('span');
+    activateSlider.className = 'slider';
+    activateInput.addEventListener('change', () => {
+      if (activateInput.checked) {
+        setActiveEvent(row.dataset.uid, nameInput.value.trim());
+      }
     });
-    activateCell.appendChild(activateBtn);
+    activateLabel.appendChild(activateInput);
+    activateLabel.appendChild(activateSlider);
+    activateCell.appendChild(activateLabel);
 
     const delCell = document.createElement('td');
     const del = document.createElement('button');
-    del.className = 'uk-button uk-button-danger';
-    del.textContent = '×';
+    del.className = 'uk-icon-button uk-button-danger';
+    del.setAttribute('uk-icon', 'trash');
     del.setAttribute('aria-label', 'Löschen');
     del.addEventListener('click', () => {
       if (confirm('Veranstaltung wirklich löschen? Dabei werden auch alle angelegten Kataloge, Fragen und Teams entfernt.')) {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -62,10 +62,10 @@
           </table>
         </div>
         <div class="uk-margin">
-          <button id="eventAddBtn" class="uk-button uk-button-default" uk-tooltip="title: Neue Veranstaltung anlegen; pos: right">Hinzufügen</button>
+          <button id="eventAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neue Veranstaltung anlegen; pos: left"><span class="button-text">Hinzufügen</span></button>
         </div>
         <div class="uk-margin uk-flex uk-flex-right">
-          <button id="eventsSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Änderungen speichern; pos: right">Speichern</button>
+          <button id="eventsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Änderungen speichern; pos: left"><span class="button-text">Speichern</span></button>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- style events list as cards on small screens
- add switch-style toggle for activating events
- convert delete buttons to icon buttons
- make add/save buttons floating on mobile

## Testing
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: errors and failures)*

------
https://chatgpt.com/codex/tasks/task_e_687e6626d43c832b8a407aa80692f2c2