### PR TITLE
Improve admin event table usability

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -527,6 +527,19 @@ body.dark-mode .sticky-actions {
   transform: translateX(18px);
 }
 
+/* Event list enhancements */
+#eventsList .event-row.active-event {
+  background-color: #e7f9e7;
+}
+#eventsList td {
+  padding: 8px 4px;
+}
+#eventsList .row-num {
+  width: 3ch;
+  text-align: right;
+  color: #555;
+}
+
 /* Responsive event list */
 @media (max-width: 639px) {
   #eventsList,
@@ -544,7 +557,13 @@ body.dark-mode .sticky-actions {
     padding: 4px 0;
   }
   #eventsList td:first-child {
-    display: none;
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    display: block;
+  }
+  #eventsList tr {
+    position: relative;
   }
   #eventsList input[type="text"],
   #eventsList input[type="datetime-local"] {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -52,6 +52,7 @@
             <thead>
               <tr>
                 <th><span uk-icon="icon: question" uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></span></th>
+                <th>Nr.</th>
                 <th>Name</th>
                 <th>Beginn</th>
                 <th>Ende</th>


### PR DESCRIPTION
## Summary
- add row numbers column to event table
- highlight active event row and tweak spacing
- add calendar icons and placeholders to date inputs
- show drag handle on mobile and position it top-right
- add 'Aktivieren' tooltip and update event row numbers dynamically

## Testing
- `vendor/bin/phpunit` *(fails: 1 error, 11 failures)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpcs`

------
https://chatgpt.com/codex/tasks/task_e_687e7f50504c832b8556d5f09ea10342