### PR TITLE
Improve license overview

### DIFF
--- a/DEPENDENCY_LICENSES.md
+++ b/DEPENDENCY_LICENSES.md
@@ -1,0 +1,68 @@
+## BSD-2-Clause
+Die BSD-2-Clause-Lizenz erlaubt freie Nutzung, Veraenderung und Weitergabe, auch kommerziell, sofern der urspruengliche Copyright-Hinweis bestehen bleibt.
+
+- bacon/bacon-qr-code
+- dasprid/enum
+
+## BSD-3-Clause
+Die BSD-3-Clause-Lizenz erweitert die BSD-2-Variante um einen Haftungsausschluss. Kommerzielle Nutzung ist erlaubt, sofern Lizenz- und Urheberhinweise erhalten bleiben.
+
+- nikic/fast-route
+- nikic/php-parser
+- phar-io/manifest
+- phar-io/version
+- phpunit/php-code-coverage
+- phpunit/php-file-iterator
+- phpunit/php-invoker
+- phpunit/php-text-template
+- phpunit/php-timer
+- phpunit/phpunit
+- sebastian/cli-parser
+- sebastian/code-unit
+- sebastian/code-unit-reverse-lookup
+- sebastian/comparator
+- sebastian/complexity
+- sebastian/diff
+- sebastian/environment
+- sebastian/exporter
+- sebastian/global-state
+- sebastian/lines-of-code
+- sebastian/object-enumerator
+- sebastian/object-reflector
+- sebastian/recursion-context
+- sebastian/type
+- sebastian/version
+- squizlabs/php_codesniffer
+- theseer/tokenizer
+- twig/twig
+
+## MIT
+Die MIT-Lizenz erlaubt die Nutzung, Aenderung und Weitergabe der Software ohne Einschraenkung, auch fuer kommerzielle Zwecke, solange der Lizenztext und die Urheberangaben enthalten bleiben.
+
+- endroid/qr-code
+- fig/http-message-util
+- guzzlehttp/guzzle
+- guzzlehttp/promises
+- guzzlehttp/psr7
+- intervention/image
+- myclabs/deep-copy
+- phpstan/phpstan
+- psr/container
+- psr/http-client
+- psr/http-factory
+- psr/http-message
+- psr/http-server-handler
+- psr/http-server-middleware
+- psr/log
+- ralouphie/getallheaders
+- setasign/fpdf
+- setasign/fpdi
+- slim/psr7
+- slim/slim
+- slim/twig-view
+- symfony/deprecation-contracts
+- symfony/polyfill-ctype
+- symfony/polyfill-mbstring
+- symfony/polyfill-php80
+- symfony/polyfill-php81
+


### PR DESCRIPTION
## Summary
- add explanations about commercial use for each license group in `DEPENDENCY_LICENSES.md`

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: 1 error, 16 failures)*

------
https://chatgpt.com/codex/tasks/task_e_688a35c60124832ba52a870888aba7d9