### PR TITLE
Add landing page home option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - *(migrations)* Add admin seed
 - Allow restore and delete of old backups
 - *(admin)* Add dropdown for active event
+- *(admin)* Allow landing page as home option
 
 ### Fix
 

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -54,6 +54,9 @@ class HomeController
             } elseif ($home === 'help') {
                 $ctrl = new HelpController();
                 return $ctrl($request, $response);
+            } elseif ($home === 'landing' && $request->getAttribute('domainType') === 'main') {
+                $ctrl = new \App\Controller\Marketing\LandingController();
+                return $ctrl($request, $response);
             }
         }
         if (session_status() === PHP_SESSION_NONE) {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -503,8 +503,9 @@
         <h3 class="uk-heading-bullet">Startseite</h3>
         <div class="uk-margin uk-flex uk-flex-middle">
           <select id="cfgHomePage" class="uk-select uk-width-auto">
-            <option value="help"{% if settings.home_page != 'events' %} selected{% endif %}>Hilfe-Seite</option>
+            <option value="help"{% if settings.home_page != 'events' and settings.home_page != 'landing' %} selected{% endif %}>Hilfe-Seite</option>
             <option value="events"{% if settings.home_page == 'events' %} selected{% endif %}>Veranstaltungen</option>
+            <option value="landing"{% if settings.home_page == 'landing' %} selected{% endif %}>Landing-Page</option>
           </select>
           <button id="homePageSaveBtn" class="uk-button uk-button-primary uk-margin-small-left">Speichern</button>
         </div>

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -97,4 +97,23 @@ class HomeControllerTest extends TestCase
             unlink($db);
         }
     }
+
+    public function testLandingAsHomePage(): void
+    {
+        $db = $this->setupDb();
+        $this->getAppInstance();
+        $pdo = \App\Infrastructure\Database::connectFromEnv();
+        \App\Infrastructure\Migrations\Migrator::migrate($pdo, dirname(__DIR__, 2) . '/migrations');
+        (new \App\Service\SettingsService($pdo))->save(['home_page' => 'landing']);
+
+        try {
+            $app = $this->getAppInstance();
+            $request = $this->createRequest('GET', '/');
+            $response = $app->handle($request);
+            $this->assertEquals(200, $response->getStatusCode());
+            $this->assertStringContainsString('Willkommen beim QuizRace', (string)$response->getBody());
+        } finally {
+            unlink($db);
+        }
+    }
 }

--- a/tests/Service/SettingsServiceTest.php
+++ b/tests/Service/SettingsServiceTest.php
@@ -15,8 +15,10 @@ class SettingsServiceTest extends TestCase
         $svc = new SettingsService($pdo);
         $svc->save(['home_page' => 'events']);
         $this->assertSame('events', $svc->get('home_page'));
+        $svc->save(['home_page' => 'landing']);
+        $this->assertSame('landing', $svc->get('home_page'));
         $all = $svc->getAll();
         $this->assertArrayHasKey('home_page', $all);
-        $this->assertEquals('events', $all['home_page']);
+        $this->assertEquals('landing', $all['home_page']);
     }
 }


### PR DESCRIPTION
## Summary
- extend home page settings with `landing`
- handle `landing` start page in controller
- test landing start page
- document new feature in changelog

## Testing
- `vendor/bin/phpunit --filter HomeControllerTest::testLandingAsHomePage --testdox`

------
https://chatgpt.com/codex/tasks/task_e_687e885b7b5c832b912af1d592eccc56