### PR TITLE
Add language selector to admin interface

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1276,6 +1276,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const eventAddBtn = document.getElementById('eventAddBtn');
   const eventsSaveBtn = document.getElementById('eventsSaveBtn');
   const eventSelect = document.getElementById('eventSelect');
+  const langSelect = document.getElementById('langSelect');
   let activeEventUid = cfgInitial.event_uid || '';
 
   function collectEvents() {
@@ -1506,6 +1507,13 @@ document.addEventListener('DOMContentLoaded', function () {
     if (uid && uid !== activeEventUid) {
       setActiveEvent(uid, name);
     }
+  });
+
+  langSelect?.addEventListener('change', () => {
+    const lang = langSelect.value;
+    const url = new URL(window.location.href);
+    url.searchParams.set('lang', lang);
+    window.location.href = url.toString();
   });
 
   // --------- Teams/Personen ---------

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -10,4 +10,7 @@ return [
     'license' => 'Lizenz',
     'game_flow' => 'Spielablauf',
     'title_help' => 'Hilfe',
+    'language' => 'Sprache',
+    'german' => 'Deutsch',
+    'english' => 'Englisch',
 ];

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -10,4 +10,7 @@ return [
     'license' => 'License',
     'game_flow' => 'Game flow',
     'title_help' => 'Help',
+    'language' => 'Language',
+    'german' => 'German',
+    'english' => 'English',
 ];

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -31,6 +31,12 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
+      <div class="lang-switch uk-margin-small-left">
+        <select id="langSelect" class="uk-select uk-form-width-small">
+          <option value="de" {{ locale() == 'de' ? 'selected' }}>{{ t('german') }}</option>
+          <option value="en" {{ locale() == 'en' ? 'selected' }}>{{ t('english') }}</option>
+        </select>
+      </div>
       <button id="helpBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" aria-label="Hilfe"></button>
     {% endblock %}
   {% endembed %}


### PR DESCRIPTION
## Summary
- extend translations for language names
- add language dropdown in the admin navbar
- reload admin UI when the language is changed

## Testing
- `pytest -q`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpunit --colors=never` *(fails)*
- `vendor/bin/phpstan analyse --no-progress` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6883e1c55544832ba127877f1f331ac7