### PR TITLE
Implement nginx vhost management

### DIFF
--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -26,7 +26,12 @@ class TenantController
         if (!is_array($data) || !isset($data['uid'], $data['schema'])) {
             return $response->withStatus(400);
         }
-        $this->service->createTenant((string) $data['uid'], (string) $data['schema']);
+        try {
+            $this->service->createTenant((string) $data['uid'], (string) $data['schema']);
+        } catch (\RuntimeException $e) {
+            $response->getBody()->write($e->getMessage());
+            return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
+        }
         return $response->withStatus(201);
     }
 

--- a/src/Service/NginxService.php
+++ b/src/Service/NginxService.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class NginxService
+{
+    private string $vhostDir;
+    private string $domain;
+    private string $clientMaxBodySize;
+
+    public function __construct(
+        ?string $vhostDir = null,
+        ?string $domain = null,
+        ?string $clientMaxBodySize = null
+    ) {
+        $this->vhostDir = $vhostDir ?? dirname(__DIR__, 2) . '/vhost.d';
+        $this->domain = $domain ?? (getenv('DOMAIN') ?: '');
+        $this->clientMaxBodySize = $clientMaxBodySize ?? (getenv('CLIENT_MAX_BODY_SIZE') ?: '50m');
+    }
+
+    public function createVhost(string $sub): void
+    {
+        if ($this->domain === '') {
+            throw new \RuntimeException('DOMAIN not configured');
+        }
+        if (!is_dir($this->vhostDir) && !mkdir($this->vhostDir, 0777, true) && !is_dir($this->vhostDir)) {
+            throw new \RuntimeException('Unable to create vhost directory');
+        }
+        $file = $this->vhostDir . '/' . $sub . '.' . $this->domain;
+        if (file_put_contents($file, 'client_max_body_size ' . $this->clientMaxBodySize . ';') === false) {
+            throw new \RuntimeException('Unable to write vhost file');
+        }
+        $output = [];
+        $status = 0;
+        exec('nginx -s reload 2>&1', $output, $status);
+        if ($status !== 0) {
+            throw new \RuntimeException('nginx reload failed: ' . implode("\n", $output));
+        }
+    }
+}

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -13,13 +13,14 @@ use App\Infrastructure\Migrations\Migrator;
 class TenantService
 {
     private PDO $pdo;
-
     private string $migrationsDir;
+    private ?NginxService $nginxService;
 
-    public function __construct(PDO $pdo, ?string $migrationsDir = null)
+    public function __construct(PDO $pdo, ?string $migrationsDir = null, ?NginxService $nginxService = null)
     {
         $this->pdo = $pdo;
         $this->migrationsDir = $migrationsDir ?? dirname(__DIR__, 2) . '/migrations';
+        $this->nginxService = $nginxService;
     }
 
     /**
@@ -37,6 +38,10 @@ class TenantService
         }
         $stmt = $this->pdo->prepare('INSERT INTO tenants(uid, subdomain) VALUES(?, ?)');
         $stmt->execute([$uid, $schema]);
+
+        if ($this->nginxService !== null) {
+            $this->nginxService->createVhost($schema);
+        }
     }
 
     /**

--- a/src/routes.php
+++ b/src/routes.php
@@ -24,6 +24,7 @@ use App\Service\EventService;
 use App\Service\SummaryPhotoService;
 use App\Service\UserService;
 use App\Service\TenantService;
+use App\Service\NginxService;
 use App\Service\SettingsService;
 use App\Service\TranslationService;
 use App\Application\Middleware\LanguageMiddleware;
@@ -108,7 +109,8 @@ return function (\Slim\App $app, TranslationService $translator) {
         $consentService = new PhotoConsentService($pdo, $configService);
         $summaryService = new SummaryPhotoService($pdo, $configService);
         $eventService = new EventService($pdo);
-        $tenantService = new TenantService($pdo);
+        $nginxService = new NginxService();
+        $tenantService = new TenantService($pdo, null, $nginxService);
         $userService = new \App\Service\UserService($pdo);
         $settingsService = new \App\Service\SettingsService($pdo);
 

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -42,7 +42,16 @@ CREATE TABLE question_results(
 );
 SQL;
         file_put_contents($dir . '/20240910_base_schema.sql', $sql);
-        return new TenantService($pdo, $dir);
+        $nginx = new class extends \App\Service\NginxService {
+            public function __construct()
+            {
+            }
+
+            public function createVhost(string $sub): void
+            {
+            }
+        };
+        return new TenantService($pdo, $dir, $nginx);
     }
 
     public function testCreateTenantInsertsRow(): void


### PR DESCRIPTION
## Summary
- add `NginxService` for vhost file creation and nginx reload
- extend `TenantService` to call the new service when creating tenants
- handle runtime errors in `TenantController`
- wire service up in the route bootstrap
- adjust tests for updated constructor

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/phpunit --do-not-cache-result` *(fails: Tests: 105, Assertions: 203, Errors: 1, Failures: 12, Warnings: 9)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest -q tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_68845384c6e8832ba43492be1787a9f2