### PR TITLE
Improve onboarding success info

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -42,6 +42,20 @@
     const createBtn = document.getElementById('create');
     const adminPassInput = document.getElementById('admin-pass');
 
+    async function waitForHttps(url) {
+      for (let i = 0; i < 30; i++) {
+        try {
+          await fetch(url, { method: 'HEAD', mode: 'no-cors' });
+          window.location.href = url;
+          return;
+        } catch (e) {
+          // ignore errors until certificate is ready
+        }
+        await new Promise(resolve => setTimeout(resolve, 5000));
+      }
+      window.location.href = url;
+    }
+
     loginBtn.addEventListener('click', async () => {
       loginError.hidden = true;
       try {
@@ -139,9 +153,7 @@
           link.href = 'https://' + data.subdomain + '.quizrace.app';
           link.textContent = 'Zu Ihrem QuizRace';
           successEl.appendChild(link);
-          setTimeout(() => {
-            window.location.href = link.href;
-          }, 5000);
+          waitForHttps(link.href);
         }
       } catch (err) {
         if (typeof UIkit !== 'undefined') {

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -89,6 +89,7 @@
       <h3 class="uk-card-title">Ihre QuizRace-Umgebung ist bereit!</h3>
       <p id="success-domain"></p>
       <p id="success-pass"></p>
+      <p>Die Subdomain ist in wenigen Minuten erreichbar, sobald das SSL-Zertifikat erstellt wurde.</p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show note about SSL certificate readiness on the onboarding success page
- poll for HTTPS availability before redirecting to the new subdomain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f3167384832b93dd3c7b8e565a32