### PR TITLE
Implement tenant availability check

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -92,6 +92,18 @@
       }
       data.adminPass = adminPassInput.value;
       try {
+        const checkRes = await fetch('/tenants/' + encodeURIComponent(data.subdomain), {
+          credentials: 'include'
+        });
+        if (checkRes.ok) {
+          if (typeof UIkit !== 'undefined') {
+            UIkit.notification({ message: 'Subdomain bereits vergeben', status: 'danger' });
+          } else {
+            alert('Subdomain bereits vergeben');
+          }
+          show('step1');
+          return;
+        }
         const tenantRes = await fetch('/tenants', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -44,4 +44,15 @@ class TenantController
         $this->service->deleteTenant((string) $data['uid']);
         return $response->withStatus(204);
     }
+
+    /**
+     * Check if a tenant with the given subdomain already exists.
+     */
+    public function exists(Request $request, Response $response, array $args): Response
+    {
+        $sub = (string) ($args['subdomain'] ?? '');
+        return $this->service->exists($sub)
+            ? $response->withStatus(200)
+            : $response->withStatus(404);
+    }
 }

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -61,4 +61,14 @@ class TenantService
         $del = $this->pdo->prepare('DELETE FROM tenants WHERE uid = ?');
         $del->execute([$uid]);
     }
+
+    /**
+     * Check whether a tenant with the given subdomain exists.
+     */
+    public function exists(string $subdomain): bool
+    {
+        $stmt = $this->pdo->prepare('SELECT 1 FROM tenants WHERE subdomain = ?');
+        $stmt->execute([$subdomain]);
+        return $stmt->fetchColumn() !== false;
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -319,6 +319,14 @@ return function (\Slim\App $app, TranslationService $translator) {
         }
         return $request->getAttribute('tenantController')->create($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
+
+    $app->get('/tenants/{subdomain}', function (Request $request, Response $response, array $args) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(403);
+        }
+        return $request->getAttribute('tenantController')->exists($request, $response, $args);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
+
     $app->delete('/tenants', function (Request $request, Response $response) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(403);

--- a/tests/Controller/DomainAccessTest.php
+++ b/tests/Controller/DomainAccessTest.php
@@ -42,4 +42,23 @@ class DomainAccessTest extends TestCase
             putenv('MAIN_DOMAIN=' . $old);
         }
     }
+
+    public function testTenantCheckRejectedOnSubdomain(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $req = $this->createRequest('GET', '/tenants/foo');
+        $req = $req->withUri($req->getUri()->withHost('tenant.test'));
+        $res = $app->handle($req);
+        $this->assertEquals(403, $res->getStatusCode());
+        session_destroy();
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
 }

--- a/tests/Controller/TenantControllerTest.php
+++ b/tests/Controller/TenantControllerTest.php
@@ -136,4 +136,25 @@ class TenantControllerTest extends TestCase
             putenv('MAIN_DOMAIN=' . $old);
         }
     }
+
+    public function testExistsReturns404ForUnknown(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT);');
+        $controller = new TenantController(new TenantService($pdo));
+        $req = $this->createRequest('GET', '/tenants/foo');
+        $res = $controller->exists($req, new Response(), ['subdomain' => 'foo']);
+        $this->assertEquals(404, $res->getStatusCode());
+    }
+
+    public function testExistsReturns200ForExisting(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT);');
+        $pdo->exec("INSERT INTO tenants(uid, subdomain) VALUES('u1', 'bar')");
+        $controller = new TenantController(new TenantService($pdo));
+        $req = $this->createRequest('GET', '/tenants/bar');
+        $res = $controller->exists($req, new Response(), ['subdomain' => 'bar']);
+        $this->assertEquals(200, $res->getStatusCode());
+    }
 }


### PR DESCRIPTION
## Summary
- add `TenantService::exists` and `TenantController::exists`
- expose GET `/tenants/{subdomain}` route
- query the new endpoint in `onboarding.js`
- show notification when subdomain is taken
- cover the new behaviour with unit tests

## Testing
- `vendor/bin/phpunit` *(fails: Errors: 1, Failures: 15)*
- `python3 -m pytest -q tests/test_html_validity.py tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpstan analyse --no-progress -c phpstan.neon.dist` *(fails: PHP memory limit)*
- `vendor/bin/phpcs`

------
https://chatgpt.com/codex/tasks/task_e_6884f171cfb0832ba888b778a3cc7056