### PR TITLE
Fix nginx reload command

### DIFF
--- a/src/Service/NginxService.php
+++ b/src/Service/NginxService.php
@@ -34,7 +34,7 @@ class NginxService
         }
         $output = [];
         $status = 0;
-        exec('nginx -s reload 2>&1', $output, $status);
+        exec('docker compose exec nginx nginx -s reload 2>&1', $output, $status);
         if ($status !== 0) {
             throw new \RuntimeException('nginx reload failed: ' . implode("\n", $output));
         }


### PR DESCRIPTION
## Summary
- update nginx reload to use `docker compose exec`

## Testing
- `vendor/bin/phpcs src/`
- `vendor/bin/phpstan analyse src/ --memory-limit=512M`
- `vendor/bin/phpunit` *(fails: Errors: 1, Failures: 15, Warnings: 9)*

------
https://chatgpt.com/codex/tasks/task_e_6884f54195b0832b8a82c526d1a8966f