### PR TITLE
Add HTML code editing to Quill editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,26 @@ kopiert oder per CDN eingebunden werden:
 ```
 
 Das Template `templates/admin/pages/edit.twig` initialisiert den Editor mit
-`new Quill('#editor', { theme: 'snow' });`. Beim Absenden des Formulars wird der
-HTML-Inhalt in das versteckte Feld `content` geschrieben.
+einer erweiterten Werkzeugleiste und einem Button zum direkten Bearbeiten des
+HTML-Codes:
+
+```javascript
+new Quill('#editor', {
+  theme: 'snow',
+  modules: {
+    toolbar: [
+      [{ header: [1, 2, false] }],
+      ['bold', 'italic', 'underline', 'link'],
+      [{ list: 'ordered' }, { list: 'bullet' }],
+      ['clean', 'html']
+    ],
+    htmlEditButton: {}
+  }
+});
+```
+
+Beim Absenden des Formulars wird der HTML-Inhalt in das versteckte Feld
+`content` geschrieben.
 
 ## Tests
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1972,7 +1972,18 @@ document.addEventListener('DOMContentLoaded', function () {
     const slug = form.dataset.slug;
     const input = form.querySelector('input[name="content"]');
     const editorEl = form.querySelector('.quill-editor');
-    const quill = new Quill(editorEl, { theme: 'snow' });
+    const quill = new Quill(editorEl, {
+      theme: 'snow',
+      modules: {
+        toolbar: [
+          [{ header: [1, 2, false] }],
+          ['bold', 'italic', 'underline', 'link'],
+          [{ list: 'ordered' }, { list: 'bullet' }],
+          ['clean', 'html']
+        ],
+        htmlEditButton: {}
+      }
+    });
     const saveBtn = form.querySelector('.save-page-btn');
     saveBtn?.addEventListener('click', e => {
       e.preventDefault();

--- a/public/js/quill-html-edit.js
+++ b/public/js/quill-html-edit.js
@@ -1,0 +1,49 @@
+(function(){
+  function HtmlEditButton(quill, options) {
+    this.quill = quill;
+    const toolbar = quill.getModule('toolbar');
+    if (!toolbar) return;
+    toolbar.addHandler('html', this.toggleHtmlEdit.bind(this));
+    const button = toolbar.container.querySelector('.ql-html');
+    if (button) button.innerHTML = options.buttonHTML || '&lt;/&gt;';
+  }
+  HtmlEditButton.prototype.toggleHtmlEdit = function() {
+    const quill = this.quill;
+    const modal = document.createElement('div');
+    modal.className = 'uk-modal';
+    const textarea = document.createElement('textarea');
+    textarea.className = 'uk-textarea';
+    textarea.style.width = '100%';
+    textarea.style.height = '300px';
+    textarea.value = quill.root.innerHTML;
+    const apply = document.createElement('button');
+    apply.className = 'uk-button uk-button-primary apply-btn';
+    apply.textContent = 'Übernehmen';
+    const cancel = document.createElement('button');
+    cancel.className = 'uk-button uk-button-default uk-modal-close';
+    cancel.textContent = 'Abbrechen';
+    const footer = document.createElement('p');
+    footer.className = 'uk-text-right';
+    footer.appendChild(cancel);
+    footer.appendChild(document.createTextNode(' '));
+    footer.appendChild(apply);
+    const dialog = document.createElement('div');
+    dialog.className = 'uk-modal-dialog uk-modal-body';
+    dialog.appendChild(textarea);
+    dialog.appendChild(footer);
+    modal.appendChild(dialog);
+    document.body.appendChild(modal);
+    const modalObj = UIkit.modal(modal);
+    modalObj.show();
+    apply.addEventListener('click', function(){
+      quill.root.innerHTML = textarea.value;
+      modalObj.hide();
+    });
+    modal.addEventListener('hidden', function(){
+      modal.remove();
+    });
+  };
+  if (window.Quill) {
+    window.Quill.register('modules/htmlEditButton', HtmlEditButton);
+  }
+})();

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="{{ basePath }}/css/quill.snow.css">
   <script src="{{ basePath }}/js/quill.min.js"></script>
+  <script src="{{ basePath }}/js/quill-html-edit.js"></script>
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}

--- a/templates/admin/pages/edit.twig
+++ b/templates/admin/pages/edit.twig
@@ -3,8 +3,12 @@
 {% block title %}Seite bearbeiten{% endblock %}
 
 {% block head %}
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="{{ basePath }}/css/quill.snow.css">
   <script src="{{ basePath }}/js/quill.min.js"></script>
+  <script src="{{ basePath }}/js/quill-html-edit.js"></script>
 {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
@@ -22,7 +26,18 @@
     </form>
   </div>
   <script>
-    const quill = new Quill('#editor', { theme: 'snow' });
+    const quill = new Quill('#editor', {
+      theme: 'snow',
+      modules: {
+        toolbar: [
+          [{ header: [1, 2, false] }],
+          ['bold', 'italic', 'underline', 'link'],
+          [{ list: 'ordered' }, { list: 'bullet' }],
+          ['clean', 'html']
+        ],
+        htmlEditButton: {}
+      }
+    });
     document.querySelector('form').addEventListener('submit', () => {
       document.getElementById('pageContent').value = quill.root.innerHTML;
     });


### PR DESCRIPTION
## Summary
- allow HTML editing with a new Quill module
- load page styles during page editing
- update admin code to use the new module
- document new toolbar setup

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit` *(fails: Unsupported operand types, failing tests)*
- `vendor/bin/phpstan analyse` *(fails: PHPStan process crashed due to memory limit)*
- `vendor/bin/phpcs -q`


------
https://chatgpt.com/codex/tasks/task_e_687f6c40f058832b935fbda9b8077f95