### PR TITLE
Fix hero height in editor

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -677,4 +677,10 @@ body.dark-mode .sticky-actions {
   background: #fff;
 }
 
+/* Prevent huge heights from UIkit's height-viewport plugin inside the editor */
+.page-editor [uk-height-viewport] {
+  min-height: auto !important;
+  height: auto !important;
+}
+
 


### PR DESCRIPTION
## Summary
- prevent huge `uk-height-viewport` height in page editor

## Testing
- `vendor/bin/phpunit --testdox` *(fails: Errors: 1, Failures: 12)*

------
https://chatgpt.com/codex/tasks/task_e_6881473ba36c832b93fb4e370a318937