### PR TITLE
Fix icons on events overview

### DIFF
--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -44,5 +44,6 @@
 {% endblock %}
 
 {% block scripts %}
+  <script src="{{ basePath }}/js/custom-icons.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- include custom icon scripts on events overview so dark mode and handbook buttons work

## Testing
- `vendor/bin/phpunit -c phpunit.xml tests` *(fails: Unsupported operand types, failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687eadcfdfa0832bb559c258fde287e5