### PR TITLE
Support base path and custom domains in onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -34,6 +34,10 @@
 
     show('login');
 
+    const basePath = window.basePath || '';
+    const mainDomain = window.mainDomain || '';
+    const withBase = p => basePath + p;
+
     const nameInput = document.getElementById('customer-name');
     const subdomainPreview = document.getElementById('subdomain-preview');
     const next1 = document.getElementById('next1');
@@ -59,7 +63,7 @@
     loginBtn.addEventListener('click', async () => {
       loginError.hidden = true;
       try {
-        const res = await fetch('/login', {
+        const res = await fetch(withBase('/login'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -106,7 +110,7 @@
       }
       data.adminPass = adminPassInput.value;
       try {
-        const checkRes = await fetch('/tenants/' + encodeURIComponent(data.subdomain), {
+        const checkRes = await fetch(withBase('/tenants/' + encodeURIComponent(data.subdomain)), {
           credentials: 'include'
         });
         if (checkRes.ok) {
@@ -118,7 +122,7 @@
           show('step1');
           return;
         }
-        const tenantRes = await fetch('/tenants', {
+        const tenantRes = await fetch(withBase('/tenants'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -126,13 +130,13 @@
         });
         if (!tenantRes.ok) throw new Error('tenant');
 
-        const importRes = await fetch('/restore-default', {
+        const importRes = await fetch(withBase('/restore-default'), {
           method: 'POST',
           credentials: 'include'
         });
         if (!importRes.ok) throw new Error('import');
 
-        const userRes = await fetch('/users.json', {
+        const userRes = await fetch(withBase('/users.json'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
@@ -141,7 +145,7 @@
         if (!userRes.ok) throw new Error('user');
 
         document.getElementById('success-domain').textContent =
-          data.subdomain + '.quizrace.app';
+          data.subdomain + '.' + mainDomain;
         document.getElementById('success-pass').textContent =
           'Ihr Admin-Login lautet: admin / ' + data.adminPass;
         show('success');
@@ -150,7 +154,7 @@
           const link = document.createElement('a');
           link.id = 'success-link';
           link.className = 'uk-button uk-button-primary uk-margin-top';
-          link.href = 'https://' + data.subdomain + '.quizrace.app';
+          link.href = 'https://' + data.subdomain + '.' + mainDomain;
           link.textContent = 'Zu Ihrem QuizRace';
           successEl.appendChild(link);
           waitForHttps(link.href);

--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -16,6 +16,12 @@ class OnboardingController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'onboarding.twig');
+        $mainDomain = getenv('MAIN_DOMAIN')
+            ?: getenv('DOMAIN')
+            ?: $request->getUri()->getHost();
+
+        return $view->render($response, 'onboarding.twig', [
+            'main_domain' => $mainDomain,
+        ]);
     }
 }

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -42,7 +42,7 @@
         <input id="customer-name" class="uk-input" type="text" placeholder="Kundenname" required>
       </div>
       <div class="uk-margin">
-        <label>Subdomain: <span id="subdomain-preview">-</span>.quizrace.app</label>
+        <label>Subdomain: <span id="subdomain-preview">-</span>.{{ main_domain }}</label>
       </div>
       <button class="uk-button uk-button-primary" id="next1" disabled>Weiter</button>
     </div>
@@ -75,7 +75,7 @@
       <h3 class="uk-card-title">4. Erstellung</h3>
       <ul class="uk-list">
         <li><strong>Kunde:</strong> <span id="summary-name"></span></li>
-        <li><strong>Subdomain:</strong> <span id="summary-subdomain"></span>.quizrace.app</li>
+        <li><strong>Subdomain:</strong> <span id="summary-subdomain"></span>.{{ main_domain }}</li>
         <li><strong>Abo:</strong> <span id="summary-plan"></span></li>
         <li><strong>Zahlung:</strong> <span id="summary-payment"></span></li>
       </ul>
@@ -96,6 +96,7 @@
 
 {% block scripts %}
   <script src="{{ basePath }}/js/app.js"></script>
+  <script>window.mainDomain = '{{ main_domain }}';</script>
   <script src="{{ basePath }}/js/onboarding.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- update onboarding JS to use `withBase()` and `mainDomain`
- expose `main_domain` in `OnboardingController`
- show configured domain in onboarding template and pass `mainDomain` to JS

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: 1 error, 12 failures)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68851bdf9768832b8ddc44ed8b9fb019