### PR TITLE
Improve mobile event list

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -540,8 +540,16 @@ body.dark-mode .sticky-actions {
   color: #555;
 }
 
+#eventsTable {
+  width: 100%;
+  max-width: 100%;
+}
+
 /* Responsive event list */
 @media (max-width: 639px) {
+  #eventsTable thead {
+    display: none;
+  }
   #eventsList,
   #eventsList tr,
   #eventsList td {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -48,8 +48,8 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Veranstaltungen</h2>
         <div class="uk-overflow-auto">
-          <table class="uk-table uk-table-divider uk-table-small">
-            <thead>
+          <table id="eventsTable" class="uk-table uk-table-divider uk-table-small">
+            <thead class="table-headings">
               <tr>
                 <th><span uk-icon="icon: question" uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></span></th>
                 <th>Nr.</th>


### PR DESCRIPTION
## Summary
- hide table headings on mobile for the event list
- stretch event table width and ensure responsive layout

## Testing
- `./vendor/bin/phpstan analyse -c phpstan.neon.dist --no-progress --memory-limit=1G`
- `./vendor/bin/phpcs -n`
- `./vendor/bin/phpunit --no-coverage --display-incomplete` *(fails: 1 error, 11 failures)*

------
https://chatgpt.com/codex/tasks/task_e_687e8fc52608832bb6b3c8c27898848d