### PR TITLE
Fix onboarding link availability after SSL setup

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -106,14 +106,13 @@
       for (let i = 0; i < 30; i++) {
         try {
           await fetch(url, { method: 'HEAD', mode: 'no-cors' });
-          window.location.href = url;
-          return;
+          return true;
         } catch (e) {
           // ignore errors until certificate is ready
         }
         await new Promise(resolve => setTimeout(resolve, 5000));
       }
-      window.location.href = url;
+      return false;
     }
 
     if (loginBtn) {
@@ -326,8 +325,12 @@
           link.className = 'uk-button uk-button-primary uk-margin-top';
           link.href = 'https://' + data.subdomain + '.' + mainDomain;
           link.textContent = 'Zu Ihrem QuizRace';
+          link.hidden = true;
           successEl.appendChild(link);
-          waitForHttps(link.href);
+          const sslReady = await waitForHttps(link.href);
+          if (sslReady) {
+            link.hidden = false;
+          }
         }
       } catch (err) {
         logMessage('Fehler beim Anlegen: ' + (err.message || err));


### PR DESCRIPTION
## Summary
- wait for HTTPS availability to succeed before showing success link
- only show the final onboarding link if SSL works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc78dacfc832bac3c81142cf242ac