### PR TITLE
Move handbook button to left side

### DIFF
--- a/public/Impressum.html
+++ b/public/Impressum.html
@@ -36,18 +36,18 @@
 
   <div class="footer-placeholder"></div>
   <nav class="uk-navbar-container bottombar" uk-navbar>
+    <div class="uk-navbar-left">
+      <ul class="uk-navbar-nav">
+        <li>
+          <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="book" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
+        </li>
+      </ul>
+    </div>
     <div class="uk-navbar-center">
       <ul class="uk-navbar-nav">
         <li><a href="Datenschutz.html">Datenschutz</a></li>
         <li><a href="Impressum.html">Impressum</a></li>
         <li><a href="Lizenz.html">Lizenz</a></li>
-      </ul>
-    </div>
-    <div class="uk-navbar-right">
-      <ul class="uk-navbar-nav">
-        <li>
-          <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="book" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
-        </li>
       </ul>
     </div>
   </nav>

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -17,17 +17,17 @@
 {% block body %}{% endblock %}
   <div class="footer-placeholder"></div>
   <nav class="uk-navbar-container bottombar" uk-navbar>
+    <div class="uk-navbar-left">
+      <div class="uk-navbar-item uk-margin-small-left">
+        <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="icon: handbook; ratio: 2" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
+      </div>
+    </div>
     <div class="uk-navbar-center">
       <ul class="uk-navbar-nav">
         <li><a href="{{ basePath }}/datenschutz">Datenschutz</a></li>
         <li><a href="{{ basePath }}/impressum">Impressum</a></li>
         <li><a href="{{ basePath }}/lizenz">Lizenz</a></li>
       </ul>
-    </div>
-    <div class="uk-navbar-right">
-      <div class="uk-navbar-item uk-margin-small-right">
-        <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="icon: handbook; ratio: 2" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
-      </div>
     </div>
   </nav>
   <script src="{{ basePath }}/js/uikit.min.js"></script>


### PR DESCRIPTION
## Summary
- shift handbook icon button to the left in the layout
- adjust Impressum.html footer to keep handbook button left

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `pytest -q`
- `vendor/bin/phpcs`
- `vendor/bin/phpstan --memory-limit=1G`
- `vendor/bin/phpunit` *(fails: 1 error, 11 failures)*

------
https://chatgpt.com/codex/tasks/task_e_687ebb150f08832b8f380c602bd90357