### PR TITLE
Add unified test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,16 +275,13 @@ Vorschau lässt sich direkt im Modal aufrufen.
 
 ## Tests
 
-PHP-Tests werden mit PHPUnit ausgeführt:
+Alle Tests lassen sich komfortabel über Composer starten:
 ```bash
-vendor/bin/phpunit
+composer test
 ```
 
-Zusätzlich prüfen Python-Skripte die Gültigkeit der HTML- und JSON-Dateien:
-```bash
-python3 tests/test_html_validity.py
-python3 tests/test_json_validity.py
-```
+Dabei führt der Befehl zunächst PHPUnit aus und ruft anschließend die beiden
+Python-Skripte zur Prüfung der HTML- bzw. JSON-Dateien auf.
 
 ## Teams/Personen
 

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,13 @@
         "phpunit/phpunit": "^10.0",
         "phpstan/phpstan": "^2.1",
         "squizlabs/php_codesniffer": "^3.13"
+    },
+    "scripts": {
+        "phpunit": "vendor/bin/phpunit",
+        "test": [
+            "@phpunit",
+            "python3 tests/test_html_validity.py",
+            "python3 tests/test_json_validity.py"
+        ]
     }
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Run all tests via Composer
+set -e
+composer test


### PR DESCRIPTION
## Summary
- add Composer test script for PHP and Python
- document new command in README
- provide helper script to run tests

## Testing
- `composer test` *(fails: errors in PHP unit tests)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`

------
https://chatgpt.com/codex/tasks/task_e_68890506a964832bb2630e34771d440c