### PR TITLE
Update onboarding API logic

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -60,12 +60,16 @@
 
     createBtn.addEventListener('click', async () => {
       try {
-        const res = await fetch('/tenants', {
+        const tenantRes = await fetch('/tenants', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ uid: data.subdomain, schema: data.subdomain })
         });
-        if (!res.ok) throw new Error('API error');
+        if (!tenantRes.ok) throw new Error('tenant');
+
+        const importRes = await fetch('/restore-default', { method: 'POST' });
+        if (!importRes.ok) throw new Error('import');
+
         document.getElementById('success-domain').textContent =
           data.subdomain + '.quizrace.app';
         show('success');


### PR DESCRIPTION
## Summary
- run `POST /restore-default` after creating tenant via `POST /tenants`

## Testing
- `composer install --ansi --no-interaction`
- `vendor/bin/phpunit tests/Controller/CatalogControllerTest.php --stop-on-failure` *(fails: TypeError)*
- `python3 tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_68841cdcdde4832bb8be0b6c414b147f