### PR TITLE
Fix unreachable statement in routes.php

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -501,10 +501,6 @@ return function (\Slim\App $app, TranslationService $translator) {
         $response->getBody()->write(json_encode(['status' => 'nginx reloaded']));
 
         return $response->withHeader('Content-Type', 'application/json');
-
-        $response->getBody()->write(json_encode(['status' => 'nginx reloaded']));
-
-        return $response->withHeader('Content-Type', 'application/json');
     });
 
     $app->post('/api/tenants/{slug}/onboard', function (Request $request, Response $response, array $args) {


### PR DESCRIPTION
## Summary
- remove duplicate unreachable code in nginx reload route

## Testing
- `vendor/bin/phpstan --memory-limit=256M`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688bdbad904c832b9074382fcaf4e09b