### PR TITLE
Enhance page editor with custom UIkit blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Die Übersichtsseiten erzeugen ihre QR-Codes jetzt lokal mit der Bibliothek *End
 
 ### Rich-Text-Editor
 
-Zum Bearbeiten der statischen Seiten wird jetzt **Trumbowyg** verwendet. Die Bibliothek
+Zum Bearbeiten der statischen Seiten wird **Trumbowyg** eingesetzt. Die Bibliothek
 kann per CDN eingebunden werden:
 
 ```html
@@ -259,8 +259,10 @@ kann per CDN eingebunden werden:
 <script src="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/trumbowyg.min.js"></script>
 ```
 
-Die Initialisierung erfolgt im Skript `public/js/trumbowyg-pages.js` und überträgt
-beim Speichern das generierte HTML in das Feld `content`.
+Die Initialisierung erfolgt im Skript `public/js/trumbowyg-pages.js`. Dort sind
+auch eigene UIkit-Vorlagen wie ein Hero-Block oder eine Card hinterlegt. Beim
+Speichern wird das generierte HTML in das Feld `content` übertragen. Eine
+Vorschau lässt sich direkt im Modal aufrufen.
 
 ## Tests
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -18,4 +18,4 @@ Weitere Funktionen wie der QR-Code-Login oder der Wettkampfmodus lassen sich in 
 
 ## Statische Seiten bearbeiten
 
-Im Tab **Seiten** können Administratoren die HTML-Dateien `landing`, `impressum`, `lizenz` und `datenschutz` anpassen. Über das Untermenü wird die gewünschte Seite ausgewählt und im TinyMCE-Editor bearbeitet. Mit **Speichern** werden die Änderungen in den jeweiligen Dateien im Ordner `content/` abgelegt. Die Schaltfläche *Vorschau* öffnet die Seite in einem neuen Tab. Alternativ kann der Editor direkt über `/admin/pages/{slug}` aufgerufen werden.
+Im Tab **Seiten** können Administratoren die HTML-Dateien `landing`, `impressum`, `lizenz` und `datenschutz` anpassen. Über das Untermenü wird die gewünschte Seite ausgewählt und im **Trumbowyg**-Editor bearbeitet. Zusätzlich stehen eigene UIkit-Blöcke zur Verfügung, etwa ein Hero-Abschnitt oder eine Card. Mit **Speichern** werden die Änderungen im Ordner `content/` abgelegt. Die Schaltfläche *Vorschau* zeigt den aktuellen Stand direkt im Modal an. Alternativ kann der Editor weiterhin über `/admin/pages/{slug}` aufgerufen werden.

--- a/public/js/trumbowyg-pages.js
+++ b/public/js/trumbowyg-pages.js
@@ -1,11 +1,63 @@
 /* global $, apiFetch, notify */
 
+// Define custom UIkit templates for Trumbowyg
+$.extend(true, $.trumbowyg, {
+  langs: { de: { template: 'Vorlage' } },
+  plugins: {
+    template: {
+      init: function (trumbowyg) {
+        trumbowyg.addBtnDef('template', {
+          dropdown: ['uikit-hero', 'uikit-card'],
+          ico: 'insertTemplate'
+        });
+
+        trumbowyg.addBtnDef('uikit-hero', {
+          fn: function () {
+            trumbowyg.execCmd('insertHTML',
+              `<div class="uk-section uk-section-primary uk-light">
+                <div class="uk-container">
+                  <h1 class="uk-heading-large">Hero-Titel</h1>
+                  <p class="uk-text-lead">Introtext</p>
+                </div>
+              </div>`);
+          },
+          title: 'UIkit Hero'
+        });
+
+        trumbowyg.addBtnDef('uikit-card', {
+          fn: function () {
+            trumbowyg.execCmd('insertHTML',
+              `<div class="uk-card uk-card-default uk-card-body">
+                <h3 class="uk-card-title">Karte</h3>
+                <p>Inhalt hier</p>
+              </div>`);
+          },
+          title: 'UIkit Card'
+        });
+      }
+    }
+  }
+});
+
 export function initPageEditors() {
   document.querySelectorAll('.page-form').forEach(form => {
     const slug = form.dataset.slug;
     const input = form.querySelector('input[name="content"]');
     const editorEl = form.querySelector('.page-editor');
-    $(editorEl).trumbowyg();
+    $(editorEl).trumbowyg({
+      lang: 'de',
+      btns: [
+        ['viewHTML'],
+        ['formatting'],
+        ['bold', 'italic', 'underline'],
+        ['link'],
+        ['insertImage'],
+        ['unorderedList', 'orderedList'],
+        ['template'],
+        ['fullscreen']
+      ],
+      plugins: { template: true }
+    });
     const saveBtn = form.querySelector('.save-page-btn');
     saveBtn?.addEventListener('click', e => {
       e.preventDefault();
@@ -22,5 +74,18 @@ export function initPageEditors() {
     });
   });
 }
+
+export function showPreview() {
+  const editor = document.querySelector('.page-editor');
+  if (!editor) return;
+  const html = $(editor).trumbowyg('html');
+  const target = document.getElementById('preview-content');
+  if (target) target.innerHTML = html;
+  if (window.UIkit) {
+    window.UIkit.modal('#preview-modal').show();
+  }
+}
+
+window.showPreview = showPreview;
 
 document.addEventListener('DOMContentLoaded', initPageEditors);

--- a/templates/admin/pages/edit.twig
+++ b/templates/admin/pages/edit.twig
@@ -22,9 +22,17 @@
       <textarea class="page-editor">{{ content|raw }}</textarea>
       <div class="uk-margin-top">
         <button type="button" class="uk-button uk-button-primary save-page-btn">Speichern</button>
-        <a href="{{ basePath }}/{{ slug }}" target="_blank" class="uk-button uk-button-default">Vorschau</a>
+        <button type="button" class="uk-button uk-button-default" onclick="showPreview()">Vorschau</button>
       </div>
     </form>
+
+    <div id="preview-modal" uk-modal>
+      <div class="uk-modal-dialog uk-modal-body">
+        <h3>Vorschau</h3>
+        <div id="preview-content"></div>
+        <button class="uk-button uk-button-default uk-modal-close" type="button">Schließen</button>
+      </div>
+    </div>
   </div>
   {# Page editor initialization handled by trumbowyg-pages.js #}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add custom UIkit template plugin for Trumbowyg
- integrate preview modal and template dropdown in admin page editor
- document updated editor features with UIkit blocks

## Testing
- `vendor/bin/phpunit --testdox`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687fba968acc832b81a9a4bf383c5ac1