### PR TITLE
Add note on nginx reload flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ scripts/delete_tenant.sh foo
 Beide Skripte lesen die Variable `DOMAIN` aus `.env` und nutzen sie
 für die vhost-Konfiguration.
 
+Weitere Hinweise zur Abhängigkeit von Docker und zum Flag `NGINX_RELOAD` findest du im Abschnitt [Docker-Abhängigkeit beim Mandanten-Onboarding](docs-jtd/installation.md#tenant-onboarding-docker).
+
 Für den eigentlichen Quiz-Container lässt sich der Hostname über die
 Umgebungsvariable `SLIM_VIRTUAL_HOST` steuern. Starte mehrere Instanzen
 mit unterschiedlichen Werten, werden die Subdomains automatisch als

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -50,3 +50,8 @@ gesetzt, versucht die Anwendung, das externe Programm `convert` aus ImageMagick
 installiert sein.
 Im Docker-Container wird ImageMagick bereits installiert.
 
+## Docker-Abhängigkeit beim Mandanten-Onboarding {#tenant-onboarding-docker}
+
+Die Skripte `create_tenant.sh` und `delete_tenant.sh` richten neue Subdomains ein und laden danach den Reverse Proxy neu. Sie gehen davon aus, dass ein nginx-Container über Docker Compose läuft. Ohne diesen Container schlägt der Reload-Befehl fehl.
+
+Ist Docker nicht verfügbar oder wird der Proxy anderweitig betrieben, kann der Reload über die Umgebungsvariable `NGINX_RELOAD` deaktiviert werden. Setze sie auf `0`, um nur die Vhost-Dateien anzulegen. Der Proxy muss dann manuell neu geladen werden.


### PR DESCRIPTION
## Summary
- document docker dependency for tenant onboarding
- explain disabling reload with NGINX_RELOAD
- reference new docs from README

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Unsupported operand types: string + int)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_688668558228832bbe13959e408cf390