### PR TITLE
Add APP_IMAGE variable and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Das Skript `scripts/onboard_tenant.sh` steht weiterhin zur Verfügung, um
 einen Container manuell zu starten oder neu aufzusetzen. Es schreibt unter
 `tenants/<slug>/` eine eigene `docker-compose.yml` und fordert ebenfalls das
 SSL-Zertifikat an.
-Welches Docker-Image dabei verwendet wird, lässt sich über die Variable `APP_IMAGE` in der `.env` steuern.
+Welches Docker-Image dabei verwendet wird, legt die Variable `APP_IMAGE` in der `.env` fest. Sie definiert das Image, das beim Start einzelner Tenant-Container genutzt wird.
 
 Das Skript legt dabei eine Compose-Datei an, die analog zum Hauptcontainer
 einen PHP-Webserver auf Port `8080` startet und `VIRTUAL_PORT=8080` setzt.
@@ -292,7 +292,7 @@ Weitere nützliche Variablen in `.env` sind:
 
 - `LETSENCRYPT_EMAIL` – Kontaktadresse für die automatische Zertifikatserstellung.
 - `MAIN_DOMAIN` – zentrale Domain des Quiz-Containers (z.B. `quizrace.app`).
-- `APP_IMAGE` – Docker-Image, das für neue Mandanten verwendet wird.
+- `APP_IMAGE` – definiert das Docker-Image, das für neue Mandanten-Container verwendet wird.
 - `BASE_PATH` – optionaler Basis-Pfad, falls die Anwendung nicht im Root der Domain liegt.
 - `SERVICE_USER` – Benutzername für den automatischen Login des Onboarding-Assistenten.
 - `SERVICE_PASS` – Passwort dieses Service-Benutzers.

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -38,7 +38,7 @@ toc: true
    php scripts/import_to_pgsql.php
    ```
 
- Das mitgelieferte `docker-compose.yml` startet die Anwendung samt Reverse Proxy. Daten werden dauerhaft in einem Volume gesichert, Beweisfotos bleiben als JPEG im Ordner `data/photos` erhalten. Dabei richtet die Anwendung Fotos, sofern möglich, anhand ihrer EXIF-Daten aus. Die Domain (`MAIN_DOMAIN`), das Docker-Image (`APP_IMAGE`) und weitere Parameter lassen sich über die Datei `.env` anpassen.
+ Das mitgelieferte `docker-compose.yml` startet die Anwendung samt Reverse Proxy. Daten werden dauerhaft in einem Volume gesichert, Beweisfotos bleiben als JPEG im Ordner `data/photos` erhalten. Dabei richtet die Anwendung Fotos, sofern möglich, anhand ihrer EXIF-Daten aus. Die Domain (`MAIN_DOMAIN`), das Docker-Image (`APP_IMAGE`) und weitere Parameter lassen sich über die Datei `.env` anpassen. Die Variable `APP_IMAGE` bestimmt dabei explizit, welches Docker-Image für Tenant-Container verwendet wird.
 **Wichtig:** Damit Fotos automatisch gedreht werden können, muss die PHP-Erweiterung `exif` installiert und aktiviert sein. Prüfen lässt sich das mit:
 ```bash
 php -m | grep exif

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ Die Mandanten-Logik nutzt folgende Variablen aus `.env` oder `sample.env`:
 
 - `DOMAIN` legt die Basis-Domain für alle Mandanten fest.
 - `MAIN_DOMAIN` definiert die Hauptdomain des Quiz-Containers.
+- `APP_IMAGE` bestimmt das Docker-Image für neu angelegte Tenant-Container.
 - `POSTGRES_DSN`, `POSTGRES_USER` und `POSTGRES_PASSWORD` bestimmen den Datenbankzugang.
 
 ### Anmelde-Workflow

--- a/sample.env
+++ b/sample.env
@@ -5,7 +5,7 @@
 # Domain-Routing (z. B. für VIRTUAL_HOST)
 DOMAIN=example.com            # Basis-Domain aller Mandanten
 MAIN_DOMAIN=quizrace.app      # Hauptdomain des Quiz-Containers
-APP_IMAGE=sommerfest-quiz:latest # Docker-Image für Tenant-Container
+APP_IMAGE=<image>             # Docker-Image für Tenant-Container
 SLIM_VIRTUAL_HOST=example.com # Hostname des Quiz-Containers
 
 # Let's Encrypt


### PR DESCRIPTION
## Summary
- add placeholder `APP_IMAGE` variable in `sample.env`
- clarify in README and docs that `APP_IMAGE` selects the Docker image used for tenant instances

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688bffaee540832bb4bdbdf5f43675b5