### PR TITLE
Remove hamburger menu from legal pages

### DIFF
--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -12,6 +12,7 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}{% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
@@ -26,6 +27,7 @@
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
     {% endblock %}
+    {% block offcanvas %}{% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small legal-container">
     <h1 class="uk-heading-divider uk-hidden">Datenschutzerklärung</h1>

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -12,6 +12,7 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}{% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
@@ -26,6 +27,7 @@
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
     {% endblock %}
+    {% block offcanvas %}{% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small legal-container">
     <h1 class="uk-heading-divider uk-hidden">Impressum</h1>

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -12,6 +12,7 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}{% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
@@ -26,6 +27,7 @@
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
     {% endblock %}
+    {% block offcanvas %}{% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small legal-container">
     <h1 class="uk-heading-divider uk-hidden">Lizenz</h1>


### PR DESCRIPTION
## Summary
- hide the landing page hamburger menu on Impressum, Datenschutz and Lizenz pages

## Testing
- `python3 -m pytest -q tests/test_html_validity.py tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpunit` *(fails: Errors:1, Failures:11)*

------
https://chatgpt.com/codex/tasks/task_e_687eb7add3bc832b980e0577bdeaf8f7