### PR TITLE
Update tenant onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Das Skript `scripts/onboard_tenant.sh` steht weiterhin zur Verfügung, um
 einen Container manuell zu starten oder neu aufzusetzen. Es schreibt unter
 `tenants/<slug>/` eine eigene `docker-compose.yml` und fordert ebenfalls das
 SSL-Zertifikat an.
+Welches Docker-Image dabei verwendet wird, lässt sich über die Variable `APP_IMAGE` in der `.env` steuern.
 
 Das Skript legt dabei eine Compose-Datei an, die analog zum Hauptcontainer
 einen PHP-Webserver auf Port `8080` startet und `VIRTUAL_PORT=8080` setzt.
@@ -283,6 +284,7 @@ Weitere nützliche Variablen in `.env` sind:
 
 - `LETSENCRYPT_EMAIL` – Kontaktadresse für die automatische Zertifikatserstellung.
 - `MAIN_DOMAIN` – zentrale Domain des Quiz-Containers (z.B. `quizrace.app`).
+- `APP_IMAGE` – Docker-Image, das für neue Mandanten verwendet wird.
 - `BASE_PATH` – optionaler Basis-Pfad, falls die Anwendung nicht im Root der Domain liegt.
 - `SERVICE_USER` – Benutzername für den automatischen Login des Onboarding-Assistenten.
 - `SERVICE_PASS` – Passwort dieses Service-Benutzers.

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -38,7 +38,7 @@ toc: true
    php scripts/import_to_pgsql.php
    ```
 
- Das mitgelieferte `docker-compose.yml` startet die Anwendung samt Reverse Proxy. Daten werden dauerhaft in einem Volume gesichert, Beweisfotos bleiben als JPEG im Ordner `data/photos` erhalten. Dabei richtet die Anwendung Fotos, sofern möglich, anhand ihrer EXIF-Daten aus. Die Domain (`MAIN_DOMAIN`) und weitere Parameter lassen sich über die Datei `.env` anpassen.
+ Das mitgelieferte `docker-compose.yml` startet die Anwendung samt Reverse Proxy. Daten werden dauerhaft in einem Volume gesichert, Beweisfotos bleiben als JPEG im Ordner `data/photos` erhalten. Dabei richtet die Anwendung Fotos, sofern möglich, anhand ihrer EXIF-Daten aus. Die Domain (`MAIN_DOMAIN`), das Docker-Image (`APP_IMAGE`) und weitere Parameter lassen sich über die Datei `.env` anpassen.
 **Wichtig:** Damit Fotos automatisch gedreht werden können, muss die PHP-Erweiterung `exif` installiert und aktiviert sein. Prüfen lässt sich das mit:
 ```bash
 php -m | grep exif

--- a/sample.env
+++ b/sample.env
@@ -5,6 +5,7 @@
 # Domain-Routing (z. B. für VIRTUAL_HOST)
 DOMAIN=example.com            # Basis-Domain aller Mandanten
 MAIN_DOMAIN=quizrace.app      # Hauptdomain des Quiz-Containers
+APP_IMAGE=sommerfest-quiz:latest # Docker-Image für Tenant-Container
 SLIM_VIRTUAL_HOST=example.com # Hostname des Quiz-Containers
 
 # Let's Encrypt

--- a/scripts/onboard_tenant.sh
+++ b/scripts/onboard_tenant.sh
@@ -14,9 +14,18 @@ fi
 SLUG=$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
 TENANT_DIR="$(dirname "$0")/../tenants/$SLUG"
 COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
-DOMAIN_SUFFIX="quizrace.app"
+DOMAIN_SUFFIX="${MAIN_DOMAIN:-$DOMAIN}"
 EMAIL="${LETSENCRYPT_EMAIL:-admin@quizrace.app}"
-IMAGE="${APP_IMAGE:-your-app-image}"
+
+if [ -z "$DOMAIN_SUFFIX" ]; then
+  error_exit "MAIN_DOMAIN oder DOMAIN muss gesetzt sein"
+fi
+
+if [ -z "$APP_IMAGE" ]; then
+  error_exit "APP_IMAGE ist nicht gesetzt"
+fi
+
+IMAGE="$APP_IMAGE"
 NETWORK="webproxy"
 
 # minimal free space in MB required to create a tenant


### PR DESCRIPTION
## Summary
- use MAIN_DOMAIN with DOMAIN fallback
- require APP_IMAGE and update sample env
- document APP_IMAGE usage in README and docs

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688bf63500dc832b968353c9f9093dd0