### PR TITLE
Fix schema checks in onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -26,6 +26,8 @@
       .replace(/^-+|-+$/g, '');
   }
 
+  const RESERVED_SUBDOMAINS = new Set(['public']);
+
   document.addEventListener('DOMContentLoaded', () => {
     const loginBtn = document.getElementById('login-btn');
     const loginUser = document.getElementById('login-user');
@@ -135,7 +137,7 @@
       data.name = nameInput.value.trim();
       data.subdomain = slugify(data.name);
       subdomainPreview.textContent = data.subdomain || '-';
-      next1.disabled = data.name === '';
+      next1.disabled = data.name === '' || RESERVED_SUBDOMAINS.has(data.subdomain);
     });
 
     next1.addEventListener('click', async () => {
@@ -173,6 +175,13 @@
 
     createBtn.addEventListener('click', async () => {
       if (!adminPassInput) {
+        return;
+      }
+
+      if (data.subdomain === '' || RESERVED_SUBDOMAINS.has(data.subdomain)) {
+        if (typeof UIkit !== 'undefined') {
+          UIkit.notification({ message: 'Ungültige Subdomain', status: 'danger' });
+        }
         return;
       }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -383,10 +383,12 @@ return function (\Slim\App $app, TranslationService $translator) {
             return $response->withStatus(400);
         }
         $schema = preg_replace('/[^a-z0-9_\-]/i', '', (string)$data['schema']);
-        if ($schema === '') {
+        $schema = strtolower($schema);
+        if ($schema === '' || $schema === 'public') {
             return $response->withStatus(400);
         }
         $pdo = Database::connectWithSchema($schema);
+        Migrator::migrate($pdo, __DIR__ . '/../migrations');
         $userService = new UserService($pdo);
         $existing = $userService->getByUsername('admin');
         if ($existing === null) {


### PR DESCRIPTION
## Summary
- avoid `public` schema in onboarding wizard
- run migrations when handling `/tenant-admin`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688b6b24dd38832b97a168aa9b2b1f26