### PR TITLE
Update question admin UI buttons

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -751,8 +751,9 @@ document.addEventListener('DOMContentLoaded', function () {
     const fields = document.createElement('div');
     fields.className = 'fields';
     const removeBtn = document.createElement('button');
-    removeBtn.className = 'uk-button uk-button-danger uk-margin-small-top uk-align-right';
-    removeBtn.textContent = 'Entfernen';
+    removeBtn.className = 'uk-icon-button uk-button-danger uk-margin-small-top uk-align-right';
+    removeBtn.setAttribute('uk-icon', 'trash');
+    removeBtn.setAttribute('aria-label', 'Entfernen');
     removeBtn.onclick = () => {
       const idx = card.dataset.index;
       if (idx !== undefined) {
@@ -781,8 +782,8 @@ document.addEventListener('DOMContentLoaded', function () {
       input.value = value;
       input.setAttribute('aria-label', 'Item');
       const btn = document.createElement('button');
-      btn.className = 'uk-button uk-button-danger uk-button-small uk-margin-left';
-      btn.textContent = '×';
+      btn.className = 'uk-icon-button uk-button-danger uk-button-small uk-margin-left';
+      btn.setAttribute('uk-icon', 'trash');
       btn.setAttribute('aria-label', 'Entfernen');
       btn.onclick = () => div.remove();
       div.appendChild(input);
@@ -807,8 +808,8 @@ document.addEventListener('DOMContentLoaded', function () {
       dInput.value = def;
       dInput.setAttribute('aria-label', 'Definition');
       const rem = document.createElement('button');
-      rem.className = 'uk-button uk-button-danger uk-button-small';
-      rem.textContent = '×';
+      rem.className = 'uk-icon-button uk-button-danger uk-button-small';
+      rem.setAttribute('uk-icon', 'trash');
       rem.setAttribute('aria-label', 'Entfernen');
       rem.onclick = () => row.remove();
       const tDiv = document.createElement('div');
@@ -841,8 +842,8 @@ document.addEventListener('DOMContentLoaded', function () {
       input.id = optId;
       radio.setAttribute('aria-labelledby', optId);
       const rem = document.createElement('button');
-      rem.className = 'uk-button uk-button-danger uk-button-small uk-margin-left';
-      rem.textContent = '×';
+      rem.className = 'uk-icon-button uk-button-danger uk-button-small uk-margin-left';
+      rem.setAttribute('uk-icon', 'trash');
       rem.setAttribute('aria-label', 'Entfernen');
       rem.onclick = () => row.remove();
       row.appendChild(radio);
@@ -866,8 +867,8 @@ document.addEventListener('DOMContentLoaded', function () {
       check.checked = correct;
       check.setAttribute('aria-label', 'Richtige Antwort (rechts)');
       const rem = document.createElement('button');
-      rem.className = 'uk-button uk-button-danger uk-button-small uk-margin-left';
-      rem.textContent = '×';
+      rem.className = 'uk-icon-button uk-button-danger uk-button-small uk-margin-left';
+      rem.setAttribute('uk-icon', 'trash');
       rem.setAttribute('aria-label', 'Entfernen');
       rem.onclick = () => row.remove();
       row.appendChild(input);
@@ -1695,8 +1696,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const delCell = document.createElement('td');
     const delBtn = document.createElement('button');
-    delBtn.className = 'uk-button uk-button-danger';
-    delBtn.textContent = '×';
+    delBtn.className = 'uk-icon-button uk-button-danger';
+    delBtn.setAttribute('uk-icon', 'trash');
     delBtn.setAttribute('aria-label', 'Löschen');
     delBtn.addEventListener('click', () => row.remove());
     delCell.appendChild(delBtn);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -38,7 +38,7 @@
     <li class="uk-active" data-route="events" data-help="Veranstaltungen anlegen oder bearbeiten. Jede Zeile enthält Name, Beginn, Ende und Beschreibung. 'Hinzufügen' erstellt einen neuen Eintrag. Speichern übernimmt die Änderungen."><a href="{{ basePath }}/admin/events">Events</a></li>
     <li data-route="event/settings" data-help="Logo hochladen und Vorschau ansehen. Seitentitel, Überschrift und Untertitel festlegen. Hintergrund- und Buttonfarbe wählen. Optional den Button 'Antwort prüfen' und den QR-Code-Login aktivieren. 'Zurücksetzen' lädt gespeicherte Werte, 'Speichern' übernimmt Änderungen."><a href="{{ basePath }}/admin/event/settings">Event Configuration</a></li>
     <li data-route="catalogs" data-help="Fragenkataloge anlegen oder bearbeiten. Jede Zeile enthält einen Slug, Name, Beschreibung und optional einen Buchstaben für das Rätselwort. Der Slug kann angepasst werden. 'Hinzufügen' erstellt einen neuen Katalog, das rote × entfernt einen Eintrag. Speichern übernimmt die Änderungen."><a href="{{ basePath }}/admin/catalogs">Catalogs</a></li>
-    <li data-route="questions" data-help="Nach Auswahl eines Katalogs einzelne Fragen bearbeiten oder neue anlegen. 'Neue Frage' fügt eine weitere hinzu, 'Zurücksetzen' verwirft Änderungen, 'Speichern' sichert den gesamten Katalog."><a href="{{ basePath }}/admin/questions">Edit Questions</a></li>
+    <li data-route="questions" data-help="Nach Auswahl eines Katalogs einzelne Fragen bearbeiten oder neue anlegen. Das Plus-Symbol legt eine weitere Frage an, 'Zurücksetzen' verwirft Änderungen, 'Speichern' sichert den gesamten Katalog."><a href="{{ basePath }}/admin/questions">Edit Questions</a></li>
     <li data-route="teams" data-help="Teilnehmerliste pflegen. Über 'Hinzufügen' Teams oder Personen ergänzen. Die Checkbox beschränkt die Teilnahme auf gelistete Namen. Speichern aktualisiert die Liste."><a href="{{ basePath }}/admin/teams">Teams/People</a></li>
     <li data-route="summary" data-help="QR-Codes für alle Kataloge und Teams anzeigen, um Quizlinks oder Anmeldungen weiterzugeben. 'Drucken' erstellt eine übersichtliche Liste."><a href="{{ basePath }}/admin/summary">Summary</a></li>
     <li data-route="results" data-help="Gespeicherte Ergebnisse mit richtigen Antworten und Zeit einsehen. 'Zurücksetzen' löscht alle Daten, 'Herunterladen' exportiert sie als CSV."><a href="{{ basePath }}/admin/results">Results</a></li>
@@ -302,11 +302,13 @@
         <!-- Hauptdatenbereich: Frageneditor -->
         <div id="questions" class="uk-margin"></div>
         <!-- Bedienleiste fuer Frageneditor -->
-        <div id="questionActions" class="sticky-actions uk-flex uk-flex-between uk-flex-middle uk-margin">
-          <button id="addBtn" class="uk-button uk-button-default" uk-tooltip="title: Neue Frage im aktuellen Katalog anlegen; pos: right">Neue Frage</button>
-          <div>
-            <button id="resetBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Änderungen am Fragenkatalog verwerfen; pos: right">Zurücksetzen</button>
-            <button id="saveBtn" class="uk-icon-button uk-button-primary" uk-icon="check" uk-tooltip="title: Fragenkatalog speichern; pos: right"></button>
+        <div id="questionActions">
+          <div class="uk-margin">
+            <button id="addBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: Neue Frage im aktuellen Katalog anlegen; pos: left"></button>
+          </div>
+          <div class="uk-margin uk-flex uk-flex-right">
+            <button id="resetBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: Änderungen am Fragenkatalog verwerfen; pos: left">Zurücksetzen</button>
+            <button id="saveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: Fragenkatalog speichern; pos: left"></button>
           </div>
         </div>
         <!-- Ende Hauptdatenbereich -->


### PR DESCRIPTION
## Summary
- revise help text for question section
- switch question add/save buttons to floating action style
- align question deletion buttons with catalog/event styling

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `pytest -q`
- `vendor/bin/phpunit -c phpunit.xml` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6883b71c754c832b95684e56d0e15f9a