### PR TITLE
Add Docker CLI requirement for tenant onboarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:8.2-alpine
 # allow Composer to run as root inside the container
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
-RUN apk add --no-cache libpng libjpeg-turbo freetype libwebp postgresql-client imagemagick && \
+RUN apk add --no-cache docker-cli libpng libjpeg-turbo freetype libwebp postgresql-client imagemagick && \
     apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev postgresql-dev $PHPIZE_DEPS && \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp && \
     docker-php-ext-install gd pdo_pgsql exif && \

--- a/README.md
+++ b/README.md
@@ -254,6 +254,12 @@ einen PHP-Webserver auf Port `8080` startet und `VIRTUAL_PORT=8080` setzt.
 Nur so kann der `acme-companion` die HTTP-Challenge beantworten und das
 Zertifikat erstellen.
 
+Um diese Container auch aus dem `slim`-Service heraus starten zu können,
+benötigt das Image ein Docker-CLI und Zugriff auf den Docker-Daemon. Binde
+dafür `/var/run/docker.sock` ein oder führe `scripts/onboard_tenant.sh`
+alternativ direkt auf dem Host aus, wenn Docker im Container nicht
+verfügbar ist.
+
 Zum Entfernen einer isolierten Instanz nutzt du `scripts/offboard_tenant.sh`.
 Das Skript stoppt den Container und löscht das Verzeichnis `tenants/<slug>/`:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
       - ./:/var/www
       # Mount custom PHP settings (overrides copy in Dockerfile)
       - ./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - VIRTUAL_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}
       - LETSENCRYPT_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -61,4 +61,6 @@ Auch die Anwendung selbst stößt den Reload nun über diesen HTTP-Service an un
 Möchtest du für jeden Mandanten einen eigenen Docker-Stack starten, übernimmt dies nun automatisch das Onboarding. Dabei wird unter `tenants/<slug>/` eine individuelle `docker-compose.yml` angelegt und die Instanz gestartet. `acme-companion` kümmert sich um das Zertifikat für `<slug>.quizrace.app>`.
 Das Skript `scripts/onboard_tenant.sh` kann weiterhin genutzt werden, um bei Bedarf einen Container manuell zu initialisieren. Die erzeugte Compose-Datei startet den PHP-Webserver auf Port `8080` und setzt `VIRTUAL_PORT=8080`, sodass der Reverse Proxy die ACME-Challenge bedienen kann.
 
+Damit das Skript im Container funktioniert, muss dort die Docker-CLI verfügbar sein und das Socket des Host-Daemons eingebunden werden. Andernfalls führe das Skript direkt auf dem Host aus.
+
 Zum Entfernen einer Instanz steht `scripts/offboard_tenant.sh` bereit. Es stoppt den Container, entfernt dessen Volumes und löscht das Unterverzeichnis `tenants/<slug>/`.


### PR DESCRIPTION
## Summary
- install `docker-cli` in the main image
- mount Docker socket into the `slim` service
- document Docker requirement for `onboard_tenant.sh`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688bfa6815cc832bb21dd16e67e0020b