### PR TITLE
Add static page editing tab

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -9,8 +9,13 @@ Die Administrationsoberfl\u00e4che erreichen Sie \u00fcber `/admin` nach einem e
 5. **Teams/Personen** – Teilnehmerlisten pflegen und optional den Zugang einschränken.
 6. **Ergebnisse** – Spielstände einsehen und als CSV herunterladen.
 7. **Statistik** – Einzelne Antworten analysieren und nach Teams filtern.
-8. **Administration** – Benutzer und Backups verwalten.
+8. **Seiten** – Statische Inhalte wie Landing-Page, Impressum, Lizenz und Datenschutz bearbeiten.
+9. **Administration** – Benutzer und Backups verwalten.
 Im Tab "Administration" lassen sich JSON-Sicherungen exportieren und bei Bedarf wiederherstellen.
 Der Statistik-Tab listet jede Antwort mit Name, Versuch, Katalog, Frage, Antwort, Richtig-Status und optionalem Beweisfoto. Über ein Auswahlfeld lassen sich die Daten nach Teams oder Personen filtern.
 
 Weitere Funktionen wie der QR-Code-Login oder der Wettkampfmodus lassen sich in der Datei `data/config.json` aktivieren.
+
+## Statische Seiten bearbeiten
+
+Im Tab **Seiten** können Administratoren die HTML-Dateien `landing`, `impressum`, `lizenz` und `datenschutz` anpassen. Über das Untermenü wird die gewünschte Seite ausgewählt und im TinyMCE-Editor bearbeitet. Mit **Speichern** werden die Änderungen in den jeweiligen Dateien im Ordner `content/` abgelegt. Die Schaltfläche *Vorschau* öffnet die Seite in einem neuen Tab. Alternativ kann der Editor direkt über `/admin/pages/{slug}` aufgerufen werden.

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const basePath = window.basePath || '';
   const withBase = path => basePath + path;
   const settingsInitial = window.quizSettings || {};
+  const pagesInitial = window.pagesContent || {};
   const apiFetch = (path, options = {}) => {
     return fetch(withBase(path), {
       credentials: 'same-origin',
@@ -1966,6 +1967,28 @@ document.addEventListener('DOMContentLoaded', function () {
       });
     });
   }
+
+  if (typeof tinymce !== 'undefined') {
+    tinymce.init({ selector: '.page-content', height: 500 });
+  }
+
+  document.querySelectorAll('.page-form').forEach(form => {
+    const slug = form.dataset.slug;
+    const textarea = form.querySelector('.page-content');
+    const saveBtn = form.querySelector('.save-page-btn');
+    saveBtn?.addEventListener('click', e => {
+      e.preventDefault();
+      const content = tinymce?.get(textarea.id)?.getContent ? tinymce.get(textarea.id).getContent() : textarea.value;
+      apiFetch('/admin/pages/' + slug, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ content })
+      }).then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        notify('Seite gespeichert', 'success');
+      }).catch(() => notify('Fehler beim Speichern', 'danger'));
+    });
+  });
 
   loadBackups();
 });

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -101,6 +101,14 @@ class AdminController
 
         $teams  = (new TeamService($pdo, $configSvc))->getAll();
         $users  = (new UserService($pdo))->getAll();
+
+        $pageSlugs = ['landing', 'impressum', 'lizenz', 'datenschutz'];
+        $pages     = [];
+        foreach ($pageSlugs as $slug) {
+            $path          = dirname(__DIR__, 2) . '/content/' . $slug . '.html';
+            $pages[$slug] = is_file($path) ? file_get_contents($path) : '';
+        }
+
         return $view->render($response, 'admin.twig', [
             'config' => $cfg,
             'settings' => $settings,
@@ -112,6 +120,7 @@ class AdminController
             'baseUrl' => $baseUrl,
             'event' => $event,
             'role' => $role,
+            'pages' => $pages,
         ]);
     }
 }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+  <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -40,6 +41,7 @@
     <li data-help="Gespeicherte Ergebnisse mit richtigen Antworten und Zeit einsehen. 'Zurücksetzen' löscht alle Daten, 'Herunterladen' exportiert sie als CSV."><a href="#">Ergebnisse</a></li>
     <li data-help="Einzelne Antworten analysieren. Tabelle filtert nach Teams/Personen."><a href="#">Statistik</a></li>
     {% if role == 'admin' %}
+    <li data-help="Statische Seiten bearbeiten."><a href="#">Seiten</a></li>
     <li data-help="Benutzer verwalten, Rollen zuweisen und Sicherungen erstellen. Rollen: admin – Administrator; catalog-editor – Fragenkataloge bearbeiten; event-manager – Veranstaltungen verwalten; analyst – Ergebnisse analysieren; team-manager – Teams verwalten."><a href="#">Administration</a></li>
     {% endif %}
   </ul>
@@ -506,6 +508,30 @@
     </li>
       {% if role == 'admin' %}
       <li>
+        <div class="uk-container uk-container-large">
+          <h2 class="uk-heading-bullet">Seiten</h2>
+          <ul id="pageTabs" class="uk-tab" uk-switcher>
+            <li class="uk-active" data-slug="landing"><a href="#">Landing</a></li>
+            <li data-slug="impressum"><a href="#">Impressum</a></li>
+            <li data-slug="lizenz"><a href="#">Lizenz</a></li>
+            <li data-slug="datenschutz"><a href="#">Datenschutz</a></li>
+          </ul>
+          <ul class="uk-switcher uk-margin">
+            {% for slug, html in pages %}
+            <li>
+              <form class="page-form" data-slug="{{ slug }}">
+                <textarea id="page_{{ slug }}" name="content" class="uk-textarea page-content" rows="20">{{ html }}</textarea>
+                <div class="uk-margin-top">
+                  <button class="uk-button uk-button-primary save-page-btn">Speichern</button>
+                  <a class="uk-button uk-button-default preview-link" href="{{ basePath }}/{{ slug }}" target="_blank">Vorschau</a>
+                </div>
+              </form>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </li>
+      <li>
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">Administration</h2>
 
@@ -589,7 +615,8 @@
         <li><a href="#" data-tab="6">Ergebnisse</a></li>
         <li><a href="#" data-tab="7">Statistik</a></li>
         {% if role == 'admin' %}
-        <li><a href="#" data-tab="8">Administration</a></li>
+        <li><a href="#" data-tab="8">Seiten</a></li>
+        <li><a href="#" data-tab="9">Administration</a></li>
         {% endif %}
         <li class="uk-nav-divider"></li>
         <li><a href="{{ basePath }}/logout">Abmelden</a></li>
@@ -605,6 +632,7 @@
     window.quizSettings = {{ settings|json_encode|raw }};
     window.roles = {{ roles|json_encode|raw }};
     window.baseUrl = '{{ baseUrl }}';
+    window.pagesContent = {{ pages|json_encode|raw }};
   </script>
   <script src="{{ basePath }}/js/admin.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>


### PR DESCRIPTION
## Summary
- allow editing of landing, impressum, lizenz and datenschutz from admin dashboard
- expose page contents to the admin template
- embed TinyMCE page editor in new "Seiten" tab
- document editing of static pages in admin guide

## Testing
- `vendor/bin/phpunit --no-coverage` *(fails: TypeError & 14 failures)*

------
https://chatgpt.com/codex/tasks/task_e_687f4c48d3c0832bba251cbbfbaa661f