### PR TITLE
Fix tenant migrations with user_role enum

### DIFF
--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -32,7 +32,7 @@ class TenantService
             Migrator::migrate($this->pdo, $this->migrationsDir);
         } else {
             $this->pdo->exec(sprintf('CREATE SCHEMA "%s"', $schema));
-            $this->pdo->exec(sprintf('SET search_path TO "%s"', $schema));
+            $this->pdo->exec(sprintf('SET search_path TO "%s", public', $schema));
             Migrator::migrate($this->pdo, $this->migrationsDir);
             $this->pdo->exec('SET search_path TO public');
         }


### PR DESCRIPTION
## Summary
- include `public` schema in search path before running migrations

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml` *(fails: Errors: 1, Failures: 12)*

------
https://chatgpt.com/codex/tasks/task_e_6887c2596c74832bb7cb54fb03df1ae1