### PR TITLE
Add FAQ page to admin editing

### DIFF
--- a/content/faq.html
+++ b/content/faq.html
@@ -1,0 +1,62 @@
+<div class="uk-container uk-container-small">
+  <h1 class="uk-heading-divider uk-hidden">FAQ</h1>
+  <p class="uk-text-lead">Hier beantworten wir häufige Fragen zur Nutzung des QuizRace.</p>
+
+  <h2 class="uk-heading-bullet">Allgemeines</h2>
+  <ul class="uk-accordion" uk-accordion>
+    <li>
+      <a class="uk-accordion-title" href="#">Wie starte ich das Quiz?</a>
+      <div class="uk-accordion-content">
+        <p>Scanne an der ersten Station den QR-Code oder öffne den bereitgestellten Link. Wähle den Name aus und schon geht es los.</p>
+      </div>
+    </li>
+    <li>
+      <a class="uk-accordion-title" href="#">Kann ich das Quiz unterwegs spielen?</a>
+      <div class="uk-accordion-content">
+        <p>Ja, die Oberfläche passt sich jedem Gerät an – ob Handy, Tablet oder PC.</p>
+      </div>
+    </li>
+    <li>
+      <a class="uk-accordion-title" href="#">Welche Fragetypen gibt es?</a>
+      <div class="uk-accordion-content">
+        <p>Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten.</p>
+      </div>
+    </li>
+    <li>
+      <a class="uk-accordion-title" href="#">Wie bediene ich Drag &amp; Drop?</a>
+      <div class="uk-accordion-content">
+        <p>Halte ein Element gedrückt und ziehe es an die gewünschte Stelle.</p>
+      </div>
+    </li>
+    <li>
+      <a class="uk-accordion-title" href="#">Gibt es einen Dunkelmodus?</a>
+      <div class="uk-accordion-content">
+        <p>Ja. Über das Mond-Symbol oben rechts lässt sich die dunkle Ansicht einschalten.</p>
+      </div>
+    </li>
+    <li>
+      <a class="uk-accordion-title" href="#">Was passiert mit meinen Ergebnissen?</a>
+      <div class="uk-accordion-content">
+        <p>Die Punkte werden anonym gezählt und können am Ende als Statistik exportiert werden.</p>
+      </div>
+    </li>
+    <li>
+      <a class="uk-accordion-title" href="#">Warum wurde das Quiz entwickelt?</a>
+      <div class="uk-accordion-content">
+        <p>Es zeigt, wie Menschen und KI gemeinsam neue digitale Möglichkeiten schaffen können.</p>
+      </div>
+    </li>
+  </ul>
+
+  <h2 class="uk-heading-bullet">Unser Anspruch</h2>
+  <p>Bei der Entwicklung wurde besonders geachtet auf:</p>
+  <ul class="uk-list uk-list-bullet">
+    <li><strong>Barrierefreiheit:</strong> Die App ist auch für Menschen mit Einschränkungen gut nutzbar.</li>
+    <li><strong>Datenschutz:</strong> Die Daten werden vertraulich behandelt.</li>
+    <li><strong>Schnelle und stabile Nutzung:</strong> Die Anwendung läuft zuverlässig, auch bei vielen Teilnehmenden.</li>
+    <li><strong>Einfache Bedienung:</strong> Alle Funktionen sind selbsterklärend.</li>
+    <li><strong>Funktioniert auf allen Geräten:</strong> Handy, Tablet oder PC – freie Wahl.</li>
+    <li><strong>Nachhaltigkeit:</strong> Die App wurde ressourcenschonend umgesetzt.</li>
+    <li><strong>Offene Schnittstellen:</strong> Sie lässt sich leicht mit anderen Systemen verbinden.</li>
+  </ul>
+</div>

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -113,7 +113,7 @@ class AdminController
         }
 
         if ($section === 'pages') {
-            $pageSlugs = ['landing', 'impressum', 'lizenz', 'datenschutz'];
+            $pageSlugs = ['landing', 'impressum', 'lizenz', 'datenschutz', 'faq'];
             foreach ($pageSlugs as $slug) {
                 $path       = dirname(__DIR__, 2) . '/content/' . $slug . '.html';
                 $pages[$slug] = is_file($path) ? file_get_contents($path) : '';

--- a/src/Controller/FaqController.php
+++ b/src/Controller/FaqController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use Slim\Routing\RouteContext;
 
 /**
  * Displays the frequently asked questions.
@@ -18,7 +19,17 @@ class FaqController
      */
     public function __invoke(Request $request, Response $response): Response
     {
+        $path = dirname(__DIR__, 2) . '/content/faq.html';
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+        $html = (string) file_get_contents($path);
+        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $html = str_replace('{{ basePath }}', $basePath, $html);
+
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'faq.twig');
+        return $view->render($response, 'faq.twig', [
+            'content' => $html,
+        ]);
     }
 }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -518,6 +518,7 @@
             <li data-slug="impressum"><a href="#">Impressum</a></li>
             <li data-slug="lizenz"><a href="#">Lizenz</a></li>
             <li data-slug="datenschutz"><a href="#">Datenschutz</a></li>
+            <li data-slug="faq"><a href="#">FAQ</a></li>
           </ul>
           <ul id="pageSwitcher" class="uk-switcher uk-margin">
             {% for slug, html in pages %}

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -27,68 +27,7 @@
       </div>
     {% endblock %}
   {% endembed %}
-  <div class="uk-container uk-container-small">
-    <h1 class="uk-heading-divider uk-hidden">FAQ</h1>
-    <p class="uk-text-lead">Hier beantworten wir häufige Fragen zur Nutzung des QuizRace.</p>
-
-    <h2 class="uk-heading-bullet">Allgemeines</h2>
-    <ul class="uk-accordion" uk-accordion>
-      <li>
-        <a class="uk-accordion-title" href="#">Wie starte ich das Quiz?</a>
-        <div class="uk-accordion-content">
-          <p>Scanne an der ersten Station den QR-Code oder öffne den bereitgestellten Link. Wähle den Name aus und schon geht es los.</p>
-        </div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Kann ich das Quiz unterwegs spielen?</a>
-        <div class="uk-accordion-content">
-          <p>Ja, die Oberfläche passt sich jedem Gerät an – ob Handy, Tablet oder PC.</p>
-        </div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Welche Fragetypen gibt es?</a>
-        <div class="uk-accordion-content">
-          <p>Das Quiz bietet Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten.</p>
-        </div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Wie bediene ich Drag &amp; Drop?</a>
-        <div class="uk-accordion-content">
-          <p>Halte ein Element gedrückt und ziehe es an die gewünschte Stelle.</p>
-        </div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Gibt es einen Dunkelmodus?</a>
-        <div class="uk-accordion-content">
-          <p>Ja. Über das Mond-Symbol oben rechts lässt sich die dunkle Ansicht einschalten.</p>
-        </div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Was passiert mit meinen Ergebnissen?</a>
-        <div class="uk-accordion-content">
-          <p>Die Punkte werden anonym gezählt und können am Ende als Statistik exportiert werden.</p>
-        </div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Warum wurde das Quiz entwickelt?</a>
-        <div class="uk-accordion-content">
-          <p>Es zeigt, wie Menschen und KI gemeinsam neue digitale Möglichkeiten schaffen können.</p>
-        </div>
-      </li>
-    </ul>
-
-    <h2 class="uk-heading-bullet">Unser Anspruch</h2>
-    <p>Bei der Entwicklung wurde besonders geachtet auf:</p>
-    <ul class="uk-list uk-list-bullet">
-      <li><strong>Barrierefreiheit:</strong> Die App ist auch für Menschen mit Einschränkungen gut nutzbar.</li>
-      <li><strong>Datenschutz:</strong> Die Daten werden vertraulich behandelt.</li>
-      <li><strong>Schnelle und stabile Nutzung:</strong> Die Anwendung läuft zuverlässig, auch bei vielen Teilnehmenden.</li>
-      <li><strong>Einfache Bedienung:</strong> Alle Funktionen sind selbsterklärend.</li>
-      <li><strong>Funktioniert auf allen Geräten:</strong> Handy, Tablet oder PC – freie Wahl.</li>
-      <li><strong>Nachhaltigkeit:</strong> Die App wurde ressourcenschonend umgesetzt.</li>
-      <li><strong>Offene Schnittstellen:</strong> Sie lässt sich leicht mit anderen Systemen verbinden.</li>
-    </ul>
-  </div>
+  {{ content|raw }}
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- allow editing of FAQ page via admin dashboard
- load FAQ content from `content/faq.html`
- display FAQ page content dynamically
- include new FAQ tab under Pages

## Testing
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: CatalogControllerTest, AdminControllerTest, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6880e4717c98832ba6a655198c2b5c5a