### PR TITLE
Fix create/delete tenant scripts without Docker reload

### DIFF
--- a/scripts/create_tenant.sh
+++ b/scripts/create_tenant.sh
@@ -24,14 +24,16 @@ SERVICE_PASS="$(grep '^SERVICE_PASS=' "$ENV_FILE" | cut -d '=' -f2)"
 [ -z "$NGINX_RELOAD" ] && NGINX_RELOAD=1
 [ -z "$NGINX_CONTAINER" ] && NGINX_CONTAINER="nginx"
 
-# detect docker compose command
-if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
-  DOCKER_COMPOSE="docker compose"
-elif command -v docker-compose >/dev/null 2>&1; then
-  DOCKER_COMPOSE="docker-compose"
-else
-  echo "docker compose oder docker-compose ist nicht verf\u00fcgbar" >&2
-  exit 1
+# detect docker compose only when a reload via Docker is required
+if [ "$NGINX_RELOAD" = "1" ] && [ -z "$RELOADER_URL" ]; then
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    DOCKER_COMPOSE="docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    DOCKER_COMPOSE="docker-compose"
+  else
+    echo "docker compose oder docker-compose ist nicht verf\u00fcgbar" >&2
+    exit 1
+  fi
 fi
 [ -z "$BASE_PATH" ] && BASE_PATH=""
 

--- a/scripts/delete_tenant.sh
+++ b/scripts/delete_tenant.sh
@@ -19,14 +19,16 @@ NGINX_CONTAINER="$(grep '^NGINX_CONTAINER=' "$ENV_FILE" | cut -d '=' -f2)"
 [ -z "$NGINX_RELOAD" ] && NGINX_RELOAD=1
 [ -z "$NGINX_CONTAINER" ] && NGINX_CONTAINER="nginx"
 
-# detect docker compose command
-if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
-  DOCKER_COMPOSE="docker compose"
-elif command -v docker-compose >/dev/null 2>&1; then
-  DOCKER_COMPOSE="docker-compose"
-else
-  echo "docker compose oder docker-compose ist nicht verf\u00fcgbar" >&2
-  exit 1
+# detect docker compose only when a reload via Docker is required
+if [ "$NGINX_RELOAD" = "1" ] && [ -z "$RELOADER_URL" ]; then
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    DOCKER_COMPOSE="docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    DOCKER_COMPOSE="docker-compose"
+  else
+    echo "docker compose oder docker-compose ist nicht verf\u00fcgbar" >&2
+    exit 1
+  fi
 fi
 
 if [ -z "$DOMAIN" ]; then


### PR DESCRIPTION
## Summary
- skip docker compose check if reload is disabled or handled via webhook
- allow create/delete scripts to run on systems without Docker

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`
- `vendor/bin/phpstan analyse -c phpstan.neon.dist --memory-limit=512M`


------
https://chatgpt.com/codex/tasks/task_e_688ce67823d0832b9b839f4c1d840cdd