### PR TITLE
Fix migration script env handling

### DIFF
--- a/scripts/run_migrations.php
+++ b/scripts/run_migrations.php
@@ -4,6 +4,20 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+// Load environment variables from .env if available
+$envFile = __DIR__ . '/../.env';
+if (is_readable($envFile)) {
+    $vars = parse_ini_file($envFile, false, INI_SCANNER_RAW);
+    if (is_array($vars)) {
+        foreach ($vars as $key => $value) {
+            if (getenv($key) === false) {
+                putenv($key . '=' . $value);
+                $_ENV[$key] = $value;
+            }
+        }
+    }
+}
+
 use App\Infrastructure\Database;
 use App\Infrastructure\Migrations\Migrator;
 


### PR DESCRIPTION
## Summary
- load variables from `.env` in `scripts/run_migrations.php`

## Testing
- `vendor/bin/phpunit --stop-on-failure | head -n 15`

------
https://chatgpt.com/codex/tasks/task_e_687e80d8d8ac832b905f4b8c1b1a2273