### PR TITLE
Update license to proprietary

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,13 @@
-MIT License
+Proprietary License - Sommerfest Quiz
 
-Copyright (c) 2025 calhelp
+Copyright (c) 2025 René Buske
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+The "Sommerfest Quiz" software ("Software") is the sole property of René Buske. 
+Commercial use of the Software is permitted. The source code remains confidential 
+and may not be copied, distributed, modified or made publicly accessible without 
+prior written permission from René Buske.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The Software is provided "as is" without warranty of any kind. René Buske shall 
+not be liable for any damages arising from the use of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ beschreibbar sein.
 Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue PNG- oder WebP-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert. Die Datei landet im Verzeichnis `data/`, damit auch PDFs das Logo einbinden können.
 
 ### Sicherheit und Haftung
-Die Software wird unter der MIT-Lizenz bereitgestellt und erfolgt ohne Gewähr. Die Urheber haften nicht für Schäden, die aus der Nutzung entstehen. Die integrierten Maßnahmen zur Barrierefreiheit verbessern die Zugänglichkeit, sie ersetzen jedoch keine individuelle Prüfung.
+Die Software wird ohne Gewähr bereitgestellt. Alle Rechte liegen bei René Buske. Eine Haftung für Schäden, die aus der Nutzung entstehen, ist ausgeschlossen. Die integrierten Maßnahmen zur Barrierefreiheit verbessern die Zugänglichkeit, sie ersetzen jedoch keine individuelle Prüfung.
 
 ### Fazit
 Die API ermöglicht die komplette Verwaltung eines Quizsystems:
@@ -440,5 +440,5 @@ Durch den Einsatz von Slim Framework und standardisierten Endpunkten ist die Anw
 
 ## Lizenz
 
-Dieses Projekt steht unter der MIT-Lizenz. Weitere Informationen finden Sie in der Datei `LICENSE`.
+Dieses Projekt steht unter einer proprietären Lizenz. Alle Rechte gehören René Buske. Eine kommerzielle Nutzung ist erlaubt. Weitere Informationen finden Sie in der Datei `LICENSE`.
 

--- a/docs-jtd/impressum.md
+++ b/docs-jtd/impressum.md
@@ -31,5 +31,6 @@ Die durch den Seitenbetreiber erstellten Inhalte und Werke auf dieser Website un
 
 ## Quellcode
 
-Der Quellcode dieser Anwendung ist unter der MIT-Lizenz auf GitHub verfügbar: <https://github.com/bastelix/sommerfest-quiz>
+Der Quellcode dieser Anwendung ist Eigentum von René Buske und nicht öffentlich zugänglich.
+
 

--- a/docs-jtd/lizenz.md
+++ b/docs-jtd/lizenz.md
@@ -8,7 +8,7 @@ toc: true
 
 # Lizenz, Haftung, Impressum
 
-Diese Anwendung steht unter der [MIT-Lizenz](https://opensource.org/licenses/MIT). Den vollständigen Text finden Sie auch in der Datei `LICENSE`.
+Diese Anwendung steht unter einer proprietären Lizenz. Alle Rechte liegen bei René Buske. Weitere Informationen finden Sie in der Datei `LICENSE`.
 
 ## Disclaimer / Hinweis
 
@@ -18,57 +18,20 @@ Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial 
 
 Mit dieser App zeigen wir, was heute möglich ist, wenn Menschen und KI gemeinsam digitale Ideen entwickeln.
 
-## MIT-Lizenz (Deutsch)
+## Proprietäre Lizenz
 
 ```
-MIT-Lizenz
+Proprietary License - Sommerfest Quiz
 
-Copyright (c) 2025 calhelp
+Copyright (c) 2025 René Buske
+Alle Rechte vorbehalten.
 
-Hiermit wird unentgeltlich jeder Person, die eine Kopie der Software
-und der zugehörigen Dokumentationsdateien (die "Software") erhält,
-die Erlaubnis erteilt, uneingeschränkt mit der Software zu verfahren,
-einschließlich aber nicht beschränkt auf die Rechte, die Software zu
-nutzen, zu kopieren, zu modifizieren, zusammenzuführen, zu veröffentlichen,
-zu verbreiten, zu unterlizenzieren und/oder zu verkaufen, sowie Personen,
-denen die Software bereitgestellt wird, diese Rechte zu gewähren, vorbehaltlich
-der folgenden Bedingungen:
+Die Nutzung der Software "Sommerfest Quiz" ist für kommerzielle Zwecke erlaubt.
+Der Quellcode bleibt Eigentum von René Buske und darf weder kopiert noch veröffentlicht
+oder verändert werden, sofern keine schriftliche Genehmigung vorliegt.
 
-Der obige Urheberrechtsvermerk und dieser Erlaubnisvermerk sind in allen
-Kopien oder wesentlichen Teilen der Software beizulegen.
-
-DIE SOFTWARE WIRD OHNE JEDE AUSDRÜCKLICHE ODER STILLSCHWEIGENDE GEWÄHRLEISTUNG
-BEREITGESTELLT, EINSCHLIEßLICH UND NICHT BESCHRÄNKT AUF DIE GEWÄHRLEISTUNGEN
-DER MARKTGÄNGIGKEIT, DER EIGNUNG FÜR EINEN BESTIMMTEN ZWECK UND DER NICHTVERLETZUNG.
-IN KEINEM FALL SIND DIE AUTOREN ODER URHEBERRECHTSINHABER FÜR JEGLICHE ANSPRÜCHE,
-SCHÄDEN ODER SONSTIGE HAFTUNGEN VERANTWORTLICH, OB IN EINEM VERTRAGSVERHÄLTNIS,
-EINER UNERLAUBTEN HANDLUNG ODER ANDERWEITIG, DIE SICH AUS DER SOFTWARE ODER DER
-NUTZUNG ODER ANDEREN GESCHÄFTEN MIT DER SOFTWARE ERGEBEN.
+Die Software wird ohne Gewähr bereitgestellt. René Buske haftet nicht für Schäden,
+die aus der Nutzung entstehen.
 ```
 
-## MIT License (English)
-
-```
-MIT License
-
-Copyright (c) 2025 calhelp
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
 

--- a/docs/impressum.md
+++ b/docs/impressum.md
@@ -29,4 +29,5 @@ Die durch den Seitenbetreiber erstellten Inhalte und Werke auf dieser Website un
 
 ## Quellcode
 
-Der Quellcode dieser Anwendung ist unter der MIT-Lizenz auf GitHub verfügbar: <https://github.com/bastelix/sommerfest-quiz>
+Der Quellcode dieser Anwendung ist Eigentum von René Buske und nicht öffentlich zugänglich.
+

--- a/docs/lizenz.md
+++ b/docs/lizenz.md
@@ -3,7 +3,7 @@ layout: default
 title: Lizenz
 ---
 
-Diese Anwendung steht unter der [MIT-Lizenz](https://opensource.org/licenses/MIT). Den vollständigen Text finden Sie auch in der Datei `LICENSE`.
+Diese Anwendung steht unter einer proprietären Lizenz. Alle Rechte liegen bei René Buske. Weitere Informationen finden Sie in der Datei `LICENSE`.
 
 ## Disclaimer / Hinweis
 
@@ -13,56 +13,19 @@ Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial 
 
 Mit dieser App zeigen wir, was heute möglich ist, wenn Menschen und KI gemeinsam digitale Ideen entwickeln.
 
-## MIT-Lizenz (Deutsch)
+## Proprietäre Lizenz
 
 ```
-MIT-Lizenz
+Proprietary License - Sommerfest Quiz
 
-Copyright (c) 2025 calhelp
+Copyright (c) 2025 René Buske
+Alle Rechte vorbehalten.
 
-Hiermit wird unentgeltlich jeder Person, die eine Kopie der Software
-und der zugehörigen Dokumentationsdateien (die "Software") erhält,
-die Erlaubnis erteilt, uneingeschränkt mit der Software zu verfahren,
-einschließlich aber nicht beschränkt auf die Rechte, die Software zu
-nutzen, zu kopieren, zu modifizieren, zusammenzuführen, zu veröffentlichen,
-zu verbreiten, zu unterlizenzieren und/oder zu verkaufen, sowie Personen,
-denen die Software bereitgestellt wird, diese Rechte zu gewähren, vorbehaltlich
-der folgenden Bedingungen:
+Die Nutzung der Software "Sommerfest Quiz" ist für kommerzielle Zwecke erlaubt. 
+Der Quellcode bleibt Eigentum von René Buske und darf weder kopiert noch veröffentlicht 
+oder verändert werden, sofern keine schriftliche Genehmigung vorliegt.
 
-Der obige Urheberrechtsvermerk und dieser Erlaubnisvermerk sind in allen
-Kopien oder wesentlichen Teilen der Software beizulegen.
-
-DIE SOFTWARE WIRD OHNE JEDE AUSDRÜCKLICHE ODER STILLSCHWEIGENDE GEWÄHRLEISTUNG
-BEREITGESTELLT, EINSCHLIESSLICH UND NICHT BESCHRÄNKT AUF DIE GEWÄHRLEISTUNGEN
-DER MARKTGÄNGIGKEIT, DER EIGNUNG FÜR EINEN BESTIMMTEN ZWECK UND DER NICHTVERLETZUNG.
-IN KEINEM FALL SIND DIE AUTOREN ODER URHEBERRECHTSINHABER FÜR JEGLICHE ANSPRÜCHE,
-SCHÄDEN ODER SONSTIGE HAFTUNGEN VERANTWORTLICH, OB IN EINEM VERTRAGSVERHÄLTNIS,
-EINER UNERLAUBTEN HANDLUNG ODER ANDERWEITIG, DIE SICH AUS DER SOFTWARE ODER DER
-NUTZUNG ODER ANDEREN GESCHÄFTEN MIT DER SOFTWARE ERGEBEN.
+Die Software wird ohne Gewähr bereitgestellt. René Buske haftet nicht für Schäden, 
+die aus der Nutzung entstehen.
 ```
 
-## MIT License (English)
-
-```
-MIT License
-
-Copyright (c) 2025 calhelp
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```


### PR DESCRIPTION
## Summary
- replace MIT license with proprietary license belonging to René Buske
- update documentation to reference the new proprietary license

## Testing
- `composer test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3c3dca38832b84dfba11ea18a215