### PR TITLE
Enable editing static pages via admin interface

### DIFF
--- a/content/datenschutz.html
+++ b/content/datenschutz.html
@@ -1,0 +1,37 @@
+  <div class="uk-container uk-container-small legal-container">
+    <h1 class="uk-heading-divider uk-hidden">Datenschutzerklärung</h1>
+
+    <h2 class="uk-heading-bullet">1. Verantwortlicher</h2>
+    <p>Verantwortlich für die Datenverarbeitung im Rahmen dieser Anwendung ist:<br>
+    René Buske<br>
+    Weidenbusch 8<br>
+    14532 Kleinmachnow<br>
+    E-Mail: <a href="mailto:info@calhelp.de">info@calhelp.de</a></p>
+
+    <h2 class="uk-heading-bullet">2. Zweck der Datenverarbeitung</h2>
+    <p>Die Quiz-App dient der Durchführung eines digitalen Quiz im Rahmen der Sommerfeier 2025. Die Erhebung und Verarbeitung von Daten erfolgt ausschließlich zur Bereitstellung und Verbesserung des Quiz-Angebots.</p>
+
+    <h2 class="uk-heading-bullet">3. Art und Umfang der erhobenen Daten</h2>
+    <p><strong>Keine Erhebung personenbezogener Daten:</strong> Es werden keinerlei personenbezogene Daten (wie Name, E-Mail, Adresse etc.) abgefragt, gespeichert oder verarbeitet.</p>
+    <p><strong>Quiz-Daten:</strong> Bei der Nutzung der App werden lediglich pseudonymisierte Daten wie frei gewählte Benutzernamen, erzielte Punktzahlen und ggf. technische Informationen zum Ablauf des Quiz verarbeitet.</p>
+    <p><strong>Serverdatei ([Veranstaltungsname].csv):</strong> Bei aktivierter Speicherung werden Pseudonyme, Katalogname, Versuch, Punktzahl und Zeitpunkt serverseitig gesichert. Die Ablage erfolgt anonymisiert und konform zur DSGVO.</p>
+
+    <h2 class="uk-heading-bullet">4. Speicherung und Löschung</h2>
+    <p><strong>Serverseitige Speicherung:</strong> Je nach Konfiguration werden Quiz-Ergebnisse anonymisiert auf dem Server gespeichert. Diese Speicherung erfolgt entsprechend den Anforderungen der DSGVO.</p>
+    <p><strong>Lokal gespeicherte Daten:</strong> Sofern lokal gespeichert wird (z. B. im Browser-Storage), verbleiben die Daten ausschließlich auf dem Endgerät des Nutzers und werden nicht an Dritte übermittelt.</p>
+    <p><strong>Löschung:</strong> Alle gespeicherten Daten werden spätestens nach Abschluss des Quiz-Events gelöscht oder anonymisiert.</p>
+
+    <h2 class="uk-heading-bullet">5. Keine Weitergabe an Dritte</h2>
+    <p>Es findet keine Übermittlung oder Weitergabe von Daten an Dritte statt.</p>
+
+    <h2 class="uk-heading-bullet">6. Cookies und Tracking</h2>
+    <p>Die App setzt ein technisch notwendiges Session-Cookie (<code>PHPSESSID</code>), das für den Betrieb erforderlich ist – etwa für den Admin-Login. Dieses Cookie enthält keine personenbezogenen Daten und wird nach Beenden des Browsers gelöscht. Ein darüber hinaus gehendes Tracking zur Nutzerverfolgung findet nicht statt.</p>
+
+    <h2 class="uk-heading-bullet">7. Rechte der Nutzer</h2>
+    <p>Da keine personenbezogenen Daten verarbeitet werden, bestehen keine Betroffenenrechte im Sinne der DSGVO bezüglich Auskunft, Berichtigung, Löschung oder Übertragbarkeit.</p>
+
+    <h2 class="uk-heading-bullet">8. Kontakt</h2>
+    <p>Für Fragen zum Datenschutz oder zur Anwendung wenden Sie sich bitte an: <a href="mailto:info@calhelp.de">info@calhelp.de</a></p>
+
+    <p class="uk-text-small"><strong>Hinweis:</strong> Diese Datenschutzerklärung basiert auf dem aktuellen Stand der Technik und des Projekts. <strong>CalHelp übernimmt keine Verantwortung</strong> für bereits durch Administrator:innen eingegebene personenbezogene Daten. Sollte sich der Funktionsumfang ändern oder die App personenbezogene Daten erheben, ist eine Anpassung dieser Datenschutzerklärung erforderlich.</p>
+  </div>

--- a/content/impressum.html
+++ b/content/impressum.html
@@ -1,0 +1,27 @@
+  <div class="uk-container uk-container-small legal-container">
+    <h1 class="uk-heading-divider uk-hidden">Impressum</h1>
+
+    <p>Angaben gemäß § 5 TMG</p>
+    <p>René Buske<br>
+    Weidenbusch 8<br>
+    14532 Kleinmachnow<br>
+    Deutschland</p>
+    <p>E-Mail: <a href="mailto:office@calhelp.de">office@calhelp.de</a></p>
+
+    <p><strong>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:</strong><br>
+    René Buske<br>
+    Weidenbusch 8<br>
+    14532 Kleinmachnow</p>
+
+    <p>Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz: DE 259645623</p>
+
+    <h2 class="uk-heading-bullet">Haftungsausschluss</h2>
+    <p>Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung für die Inhalte externer Links. Für den Inhalt der verlinkten Seiten sind ausschließlich deren Betreiber verantwortlich.</p>
+
+    <h2 class="uk-heading-bullet">Urheberrecht</h2>
+    <p>Die durch den Seitenbetreiber erstellten Inhalte und Werke auf dieser Website unterliegen dem deutschen Urheberrecht. Beiträge Dritter sind als solche gekennzeichnet.</p>
+
+    <h2 class="uk-heading-bullet">Quellcode</h2>
+    <p>Der Quellcode dieser Anwendung ist unter der MIT-Lizenz auf GitHub verfügbar:<br>
+    <a href="https://github.com/bastelix/sommerfest-quiz">https://github.com/bastelix/sommerfest-quiz</a></p>
+  </div>

--- a/content/landing.html
+++ b/content/landing.html
@@ -1,0 +1,63 @@
+
+  <section class="uk-section uk-section-primary uk-flex uk-flex-middle" uk-height-viewport="offset-top: true">
+    <div class="uk-container">
+      <h1 class="uk-heading-medium">Willkommen beim QuizRace</h1>
+      <p class="uk-text-lead">Trete gegen Freunde und Kollegen an und finde heraus, wer das meiste Wissen hat.</p>
+      <p class="uk-margin-large-top">
+        <a class="uk-button uk-button-secondary uk-button-large" href="{{ basePath }}/login">Jetzt starten</a>
+      </p>
+    </div>
+  </section>
+
+  <section id="features" class="uk-section uk-section-default">
+    <div class="uk-container">
+      <div class="uk-child-width-1-3@m uk-grid-match" uk-grid>
+        <div>
+          <div class="uk-card uk-card-body">
+            <h3 class="uk-card-title">Einfach</h3>
+            <p>Intuitive Bedienung und schnelle Registrierung.</p>
+          </div>
+        </div>
+        <div>
+          <div class="uk-card uk-card-body">
+            <h3 class="uk-card-title">Sicher</h3>
+            <p>Alle Daten bleiben auf Ihrem eigenen Server.</p>
+          </div>
+        </div>
+        <div>
+          <div class="uk-card uk-card-body">
+            <h3 class="uk-card-title">Auswertungen</h3>
+            <p>Ergebnisse und Ranglisten in Echtzeit.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="pricing" class="uk-section uk-section-muted">
+    <div class="uk-container">
+      <h2 class="uk-heading-small">Preise</h2>
+      <p class="uk-text-lead">Informationen zu unseren Preisen.</p>
+    </div>
+  </section>
+
+  <section id="contact" class="uk-section uk-section-muted">
+    <div class="uk-container">
+      <h2 class="uk-heading-small">Kontakt</h2>
+      <form class="uk-grid-small" uk-grid>
+        <div class="uk-width-1-2@s">
+          <input class="uk-input" type="text" placeholder="Ihr Name">
+        </div>
+        <div class="uk-width-1-2@s">
+          <input class="uk-input" type="email" placeholder="Ihre E-Mail">
+        </div>
+        <div class="uk-width-1-1">
+          <textarea class="uk-textarea" rows="5" placeholder="Ihre Nachricht"></textarea>
+        </div>
+        <div class="uk-width-1-1">
+          <button class="uk-button uk-button-primary" type="submit">Senden</button>
+        </div>
+      </form>
+    </div>
+  </section>
+{% endblock %}

--- a/content/lizenz.html
+++ b/content/lizenz.html
@@ -1,0 +1,64 @@
+  <div class="uk-container uk-container-small legal-container">
+    <h1 class="uk-heading-divider uk-hidden">Lizenz</h1>
+    <p>Diese Anwendung steht unter der <a href="https://opensource.org/licenses/MIT">MIT-Lizenz</a>. Den vollständigen Text finden Sie auch untenstehend sowie in der Datei <code>LICENSE</code>.</p>
+    <div class="uk-card uk-card-default uk-card-body uk-margin">
+      <h3 class="uk-heading-bullet">Disclaimer / Hinweis</h3>
+        <p>Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer spannenden Zusammenarbeit zwischen menschlicher Erfahrung und k&uuml;nstlicher Intelligenz. W&auml;hrend Ideen, Organisation und jede Menge Praxiswissen von Menschen stammen, wurden alle Codezeilen experimentell komplett von OpenAI Codex geschrieben. F&uuml;r die kreativen Konzepte und Inhalte kam ChatGPT 4.1 zum Einsatz, bei der Fehlersuche half Github Copilot und das Logo wurde von der KI Sora entworfen.</p>
+        <p>Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial moderner Codeassistenten in der Praxis zu erproben.</p>
+        <p>Im Mittelpunkt stand die Zug&auml;nglichkeit f&uuml;r alle Nutzergruppen &ndash; daher ist die Anwendung barrierefrei gestaltet und eignet sich auch f&uuml;r Menschen mit Einschr&auml;nkungen. Datenschutz und Sicherheit werden konsequent beachtet, sodass alle Daten gesch&uuml;tzt sind.</p>
+        <p>Die App zeichnet sich durch eine hohe Performance und Stabilit&auml;t auch bei vielen gleichzeitigen Teilnehmenden aus. Das Bedienkonzept ist selbsterkl&auml;rend, wodurch eine schnelle und intuitive Nutzung auf allen Endger&auml;ten &ndash; ob Smartphone, Tablet oder Desktop &ndash; gew&auml;hrleistet wird.</p>
+        <p>Zudem wurde auf eine ressourcenschonende Arbeitsweise und eine unkomplizierte Anbindung an andere Systeme Wert gelegt.</p>
+      <p>Mit dieser App zeigen wir, was heute schon m&ouml;glich ist, wenn Menschen und verschiedene KI-Tools wie ChatGPT, Codex, Copilot und Sora gemeinsam an neuen digitalen Ideen t&uuml;fteln.</p>
+    </div>
+    <h2 class="uk-heading-bullet">MIT-Lizenz (Deutsch)</h2>
+<pre class="uk-text-small">
+MIT-Lizenz
+
+Copyright (c) 2025 calhelp
+
+Hiermit wird unentgeltlich jeder Person, die eine Kopie der Software
+und der zugehörigen Dokumentationsdateien (die "Software") erhält,
+die Erlaubnis erteilt, uneingeschränkt mit der Software zu verfahren,
+einschließlich aber nicht beschränkt auf die Rechte, die Software zu
+nutzen, zu kopieren, zu modifizieren, zusammenzuführen, zu veröffentlichen,
+zu verbreiten, zu unterlizenzieren und/oder zu verkaufen, sowie Personen,
+denen die Software bereitgestellt wird, diese Rechte zu gewähren, vorbehaltlich
+der folgenden Bedingungen:
+
+Der obige Urheberrechtsvermerk und dieser Erlaubnisvermerk sind in allen
+Kopien oder wesentlichen Teilen der Software beizulegen.
+
+DIE SOFTWARE WIRD OHNE JEDE AUSDRÜCKLICHE ODER STILLSCHWEIGENDE GEWÄHRLEISTUNG
+BEREITGESTELLT, EINSCHLIESSLICH UND NICHT BESCHRÄNKT AUF DIE GEWÄHRLEISTUNGEN
+DER MARKTGÄNGIGKEIT, DER EIGNUNG FÜR EINEN BESTIMMTEN ZWECK UND DER NICHTVERLETZUNG.
+IN KEINEM FALL SIND DIE AUTOREN ODER URHEBERRECHTSINHABER FÜR JEGLICHE ANSPRÜCHE,
+SCHÄDEN ODER SONSTIGE HAFTUNGEN VERANTWORTLICH, OB IN EINEM VERTRAGSVERHÄLTNIS,
+EINER UNERLAUBTEN HANDLUNG ODER ANDERWEITIG, DIE SICH AUS DER SOFTWARE ODER DER
+NUTZUNG ODER ANDEREN GESCHÄFTEN MIT DER SOFTWARE ERGEBEN.
+</pre>
+
+    <h2 class="uk-heading-bullet">MIT License (English)</h2>
+<pre class="uk-text-small">
+MIT License
+
+Copyright (c) 2025 calhelp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+  </div>

--- a/src/Controller/Admin/PageController.php
+++ b/src/Controller/Admin/PageController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
+
+class PageController
+{
+    /**
+     * Display the edit form for a static page.
+     */
+    public function edit(Request $request, Response $response, array $args): Response
+    {
+        $slug = $args['slug'] ?? '';
+        $allowed = ['landing', 'impressum', 'lizenz', 'datenschutz'];
+        if (!in_array($slug, $allowed, true)) {
+            return $response->withStatus(404);
+        }
+
+        $path = dirname(__DIR__, 3) . '/content/' . $slug . '.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+        $content = file_get_contents($path) ?: '';
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'admin/pages/edit.twig', [
+            'slug' => $slug,
+            'content' => $content,
+        ]);
+    }
+
+    /**
+     * Persist new HTML for a static page.
+     */
+    public function update(Request $request, Response $response, array $args): Response
+    {
+        $slug = $args['slug'] ?? '';
+        $allowed = ['landing', 'impressum', 'lizenz', 'datenschutz'];
+        if (!in_array($slug, $allowed, true)) {
+            return $response->withStatus(404);
+        }
+        $path = dirname(__DIR__, 3) . '/content/' . $slug . '.html';
+        $data = $request->getParsedBody();
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $html = (string)($data['content'] ?? '');
+        file_put_contents($path, $html);
+        return $response->withStatus(204);
+    }
+}

--- a/src/Controller/DatenschutzController.php
+++ b/src/Controller/DatenschutzController.php
@@ -7,18 +7,27 @@ namespace App\Controller;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use Slim\Routing\RouteContext;
 
 /**
  * Renders the privacy policy page.
  */
 class DatenschutzController
 {
-    /**
-     * Display the Datenschutz page.
-     */
     public function __invoke(Request $request, Response $response): Response
     {
+        $path = dirname(__DIR__, 2) . '/content/datenschutz.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+
+        $html = (string) file_get_contents($path);
+        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $html = str_replace('{{ basePath }}', $basePath, $html);
+
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'datenschutz.twig');
+        return $view->render($response, 'datenschutz.twig', [
+            'content' => $html,
+        ]);
     }
 }

--- a/src/Controller/ImpressumController.php
+++ b/src/Controller/ImpressumController.php
@@ -7,18 +7,27 @@ namespace App\Controller;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use Slim\Routing\RouteContext;
 
 /**
  * Displays the legal notice page.
  */
 class ImpressumController
 {
-    /**
-     * Render the Impressum page.
-     */
     public function __invoke(Request $request, Response $response): Response
     {
+        $path = dirname(__DIR__, 2) . '/content/impressum.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+
+        $html = (string) file_get_contents($path);
+        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $html = str_replace('{{ basePath }}', $basePath, $html);
+
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'impressum.twig');
+        return $view->render($response, 'impressum.twig', [
+            'content' => $html,
+        ]);
     }
 }

--- a/src/Controller/LizenzController.php
+++ b/src/Controller/LizenzController.php
@@ -7,18 +7,27 @@ namespace App\Controller;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use Slim\Routing\RouteContext;
 
 /**
  * Shows the open-source license information.
  */
 class LizenzController
 {
-    /**
-     * Render the license page.
-     */
     public function __invoke(Request $request, Response $response): Response
     {
+        $path = dirname(__DIR__, 2) . '/content/lizenz.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+
+        $html = (string) file_get_contents($path);
+        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $html = str_replace('{{ basePath }}', $basePath, $html);
+
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'lizenz.twig');
+        return $view->render($response, 'lizenz.twig', [
+            'content' => $html,
+        ]);
     }
 }

--- a/src/Controller/Marketing/LandingController.php
+++ b/src/Controller/Marketing/LandingController.php
@@ -7,18 +7,27 @@ namespace App\Controller\Marketing;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use Slim\Routing\RouteContext;
 
 /**
  * Displays the landing page for the marketing site.
  */
 class LandingController
 {
-    /**
-     * Render the landing page.
-     */
     public function __invoke(Request $request, Response $response): Response
     {
+        $path = dirname(__DIR__, 3) . '/content/landing.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+
+        $html = (string) file_get_contents($path);
+        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $html = str_replace('{{ basePath }}', $basePath, $html);
+
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'marketing/landing.twig');
+        return $view->render($response, 'marketing/landing.twig', [
+            'content' => $html,
+        ]);
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -39,6 +39,7 @@ use App\Controller\EvidenceController;
 use App\Controller\EventController;
 use App\Controller\EventListController;
 use App\Controller\SettingsController;
+use App\Controller\Admin\PageController;
 use App\Controller\TenantController;
 use App\Controller\Marketing\LandingController;
 use Psr\Log\NullLogger;
@@ -60,6 +61,7 @@ require_once __DIR__ . '/Controller/ResultController.php';
 require_once __DIR__ . '/Controller/TeamController.php';
 require_once __DIR__ . '/Controller/PasswordController.php';
 require_once __DIR__ . '/Controller/AdminCatalogController.php';
+require_once __DIR__ . '/Controller/Admin/PageController.php';
 require_once __DIR__ . '/Controller/QrController.php';
 require_once __DIR__ . '/Controller/LogoController.php';
 require_once __DIR__ . '/Controller/CatalogDesignController.php';
@@ -193,6 +195,16 @@ return function (\Slim\App $app) {
     $app->get('/admin', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/kataloge', AdminCatalogController::class)
         ->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
+
+    $app->get('/admin/pages/{slug}', function (Request $request, Response $response, array $args) {
+        $controller = new PageController();
+        return $controller->edit($request, $response, $args);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+
+    $app->post('/admin/pages/{slug}', function (Request $request, Response $response, array $args) {
+        $controller = new PageController();
+        return $controller->update($request, $response, $args);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
     $app->get('/results', function (Request $request, Response $response) {
         return $request->getAttribute('resultController')->page($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::ANALYST));

--- a/templates/admin/pages/edit.twig
+++ b/templates/admin/pages/edit.twig
@@ -1,0 +1,25 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Seite bearbeiten{% endblock %}
+
+{% block head %}
+  <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+{% endblock %}
+
+{% block body_class %}uk-background-muted uk-padding{% endblock %}
+
+{% block body %}
+  <div class="uk-container uk-container-expand">
+    <h1 class="uk-heading-bullet">Seite bearbeiten: {{ slug }}</h1>
+    <form method="post" class="uk-form-stacked">
+      <textarea id="pageContent" name="content" class="uk-textarea" rows="20">{{ content }}</textarea>
+      <div class="uk-margin-top">
+        <button type="submit" class="uk-button uk-button-primary">Speichern</button>
+        <a href="{{ basePath }}/{{ slug }}" target="_blank" class="uk-button uk-button-default">Vorschau</a>
+      </div>
+    </form>
+  </div>
+  <script>
+    tinymce.init({ selector: '#pageContent', height: 500 });
+  </script>
+{% endblock %}

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -29,43 +29,7 @@
     {% endblock %}
     {% block offcanvas %}{% endblock %}
   {% endembed %}
-  <div class="uk-container uk-container-small legal-container">
-    <h1 class="uk-heading-divider uk-hidden">Datenschutzerklärung</h1>
-
-    <h2 class="uk-heading-bullet">1. Verantwortlicher</h2>
-    <p>Verantwortlich für die Datenverarbeitung im Rahmen dieser Anwendung ist:<br>
-    René Buske<br>
-    Weidenbusch 8<br>
-    14532 Kleinmachnow<br>
-    E-Mail: <a href="mailto:info@calhelp.de">info@calhelp.de</a></p>
-
-    <h2 class="uk-heading-bullet">2. Zweck der Datenverarbeitung</h2>
-    <p>Die Quiz-App dient der Durchführung eines digitalen Quiz im Rahmen der Sommerfeier 2025. Die Erhebung und Verarbeitung von Daten erfolgt ausschließlich zur Bereitstellung und Verbesserung des Quiz-Angebots.</p>
-
-    <h2 class="uk-heading-bullet">3. Art und Umfang der erhobenen Daten</h2>
-    <p><strong>Keine Erhebung personenbezogener Daten:</strong> Es werden keinerlei personenbezogene Daten (wie Name, E-Mail, Adresse etc.) abgefragt, gespeichert oder verarbeitet.</p>
-    <p><strong>Quiz-Daten:</strong> Bei der Nutzung der App werden lediglich pseudonymisierte Daten wie frei gewählte Benutzernamen, erzielte Punktzahlen und ggf. technische Informationen zum Ablauf des Quiz verarbeitet.</p>
-    <p><strong>Serverdatei ([Veranstaltungsname].csv):</strong> Bei aktivierter Speicherung werden Pseudonyme, Katalogname, Versuch, Punktzahl und Zeitpunkt serverseitig gesichert. Die Ablage erfolgt anonymisiert und konform zur DSGVO.</p>
-
-    <h2 class="uk-heading-bullet">4. Speicherung und Löschung</h2>
-    <p><strong>Serverseitige Speicherung:</strong> Je nach Konfiguration werden Quiz-Ergebnisse anonymisiert auf dem Server gespeichert. Diese Speicherung erfolgt entsprechend den Anforderungen der DSGVO.</p>
-    <p><strong>Lokal gespeicherte Daten:</strong> Sofern lokal gespeichert wird (z. B. im Browser-Storage), verbleiben die Daten ausschließlich auf dem Endgerät des Nutzers und werden nicht an Dritte übermittelt.</p>
-    <p><strong>Löschung:</strong> Alle gespeicherten Daten werden spätestens nach Abschluss des Quiz-Events gelöscht oder anonymisiert.</p>
-
-    <h2 class="uk-heading-bullet">5. Keine Weitergabe an Dritte</h2>
-    <p>Es findet keine Übermittlung oder Weitergabe von Daten an Dritte statt.</p>
-
-    <h2 class="uk-heading-bullet">6. Cookies und Tracking</h2>
-    <p>Die App setzt ein technisch notwendiges Session-Cookie (<code>PHPSESSID</code>), das für den Betrieb erforderlich ist – etwa für den Admin-Login. Dieses Cookie enthält keine personenbezogenen Daten und wird nach Beenden des Browsers gelöscht. Ein darüber hinaus gehendes Tracking zur Nutzerverfolgung findet nicht statt.</p>
-
-    <h2 class="uk-heading-bullet">7. Rechte der Nutzer</h2>
-    <p>Da keine personenbezogenen Daten verarbeitet werden, bestehen keine Betroffenenrechte im Sinne der DSGVO bezüglich Auskunft, Berichtigung, Löschung oder Übertragbarkeit.</p>
-
-    <h2 class="uk-heading-bullet">8. Kontakt</h2>
-    <p>Für Fragen zum Datenschutz oder zur Anwendung wenden Sie sich bitte an: <a href="mailto:info@calhelp.de">info@calhelp.de</a></p>
-
-    <p class="uk-text-small"><strong>Hinweis:</strong> Diese Datenschutzerklärung basiert auf dem aktuellen Stand der Technik und des Projekts. <strong>CalHelp übernimmt keine Verantwortung</strong> für bereits durch Administrator:innen eingegebene personenbezogene Daten. Sollte sich der Funktionsumfang ändern oder die App personenbezogene Daten erheben, ist eine Anpassung dieser Datenschutzerklärung erforderlich.</p>
-  </div>
+  {{ content|raw }}
 {% endblock %}
 
 {% block scripts %}

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -29,33 +29,7 @@
     {% endblock %}
     {% block offcanvas %}{% endblock %}
   {% endembed %}
-  <div class="uk-container uk-container-small legal-container">
-    <h1 class="uk-heading-divider uk-hidden">Impressum</h1>
-
-    <p>Angaben gemäß § 5 TMG</p>
-    <p>René Buske<br>
-    Weidenbusch 8<br>
-    14532 Kleinmachnow<br>
-    Deutschland</p>
-    <p>E-Mail: <a href="mailto:office@calhelp.de">office@calhelp.de</a></p>
-
-    <p><strong>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:</strong><br>
-    René Buske<br>
-    Weidenbusch 8<br>
-    14532 Kleinmachnow</p>
-
-    <p>Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz: DE 259645623</p>
-
-    <h2 class="uk-heading-bullet">Haftungsausschluss</h2>
-    <p>Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung für die Inhalte externer Links. Für den Inhalt der verlinkten Seiten sind ausschließlich deren Betreiber verantwortlich.</p>
-
-    <h2 class="uk-heading-bullet">Urheberrecht</h2>
-    <p>Die durch den Seitenbetreiber erstellten Inhalte und Werke auf dieser Website unterliegen dem deutschen Urheberrecht. Beiträge Dritter sind als solche gekennzeichnet.</p>
-
-    <h2 class="uk-heading-bullet">Quellcode</h2>
-    <p>Der Quellcode dieser Anwendung ist unter der MIT-Lizenz auf GitHub verfügbar:<br>
-    <a href="https://github.com/bastelix/sommerfest-quiz">https://github.com/bastelix/sommerfest-quiz</a></p>
-  </div>
+  {{ content|raw }}
 {% endblock %}
 
 {% block scripts %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -29,70 +29,7 @@
     {% endblock %}
     {% block offcanvas %}{% endblock %}
   {% endembed %}
-  <div class="uk-container uk-container-small legal-container">
-    <h1 class="uk-heading-divider uk-hidden">Lizenz</h1>
-    <p>Diese Anwendung steht unter der <a href="https://opensource.org/licenses/MIT">MIT-Lizenz</a>. Den vollständigen Text finden Sie auch untenstehend sowie in der Datei <code>LICENSE</code>.</p>
-    <div class="uk-card uk-card-default uk-card-body uk-margin">
-      <h3 class="uk-heading-bullet">Disclaimer / Hinweis</h3>
-        <p>Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer spannenden Zusammenarbeit zwischen menschlicher Erfahrung und k&uuml;nstlicher Intelligenz. W&auml;hrend Ideen, Organisation und jede Menge Praxiswissen von Menschen stammen, wurden alle Codezeilen experimentell komplett von OpenAI Codex geschrieben. F&uuml;r die kreativen Konzepte und Inhalte kam ChatGPT 4.1 zum Einsatz, bei der Fehlersuche half Github Copilot und das Logo wurde von der KI Sora entworfen.</p>
-        <p>Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial moderner Codeassistenten in der Praxis zu erproben.</p>
-        <p>Im Mittelpunkt stand die Zug&auml;nglichkeit f&uuml;r alle Nutzergruppen &ndash; daher ist die Anwendung barrierefrei gestaltet und eignet sich auch f&uuml;r Menschen mit Einschr&auml;nkungen. Datenschutz und Sicherheit werden konsequent beachtet, sodass alle Daten gesch&uuml;tzt sind.</p>
-        <p>Die App zeichnet sich durch eine hohe Performance und Stabilit&auml;t auch bei vielen gleichzeitigen Teilnehmenden aus. Das Bedienkonzept ist selbsterkl&auml;rend, wodurch eine schnelle und intuitive Nutzung auf allen Endger&auml;ten &ndash; ob Smartphone, Tablet oder Desktop &ndash; gew&auml;hrleistet wird.</p>
-        <p>Zudem wurde auf eine ressourcenschonende Arbeitsweise und eine unkomplizierte Anbindung an andere Systeme Wert gelegt.</p>
-      <p>Mit dieser App zeigen wir, was heute schon m&ouml;glich ist, wenn Menschen und verschiedene KI-Tools wie ChatGPT, Codex, Copilot und Sora gemeinsam an neuen digitalen Ideen t&uuml;fteln.</p>
-    </div>
-    <h2 class="uk-heading-bullet">MIT-Lizenz (Deutsch)</h2>
-<pre class="uk-text-small">
-MIT-Lizenz
-
-Copyright (c) 2025 calhelp
-
-Hiermit wird unentgeltlich jeder Person, die eine Kopie der Software
-und der zugehörigen Dokumentationsdateien (die "Software") erhält,
-die Erlaubnis erteilt, uneingeschränkt mit der Software zu verfahren,
-einschließlich aber nicht beschränkt auf die Rechte, die Software zu
-nutzen, zu kopieren, zu modifizieren, zusammenzuführen, zu veröffentlichen,
-zu verbreiten, zu unterlizenzieren und/oder zu verkaufen, sowie Personen,
-denen die Software bereitgestellt wird, diese Rechte zu gewähren, vorbehaltlich
-der folgenden Bedingungen:
-
-Der obige Urheberrechtsvermerk und dieser Erlaubnisvermerk sind in allen
-Kopien oder wesentlichen Teilen der Software beizulegen.
-
-DIE SOFTWARE WIRD OHNE JEDE AUSDRÜCKLICHE ODER STILLSCHWEIGENDE GEWÄHRLEISTUNG
-BEREITGESTELLT, EINSCHLIESSLICH UND NICHT BESCHRÄNKT AUF DIE GEWÄHRLEISTUNGEN
-DER MARKTGÄNGIGKEIT, DER EIGNUNG FÜR EINEN BESTIMMTEN ZWECK UND DER NICHTVERLETZUNG.
-IN KEINEM FALL SIND DIE AUTOREN ODER URHEBERRECHTSINHABER FÜR JEGLICHE ANSPRÜCHE,
-SCHÄDEN ODER SONSTIGE HAFTUNGEN VERANTWORTLICH, OB IN EINEM VERTRAGSVERHÄLTNIS,
-EINER UNERLAUBTEN HANDLUNG ODER ANDERWEITIG, DIE SICH AUS DER SOFTWARE ODER DER
-NUTZUNG ODER ANDEREN GESCHÄFTEN MIT DER SOFTWARE ERGEBEN.
-</pre>
-
-    <h2 class="uk-heading-bullet">MIT License (English)</h2>
-<pre class="uk-text-small">
-MIT License
-
-Copyright (c) 2025 calhelp
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-  </div>
+  {{ content|raw }}
 {% endblock %}
 
 {% block scripts %}

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -25,68 +25,7 @@
       <a class="uk-button uk-button-primary" href="{{ basePath }}/login">Kostenlos testen</a>
     {% endblock %}
   {% endembed %}
-
-  <section class="uk-section uk-section-primary uk-flex uk-flex-middle" uk-height-viewport="offset-top: true">
-    <div class="uk-container">
-      <h1 class="uk-heading-medium">Willkommen beim QuizRace</h1>
-      <p class="uk-text-lead">Trete gegen Freunde und Kollegen an und finde heraus, wer das meiste Wissen hat.</p>
-      <p class="uk-margin-large-top">
-        <a class="uk-button uk-button-secondary uk-button-large" href="{{ basePath }}/login">Jetzt starten</a>
-      </p>
-    </div>
-  </section>
-
-  <section id="features" class="uk-section uk-section-default">
-    <div class="uk-container">
-      <div class="uk-child-width-1-3@m uk-grid-match" uk-grid>
-        <div>
-          <div class="uk-card uk-card-body">
-            <h3 class="uk-card-title">Einfach</h3>
-            <p>Intuitive Bedienung und schnelle Registrierung.</p>
-          </div>
-        </div>
-        <div>
-          <div class="uk-card uk-card-body">
-            <h3 class="uk-card-title">Sicher</h3>
-            <p>Alle Daten bleiben auf Ihrem eigenen Server.</p>
-          </div>
-        </div>
-        <div>
-          <div class="uk-card uk-card-body">
-            <h3 class="uk-card-title">Auswertungen</h3>
-            <p>Ergebnisse und Ranglisten in Echtzeit.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section id="pricing" class="uk-section uk-section-muted">
-    <div class="uk-container">
-      <h2 class="uk-heading-small">Preise</h2>
-      <p class="uk-text-lead">Informationen zu unseren Preisen.</p>
-    </div>
-  </section>
-
-  <section id="contact" class="uk-section uk-section-muted">
-    <div class="uk-container">
-      <h2 class="uk-heading-small">Kontakt</h2>
-      <form class="uk-grid-small" uk-grid>
-        <div class="uk-width-1-2@s">
-          <input class="uk-input" type="text" placeholder="Ihr Name">
-        </div>
-        <div class="uk-width-1-2@s">
-          <input class="uk-input" type="email" placeholder="Ihre E-Mail">
-        </div>
-        <div class="uk-width-1-1">
-          <textarea class="uk-textarea" rows="5" placeholder="Ihre Nachricht"></textarea>
-        </div>
-        <div class="uk-width-1-1">
-          <button class="uk-button uk-button-primary" type="submit">Senden</button>
-        </div>
-      </form>
-    </div>
-  </section>
+  {{ content|raw }}
 {% endblock %}
 
 {% block scripts %}

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class PageControllerTest extends TestCase
+{
+    public function testEditAndUpdate(): void
+    {
+        $dir = dirname(__DIR__, 2) . '/content';
+        if (!is_dir($dir)) {
+            mkdir($dir);
+        }
+        $file = $dir . '/landing.html';
+        file_put_contents($file, '<p>old</p>');
+
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+
+        $response = $app->handle($this->createRequest('GET', '/admin/pages/landing'));
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $req = $this->createRequest('POST', '/admin/pages/landing');
+        $req = $req->withParsedBody(['content' => '<p>new</p>']);
+        $res = $app->handle($req);
+        $this->assertEquals(204, $res->getStatusCode());
+        $this->assertStringEqualsFile($file, '<p>new</p>');
+
+        session_destroy();
+        unlink($file);
+    }
+
+    public function testInvalidSlug(): void
+    {
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $res = $app->handle($this->createRequest('GET', '/admin/pages/unknown'));
+        $this->assertEquals(404, $res->getStatusCode());
+        session_destroy();
+    }
+}


### PR DESCRIPTION
## Summary
- serve static pages from `/content` and keep original layout
- allow admin editing via TinyMCE without losing top bar and footer
- replace raw rendering with Twig-based output
- update HTML files with previous content for imprint, privacy, license and landing

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml src/Controller/ImpressumController.php src/Controller/DatenschutzController.php src/Controller/LizenzController.php src/Controller/Marketing/LandingController.php tests/Controller/PageControllerTest.php`
- `vendor/bin/phpunit tests/Controller/PageControllerTest.php`
- `vendor/bin/phpunit --testsuite "Test Suite"` *(fails: Errors: 1, Failures: 14)*

------
https://chatgpt.com/codex/tasks/task_e_687f37425f98832b90c8d9a981e16373