### PR TITLE
Harmonize team & catalog tables with events

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -579,4 +579,90 @@ body.dark-mode .sticky-actions {
   }
 }
 
+/* Catalog list enhancements */
+#catalogList td {
+  padding: 8px 4px;
+}
+
+#catalogTable {
+  width: 100%;
+  max-width: 100%;
+}
+
+/* Responsive catalog list */
+@media (max-width: 639px) {
+  #catalogTable thead {
+    display: none;
+  }
+  #catalogList,
+  #catalogList tr,
+  #catalogList td {
+    display: block;
+  }
+  #catalogList tr {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+  #catalogList td {
+    padding: 4px 0;
+  }
+  #catalogList td:first-child {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    display: block;
+  }
+  #catalogList tr {
+    position: relative;
+  }
+  #catalogList input[type="text"] {
+    width: 100%;
+  }
+}
+
+/* Team list enhancements */
+#teamsList td {
+  padding: 8px 4px;
+}
+
+#teamsTable {
+  width: 100%;
+  max-width: 100%;
+}
+
+/* Responsive team list */
+@media (max-width: 639px) {
+  #teamsTable thead {
+    display: none;
+  }
+  #teamsList,
+  #teamsList tr,
+  #teamsList td {
+    display: block;
+  }
+  #teamsList tr {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+  #teamsList td {
+    padding: 4px 0;
+  }
+  #teamsList td:first-child {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    display: block;
+  }
+  #teamsList tr {
+    position: relative;
+  }
+  #teamsList input[type="text"] {
+    width: 100%;
+  }
+}
+
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -595,8 +595,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const delCell = document.createElement('td');
     const del = document.createElement('button');
-    del.className = 'uk-button uk-button-danger';
-    del.textContent = '×';
+    del.className = 'uk-icon-button uk-button-danger';
+    del.setAttribute('uk-icon', 'trash');
     del.setAttribute('aria-label', 'Löschen');
     del.addEventListener('click', () => deleteCatalog(cat, row));
     delCell.appendChild(del);
@@ -1509,8 +1509,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const delCell = document.createElement('td');
     const del = document.createElement('button');
-    del.className = 'uk-button uk-button-danger';
-    del.textContent = '×';
+    del.className = 'uk-icon-button uk-button-danger';
+    del.setAttribute('uk-icon', 'trash');
     del.setAttribute('aria-label', 'Löschen');
     del.onclick = () => row.remove();
     delCell.appendChild(del);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -245,12 +245,12 @@
         <div>
           <h2 class="uk-heading-bullet">Kataloge</h2>
           <div class="uk-overflow-auto">
-            <table class="uk-table uk-table-divider uk-table-small">
-              <thead>
-                <tr>
-                  <th>
-                    <span uk-icon="icon: question" uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></span>
-                  </th>
+          <table id="catalogTable" class="uk-table uk-table-divider uk-table-small">
+            <thead class="table-headings">
+              <tr>
+                <th>
+                  <span uk-icon="icon: question" uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></span>
+                </th>
                   <th>Slug
                     <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: Eindeutiger Name in der URL; pos: top"></span>
                   </th>
@@ -269,17 +269,17 @@
                   <th>
                     <span uk-icon="icon: question" uk-tooltip="title: Katalog entfernen; pos: top"></span>
                   </th>
-                </tr>
-              </thead>
-              <tbody id="catalogList" uk-sortable="group: sortable-group"></tbody>
-            </table>
-          </div>
-          <div class="uk-margin">
-            <button id="newCatBtn" class="uk-button uk-button-default" uk-tooltip="title: Neuen Fragenkatalog anlegen; pos: right">Hinzufügen</button>
-          </div>
-          <div class="uk-margin uk-flex uk-flex-right">
-            <button id="catalogsSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Änderungen an den Katalogen speichern; pos: right">Speichern</button>
-          </div>
+              </tr>
+            </thead>
+            <tbody id="catalogList" uk-sortable="group: sortable-group"></tbody>
+          </table>
+        </div>
+        <div class="uk-margin">
+          <button id="newCatBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neuen Fragenkatalog anlegen; pos: left"><span class="button-text">Hinzufügen</span></button>
+        </div>
+        <div class="uk-margin uk-flex uk-flex-right">
+          <button id="catalogsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Änderungen an den Katalogen speichern; pos: left"><span class="button-text">Speichern</span></button>
+        </div>
         </div>
       </div>
     </li>
@@ -312,8 +312,8 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Teams/Personen</h2>
         <div class="uk-overflow-auto">
-          <table class="uk-table uk-table-divider uk-table-small">
-            <thead>
+          <table id="teamsTable" class="uk-table uk-table-divider uk-table-small">
+            <thead class="table-headings">
               <tr>
                 <th></th>
                 <th>Name</th>
@@ -324,10 +324,10 @@
           </table>
         </div>
         <div class="uk-margin">
-          <button id="teamAddBtn" class="uk-button uk-button-default" uk-tooltip="title: Neues Team oder Person hinzufügen; pos: right">Hinzufügen</button>
+          <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neues Team oder Person hinzufügen; pos: left"><span class="button-text">Hinzufügen</span></button>
         </div>
         <div class="uk-margin uk-flex uk-flex-right">
-          <button id="teamsSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Änderungen an Teams oder Personen speichern; pos: right">Speichern</button>
+          <button id="teamsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Änderungen an Teams oder Personen speichern; pos: left"><span class="button-text">Speichern</span></button>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- apply same FAB buttons and table style to catalog and team tables
- add responsive CSS for new catalog and team tables
- align delete buttons with event table style

## Testing
- `vendor/bin/phpunit` *(fails: errors and failures)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687e99a69974832b8367915fec97d7d9