### PR TITLE
Add onboarding login step

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -1,6 +1,6 @@
 /* global UIkit */
 (function () {
-  const steps = ['step1', 'step2', 'step3', 'step4', 'success'];
+  const steps = ['login', 'step1', 'step2', 'step3', 'step4', 'success'];
   const data = {
     name: '',
     subdomain: '',
@@ -26,12 +26,35 @@
   }
 
   document.addEventListener('DOMContentLoaded', () => {
+    const loginBtn = document.getElementById('login-btn');
+    const loginUser = document.getElementById('login-user');
+    const loginPass = document.getElementById('login-pass');
+    const loginError = document.getElementById('login-error');
+
+    show('login');
+
     const nameInput = document.getElementById('customer-name');
     const subdomainPreview = document.getElementById('subdomain-preview');
     const next1 = document.getElementById('next1');
     const next2 = document.getElementById('next2');
     const next3 = document.getElementById('next3');
     const createBtn = document.getElementById('create');
+
+    loginBtn.addEventListener('click', async () => {
+      loginError.hidden = true;
+      try {
+        const res = await fetch('/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ username: loginUser.value, password: loginPass.value })
+        });
+        if (!res.ok) throw new Error('login');
+        show('step1');
+      } catch (err) {
+        loginError.hidden = false;
+      }
+    });
 
     nameInput.addEventListener('input', () => {
       data.name = nameInput.value.trim();
@@ -63,11 +86,15 @@
         const tenantRes = await fetch('/tenants', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
           body: JSON.stringify({ uid: data.subdomain, schema: data.subdomain })
         });
         if (!tenantRes.ok) throw new Error('tenant');
 
-        const importRes = await fetch('/restore-default', { method: 'POST' });
+        const importRes = await fetch('/restore-default', {
+          method: 'POST',
+          credentials: 'include'
+        });
         if (!importRes.ok) throw new Error('import');
 
         document.getElementById('success-domain').textContent =

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -22,7 +22,21 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-margin-large-top">
-    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1">
+    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="login">
+      <h3 class="uk-card-title">Login</h3>
+      <div id="login-error" class="uk-alert-danger" uk-alert hidden>
+        <p>Benutzername oder Passwort falsch.</p>
+      </div>
+      <div class="uk-margin">
+        <input id="login-user" class="uk-input" type="text" placeholder="Benutzername" required>
+      </div>
+      <div class="uk-margin">
+        <input id="login-pass" class="uk-input" type="password" placeholder="Passwort" required>
+      </div>
+      <button class="uk-button uk-button-primary" id="login-btn">Login</button>
+    </div>
+
+    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1" hidden>
       <h3 class="uk-card-title">1. Kundendaten</h3>
       <div class="uk-margin">
         <input id="customer-name" class="uk-input" type="text" placeholder="Kundenname" required>


### PR DESCRIPTION
## Summary
- add service account login step before tenant setup
- send session cookie in onboarding requests

## Testing
- `vendor/bin/phpunit` *(fails: Unsupported operand types & other test failures)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68844fdda198832bba23209da5492d38