### PR TITLE
Handle duplicate tenant schema

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -200,7 +200,14 @@
         });
         if (!tenantRes.ok) {
           const text = await tenantRes.text();
-          logMessage('Fehler Mandant: ' + text);
+          if (tenantRes.status === 409) {
+            logMessage('Subdomain bereits vergeben');
+            if (typeof UIkit !== 'undefined') {
+              UIkit.notification({ message: 'Subdomain bereits vergeben', status: 'danger' });
+            }
+          } else {
+            logMessage('Fehler Mandant: ' + text);
+          }
           setTaskStatus('tenant', 'failed');
           throw new Error(text || 'tenant');
         }

--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -29,8 +29,12 @@ class TenantController
         try {
             $this->service->createTenant((string) $data['uid'], (string) $data['schema']);
         } catch (\RuntimeException $e) {
-            $response->getBody()->write($e->getMessage());
-            return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
+            $msg = $e->getMessage();
+            $status = $msg === 'tenant-exists' ? 409 : 500;
+            if ($status !== 409) {
+                $response->getBody()->write($msg);
+            }
+            return $response->withStatus($status)->withHeader('Content-Type', 'text/plain');
         }
         return $response->withStatus(201);
     }

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -110,4 +110,17 @@ SQL;
 
         $service->createTenant('u4', 's4');
     }
+
+    public function testCreateTenantFailsOnDuplicate(): void
+    {
+        $dir = sys_get_temp_dir() . '/mig' . uniqid();
+        $pdo = new PDO('sqlite::memory:');
+        $service = $this->createService($dir, $pdo);
+        $service->createTenant('u5', 'dup');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('tenant-exists');
+
+        $service->createTenant('u5b', 'dup');
+    }
 }


### PR DESCRIPTION
## Summary
- detect if tenant already exists at service level
- return conflict status from controller when duplicate tenant
- notify user in onboarding UI if creation fails because subdomain exists
- test duplicate tenant creation

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: 1 error, 13 failures)*
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `vendor/bin/phpcs src/`
- `vendor/bin/phpstan analyse src/ --memory-limit=256M`

------
https://chatgpt.com/codex/tasks/task_e_688903a541d4832ba5cbfebfb93ee2ac