### PR TITLE
Add composer test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,16 +273,12 @@ Vorschau lässt sich direkt im Modal aufrufen.
 
 ## Tests
 
-PHP-Tests werden mit PHPUnit ausgeführt:
+Alle Tests lassen sich gesammelt über Composer ausführen:
 ```bash
-vendor/bin/phpunit
+composer test
 ```
 
-Zusätzlich prüfen Python-Skripte die Gültigkeit der HTML- und JSON-Dateien:
-```bash
-python3 tests/test_html_validity.py
-python3 tests/test_json_validity.py
-```
+Im Hintergrund ruft dieser Befehl PHPUnit sowie zwei Python-Prüfskripte auf.
 
 ## Teams/Personen
 

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,12 @@
         "phpunit/phpunit": "^10.0",
         "phpstan/phpstan": "^2.1",
         "squizlabs/php_codesniffer": "^3.13"
+    },
+    "scripts": {
+        "test": [
+            "phpunit",
+            "python3 tests/test_html_validity.py",
+            "pytest tests/test_json_validity.py"
+        ]
     }
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+composer test


### PR DESCRIPTION
## Summary
- run `phpunit` and python checks via a new composer `test` script
- add helper `scripts/run_tests.sh`
- document unified test command

## Testing
- `composer test` *(fails: ResultServiceTest::testMarkPuzzleReturnsTrueIfAlreadySolved)*
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_6887e81dcb58832ba57f28e6a5232212