### PR TITLE
Fix catalog import sort order

### DIFF
--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -250,4 +250,22 @@ class CatalogServiceTest extends TestCase
         $stmt = $pdo->query('SELECT event_uid FROM catalogs');
         $this->assertSame('1', (string)$stmt->fetchColumn());
     }
+
+    public function testWriteAcceptsIdField(): void
+    {
+        $pdo = $this->createPdo();
+        $cfg = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfg);
+        $catalog = [[
+            'uid' => 'uid6',
+            'id' => 4,
+            'slug' => 'foo',
+            'file' => 'foo.json',
+            'name' => 'Foo',
+            'comment' => ''
+        ]];
+        $service->write('catalogs.json', $catalog);
+        $rows = json_decode($service->read('catalogs.json'), true);
+        $this->assertSame(4, $rows[0]['sort_order']);
+    }
 }


### PR DESCRIPTION
## Summary
- fix CatalogService to accept `id` as fallback for `sort_order`
- auto-assign numeric sort order when creating missing catalog
- add regression test for accepting `id` field in catalog data

## Testing
- `composer test`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_688a992c2b78832b9cc4fd32a092629b