### PR TITLE
Add dropdown for invitation text tags

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -170,7 +170,7 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   inviteToolbar?.addEventListener('click', (e) => {
-    const btn = e.target.closest('button[data-format],button[data-insert]');
+    const btn = e.target.closest('[data-format],[data-insert]');
     if (!btn) return;
     if (btn.dataset.insert) {
       insertText(inviteTextarea, btn.dataset.insert);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -396,12 +396,21 @@
           <div class="uk-modal-dialog uk-modal-body">
             <h2 class="uk-modal-title">Einladungstext</h2>
             <div id="inviteTextToolbar" class="uk-margin-small-bottom">
-              <button class="uk-button uk-button-default" type="button" data-format="h2">H2</button>
-              <button class="uk-button uk-button-default" type="button" data-format="h3">H3</button>
-              <button class="uk-button uk-button-default" type="button" data-format="h4">H4</button>
-              <button class="uk-button uk-button-default" type="button" data-format="h5">H5</button>
-              <button class="uk-button uk-button-default" type="button" data-format="bold"><strong>B</strong></button>
-              <button class="uk-button uk-button-default" type="button" data-format="italic"><em>I</em></button>
+              <div class="uk-inline">
+                <button class="uk-button uk-button-default" type="button">
+                  Tags <span uk-icon="icon: triangle-down"></span>
+                </button>
+                <div uk-dropdown="mode: click">
+                  <ul class="uk-nav uk-dropdown-nav">
+                    <li><button class="uk-button uk-button-text" type="button" data-format="h2">H2</button></li>
+                    <li><button class="uk-button uk-button-text" type="button" data-format="h3">H3</button></li>
+                    <li><button class="uk-button uk-button-text" type="button" data-format="h4">H4</button></li>
+                    <li><button class="uk-button uk-button-text" type="button" data-format="h5">H5</button></li>
+                    <li><button class="uk-button uk-button-text" type="button" data-format="bold"><strong>B</strong></button></li>
+                    <li><button class="uk-button uk-button-text" type="button" data-format="italic"><em>I</em></button></li>
+                  </ul>
+                </div>
+              </div>
               <button class="uk-button uk-button-default" type="button" data-insert="[TEAM]">[TEAM]</button>
               <button class="uk-button uk-button-default" type="button" data-insert="[EVENT_NAME]">[EVENT_NAME]</button>
               <button class="uk-button uk-button-default" type="button" data-insert="[EVENT_START]">[EVENT_START]</button>


### PR DESCRIPTION
## Summary
- replace invitation text toolbar buttons with dropdown to save space
- adjust admin.js to accept dropdown entries

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `./vendor/bin/phpunit` *(fails: Unsupported operand types and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_687ea15c5de4832bba0bc966d21e2fab