### PR TITLE
Fix compose detection in tenant scripts

### DIFF
--- a/scripts/create_tenant.sh
+++ b/scripts/create_tenant.sh
@@ -23,6 +23,16 @@ SERVICE_PASS="$(grep '^SERVICE_PASS=' "$ENV_FILE" | cut -d '=' -f2)"
 [ -z "$CLIENT_MAX_BODY_SIZE" ] && CLIENT_MAX_BODY_SIZE="50m"
 [ -z "$NGINX_RELOAD" ] && NGINX_RELOAD=1
 [ -z "$NGINX_CONTAINER" ] && NGINX_CONTAINER="nginx"
+
+# detect docker compose command
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  echo "docker compose oder docker-compose ist nicht verf\u00fcgbar" >&2
+  exit 1
+fi
 [ -z "$BASE_PATH" ] && BASE_PATH=""
 
 if [ -z "$DOMAIN" ]; then
@@ -40,7 +50,7 @@ echo "client_max_body_size $CLIENT_MAX_BODY_SIZE;" > "$BASE_DIR/vhost.d/${SUBDOM
 if [ -n "$RELOADER_URL" ]; then
   curl -s -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL"
 elif [ "$NGINX_RELOAD" = "1" ]; then
-  docker compose exec "$NGINX_CONTAINER" nginx -s reload
+  $DOCKER_COMPOSE exec "$NGINX_CONTAINER" nginx -s reload
 fi
 
 API_BASE="http://$DOMAIN${BASE_PATH}"

--- a/scripts/delete_tenant.sh
+++ b/scripts/delete_tenant.sh
@@ -19,6 +19,16 @@ NGINX_CONTAINER="$(grep '^NGINX_CONTAINER=' "$ENV_FILE" | cut -d '=' -f2)"
 [ -z "$NGINX_RELOAD" ] && NGINX_RELOAD=1
 [ -z "$NGINX_CONTAINER" ] && NGINX_CONTAINER="nginx"
 
+# detect docker compose command
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  echo "docker compose oder docker-compose ist nicht verf\u00fcgbar" >&2
+  exit 1
+fi
+
 if [ -z "$DOMAIN" ]; then
   echo "DOMAIN not found in $ENV_FILE" >&2
   exit 1
@@ -34,5 +44,5 @@ rm -f "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"
 if [ -n "$RELOADER_URL" ]; then
   curl -s -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL"
 elif [ "$NGINX_RELOAD" = "1" ]; then
-  docker compose exec "$NGINX_CONTAINER" nginx -s reload
+  $DOCKER_COMPOSE exec "$NGINX_CONTAINER" nginx -s reload
 fi

--- a/scripts/offboard_tenant.sh
+++ b/scripts/offboard_tenant.sh
@@ -11,10 +11,20 @@ SLUG=$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
 TENANT_DIR="$(dirname "$0")/../tenants/$SLUG"
 COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
 
+# detect docker compose command
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  echo "docker compose oder docker-compose ist nicht verf\u00fcgbar" >&2
+  exit 1
+fi
+
 if [ ! -f "$COMPOSE_FILE" ]; then
   echo "Compose file '$COMPOSE_FILE' not found" >&2
 else
-  docker compose -f "$COMPOSE_FILE" -p "$SLUG" down -v || true
+  $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" down -v || true
 fi
 
 rm -rf "$TENANT_DIR"

--- a/scripts/run_psql_in_docker.sh
+++ b/scripts/run_psql_in_docker.sh
@@ -3,5 +3,15 @@
 # Requires docker compose and the environment variables from .env.
 set -e
 
-docker compose exec slim sh -c 'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && php scripts/import_to_pgsql.php'
+# detect docker compose command
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  echo "docker compose oder docker-compose ist nicht verf\u00fcgbar" >&2
+  exit 1
+fi
+
+$DOCKER_COMPOSE exec slim sh -c 'psql -h postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f docs/schema.sql && php scripts/import_to_pgsql.php'
 


### PR DESCRIPTION
## Summary
- support both `docker compose` and `docker-compose` in helper scripts
- use detected command for tenant management and DB helper

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688c2d1c9dfc832b94c893e8579d35d8