### PR TITLE
Fix admin tab routing

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -205,6 +205,11 @@ return function (\Slim\App $app) {
         $controller = new PageController();
         return $controller->update($request, $response, $args);
     })->add(new RoleAuthMiddleware(Roles::ADMIN));
+
+    $app->get('/admin/{path:.*}', function (Request $request, Response $response) {
+        $base = \Slim\Routing\RouteContext::fromRequest($request)->getBasePath();
+        return $response->withHeader('Location', $base . '/admin')->withStatus(302);
+    });
     $app->get('/results', function (Request $request, Response $response) {
         return $request->getAttribute('resultController')->page($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::ANALYST));

--- a/tests/Controller/AdminRedirectTest.php
+++ b/tests/Controller/AdminRedirectTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class AdminRedirectTest extends TestCase
+{
+    public function testUnknownAdminPathRedirectsToAdmin(): void
+    {
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $response = $app->handle($this->createRequest('GET', '/admin/unknown'));
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('/admin', $response->getHeaderLine('Location'));
+        session_destroy();
+    }
+}


### PR DESCRIPTION
## Summary
- redirect unknown /admin subpaths back to the admin dashboard
- cover the redirect with a new PHPUnit test

## Testing
- `vendor/bin/phpunit --filter AdminRedirectTest tests/Controller/AdminRedirectTest.php`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_687fe6decff4832b8d8fb4e11a646f3f