### PR TITLE
Fix admin FAB button placement

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -466,14 +466,18 @@ body.dark-mode .sticky-actions {
 /* Floating action buttons */
 .fab {
   position: fixed;
-  bottom: 1rem;
+  bottom: calc(4rem + env(safe-area-inset-bottom));
   right: 1rem;
+  width: 56px;
+  height: 56px;
+  line-height: 56px;
+  font-size: 24px;
   z-index: 1100;
   border-radius: 50%;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 }
 .fab-save {
-  bottom: 4.5rem;
+  bottom: calc(8rem + env(safe-area-inset-bottom));
 }
 
 /* Hide button text on small screens */


### PR DESCRIPTION
## Summary
- adjust Floating Action Button styles so Add/Save are larger
- raise buttons higher above the footer

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml --display-errors` *(fails: Errors: 1, Failures: 11)*
- `pytest -q`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_687ea7042b90832baf6a74c8f53da5b0