### PR TITLE
Add proxy network variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ scripts/delete_tenant.sh foo
 Beide Skripte lesen die Variable `DOMAIN` aus `.env` und nutzen sie
 für die vhost-Konfiguration.
 
-Das Proxy-Setup legt zudem ein Docker-Netzwerk mit dem festen Namen
+Das Proxy-Setup legt zudem standardmäßig ein Docker-Netzwerk namens
 `webproxy` an. Nach dem Aufruf von `scripts/create_tenant.sh` oder einem
 `POST /tenants` muss das Onboarding angestoßen werden, damit der neue
 Mandant diesem Netzwerk beitritt und ein Let's-Encrypt-Zertifikat erhält.
 Starte dazu den Web-Assistenten unter `/onboarding` oder führe
 `scripts/onboard_tenant.sh <subdomain>` aus. Stelle sicher, dass dein
-Haupt-Stack dieses Netzwerk erstellt oder verwaltet. Bei einem abweichenden
-Namen passe die Variable `NETWORK` im Skript an.
+Haupt-Stack dieses Netzwerk erstellt oder verwaltet. Den Namen kannst du
+über die Umgebungsvariable `NETWORK` im Skript anpassen.
 
 Das Skript `scripts/onboard_tenant.sh` steht weiterhin zur Verfügung, um
 einen Container manuell zu starten oder neu aufzusetzen. Es schreibt unter
@@ -293,6 +293,7 @@ Weitere nützliche Variablen in `.env` sind:
 - `LETSENCRYPT_EMAIL` – Kontaktadresse für die automatische Zertifikatserstellung.
 - `MAIN_DOMAIN` – zentrale Domain des Quiz-Containers (z.B. `quizrace.app`).
 - `APP_IMAGE` – Docker-Image, das für neue Mandanten verwendet wird.
+- `NETWORK` – Name des Docker-Netzwerks des Reverse Proxy (Standard `webproxy`).
 - `BASE_PATH` – optionaler Basis-Pfad, falls die Anwendung nicht im Root der Domain liegt.
 - `SERVICE_USER` – Benutzername für den automatischen Login des Onboarding-Assistenten.
 - `SERVICE_PASS` – Passwort dieses Service-Benutzers.

--- a/sample.env
+++ b/sample.env
@@ -7,6 +7,7 @@ DOMAIN=example.com            # Basis-Domain aller Mandanten
 MAIN_DOMAIN=quizrace.app      # Hauptdomain des Quiz-Containers
 APP_IMAGE=sommerfest-quiz:latest # Docker-Image für Tenant-Container
 SLIM_VIRTUAL_HOST=example.com # Hostname des Quiz-Containers
+NETWORK=webproxy                # Docker-Netzwerk des Reverse Proxy
 
 # Let's Encrypt
 LETSENCRYPT_EMAIL=admin@example.com # Kontaktadresse für Zertifikate

--- a/scripts/onboard_tenant.sh
+++ b/scripts/onboard_tenant.sh
@@ -26,7 +26,8 @@ if [ -z "$APP_IMAGE" ]; then
 fi
 
 IMAGE="$APP_IMAGE"
-NETWORK="webproxy"
+# Docker network for reverse proxy
+NETWORK="${NETWORK:-webproxy}"
 
 # minimal free space in MB required to create a tenant
 MIN_DISK_MB=100


### PR DESCRIPTION
## Summary
- configure reverse proxy network via `NETWORK` variable in `onboard_tenant.sh`
- document `NETWORK` in `sample.env`
- note `NETWORK` usage in README instructions

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688bffadc13c832bbd0cad5a507e1a76