### PR TITLE
Add link to tenant domains in admin UI

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1874,6 +1874,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function loadTenants() {
     if (!tenantTableBody) return;
+    const mainDomain = window.mainDomain || '';
     apiFetch('/tenants.json', { headers: { 'Accept': 'application/json' } })
       .then(r => r.json())
       .then(list => {
@@ -1881,7 +1882,17 @@ document.addEventListener('DOMContentLoaded', function () {
         list.forEach(t => {
           const tr = document.createElement('tr');
           const subTd = document.createElement('td');
-          subTd.textContent = t.subdomain || '';
+          const sub = t.subdomain || '';
+          if (sub && mainDomain) {
+            const a = document.createElement('a');
+            a.href = 'https://' + sub + '.' + mainDomain;
+            a.target = '_blank';
+            a.rel = 'noopener';
+            a.textContent = sub;
+            subTd.appendChild(a);
+          } else {
+            subTd.textContent = sub;
+          }
           const createdTd = document.createElement('td');
           createdTd.textContent = (t.created_at || '').replace('T', ' ').replace(/\..*/, '');
           const actionTd = document.createElement('td');

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -136,6 +136,10 @@ class AdminController
             }
         }
 
+        $mainDomain = getenv('MAIN_DOMAIN')
+            ?: getenv('DOMAIN')
+            ?: $uri->getHost();
+
         return $view->render($response, 'admin.twig', [
             'config' => $cfg,
             'settings' => $settings,
@@ -145,6 +149,7 @@ class AdminController
             'users' => $users,
             'roles' => Roles::ALL,
             'baseUrl' => $baseUrl,
+            'main_domain' => $mainDomain,
             'event' => $event,
             'role' => $role,
             'pages' => $pages,

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -684,6 +684,7 @@
     window.quizSettings = {{ settings|json_encode|raw }};
     window.roles = {{ roles|json_encode|raw }};
     window.baseUrl = '{{ baseUrl }}';
+    window.mainDomain = '{{ main_domain }}';
     window.pagesContent = {{ pages|json_encode|raw }};
   </script>
   <script src="{{ basePath }}/js/admin.js"></script>


### PR DESCRIPTION
## Summary
- expose `main_domain` to admin template
- link tenant subdomain entries to the full domain

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c2e47ffd0832b856e177bd66f73b0