### PR TITLE
Fix static page editor initialization

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1,7 +1,22 @@
 /* global UIkit */
+
+const basePath = window.basePath || '';
+const withBase = path => basePath + path;
+window.apiFetch = (path, options = {}) => {
+  return fetch(withBase(path), {
+    credentials: 'same-origin',
+    ...options
+  });
+};
+window.notify = (msg, status = 'primary') => {
+  if (typeof UIkit !== 'undefined' && UIkit.notification) {
+    UIkit.notification({ message: msg, status, pos: 'top-center', timeout: 2000 });
+  } else {
+    alert(msg);
+  }
+};
+
 document.addEventListener('DOMContentLoaded', function () {
-  const basePath = window.basePath || '';
-  const withBase = path => basePath + path;
   const adminRoutes = [
     'events',
     'event/settings',
@@ -16,19 +31,6 @@ document.addEventListener('DOMContentLoaded', function () {
   ];
   const settingsInitial = window.quizSettings || {};
   const pagesInitial = window.pagesContent || {};
-  const apiFetch = (path, options = {}) => {
-    return fetch(withBase(path), {
-      credentials: 'same-origin',
-      ...options
-    });
-  };
-  function notify(msg, status = 'primary') {
-    if (typeof UIkit !== 'undefined' && UIkit.notification) {
-      UIkit.notification({ message: msg, status, pos: 'top-center', timeout: 2000 });
-    } else {
-      alert(msg);
-    }
-  }
 
   function slugify(text) {
     return text


### PR DESCRIPTION
## Summary
- expose `apiFetch` and `notify` globally before DOM is ready
- initialize admin dashboard after defining globals

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --memory-limit=256M`
- `vendor/bin/phpunit` *(fails: Errors: 1, Failures: 13)*
- `pytest tests`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_68809968c464832ba1795b3dbfd88db0