### PR TITLE
Fix HTML code view button

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -682,4 +682,10 @@ body.dark-mode .sticky-actions {
   border-radius: 0 0 4px 4px;
 }
 
+/* Icon for HTML code button in Quill toolbar */
+.ql-html::before {
+  content: '</>';
+  font-family: monospace;
+}
+
 

--- a/public/js/quill-html-edit.js
+++ b/public/js/quill-html-edit.js
@@ -5,7 +5,10 @@
     if (!toolbar) return;
     toolbar.addHandler('html', this.toggleHtmlEdit.bind(this));
     const button = toolbar.container.querySelector('.ql-html');
-    if (button) button.innerHTML = options.buttonHTML || '&lt;/&gt;';
+    if (button) {
+      button.innerHTML = options.buttonHTML || '&lt;/&gt;';
+      button.setAttribute('type', 'button');
+    }
   }
   HtmlEditButton.prototype.toggleHtmlEdit = function() {
     const quill = this.quill;


### PR DESCRIPTION
## Summary
- ensure `Code anzeigen` button uses a button element
- add minimal styling so the button shows a `</>` label

## Testing
- `vendor/bin/phpunit --display-warnings=0` *(fails: Unsupported operand types ...)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687f756fc564832bbd423b3c08dddee0