### PR TITLE
Add reverse proxy network note

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ Zum Start genügt:
 cp sample.env .env
 docker compose up --build -d
 ```
+Falls der Reverse Proxy das Docker-Netzwerk noch nicht kennt, lege es vorher an:
+```bash
+docker network create ${NETWORK:-webproxy}
+```
+Der Name des Netzwerks lässt sich über die Umgebungsvariable `NETWORK` anpassen.
 Beenden lässt sich der Stack mit:
 ```bash
 docker compose down

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -50,6 +50,11 @@ gesetzt, versucht die Anwendung, das externe Programm `convert` aus ImageMagick
 installiert sein.
 Im Docker-Container wird ImageMagick bereits installiert.
 
+> **Hinweis:** Der Reverse Proxy verwendet ein eigenes Docker-Netzwerk. 
+> Standardmäßig heißt es `webproxy`. Existiert es nicht, kannst du es mit
+> `docker network create ${NETWORK:-webproxy}` anlegen. 
+> Über die Umgebungsvariable `NETWORK` legst du bei Bedarf einen anderen Namen fest.
+
 ## Docker-Abhängigkeit beim Mandanten-Onboarding {#tenant-onboarding-docker}
 
 Die Skripte `create_tenant.sh` und `delete_tenant.sh` richten neue Subdomains ein und laden danach den Reverse Proxy neu. Sie gehen davon aus, dass ein nginx-Container über Docker Compose läuft. Ohne diesen Container schlägt der Reload-Befehl fehl.


### PR DESCRIPTION
## Summary
- remind users to create the webproxy network if missing
- explain how to customize the name via the `NETWORK` variable

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c2c2ec384832b8900f73b780eeb77