### PR TITLE
Implement user self-registration

### DIFF
--- a/migrations/20240913_registration.sql
+++ b/migrations/20240913_registration.sql
@@ -1,0 +1,5 @@
+-- Add active column for users and registration setting
+ALTER TABLE users ADD COLUMN IF NOT EXISTS active BOOLEAN NOT NULL DEFAULT TRUE;
+
+INSERT INTO settings(key, value) VALUES('registration_enabled', '0')
+ON CONFLICT (key) DO NOTHING;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -111,7 +111,8 @@ document.addEventListener('DOMContentLoaded', function () {
     puzzleEnabled: document.getElementById('cfgPuzzleEnabled'),
     puzzleWord: document.getElementById('cfgPuzzleWord'),
     puzzleWrap: document.getElementById('cfgPuzzleWordWrap'),
-    homePage: document.getElementById('cfgHomePage')
+    homePage: document.getElementById('cfgHomePage'),
+    registrationEnabled: document.getElementById('cfgRegistrationEnabled')
   };
   const puzzleFeedbackBtn = document.getElementById('puzzleFeedbackBtn');
   const puzzleIcon = document.getElementById('puzzleFeedbackIcon');
@@ -133,6 +134,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const resultsResetModal = UIkit.modal('#resultsResetModal');
   const resultsResetConfirm = document.getElementById('resultsResetConfirm');
   const homePageSaveBtn = document.getElementById('homePageSaveBtn');
+  const registrationEnabledSaveBtn = document.getElementById('registrationEnabledSaveBtn');
   let puzzleFeedback = '';
   let inviteText = '';
   let currentCommentInput = null;
@@ -282,6 +284,9 @@ document.addEventListener('DOMContentLoaded', function () {
     if (cfgFields.homePage) {
       cfgFields.homePage.value = settingsInitial.home_page || 'help';
     }
+    if (cfgFields.registrationEnabled) {
+      cfgFields.registrationEnabled.checked = settingsInitial.registration_enabled === '1';
+    }
     puzzleFeedback = data.puzzleFeedback || '';
     updatePuzzleFeedbackUI();
     inviteText = data.inviteText || '';
@@ -360,6 +365,22 @@ document.addEventListener('DOMContentLoaded', function () {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ home_page: cfgFields.homePage.value })
+    }).then(r => {
+      if (r.ok) {
+        notify('Einstellung gespeichert', 'success');
+      } else {
+        notify('Fehler beim Speichern', 'danger');
+      }
+    }).catch(() => notify('Fehler beim Speichern', 'danger'));
+  });
+
+  registrationEnabledSaveBtn?.addEventListener('click', () => {
+    if (!cfgFields.registrationEnabled) return;
+    settingsInitial.registration_enabled = cfgFields.registrationEnabled.checked ? '1' : '0';
+    apiFetch('/settings.json', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ registration_enabled: settingsInitial.registration_enabled })
     }).then(r => {
       if (r.ok) {
         notify('Einstellung gespeichert', 'success');
@@ -1605,7 +1626,8 @@ document.addEventListener('DOMContentLoaded', function () {
       id: row.dataset.id ? parseInt(row.dataset.id, 10) : undefined,
       username: row.querySelector('.user-name').value.trim(),
       password: row.dataset.pass || '',
-      role: row.querySelector('.user-role').value
+      role: row.querySelector('.user-role').value,
+      active: row.querySelector('.user-active')?.checked
     })).filter(u => u.username);
   }
 
@@ -1636,6 +1658,13 @@ document.addEventListener('DOMContentLoaded', function () {
     nameInput.placeholder = 'Benutzername';
     nameInput.value = u.username || '';
     nameCell.appendChild(nameInput);
+
+    const activeCell = document.createElement('td');
+    const activeCheckbox = document.createElement('input');
+    activeCheckbox.type = 'checkbox';
+    activeCheckbox.className = 'user-active';
+    activeCheckbox.checked = u.active !== false;
+    activeCell.appendChild(activeCheckbox);
 
     const passCell = document.createElement('td');
     const passBtn = document.createElement('button');
@@ -1675,6 +1704,7 @@ document.addEventListener('DOMContentLoaded', function () {
     row.appendChild(handleCell);
     row.appendChild(nameCell);
     row.appendChild(roleCell);
+    row.appendChild(activeCell);
     row.appendChild(passCell);
     row.appendChild(delCell);
     return row;

--- a/src/Controller/RegisterController.php
+++ b/src/Controller/RegisterController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\UserService;
+use App\Service\SettingsService;
+use App\Domain\Roles;
+use App\Infrastructure\Database;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+use Slim\Views\Twig;
+
+/**
+ * Handles self-registration of backend users.
+ */
+class RegisterController
+{
+    /**
+     * Display the registration form.
+     */
+    public function show(Request $request, Response $response): Response
+    {
+        $pdo = Database::connectFromEnv();
+        $settings = new SettingsService($pdo);
+        $allowed = $settings->get('registration_enabled', '0') === '1';
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'register.twig', [ 'allowed' => $allowed ]);
+    }
+
+    /**
+     * Handle registration form submission.
+     */
+    public function register(Request $request, Response $response): Response
+    {
+        $pdo = Database::connectFromEnv();
+        $settings = new SettingsService($pdo);
+        if ($settings->get('registration_enabled', '0') !== '1') {
+            return $response->withStatus(403);
+        }
+
+        $data = $request->getParsedBody();
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $user = trim((string)($data['username'] ?? ''));
+        $pass = (string)($data['password'] ?? '');
+        $repeat = (string)($data['password_repeat'] ?? '');
+        if ($user === '' || $pass === '' || $pass !== $repeat) {
+            $view = Twig::fromRequest($request);
+            return $view->render($response->withStatus(400), 'register.twig', [ 'error' => true, 'allowed' => true ]);
+        }
+        $service = new UserService($pdo);
+        $service->create($user, $pass, Roles::CATALOG_EDITOR, false);
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'register.twig', [ 'success' => true, 'allowed' => true ]);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -42,6 +42,7 @@ use App\Controller\SettingsController;
 use App\Controller\Admin\PageController;
 use App\Controller\TenantController;
 use App\Controller\Marketing\LandingController;
+use App\Controller\RegisterController;
 use Psr\Log\NullLogger;
 use App\Controller\BackupController;
 use App\Domain\Roles;
@@ -75,6 +76,7 @@ require_once __DIR__ . '/Controller/BackupController.php';
 require_once __DIR__ . '/Controller/UserController.php';
 require_once __DIR__ . '/Controller/TenantController.php';
 require_once __DIR__ . '/Controller/Marketing/LandingController.php';
+require_once __DIR__ . '/Controller/RegisterController.php';
 
 use App\Infrastructure\Database;
 use App\Infrastructure\Migrations\Migrator;
@@ -191,6 +193,8 @@ return function (\Slim\App $app) {
     });
     $app->get('/login', [LoginController::class, 'show']);
     $app->post('/login', [LoginController::class, 'login']);
+    $app->get('/register', [RegisterController::class, 'show']);
+    $app->post('/register', [RegisterController::class, 'register']);
     $app->get('/logout', LogoutController::class);
     $app->get('/admin', function (Request $request, Response $response) {
         $base = \Slim\Routing\RouteContext::fromRequest($request)->getBasePath();

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -549,6 +549,12 @@
           <button id="homePageSaveBtn" class="uk-icon-button uk-button-primary uk-margin-small-left" uk-icon="check"></button>
         </div>
 
+        <h3 class="uk-heading-bullet">Registrierung</h3>
+        <div class="uk-margin uk-flex uk-flex-middle">
+          <label><input class="uk-checkbox" type="checkbox" id="cfgRegistrationEnabled" {% if settings.registration_enabled == '1' %}checked{% endif %}> Registrierung zulassen</label>
+          <button id="registrationEnabledSaveBtn" class="uk-icon-button uk-button-primary uk-margin-small-left" uk-icon="check"></button>
+        </div>
+
         <h3 class="uk-heading-bullet">Benutzer</h3>
         <div class="uk-overflow-auto">
           <table class="uk-table uk-table-divider uk-table-small">
@@ -557,6 +563,7 @@
                 <th><span uk-icon="icon: question" uk-tooltip="title: Zum Sortieren Zeile ziehen; pos: top"></span></th>
                 <th>Benutzername</th>
                 <th>Rolle</th>
+                <th>Aktiv</th>
                 <th><span uk-icon="icon: key" uk-tooltip="title: Passwort setzen; pos: top"></span></th>
                 <th><span uk-icon="icon: question" uk-tooltip="title: Benutzer entfernen; pos: top"></span></th>
               </tr>

--- a/templates/register.twig
+++ b/templates/register.twig
@@ -1,6 +1,6 @@
 {% extends 'layout.twig' %}
 
-{% block title %}Login{% endblock %}
+{% block title %}Registrieren{% endblock %}
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
@@ -24,41 +24,48 @@
       </div>
     {% endblock %}
   {% endembed %}
-<div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
-  <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
-    <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
-          <h3 class="uk-card-title uk-text-center">Login</h3>
+  <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
+    <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
+      <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+        <h3 class="uk-card-title uk-text-center">Registrieren</h3>
+        {% if not allowed %}
+        <div class="uk-alert-danger" uk-alert>
+          <p>Registrierung derzeit nicht möglich.</p>
+        </div>
+        {% elseif success %}
+        <div class="uk-alert-success" uk-alert>
+          <p>Registrierung gespeichert. Ein Admin muss den Account freischalten.</p>
+        </div>
+        {% else %}
           {% if error %}
           <div class="uk-alert-danger" uk-alert>
-            {% if inactive %}
-            <p>Account noch nicht freigeschaltet.</p>
-            {% else %}
-            <p>Benutzername oder Passwort falsch.</p>
-            {% endif %}
+            <p>Eingaben ungültig oder Passwörter stimmen nicht überein.</p>
           </div>
           {% endif %}
-          <form method="post" action="/login">
+          <form method="post" action="/register">
             <div class="uk-margin">
               <div class="uk-inline uk-width-1-1">
                 <span class="uk-form-icon" uk-icon="icon: user"></span>
-                <input class="uk-input uk-form-large" type="text" name="username" id="username" placeholder="Benutzername" required>
+                <input class="uk-input uk-form-large" type="text" name="username" placeholder="Benutzername" required>
               </div>
             </div>
             <div class="uk-margin">
               <div class="uk-inline uk-width-1-1">
                 <span class="uk-form-icon" uk-icon="icon: lock"></span>
-                <input class="uk-input uk-form-large" type="password" name="password" id="password" placeholder="Passwort" required>
+                <input class="uk-input uk-form-large" type="password" name="password" placeholder="Passwort" required>
               </div>
             </div>
             <div class="uk-margin">
-              <button class="uk-button uk-button-primary uk-button-large uk-width-1-1">Login</button>
+              <div class="uk-inline uk-width-1-1">
+                <span class="uk-form-icon" uk-icon="icon: lock"></span>
+                <input class="uk-input uk-form-large" type="password" name="password_repeat" placeholder="Passwort wiederholen" required>
+              </div>
             </div>
-            {% if registration_allowed %}
-            <div class="uk-margin uk-text-center">
-              <a href="{{ basePath }}/register">Registrieren</a>
+            <div class="uk-margin">
+              <button class="uk-button uk-button-primary uk-button-large uk-width-1-1">Registrieren</button>
             </div>
-            {% endif %}
           </form>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add migration for registration and user activation
- add RegisterController and template
- require registration approval when logging in
- extend admin interface to toggle registration and manage active users
- update JS logic for new checkbox and user field

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: CatalogControllerTest TypeError and others)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6880e6c2bf90832b800238e71915dd0b