### PR TITLE
Add invite HTML sanitization

### DIFF
--- a/docs-jtd/konfiguration.md
+++ b/docs-jtd/konfiguration.md
@@ -37,7 +37,7 @@ Das hochgeladene Logo wird in `data/` gespeichert und über `logoPath` referenzi
 
 Optional kann `baseUrl` gesetzt werden, um in QR-Codes komplette Links zu erzeugen. `QRRemember` merkt sich gescannte Namen und zeigt den Anmeldedialog nicht erneut an. Der Parameter `competitionMode` verhindert Wiederholungen bereits gelöster Kataloge. Über `teamResults` wird gesteuert, ob Teams ihre Ergebnisse einsehen dürfen, und `photoUpload` aktiviert den Upload von Beweisfotos. `puzzleWordEnabled` schaltet das Rätselwort frei und `puzzleFeedback` definiert den Erfolgshinweis nach der Lösung.
 
-`inviteText` erlaubt ein optionales Anschreiben für Teams. Zur Sicherheit werden nur die HTML-Tags `<p>`, `<br>`, `<strong>`, `<em>` sowie `<h2>` bis `<h5>` übernommen. Alle anderen Tags werden automatisch entfernt.
+`inviteText` erlaubt ein optionales Anschreiben für Teams. Zur Sicherheit werden nur die HTML-Tags `<p>`, `<br>`, `<strong>`/`<b>`, `<em>`/`<i>` sowie `<h2>` bis `<h5>` übernommen. Alle anderen Tags werden automatisch entfernt.
 
 Konfigurationswerte können per GET auf `/config.json` abgerufen und per POST aktualisiert werden.
 

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -163,6 +163,10 @@ class ConfigService
         $uid = (string)($filtered['event_uid'] ?? $this->getActiveEventUid());
         $filtered['event_uid'] = $uid;
 
+        if (isset($filtered['inviteText'])) {
+            $filtered['inviteText'] = self::sanitizeHtml((string) $filtered['inviteText']);
+        }
+
         $this->pdo->beginTransaction();
         $check = $this->pdo->prepare('SELECT 1 FROM config WHERE event_uid=?');
         $check->execute([$uid]);

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -78,4 +78,18 @@ class ConfigServiceTest extends TestCase
         $this->assertNull($service->getJson());
         $this->assertEquals([], $service->getConfig());
     }
+
+    public function testSanitizeHtmlRemovesDisallowedTags(): void
+    {
+        $html = '<p>Hello</p><script>alert(1)</script><img src="x"><a href="#">Link</a>';
+        $result = ConfigService::sanitizeHtml($html);
+        $this->assertSame('<p>Hello</p>Link', $result);
+    }
+
+    public function testSanitizeHtmlAllowsConfiguredTags(): void
+    {
+        $html = '<p><br><strong>Bold</strong><b>B</b><em>E</em><i>I</i><h2>T</h2><h3>T3</h3><h4>T4</h4><h5>T5</h5></p>';
+        $result = ConfigService::sanitizeHtml($html);
+        $this->assertSame($html, $result);
+    }
 }


### PR DESCRIPTION
## Summary
- clean inviteText when saving config
- document inviteText allowed HTML tags
- ensure HTML sanitizer keeps only permitted tags

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpstan --memory-limit=1G`
- `vendor/bin/phpunit` *(fails: TypeError in CatalogService)*
- `pytest tests/test_html_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_688809b9dc94832bae414ba4533716f7