### PR TITLE
Adjust service account role

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,15 @@ Weitere nützliche Variablen in `.env` sind:
 - `BASE_PATH` – optionaler Basis-Pfad, falls die Anwendung nicht im Root der Domain liegt.
 - `SERVICE_USER` – Benutzername für den automatischen Login des Onboarding-Assistenten.
 - `SERVICE_PASS` – Passwort dieses Service-Benutzers.
+- **Wichtig:** Der Onboarding-Assistent setzt einen Account mit mindestens der
+  Rolle `service-account` voraus, um alle Schritte (inklusive `POST /restore-default`)
+  automatisiert auszuführen. Ein Beispiel zum Anlegen:
+
+```bash
+curl -X POST http://$DOMAIN/users.json \
+  -H 'Content-Type: application/json' \
+  -d '[{"username":"robot","password":"secret","role":"service-account","active":true}]'
+```
 - `NGINX_RELOAD_TOKEN` – Token für den Webhook `http://nginx-reloader:8080/reload`.
 - `NGINX_CONTAINER` – Name des Proxy-Containers (Standard `nginx`).
 - `NGINX_RELOAD` – auf `0` setzen, wenn ein externer Webhook den Reload übernimmt.

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,17 @@ curl -c cookies.txt -X POST http://$DOMAIN/login \
   -d '{"username":"robot","password":"secret"}'
 ```
 
+Soll der Account für den Onboarding-Assistenten genutzt werden
+(Variablen `SERVICE_USER` und `SERVICE_PASS`), benötigt er mindestens die Rolle
+`service-account`. Damit kann der Assistent Standarddaten importieren (`POST
+/restore-default`).
+
+```bash
+curl -X POST http://$DOMAIN/users.json \
+  -H 'Content-Type: application/json' \
+  -d '[{"username":"robot","password":"secret","role":"service-account","active":true}]'
+```
+
 ## Weitere Seiten
 
 * [Wie läuft das Spiel?](spielablauf.md)

--- a/src/routes.php
+++ b/src/routes.php
@@ -355,7 +355,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware('admin'));
     $app->post('/restore-default', function (Request $request, Response $response) {
         return $request->getAttribute('importController')->restoreDefaults($request, $response);
-    })->add(new RoleAuthMiddleware('admin'));
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
     $app->post('/import/{name}', function (Request $request, Response $response, array $args) {
         return $request
             ->getAttribute('importController')


### PR DESCRIPTION
## Summary
- allow `/restore-default` for `service-account`
- document that service accounts suffice for automated onboarding

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688a62b5628c832bbfc52e0e093cd143