### PR TITLE
Fix drag handle in admin cards

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -66,7 +66,7 @@
                 <th><span uk-icon="icon: question" uk-tooltip="title: Veranstaltung entfernen; pos: top"></span></th>
               </tr>
             </thead>
-            <tbody id="eventsList" uk-sortable="group: sortable-group"></tbody>
+            <tbody id="eventsList" uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
           </table>
         </div>
         <div class="uk-margin">
@@ -276,7 +276,7 @@
                   </th>
               </tr>
             </thead>
-            <tbody id="catalogList" uk-sortable="group: sortable-group"></tbody>
+            <tbody id="catalogList" uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
           </table>
         </div>
         <div class="uk-margin">
@@ -325,7 +325,7 @@
                 <th></th>
               </tr>
             </thead>
-            <tbody id="teamsList" uk-sortable="group: sortable-group"></tbody>
+            <tbody id="teamsList" uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
           </table>
         </div>
         <div class="uk-margin">
@@ -569,7 +569,7 @@
                 <th><span uk-icon="icon: question" uk-tooltip="title: Benutzer entfernen; pos: top"></span></th>
               </tr>
             </thead>
-            <tbody id="usersList" uk-sortable="group: sortable-group"></tbody>
+            <tbody id="usersList" uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
           </table>
         </div>
         <div class="uk-margin">


### PR DESCRIPTION
## Summary
- restrict sortable lists to use only the visible drag handle button on admin pages

## Testing
- `vendor/bin/phpunit` *(fails: 12 failures, 1 error)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_688385ac6630832ba0762b29efc913d6