### PR TITLE
Remove extra menu in admin mobile view

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -12,6 +12,8 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}{% endblock %}
+    {% block offcanvas %}{% endblock %}
     {% block left %}
       <a id="adminMenuToggle" class="uk-icon-button" uk-icon="icon: menu; ratio: 2" aria-label="Menü" uk-toggle="target: #adminNav"></a>
     {% endblock %}

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,8 +1,10 @@
 <nav class="uk-navbar-container uk-padding-small topbar" uk-navbar>
   <div class="uk-navbar-left">
+    {% block mobile_menu_toggle %}
     <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
       <span uk-navbar-toggle-icon></span>
     </a>
+    {% endblock %}
     <div class="uk-navbar-item">
       {% block left %}{% endblock %}
     </div>
@@ -18,6 +20,7 @@
     </div>
   </div>
 </nav>
+{% block offcanvas %}
 <div id="offcanvas-nav" uk-offcanvas="overlay: true">
   <div class="uk-offcanvas-bar">
     <ul class="uk-nav uk-nav-default">
@@ -28,5 +31,6 @@
     </ul>
   </div>
 </div>
+{% endblock %}
 {% block headerbar %}{% endblock %}
 <div class="nav-placeholder"></div>


### PR DESCRIPTION
## Summary
- allow hiding the landing page offcanvas menu
- disable offcanvas menu in admin layout

## Testing
- `vendor/bin/phpunit` *(fails: 1 error, 10 failures)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_687e71f0eb10832bbabacbf0a0ffd9c5