### PR TITLE
Fix tenant endpoint paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Mandant wird mit `scripts/create_tenant.sh` angelegt:
 scripts/create_tenant.sh foo
 ```
 
-Das Skript sendet einen API-Aufruf an `/tenant`, legt die Datei
+Das Skript sendet einen API-Aufruf an `/tenants`, legt die Datei
 `vhost.d/foo.$DOMAIN` an und lädt anschließend den Proxy neu. Zum Entfernen
 eines Mandanten steht `scripts/delete_tenant.sh` bereit:
 

--- a/scripts/create_tenant.sh
+++ b/scripts/create_tenant.sh
@@ -23,7 +23,7 @@ fi
 curl -s -X POST \
   -H 'Content-Type: application/json' \
   -d "{\"subdomain\":\"$SUBDOMAIN\"}" \
-  "http://$DOMAIN/tenant"
+  "http://$DOMAIN/tenants"
 
 mkdir -p "$BASE_DIR/vhost.d"
 echo "client_max_body_size $CLIENT_MAX_BODY_SIZE;" > "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"

--- a/scripts/delete_tenant.sh
+++ b/scripts/delete_tenant.sh
@@ -20,7 +20,7 @@ fi
 curl -s -X DELETE \
   -H 'Content-Type: application/json' \
   -d "{\"subdomain\":\"$SUBDOMAIN\"}" \
-  "http://$DOMAIN/tenant"
+  "http://$DOMAIN/tenants"
 
 rm -f "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -35,8 +35,12 @@ class UserService
     /**
      * Create a new user with the given role.
      */
-    public function create(string $username, string $password, string $role = Roles::CATALOG_EDITOR, bool $active = true): void
-    {
+    public function create(
+        string $username,
+        string $password,
+        string $role = Roles::CATALOG_EDITOR,
+        bool $active = true
+    ): void {
         if (!in_array($role, Roles::ALL, true)) {
             $role = Roles::CATALOG_EDITOR;
         }


### PR DESCRIPTION
## Summary
- update create/delete scripts to use `/tenants`
- document plural endpoint in README
- wrap long method signature to keep PSR-12 compliance

## Testing
- `vendor/bin/phpcs README.md scripts/create_tenant.sh scripts/delete_tenant.sh src/Service/UserService.php`
- `vendor/bin/phpstan analyse src/ --memory-limit=256M`
- `vendor/bin/phpunit --stop-on-failure --colors=never` *(fails: Unsupported operand types in CatalogControllerTest)*

------
https://chatgpt.com/codex/tasks/task_e_68851d997694832bb1b188ab0ea4249d