### PR TITLE
Replace text labels with icons for add/save buttons

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -847,8 +847,9 @@ document.addEventListener('DOMContentLoaded', function () {
         const list = document.createElement('div');
         (q.items || ['', '']).forEach(it => list.appendChild(addItem(it)));
         const add = document.createElement('button');
-        add.className = 'uk-button uk-button-small uk-margin-small-top';
-        add.textContent = 'Item hinzufügen';
+        add.className = 'uk-icon-button uk-button-primary uk-margin-small-top';
+        add.setAttribute("uk-icon", "plus");
+        add.setAttribute("aria-label", "Item hinzufügen");
         add.onclick = e => {
           e.preventDefault();
           list.appendChild(addItem(''));
@@ -861,8 +862,9 @@ document.addEventListener('DOMContentLoaded', function () {
           list.appendChild(addPair(p.term, p.definition))
         );
         const add = document.createElement('button');
-        add.className = 'uk-button uk-button-small uk-margin-small-top';
-        add.textContent = 'Begriff hinzufügen';
+        add.className = 'uk-icon-button uk-button-primary uk-margin-small-top';
+        add.setAttribute("uk-icon", "plus");
+        add.setAttribute("aria-label", "Begriff hinzufügen");
         add.onclick = e => {
           e.preventDefault();
           list.appendChild(addPair('', ''));
@@ -895,8 +897,9 @@ document.addEventListener('DOMContentLoaded', function () {
           list.appendChild(addCard(c.text, c.correct))
         );
         const add = document.createElement('button');
-        add.className = 'uk-button uk-button-small uk-margin-small-top';
-        add.textContent = 'Karte hinzufügen';
+        add.className = 'uk-icon-button uk-button-primary uk-margin-small-top';
+        add.setAttribute("uk-icon", "plus");
+        add.setAttribute("aria-label", "Karte hinzufügen");
         add.onclick = e => { e.preventDefault(); list.appendChild(addCard('', false)); };
         fields.appendChild(list);
         fields.appendChild(add);
@@ -920,8 +923,9 @@ document.addEventListener('DOMContentLoaded', function () {
           list.appendChild(addOption(opt, (q.answers || []).includes(i)))
         );
         const add = document.createElement('button');
-        add.className = 'uk-button uk-button-small uk-margin-small-top';
-        add.textContent = 'Option hinzufügen';
+        add.className = 'uk-icon-button uk-button-primary uk-margin-small-top';
+        add.setAttribute("uk-icon", "plus");
+        add.setAttribute("aria-label", "Option hinzufügen");
         add.onclick = e => {
           e.preventDefault();
           list.appendChild(addOption(''));

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -65,10 +65,10 @@
           </table>
         </div>
         <div class="uk-margin">
-          <button id="eventAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neue Veranstaltung anlegen; pos: left"><span class="button-text">Hinzufügen</span></button>
+          <button id="eventAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neue Veranstaltung anlegen; pos: left"></button>
         </div>
         <div class="uk-margin uk-flex uk-flex-right">
-          <button id="eventsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Änderungen speichern; pos: left"><span class="button-text">Speichern</span></button>
+          <button id="eventsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Änderungen speichern; pos: left"></button>
         </div>
       </div>
     </li>
@@ -204,7 +204,7 @@
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="cfgResetBtn" class="uk-button uk-button-default" uk-tooltip="title: Setzt alle Felder auf gespeicherte Werte zurück; pos: right">Zurücksetzen</button>
           <div>
-            <button id="cfgSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Einstellungen speichern; pos: right">Speichern</button>
+            <button id="cfgSaveBtn" class="uk-icon-button uk-button-primary" uk-icon="check" uk-tooltip="title: Einstellungen speichern; pos: right"></button>
           </div>
         </div>
 
@@ -213,7 +213,7 @@
             <h2 class="uk-modal-title">Feedbacktext für das Rätselwort</h2>
             <textarea id="puzzleFeedbackTextarea" class="uk-textarea" rows="5" placeholder="Feedbacktext eingeben..."></textarea>
             <div class="uk-flex uk-flex-right uk-margin-top">
-              <button id="puzzleFeedbackSave" class="uk-button uk-button-primary" type="button">Speichern</button>
+              <button id="puzzleFeedbackSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="button"></button>
               <button class="uk-button uk-button-default uk-modal-close" type="button">Abbrechen</button>
             </div>
           </div>
@@ -232,7 +232,7 @@
             </div>
             <textarea id="catalogCommentTextarea" class="uk-textarea" rows="5" placeholder="Kommentar eingeben..."></textarea>
             <div class="uk-flex uk-flex-right uk-margin-top">
-              <button id="catalogCommentSave" class="uk-button uk-button-primary" type="button">Speichern</button>
+              <button id="catalogCommentSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="button"></button>
               <button class="uk-button uk-button-default uk-modal-close" type="button">Abbrechen</button>
             </div>
           </div>
@@ -275,10 +275,10 @@
           </table>
         </div>
         <div class="uk-margin">
-          <button id="newCatBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neuen Fragenkatalog anlegen; pos: left"><span class="button-text">Hinzufügen</span></button>
+          <button id="newCatBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neuen Fragenkatalog anlegen; pos: left"></button>
         </div>
         <div class="uk-margin uk-flex uk-flex-right">
-          <button id="catalogsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Änderungen an den Katalogen speichern; pos: left"><span class="button-text">Speichern</span></button>
+          <button id="catalogsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Änderungen an den Katalogen speichern; pos: left"></button>
         </div>
         </div>
       </div>
@@ -301,7 +301,7 @@
           <button id="addBtn" class="uk-button uk-button-default" uk-tooltip="title: Neue Frage im aktuellen Katalog anlegen; pos: right">Neue Frage</button>
           <div>
             <button id="resetBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Änderungen am Fragenkatalog verwerfen; pos: right">Zurücksetzen</button>
-            <button id="saveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Fragenkatalog speichern; pos: right">Speichern</button>
+            <button id="saveBtn" class="uk-icon-button uk-button-primary" uk-icon="check" uk-tooltip="title: Fragenkatalog speichern; pos: right"></button>
           </div>
         </div>
         <!-- Ende Hauptdatenbereich -->
@@ -324,10 +324,10 @@
           </table>
         </div>
         <div class="uk-margin">
-          <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neues Team oder Person hinzufügen; pos: left"><span class="button-text">Hinzufügen</span></button>
+          <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neues Team oder Person hinzufügen; pos: left"></button>
         </div>
         <div class="uk-margin uk-flex uk-flex-right">
-          <button id="teamsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Änderungen an Teams oder Personen speichern; pos: left"><span class="button-text">Speichern</span></button>
+          <button id="teamsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Änderungen an Teams oder Personen speichern; pos: left"></button>
         </div>
       </div>
     </li>
@@ -419,7 +419,7 @@
             </div>
             <textarea id="inviteTextTextarea" class="uk-textarea" rows="5" placeholder="Text eingeben..."></textarea>
             <div class="uk-flex uk-flex-right uk-margin-top">
-              <button id="inviteTextSave" class="uk-button uk-button-primary" type="button">Speichern</button>
+              <button id="inviteTextSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="button"></button>
               <button class="uk-button uk-button-default uk-modal-close" type="button">Abbrechen</button>
             </div>
           </div>
@@ -516,7 +516,7 @@
             <option value="events"{% if settings.home_page == 'events' %} selected{% endif %}>Veranstaltungen</option>
             <option value="landing"{% if settings.home_page == 'landing' %} selected{% endif %}>Landing-Page</option>
           </select>
-          <button id="homePageSaveBtn" class="uk-button uk-button-primary uk-margin-small-left">Speichern</button>
+          <button id="homePageSaveBtn" class="uk-icon-button uk-button-primary uk-margin-small-left" uk-icon="check"></button>
         </div>
 
         <h3 class="uk-heading-bullet">Benutzer</h3>
@@ -535,10 +535,10 @@
           </table>
         </div>
         <div class="uk-margin">
-          <button id="userAddBtn" class="uk-button uk-button-default" uk-tooltip="title: Neuen Benutzer anlegen; pos: right">Hinzufügen</button>
+          <button id="userAddBtn" class="uk-icon-button uk-button-default" uk-icon="plus" uk-tooltip="title: Neuen Benutzer anlegen; pos: right"></button>
         </div>
         <div class="uk-margin uk-flex uk-flex-right">
-          <button id="usersSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: Änderungen speichern; pos: right">Speichern</button>
+          <button id="usersSaveBtn" class="uk-icon-button uk-button-primary" uk-icon="check" uk-tooltip="title: Änderungen speichern; pos: right"></button>
         </div>
 
         <div id="userPassModal" uk-modal>
@@ -547,7 +547,7 @@
             <div class="uk-margin"><input id="userPassInput" class="uk-input" type="password" placeholder="Passwort"></div>
             <div class="uk-margin"><input id="userPassRepeat" class="uk-input" type="password" placeholder="Wiederholen"></div>
             <div class="uk-flex uk-flex-right uk-margin-top">
-              <button id="userPassSave" class="uk-button uk-button-primary" type="button">Speichern</button>
+              <button id="userPassSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="button"></button>
               <button class="uk-button uk-button-default uk-modal-close" type="button">Abbrechen</button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- use icon buttons for adding items and saving changes
- swap text labels for icons in question editor
- adjust admin templates to show icon-only buttons

## Testing
- `vendor/bin/phpcs src/`
- `vendor/bin/phpstan analyse src/ --no-progress -c phpstan.neon.dist --memory-limit=512M`
- `vendor/bin/phpunit --stop-on-failure` *(fails: Unsupported operand types)*

------
https://chatgpt.com/codex/tasks/task_e_687eb3eff018832bb732d3a32796c010