### PR TITLE
Fix onboarding admin creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
   - `analyst` – Ergebnisse analysieren
   - `team-manager` – Teams verwalten
 
-  Ab der nachfolgenden Migration 20240912 wird zudem ein Admin-Account
-  importiert, sodass direkt eine Anmeldung mit `admin` möglich ist.
+  Der Erstimport legt nur die erforderlichen Rollen an.
+  Ein Admin-Benutzer wird während des Onboardings erstellt,
+  sodass die Datenbank anfangs keine Accounts enthält.
 
    Wird `POSTGRES_DSN` gesetzt und enthält das Verzeichnis `data/` bereits JSON-Dateien,
    legt das Entrypoint-Skript des Containers die Tabellen automatisch an und importiert

--- a/migrations/20240912_seed_admin_account.sql
+++ b/migrations/20240912_seed_admin_account.sql
@@ -1,4 +1,3 @@
--- Seed admin login after roles
-INSERT INTO users (username, password, role) VALUES
-    ('admin', '$2y$12$B8GYqPQQK3F80qJeu.vRXeskUmaET17P91MmApvIahLX8qWqdC/JW', 'admin')
-ON CONFLICT (username) DO NOTHING;
+-- This migration previously inserted a default admin user.
+-- The onboarding process now creates that account when needed,
+-- therefore the database starts without any users.


### PR DESCRIPTION
## Summary
- remove seeding of default admin user
- clarify README about admin account creation

## Testing
- `vendor/bin/phpcs src/`
- `vendor/bin/phpstan analyse src/ --memory-limit=1G`
- `vendor/bin/phpunit --stop-on-failure` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_688a279ffd64832baef88880a2ca279e