### PR TITLE
Fix vendor detection in entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,8 +11,8 @@ if [ -r .env ]; then
     done < .env
 fi
 
-# Install composer dependencies if vendor directory is missing
-if [ ! -d vendor ]; then
+# Install composer dependencies if autoloader is missing
+if [ ! -f vendor/autoload.php ]; then
     composer install --no-interaction --prefer-dist --no-progress
 fi
 


### PR DESCRIPTION
## Summary
- ensure composer install runs when `vendor` exists but is empty

## Testing
- `composer test` *(fails: reload nginx failed)*

------
https://chatgpt.com/codex/tasks/task_e_68893f0ec6e4832b803ffa7c82780460