### PR TITLE
Add admin password hint and generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ Weitere nützliche Variablen in `.env` sind:
 - `SERVICE_USER` – Benutzername für den automatischen Login des Onboarding-Assistenten.
 - `SERVICE_PASS` – Passwort dieses Service-Benutzers.
 
+Bei der Mandanten-Erstellung fragt der Onboarding-Assistent nach einem Admin-Passwort.
+Bleibt das Feld leer, erzeugt die Anwendung automatisch ein sicheres Passwort und zeigt es nach der Einrichtung an.
+
 ## Anpassung
 
 Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition besitzt weiterhin ein `slug` für die URL. Fragen verknüpfen den Katalog nun über `catalog_uid`. Das bisherige `id` dient ausschließlich der Sortierung und wird automatisch vergeben.

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -152,13 +152,20 @@
     });
 
     createBtn.addEventListener('click', async () => {
-      if (!adminPassInput || adminPassInput.value === '') {
-        if (typeof UIkit !== 'undefined') {
-          UIkit.notification({ message: 'Passwort angeben', status: 'danger' });
-        }
+      if (!adminPassInput) {
         return;
       }
-      data.adminPass = adminPassInput.value;
+
+      let pass = adminPassInput.value;
+      if (pass === '') {
+        const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        const array = new Uint32Array(16);
+        crypto.getRandomValues(array);
+        pass = Array.from(array, x => charset[x % charset.length]).join('');
+        adminPassInput.value = pass;
+      }
+
+      data.adminPass = pass;
 
       show('success');
       initTaskList();

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -152,4 +152,5 @@ return [
     'action_refresh' => 'Aktualisieren',
     'action_open_evaluation' => 'Auswertung öffnen',
     'action_download' => 'Herunterladen',
+    'help_admin_pass' => 'Definiert das Admin-Passwort des neuen Mandanten. Bleibt das Feld leer, wird ein zufälliges Passwort erzeugt',
 ];

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -152,4 +152,5 @@ return [
     'action_refresh' => 'Refresh',
     'action_open_evaluation' => 'Open evaluation',
     'action_download' => 'Download',
+    'help_admin_pass' => 'Defines the admin password for the new tenant. Leave empty to generate a random one',
 ];

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -80,7 +80,8 @@
         <li><strong>Zahlung:</strong> <span id="summary-payment"></span></li>
       </ul>
       <div class="uk-margin">
-        <input id="admin-pass" class="uk-input" type="password" placeholder="Admin-Passwort" required>
+        <input id="admin-pass" class="uk-input" type="password" placeholder="Admin-Passwort">
+        <div class="uk-text-meta uk-margin-small-top">{{ t('help_admin_pass') }}</div>
       </div>
       <button class="uk-button uk-button-primary" id="create">Jetzt QuizRace-Umgebung erstellen</button>
     </div>


### PR DESCRIPTION
## Summary
- document autogenerated admin password in onboarding wizard
- show help text for admin password in the form
- auto-generate a strong password in `onboarding.js` if none was entered
- translate the new help text to English and German
- keep HTML valid via tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c946b110832b874c859315118c8e