### PR TITLE
Add onboarding wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor/
 .phpunit.result.cache
 
 .env
+data/logo-*.png
+data/logo-*.webp

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -1,0 +1,81 @@
+/* global UIkit */
+(function () {
+  const steps = ['step1', 'step2', 'step3', 'step4', 'success'];
+  const data = {
+    name: '',
+    subdomain: '',
+    plan: '',
+    payment: ''
+  };
+
+  function show(step) {
+    steps.forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.hidden = id !== step;
+    });
+  }
+
+  function slugify(text) {
+    return text
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/ß/g, 'ss')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const nameInput = document.getElementById('customer-name');
+    const subdomainPreview = document.getElementById('subdomain-preview');
+    const next1 = document.getElementById('next1');
+    const next2 = document.getElementById('next2');
+    const next3 = document.getElementById('next3');
+    const createBtn = document.getElementById('create');
+
+    nameInput.addEventListener('input', () => {
+      data.name = nameInput.value.trim();
+      data.subdomain = slugify(data.name);
+      subdomainPreview.textContent = data.subdomain || '-';
+      next1.disabled = data.name === '';
+    });
+
+    next1.addEventListener('click', () => {
+      show('step2');
+    });
+
+    next2.addEventListener('click', () => {
+      data.plan = document.getElementById('plan').value;
+      show('step3');
+    });
+
+    next3.addEventListener('click', () => {
+      data.payment = document.getElementById('payment').value;
+      document.getElementById('summary-name').textContent = data.name;
+      document.getElementById('summary-subdomain').textContent = data.subdomain;
+      document.getElementById('summary-plan').textContent = data.plan;
+      document.getElementById('summary-payment').textContent = data.payment;
+      show('step4');
+    });
+
+    createBtn.addEventListener('click', async () => {
+      try {
+        const res = await fetch('/tenants', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ uid: data.subdomain, schema: data.subdomain })
+        });
+        if (!res.ok) throw new Error('API error');
+        document.getElementById('success-domain').textContent =
+          data.subdomain + '.quizrace.app';
+        show('success');
+      } catch (err) {
+        if (typeof UIkit !== 'undefined') {
+          UIkit.notification({ message: 'Fehler beim Anlegen', status: 'danger' });
+        } else {
+          alert('Fehler beim Anlegen');
+        }
+      }
+    });
+  });
+})();

--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Slim\Views\Twig;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+/**
+ * Display the onboarding wizard for creating a new tenant.
+ */
+class OnboardingController
+{
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'onboarding.twig');
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -45,6 +45,7 @@ use App\Controller\Admin\PageController;
 use App\Controller\TenantController;
 use App\Controller\Marketing\LandingController;
 use App\Controller\RegisterController;
+use App\Controller\OnboardingController;
 use Psr\Log\NullLogger;
 use App\Controller\BackupController;
 use App\Domain\Roles;
@@ -79,6 +80,7 @@ require_once __DIR__ . '/Controller/UserController.php';
 require_once __DIR__ . '/Controller/TenantController.php';
 require_once __DIR__ . '/Controller/Marketing/LandingController.php';
 require_once __DIR__ . '/Controller/RegisterController.php';
+require_once __DIR__ . '/Controller/OnboardingController.php';
 
 use App\Infrastructure\Database;
 use App\Infrastructure\Migrations\Migrator;
@@ -196,6 +198,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = new LandingController();
         return $controller($request, $response);
     });
+    $app->get('/onboarding', OnboardingController::class);
     $app->get('/login', [LoginController::class, 'show']);
     $app->post('/login', [LoginController::class, 'login']);
     $app->get('/register', [RegisterController::class, 'show']);

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -1,0 +1,82 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Onboarding{% endblock %}
+
+{% block head %}
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+{% endblock %}
+
+{% block body_class %}uk-padding{% endblock %}
+
+{% block body %}
+  {% embed 'topbar.twig' %}
+    {% block right %}
+      <div class="theme-switch">
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
+      </div>
+    {% endblock %}
+  {% endembed %}
+  <div class="uk-container uk-margin-large-top">
+    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1">
+      <h3 class="uk-card-title">1. Kundendaten</h3>
+      <div class="uk-margin">
+        <input id="customer-name" class="uk-input" type="text" placeholder="Kundenname" required>
+      </div>
+      <div class="uk-margin">
+        <label>Subdomain: <span id="subdomain-preview">-</span>.quizrace.app</label>
+      </div>
+      <button class="uk-button uk-button-primary" id="next1" disabled>Weiter</button>
+    </div>
+
+    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step2" hidden>
+      <h3 class="uk-card-title">2. Abo wählen</h3>
+      <div class="uk-margin">
+        <select id="plan" class="uk-select">
+          <option value="demo">Demo</option>
+          <option value="standard">Standard</option>
+          <option value="premium">Premium</option>
+        </select>
+      </div>
+      <button class="uk-button uk-button-primary" id="next2">Weiter</button>
+    </div>
+
+    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step3" hidden>
+      <h3 class="uk-card-title">3. Zahlungsart</h3>
+      <div class="uk-margin">
+        <select id="payment" class="uk-select">
+          <option value="invoice">Rechnung</option>
+          <option value="credit">Kreditkarte</option>
+          <option value="paypal">PayPal</option>
+        </select>
+      </div>
+      <button class="uk-button uk-button-primary" id="next3">Weiter</button>
+    </div>
+
+    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step4" hidden>
+      <h3 class="uk-card-title">4. Erstellung</h3>
+      <ul class="uk-list">
+        <li><strong>Kunde:</strong> <span id="summary-name"></span></li>
+        <li><strong>Subdomain:</strong> <span id="summary-subdomain"></span>.quizrace.app</li>
+        <li><strong>Abo:</strong> <span id="summary-plan"></span></li>
+        <li><strong>Zahlung:</strong> <span id="summary-payment"></span></li>
+      </ul>
+      <button class="uk-button uk-button-primary" id="create">Jetzt QuizRace-Umgebung erstellen</button>
+    </div>
+
+    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto uk-text-center" id="success" hidden>
+      <h3 class="uk-card-title">Ihre QuizRace-Umgebung ist bereit!</h3>
+      <p id="success-domain"></p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ basePath }}/js/app.js"></script>
+  <script src="{{ basePath }}/js/onboarding.js"></script>
+  <script src="{{ basePath }}/js/custom-icons.js"></script>
+{% endblock %}

--- a/tests/test_html_validity.py
+++ b/tests/test_html_validity.py
@@ -60,6 +60,10 @@ class TestHTMLValidity(unittest.TestCase):
         errors = validate_html_file('templates/lizenz.twig')
         self.assertEqual(errors, [], msg='\n'.join(errors))
 
+    def test_onboarding_html_is_valid(self):
+        errors = validate_html_file('templates/onboarding.twig')
+        self.assertEqual(errors, [], msg='\n'.join(errors))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- create onboarding controller and wizard template
- wire up controller in routes
- implement onboarding.js for client logic
- check new HTML page in html-validity test
- ignore example logos in data folder

## Testing
- `pytest tests/test_html_validity.py`
- `node tests/test_results_rankings.js`
- `node tests/test_competition_mode.js`
- `vendor/bin/phpunit` *(fails: Tests: 105, Assertions: 203, Errors: 1, Failures: 15)*

------
https://chatgpt.com/codex/tasks/task_e_688417487964832b82c1298574e1ff2e