### PR TITLE
Align marketing route tests with main domain behavior

### DIFF
--- a/tests/Controller/DomainAccessTest.php
+++ b/tests/Controller/DomainAccessTest.php
@@ -16,7 +16,7 @@ class DomainAccessTest extends TestCase
         $request = $this->createRequest('GET', '/landing');
         $request = $request->withUri($request->getUri()->withHost('main.test'));
         $response = $app->handle($request);
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
         if ($old === false) {
             putenv('MAIN_DOMAIN');
         } else {

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -109,7 +109,8 @@ class HomeControllerTest extends TestCase
             $app = $this->getAppInstance();
             $request = $this->createRequest('GET', '/');
             $response = $app->handle($request);
-            $this->assertEquals(404, $response->getStatusCode());
+            $this->assertEquals(200, $response->getStatusCode());
+            $this->assertStringContainsString('Willkommen beim QuizRace', (string)$response->getBody());
         } finally {
             unlink($db);
         }

--- a/tests/Controller/LandingControllerTest.php
+++ b/tests/Controller/LandingControllerTest.php
@@ -13,7 +13,7 @@ class LandingControllerTest extends TestCase
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/landing');
         $response = $app->handle($request);
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     public function testLandingPageTenant(): void


### PR DESCRIPTION
## Summary
- update landing page tests to expect success when accessed on main domain
- ensure home controller landing page test checks for success

## Testing
- `vendor/bin/phpunit --coverage-clover clover.xml`

------
https://chatgpt.com/codex/tasks/task_e_688a37832e34832b899e699a8f639102