### PR TITLE
Switch admin pages to Quill editor

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1968,17 +1968,16 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  if (typeof tinymce !== 'undefined') {
-    tinymce.init({ selector: '.page-content', height: 500 });
-  }
-
   document.querySelectorAll('.page-form').forEach(form => {
     const slug = form.dataset.slug;
-    const textarea = form.querySelector('.page-content');
+    const input = form.querySelector('input[name="content"]');
+    const editorEl = form.querySelector('.quill-editor');
+    const quill = new Quill(editorEl, { theme: 'snow' });
     const saveBtn = form.querySelector('.save-page-btn');
     saveBtn?.addEventListener('click', e => {
       e.preventDefault();
-      const content = tinymce?.get(textarea.id)?.getContent ? tinymce.get(textarea.id).getContent() : textarea.value;
+      const content = quill.root.innerHTML;
+      input.value = content;
       apiFetch('/admin/pages/' + slug, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -6,7 +6,8 @@
   <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
-  <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+  <link rel="stylesheet" href="{{ basePath }}/css/quill.snow.css">
+  <script src="{{ basePath }}/js/quill.min.js"></script>
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -520,7 +521,8 @@
             {% for slug, html in pages %}
             <li>
               <form class="page-form" data-slug="{{ slug }}">
-                <textarea id="page_{{ slug }}" name="content" class="uk-textarea page-content" rows="20">{{ html }}</textarea>
+                <input type="hidden" id="page_{{ slug }}" name="content" value="{{ html|e('html_attr') }}">
+                <div class="quill-editor">{{ html|raw }}</div>
                 <div class="uk-margin-top">
                   <button class="uk-button uk-button-primary save-page-btn">Speichern</button>
                   <a class="uk-button uk-button-default preview-link" href="{{ basePath }}/{{ slug }}" target="_blank">Vorschau</a>


### PR DESCRIPTION
## Summary
- replace TinyMCE import with Quill in admin layout
- use Quill editor for page editing forms
- adjust admin JS to save pages using Quill

## Testing
- `vendor/bin/phpunit` *(fails: Tests: 103, Assertions: 199, Errors: 1, Failures: 11)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_687f66523fe8832b96d6672728be1df9