### PR TITLE
Enable editing static pages via admin interface

### DIFF
--- a/content/datenschutz.html
+++ b/content/datenschutz.html
@@ -1,0 +1,6 @@
+<div class="uk-section uk-section-default">
+  <div class="uk-container uk-container-small">
+    <h1 class="uk-heading-divider">Datenschutz</h1>
+    <p>Hier können Sie Ihre Datenschutzerklärung hinterlegen.</p>
+  </div>
+</div>

--- a/content/impressum.html
+++ b/content/impressum.html
@@ -1,0 +1,6 @@
+<div class="uk-section uk-section-default">
+  <div class="uk-container uk-container-small">
+    <h1 class="uk-heading-divider">Impressum</h1>
+    <p>Bitte tragen Sie hier Ihr Impressum ein.</p>
+  </div>
+</div>

--- a/content/landing.html
+++ b/content/landing.html
@@ -1,0 +1,6 @@
+<div class="uk-section uk-section-default">
+  <div class="uk-container">
+    <h1 class="uk-heading-medium">Willkommen beim QuizRace</h1>
+    <p class="uk-text-lead">Hier entsteht Ihre Landing-Page.</p>
+  </div>
+</div>

--- a/content/lizenz.html
+++ b/content/lizenz.html
@@ -1,0 +1,6 @@
+<div class="uk-section uk-section-default">
+  <div class="uk-container uk-container-small">
+    <h1 class="uk-heading-divider">Lizenz</h1>
+    <p>Informationen zur Lizenz können Sie hier bearbeiten.</p>
+  </div>
+</div>

--- a/src/Controller/Admin/PageController.php
+++ b/src/Controller/Admin/PageController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
+
+class PageController
+{
+    /**
+     * Display the edit form for a static page.
+     */
+    public function edit(Request $request, Response $response, array $args): Response
+    {
+        $slug = $args['slug'] ?? '';
+        $allowed = ['landing', 'impressum', 'lizenz', 'datenschutz'];
+        if (!in_array($slug, $allowed, true)) {
+            return $response->withStatus(404);
+        }
+
+        $path = dirname(__DIR__, 3) . '/content/' . $slug . '.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+        $content = file_get_contents($path) ?: '';
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'admin/pages/edit.twig', [
+            'slug' => $slug,
+            'content' => $content,
+        ]);
+    }
+
+    /**
+     * Persist new HTML for a static page.
+     */
+    public function update(Request $request, Response $response, array $args): Response
+    {
+        $slug = $args['slug'] ?? '';
+        $allowed = ['landing', 'impressum', 'lizenz', 'datenschutz'];
+        if (!in_array($slug, $allowed, true)) {
+            return $response->withStatus(404);
+        }
+        $path = dirname(__DIR__, 3) . '/content/' . $slug . '.html';
+        $data = $request->getParsedBody();
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $html = (string)($data['content'] ?? '');
+        file_put_contents($path, $html);
+        return $response->withStatus(204);
+    }
+}

--- a/src/Controller/DatenschutzController.php
+++ b/src/Controller/DatenschutzController.php
@@ -6,19 +6,19 @@ namespace App\Controller;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Views\Twig;
 
 /**
  * Renders the privacy policy page.
  */
 class DatenschutzController
 {
-    /**
-     * Display the Datenschutz page.
-     */
     public function __invoke(Request $request, Response $response): Response
     {
-        $view = Twig::fromRequest($request);
-        return $view->render($response, 'datenschutz.twig');
+        $path = dirname(__DIR__, 2) . '/content/datenschutz.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write((string) file_get_contents($path));
+        return $response->withHeader('Content-Type', 'text/html');
     }
 }

--- a/src/Controller/ImpressumController.php
+++ b/src/Controller/ImpressumController.php
@@ -6,19 +6,19 @@ namespace App\Controller;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Views\Twig;
 
 /**
  * Displays the legal notice page.
  */
 class ImpressumController
 {
-    /**
-     * Render the Impressum page.
-     */
     public function __invoke(Request $request, Response $response): Response
     {
-        $view = Twig::fromRequest($request);
-        return $view->render($response, 'impressum.twig');
+        $path = dirname(__DIR__, 2) . '/content/impressum.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write((string) file_get_contents($path));
+        return $response->withHeader('Content-Type', 'text/html');
     }
 }

--- a/src/Controller/LizenzController.php
+++ b/src/Controller/LizenzController.php
@@ -6,19 +6,19 @@ namespace App\Controller;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Views\Twig;
 
 /**
  * Shows the open-source license information.
  */
 class LizenzController
 {
-    /**
-     * Render the license page.
-     */
     public function __invoke(Request $request, Response $response): Response
     {
-        $view = Twig::fromRequest($request);
-        return $view->render($response, 'lizenz.twig');
+        $path = dirname(__DIR__, 2) . '/content/lizenz.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write((string) file_get_contents($path));
+        return $response->withHeader('Content-Type', 'text/html');
     }
 }

--- a/src/Controller/Marketing/LandingController.php
+++ b/src/Controller/Marketing/LandingController.php
@@ -6,19 +6,19 @@ namespace App\Controller\Marketing;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Views\Twig;
 
 /**
  * Displays the landing page for the marketing site.
  */
 class LandingController
 {
-    /**
-     * Render the landing page.
-     */
     public function __invoke(Request $request, Response $response): Response
     {
-        $view = Twig::fromRequest($request);
-        return $view->render($response, 'marketing/landing.twig');
+        $path = dirname(__DIR__, 3) . '/content/landing.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write((string) file_get_contents($path));
+        return $response->withHeader('Content-Type', 'text/html');
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -39,6 +39,7 @@ use App\Controller\EvidenceController;
 use App\Controller\EventController;
 use App\Controller\EventListController;
 use App\Controller\SettingsController;
+use App\Controller\Admin\PageController;
 use App\Controller\TenantController;
 use App\Controller\Marketing\LandingController;
 use Psr\Log\NullLogger;
@@ -60,6 +61,7 @@ require_once __DIR__ . '/Controller/ResultController.php';
 require_once __DIR__ . '/Controller/TeamController.php';
 require_once __DIR__ . '/Controller/PasswordController.php';
 require_once __DIR__ . '/Controller/AdminCatalogController.php';
+require_once __DIR__ . '/Controller/Admin/PageController.php';
 require_once __DIR__ . '/Controller/QrController.php';
 require_once __DIR__ . '/Controller/LogoController.php';
 require_once __DIR__ . '/Controller/CatalogDesignController.php';
@@ -193,6 +195,16 @@ return function (\Slim\App $app) {
     $app->get('/admin', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/kataloge', AdminCatalogController::class)
         ->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
+
+    $app->get('/admin/pages/{slug}', function (Request $request, Response $response, array $args) {
+        $controller = new PageController();
+        return $controller->edit($request, $response, $args);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+
+    $app->post('/admin/pages/{slug}', function (Request $request, Response $response, array $args) {
+        $controller = new PageController();
+        return $controller->update($request, $response, $args);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
     $app->get('/results', function (Request $request, Response $response) {
         return $request->getAttribute('resultController')->page($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::ANALYST));

--- a/templates/admin/pages/edit.twig
+++ b/templates/admin/pages/edit.twig
@@ -1,0 +1,25 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Seite bearbeiten{% endblock %}
+
+{% block head %}
+  <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+{% endblock %}
+
+{% block body_class %}uk-background-muted uk-padding{% endblock %}
+
+{% block body %}
+  <div class="uk-container uk-container-expand">
+    <h1 class="uk-heading-bullet">Seite bearbeiten: {{ slug }}</h1>
+    <form method="post" class="uk-form-stacked">
+      <textarea id="pageContent" name="content" class="uk-textarea" rows="20">{{ content }}</textarea>
+      <div class="uk-margin-top">
+        <button type="submit" class="uk-button uk-button-primary">Speichern</button>
+        <a href="{{ basePath }}/{{ slug }}" target="_blank" class="uk-button uk-button-default">Vorschau</a>
+      </div>
+    </form>
+  </div>
+  <script>
+    tinymce.init({ selector: '#pageContent', height: 500 });
+  </script>
+{% endblock %}

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class PageControllerTest extends TestCase
+{
+    public function testEditAndUpdate(): void
+    {
+        $dir = dirname(__DIR__, 2) . '/content';
+        if (!is_dir($dir)) {
+            mkdir($dir);
+        }
+        $file = $dir . '/landing.html';
+        file_put_contents($file, '<p>old</p>');
+
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+
+        $response = $app->handle($this->createRequest('GET', '/admin/pages/landing'));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $req = $this->createRequest('POST', '/admin/pages/landing');
+        $req = $req->withParsedBody(['content' => '<p>new</p>']);
+        $res = $app->handle($req);
+        $this->assertEquals(204, $res->getStatusCode());
+        $this->assertStringEqualsFile($file, '<p>new</p>');
+
+        session_destroy();
+        unlink($file);
+    }
+
+    public function testInvalidSlug(): void
+    {
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $res = $app->handle($this->createRequest('GET', '/admin/pages/unknown'));
+        $this->assertEquals(404, $res->getStatusCode());
+        session_destroy();
+    }
+}


### PR DESCRIPTION
## Summary
- serve privacy policy, imprint, license and landing pages from `/content`
- add admin `PageController` with editor form
- register routes for page editing in `src/routes.php`
- provide TinyMCE based template `templates/admin/pages/edit.twig`
- include minimal HTML pages for initial content
- add tests for the new controller

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml src/Controller/ImpressumController.php src/Controller/DatenschutzController.php src/Controller/LizenzController.php src/Controller/Marketing/LandingController.php tests/Controller/PageControllerTest.php`
- `vendor/bin/phpunit tests/Controller/PageControllerTest.php`
- `vendor/bin/phpunit --testsuite "Test Suite"` *(fails: Errors: 1, Failures: 11)*

------
https://chatgpt.com/codex/tasks/task_e_687f37425f98832b90c8d9a981e16373