### PR TITLE
Fix migrations when SQL file is comments only

### DIFF
--- a/src/Infrastructure/Migrations/Migrator.php
+++ b/src/Infrastructure/Migrations/Migrator.php
@@ -33,6 +33,14 @@ class Migrator
                 continue;
             }
 
+            // Remove pure comment lines and skip empty migrations
+            $trimmed = preg_replace('/^\s*--.*$/m', '', $sql);
+            if (trim($trimmed) === '') {
+                $ins = $pdo->prepare('INSERT INTO migrations(version) VALUES(?)');
+                $ins->execute([$version]);
+                continue;
+            }
+
             if ($driver === 'sqlite') {
                 // Strip schema prefixes and unsupported blocks
                 $sql = preg_replace('/public\./', '', $sql);


### PR DESCRIPTION
## Summary
- skip SQL migrations that contain no statements after comment removal

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688a80e61cfc832b8125c950ee61bbbe