### PR TITLE
Fix webproxy network naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,13 @@ scripts/delete_tenant.sh foo
 Beide Skripte lesen die Variable `DOMAIN` aus `.env` und nutzen sie
 für die vhost-Konfiguration.
 
+Das Proxy-Setup legt zudem ein Docker-Netzwerk mit dem festen Namen
+`webproxy` an. Neue Mandanten werden über `scripts/onboard_tenant.sh`
+mit diesem Netzwerk verbunden, damit der gemeinsame Reverse Proxy
+Zertifikate für ihre Subdomains ausstellen kann. Stelle sicher,
+dass dein Haupt-Stack dieses Netzwerk erstellt oder verwaltet. Bei
+einem abweichenden Namen passe die Variable `NETWORK` im Skript an.
+
 Für komplett isolierte Mandanten steht `scripts/onboard_tenant.sh` bereit. Es
 schreibt unter `tenants/<slug>/` eine eigene `docker-compose.yml` und startet
 den zugehörigen Container. Dadurch wird automatisch ein

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,8 @@ services:
 
 networks:
   webproxy:
+    name: webproxy
+    external: true
 
 volumes:
   certs:


### PR DESCRIPTION
## Summary
- use fixed `webproxy` network name in docker-compose
- document the requirement for a shared network in the README

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688af174f8f4832b82396d2979c8e88a