### PR TITLE
Add darkmode toggle improvements

### DIFF
--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -12,6 +12,8 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}{% endblock %}
+    {% block offcanvas %}{% endblock %}
     {% block left %}
       <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}


### PR DESCRIPTION
## Summary
- remove burger menu from events overview

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Unsupported operand types: string + int)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687e883933dc832b8741a081244b9b6d