### PR TITLE
Fix Editor.js admin page markup

### DIFF
--- a/templates/admin/pages/edit.twig
+++ b/templates/admin/pages/edit.twig
@@ -17,11 +17,11 @@
 {% block body %}
   <div class="uk-container uk-container-expand">
     <h1 class="uk-heading-bullet">Seite bearbeiten: {{ slug }}</h1>
-    <form method="post" class="uk-form-stacked">
+    <form method="post" class="uk-form-stacked page-form" data-slug="{{ slug }}">
       <input type="hidden" id="pageContent" name="content" value="{{ content|e('html_attr') }}">
-      <div id="editor" class="editorjs">{{ content|raw }}</div>
+      <div class="editorjs">{{ content|raw }}</div>
       <div class="uk-margin-top">
-        <button type="submit" class="uk-button uk-button-primary">Speichern</button>
+        <button type="button" class="uk-button uk-button-primary save-page-btn">Speichern</button>
         <a href="{{ basePath }}/{{ slug }}" target="_blank" class="uk-button uk-button-default">Vorschau</a>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- hook Editor.js editor to admin pages edit form

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml --colors=never`
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_687fa0472b40832b8a7e332893519c39