### PR TITLE
Add admin creation step in onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -5,7 +5,8 @@
     name: '',
     subdomain: '',
     plan: '',
-    payment: ''
+    payment: '',
+    adminPass: ''
   };
 
   function show(step) {
@@ -39,6 +40,7 @@
     const next2 = document.getElementById('next2');
     const next3 = document.getElementById('next3');
     const createBtn = document.getElementById('create');
+    const adminPassInput = document.getElementById('admin-pass');
 
     loginBtn.addEventListener('click', async () => {
       loginError.hidden = true;
@@ -82,6 +84,13 @@
     });
 
     createBtn.addEventListener('click', async () => {
+      if (!adminPassInput || adminPassInput.value === '') {
+        if (typeof UIkit !== 'undefined') {
+          UIkit.notification({ message: 'Passwort angeben', status: 'danger' });
+        }
+        return;
+      }
+      data.adminPass = adminPassInput.value;
       try {
         const tenantRes = await fetch('/tenants', {
           method: 'POST',
@@ -97,8 +106,18 @@
         });
         if (!importRes.ok) throw new Error('import');
 
+        const userRes = await fetch('/users.json', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify([{ username: 'admin', password: data.adminPass, role: 'admin' }])
+        });
+        if (!userRes.ok) throw new Error('user');
+
         document.getElementById('success-domain').textContent =
           data.subdomain + '.quizrace.app';
+        document.getElementById('success-pass').textContent =
+          'Ihr Admin-Login lautet: admin / ' + data.adminPass;
         show('success');
       } catch (err) {
         if (typeof UIkit !== 'undefined') {

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -79,12 +79,16 @@
         <li><strong>Abo:</strong> <span id="summary-plan"></span></li>
         <li><strong>Zahlung:</strong> <span id="summary-payment"></span></li>
       </ul>
+      <div class="uk-margin">
+        <input id="admin-pass" class="uk-input" type="password" placeholder="Admin-Passwort" required>
+      </div>
       <button class="uk-button uk-button-primary" id="create">Jetzt QuizRace-Umgebung erstellen</button>
     </div>
 
     <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto uk-text-center" id="success" hidden>
       <h3 class="uk-card-title">Ihre QuizRace-Umgebung ist bereit!</h3>
       <p id="success-domain"></p>
+      <p id="success-pass"></p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend onboarding wizard with admin password input
- show generated admin credentials after setup
- POST to `/users.json` to create admin

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: Errors: 1, Failures: 12)*
- `pytest -q tests/test_html_validity.py`
- `pytest -q tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_68845e28e814832ba4936285eedbe299