### PR TITLE
Fix admin base template assets

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{% block title %}Admin{% endblock %}</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.19.3/dist/css/uikit.min.css" />
-    <script src="https://cdn.jsdelivr.net/npm/uikit@3.19.3/dist/js/uikit.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/uikit@3.19.3/dist/js/uikit-icons.min.js"></script>
+    <link rel="stylesheet" href="{{ basePath }}/css/uikit.min.css">
+    <script src="{{ basePath }}/js/uikit.min.js"></script>
+    <script src="{{ basePath }}/js/uikit-icons.min.js"></script>
     <style>
         body { background: #111; color: #fff; min-height: 100vh; }
         .custom-card { background: #222; color: #fff; }


### PR DESCRIPTION
## Summary
- use local UIkit files in templates/base.twig so admin pages work offline

## Testing
- `./vendor/bin/phpunit` *(fails: Errors: 1, Failures: 14)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_6880084b1828832b82ce4856855901e2