### PR TITLE
Implement custom 404 handler

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -45,6 +45,13 @@ $app->add(TwigMiddleware::create($app, $twig));
 $app->add(new SessionMiddleware());
 $app->add(new DomainMiddleware());
 
-$app->addErrorMiddleware((bool)($settings['displayErrorDetails'] ?? false), true, true);
+$errorMiddleware = new \App\Application\Middleware\ErrorMiddleware(
+    $app->getCallableResolver(),
+    $app->getResponseFactory(),
+    (bool)($settings['displayErrorDetails'] ?? false),
+    true,
+    false
+);
+$app->add($errorMiddleware);
 (require __DIR__ . '/../src/routes.php')($app, $translator);
 $app->run();

--- a/src/Application/Middleware/ErrorMiddleware.php
+++ b/src/Application/Middleware/ErrorMiddleware.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Middleware\ErrorMiddleware as SlimErrorMiddleware;
+use Slim\Exception\HttpNotFoundException;
+use Slim\Psr7\Response as SlimResponse;
+use Throwable;
+
+/**
+ * Custom error middleware handling 404 responses.
+ */
+class ErrorMiddleware extends SlimErrorMiddleware
+{
+    public function __construct(
+        CallableResolverInterface $callableResolver,
+        ResponseFactoryInterface $responseFactory,
+        bool $displayErrorDetails = false,
+        bool $logErrors = false,
+        bool $logErrorDetails = false,
+        ?LoggerInterface $logger = null
+    ) {
+        parent::__construct(
+            $callableResolver,
+            $responseFactory,
+            $displayErrorDetails,
+            $logErrors,
+            $logErrorDetails,
+            $logger
+        );
+
+        $this->setErrorHandler(HttpNotFoundException::class, [$this, 'handleNotFound']);
+    }
+
+    /**
+     * Produce a minimal 404 response and log request path and IP.
+     */
+    public function handleNotFound(
+        Request $request,
+        Throwable $exception,
+        bool $displayErrorDetails,
+        bool $logErrors,
+        bool $logErrorDetails
+    ): Response {
+        $path = $request->getUri()->getPath();
+        $ip = $request->getServerParams()['REMOTE_ADDR'] ?? 'unknown';
+        if ($logErrors) {
+            $message = sprintf('404 %s from %s', $path, $ip);
+            if ($this->logger instanceof LoggerInterface) {
+                $this->logger->error($message);
+            } else {
+                error_log($message);
+            }
+        }
+
+        $response = new SlimResponse(404);
+        $response->getBody()->write('Not Found');
+
+        return $response->withHeader('Content-Type', 'text/plain');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -60,7 +60,14 @@ class TestCase extends PHPUnit_TestCase
         $app->add(new \App\Application\Middleware\LanguageMiddleware($translator));
 
         // Register error middleware
-        $app->addErrorMiddleware((bool)($settings['displayErrorDetails'] ?? false), true, true);
+        $errorMiddleware = new \App\Application\Middleware\ErrorMiddleware(
+            $app->getCallableResolver(),
+            $app->getResponseFactory(),
+            (bool)($settings['displayErrorDetails'] ?? false),
+            true,
+            false
+        );
+        $app->add($errorMiddleware);
 
         // Register routes
         $routes = require __DIR__ . '/../src/routes.php';


### PR DESCRIPTION
## Summary
- add `ErrorMiddleware` to return minimal 404 response
- register the middleware in `index.php`
- use the custom middleware in tests

## Testing
- `vendor/bin/phpunit --filter testGetNotFound tests/Controller/CatalogControllerTest.php`
- `python3 -m pytest tests/test_json_validity.py tests/test_html_validity.py`
- `vendor/bin/phpunit` *(fails: Unsupported operand types: string + int)*

------
https://chatgpt.com/codex/tasks/task_e_68890513afc8832b805cb1840602e68b