### PR TITLE
Improve error visibility in tenant onboarding

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -128,7 +128,13 @@ return function (\Slim\App $app, TranslationService $translator) {
             ))
             ->withAttribute('teamController', new TeamController($teamService))
             ->withAttribute('eventController', new EventController($eventService))
-            ->withAttribute('tenantController', new TenantController($tenantService))
+            ->withAttribute(
+                'tenantController',
+                new TenantController(
+                    $tenantService,
+                    filter_var(getenv('DISPLAY_ERROR_DETAILS'), FILTER_VALIDATE_BOOLEAN)
+                )
+            )
             ->withAttribute('passwordController', new PasswordController($userService))
             ->withAttribute('userController', new UserController($userService))
             ->withAttribute('settingsController', new SettingsController($settingsService))


### PR DESCRIPTION
## Summary
- log tenant creation errors
- include optional stack traces when `DISPLAY_ERROR_DETAILS=1`
- pass `DISPLAY_ERROR_DETAILS` to tenant controller so onboarding shows real errors

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688a79b98d74832bb920e620ff9b1458