### PR TITLE
Add Docker Compose test setup

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,36 @@
+FROM php:8.2-alpine
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+RUN apk add --no-cache \
+        libpng \
+        libjpeg-turbo \
+        freetype \
+        libwebp \
+        postgresql-client \
+        imagemagick \
+        nodejs \
+        npm \
+        python3 \
+        py3-pip \
+    && apk add --no-cache --virtual .build-deps \
+        libpng-dev \
+        libjpeg-turbo-dev \
+        freetype-dev \
+        libwebp-dev \
+        postgresql-dev \
+        $PHPIZE_DEPS \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+    && docker-php-ext-install gd pdo_pgsql exif \
+    && apk del .build-deps \
+    && pip3 install --no-cache-dir pytest
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www
+COPY . /var/www
+RUN composer install --no-interaction --prefer-dist --no-progress
+
+COPY config/php.ini /usr/local/etc/php/conf.d/custom.ini
+
+CMD ["composer", "test"]

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
         "test": [
             "@phpunit",
             "python3 tests/test_html_validity.py",
-            "python3 tests/test_json_validity.py"
+            "python3 tests/test_json_validity.py",
+            "node tests/test_competition_mode.js",
+            "node tests/test_results_rankings.js"
         ]
     }
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    volumes:
+      - ./:/var/www


### PR DESCRIPTION
## Summary
- add `Dockerfile.test` to build an environment with node and python
- extend composer test script to run JS tests
- provide `docker-compose.test.yml` for running the test container

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688b9eb57620832b93372ace5dc8bae5