### PR TITLE
Make error details configurable via .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Weitere nützliche Variablen in `.env` sind:
 - `NGINX_CONTAINER` – Name des Proxy-Containers (Standard `nginx`).
 - `NGINX_RELOAD` – auf `0` setzen, wenn ein externer Webhook den Reload übernimmt.
 - `NGINX_RELOADER_URL` – URL eines externen Webhooks für den Proxy-Reload.
+- `DISPLAY_ERROR_DETAILS` – auf `1` setzen, um detaillierte Fehlermeldungen anzuzeigen.
 
 Bei der Mandanten-Erstellung fragt der Onboarding-Assistent nach einem Admin-Passwort.
 Bleibt das Feld leer, erzeugt die Anwendung automatisch ein sicheres Passwort und zeigt es nach der Einrichtung an. Dieses Passwort ersetzt das zuvor generierte Standardpasswort des Admin-Benutzers.
@@ -378,6 +379,9 @@ Alle wesentlichen Einstellungen stehen in `data/config.json` und werden beim ers
   "postgres_pass": "***"
 }
 ```
+
+Statt in `config.json` kann der Parameter auch über die Umgebungsvariable
+`DISPLAY_ERROR_DETAILS` gesetzt werden.
 
 Optional kann `baseUrl` gesetzt werden, um in QR-Codes vollständige Links mit Domain zu erzeugen. `QRRemember` speichert gescannte Namen und erspart das erneute Einscannen. Der Parameter `competitionMode` blendet im Quiz alle Neustart-Schaltflächen aus, verhindert Wiederholungen bereits abgeschlossener Kataloge und unterbindet die Anzeige der Katalogübersicht. Ein Fragenkatalog kann dann nur über einen direkten QR-Code-Link gestartet werden. Im Wettkampfmodus führt ein Aufruf der Hauptseite ohne gültigen Katalog-Parameter automatisch zur Hilfe-Seite. Über `teamResults` lässt sich steuern, ob Teams nach Abschluss aller Kataloge ihre eigene Ergebnisübersicht angezeigt bekommen. `photoUpload` blendet die Buttons zum Hochladen von Beweisfotos ein oder aus. `puzzleWordEnabled` schaltet das Rätselwort-Spiel frei und `puzzleFeedback` definiert den Text, der nach korrekter Eingabe angezeigt wird. `inviteText` enthält ein optionales Anschreiben für teilnehmende Teams.
 

--- a/config/settings.php
+++ b/config/settings.php
@@ -24,6 +24,11 @@ $settings += [
     'displayErrorDetails' => false,
 ];
 
+$envError = getenv('DISPLAY_ERROR_DETAILS');
+if ($envError !== false) {
+    $settings['displayErrorDetails'] = filter_var($envError, FILTER_VALIDATE_BOOLEAN);
+}
+
 $settings['postgres_dsn'] = getenv('POSTGRES_DSN') ?: ($settings['postgres_dsn'] ?? null);
 $settings['postgres_user'] = getenv('POSTGRES_USER') ?: ($settings['postgres_user'] ?? null);
 $settings['postgres_pass'] = getenv('POSTGRES_PASSWORD')

--- a/docs-jtd/konfiguration.md
+++ b/docs-jtd/konfiguration.md
@@ -33,6 +33,8 @@ Alle wesentlichen Optionen stehen in `data/config.json` und werden beim ersten I
 }
 ```
 
+Alternativ kann die Variable `DISPLAY_ERROR_DETAILS` in `.env` gesetzt werden.
+
 Das hochgeladene Logo wird in `data/` gespeichert und über `logoPath` referenziert, typischerweise als `/logo.png`.
 
 Optional kann `baseUrl` gesetzt werden, um in QR-Codes komplette Links zu erzeugen. `QRRemember` merkt sich gescannte Namen und zeigt den Anmeldedialog nicht erneut an. Der Parameter `competitionMode` verhindert Wiederholungen bereits gelöster Kataloge. Über `teamResults` wird gesteuert, ob Teams ihre Ergebnisse einsehen dürfen, und `photoUpload` aktiviert den Upload von Beweisfotos. `puzzleWordEnabled` schaltet das Rätselwort frei und `puzzleFeedback` definiert den Erfolgshinweis nach der Lösung.

--- a/sample.env
+++ b/sample.env
@@ -17,6 +17,9 @@ POSTGRES_PASS=quiz                           # veraltet, s. POSTGRES_PASSWORD
 POSTGRES_PASSWORD=quiz                       # Passwort des DB-Benutzers
 POSTGRES_DB=quiz                             # Datenbankname
 
+# Fehlerdetails anzeigen? (0 oder 1)
+DISPLAY_ERROR_DETAILS=0
+
 # Optionaler Basis-Pfad (wenn die App nicht im Root liegt)
 BASE_PATH=
 


### PR DESCRIPTION
## Summary
- control Slim's error details via `DISPLAY_ERROR_DETAILS` env var
- document the new variable in the README and docs
- update sample `.env` with a template setting

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688a6bfbf668832bb34e2b2a13a01115