### PR TITLE
Improve onboarding error reporting

### DIFF
--- a/scripts/onboard_tenant.sh
+++ b/scripts/onboard_tenant.sh
@@ -2,9 +2,13 @@
 # Onboard a new tenant with dedicated subdomain and SSL
 set -e
 
-if [ "$#" -lt 1 ]; then
-  echo "Usage: $0 <tenant-slug>" >&2
+error_exit() {
+  echo "Fehler: $1"
   exit 1
+}
+
+if [ "$#" -lt 1 ]; then
+  error_exit "Usage: $0 <tenant-slug>"
 fi
 
 SLUG=$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
@@ -15,35 +19,42 @@ EMAIL="${LETSENCRYPT_EMAIL:-admin@quizrace.app}"
 IMAGE="${APP_IMAGE:-your-app-image}"
 NETWORK="webproxy"
 
+# minimal free space in MB required to create a tenant
+MIN_DISK_MB=100
+
 # validate generated domain
 if ! echo "${SLUG}.${DOMAIN_SUFFIX}" | grep -Eq '^[a-z0-9-]+(\.[a-z0-9-]+)+$'; then
-  echo "Fehler: Generierte Domain '${SLUG}.${DOMAIN_SUFFIX}' ist ungültig." >&2
-  exit 1
+  error_exit "Generierte Domain '${SLUG}.${DOMAIN_SUFFIX}' ist ungültig."
 fi
 
 # ensure required docker network exists
 if ! docker network inspect ${NETWORK} >/dev/null 2>&1; then
-  echo "Fehler: Netzwerk '${NETWORK}' existiert nicht. Bitte zuerst mit 'docker network create --driver bridge ${NETWORK}' anlegen." >&2
-  exit 1
+  error_exit "Netzwerk '${NETWORK}' existiert nicht. Bitte zuerst mit 'docker network create --driver bridge ${NETWORK}' anlegen."
 fi
 
 # avoid container name collisions
 if docker ps -a --format '{{.Names}}' | grep -q "^${SLUG}_app$"; then
-  echo "Fehler: Ein Container mit dem Namen '${SLUG}_app' existiert bereits." >&2
-  exit 1
+  error_exit "Ein Container mit dem Namen '${SLUG}_app' existiert bereits."
 fi
 
 # optional image check
 if ! docker image inspect ${IMAGE} >/dev/null 2>&1; then
-  echo "Warnung: Docker-Image '${IMAGE}' ist lokal nicht vorhanden. Der Container wird versuchen, es herunterzuladen." >&2
+  echo "Warnung: Docker-Image '${IMAGE}' ist lokal nicht vorhanden. Der Container wird versuchen, es herunterzuladen."
+fi
+
+# check for sufficient disk space
+AVAILABLE_MB=$(df -Pm "$(dirname "$TENANT_DIR")" | awk 'NR==2{print $4}')
+if [ "$AVAILABLE_MB" -lt "$MIN_DISK_MB" ]; then
+  error_exit "Zu wenig Speicherplatz (nur ${AVAILABLE_MB}MB verfügbar)."
 fi
 
 if [ -d "$TENANT_DIR" ]; then
-  echo "Tenant directory '$TENANT_DIR' already exists" >&2
-  exit 1
+  error_exit "Tenant directory '$TENANT_DIR' already exists"
 fi
 
-mkdir -p "$TENANT_DIR"
+if ! mkdir -p "$TENANT_DIR"; then
+  error_exit "Konnte Verzeichnis '$TENANT_DIR' nicht anlegen"
+fi
 
 cat > "$COMPOSE_FILE" <<YAML
 version: '3.8'
@@ -69,8 +80,16 @@ networks:
     external: true
 YAML
 
+# validate compose file syntax
+if ! docker compose -f "$COMPOSE_FILE" config >/dev/null 2>&1; then
+  error_exit "docker compose config fehlgeschlagen (Syntaxfehler?)"
+fi
+
 # start the tenant stack
-docker compose -f "$COMPOSE_FILE" -p "$SLUG" up -d
+if ! compose_out=$(docker compose -f "$COMPOSE_FILE" -p "$SLUG" up -d 2>&1); then
+  echo "$compose_out"
+  error_exit "docker compose konnte den Tenant-Container nicht starten."
+fi
 
 # optional reload to speed up certificate issuance
 RELOADER_URL="${NGINX_RELOADER_URL:-http://nginx-reloader:8080/reload}"

--- a/src/routes.php
+++ b/src/routes.php
@@ -513,13 +513,15 @@ return function (\Slim\App $app, TranslationService $translator) {
             return $response->withHeader('Content-Type', 'application/json')->withStatus(500);
         }
 
-        $cmd = escapeshellcmd($script . ' ' . $slug);
+        $cmd = escapeshellcmd($script . ' ' . $slug) . ' 2>&1';
         exec($cmd, $output, $exitCode);
 
         if ($exitCode !== 0) {
+            $msg = implode("\n", $output);
+            $first = strtok($msg, "\n");
             $response->getBody()->write(json_encode([
-                'error' => 'Failed to start tenant',
-                'details' => implode("\n", $output),
+                'error' => $first ?: 'Failed to start tenant',
+                'details' => $msg,
             ]));
 
             return $response->withHeader('Content-Type', 'application/json')->withStatus(500);


### PR DESCRIPTION
## Summary
- add `error_exit` helper and disk space check to `onboard_tenant.sh`
- validate compose file syntax and capture docker compose output
- surface first error line in `/api/tenants/{slug}/onboard`

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bef1b26b8832b950cc0a68e8f52eb