### PR TITLE
Add onboarding success link

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -101,6 +101,7 @@
     const successPass = document.getElementById('success-pass');
     const successInfo = document.getElementById('success-info');
     const successScript = document.getElementById('success-script');
+    const successLink = document.getElementById('success-link');
 
     async function waitForHttps(url) {
       for (let i = 0; i < 30; i++) {
@@ -318,19 +319,9 @@
           successScript.hidden = false;
         }
 
-        const successEl = document.getElementById('success');
-        if (successEl && !document.getElementById('success-link')) {
-          const link = document.createElement('a');
-          link.id = 'success-link';
-          link.className = 'uk-button uk-button-primary uk-margin-top';
-          link.href = 'https://' + data.subdomain + '.' + mainDomain;
-          link.textContent = 'Zu Ihrem QuizRace';
-          link.hidden = true;
-          successEl.appendChild(link);
-          const sslReady = await waitForHttps(link.href);
-          if (sslReady) {
-            link.hidden = false;
-          }
+        if (successLink) {
+          successLink.href = 'https://' + data.subdomain + '.' + mainDomain;
+          successLink.hidden = false;
         }
       } catch (err) {
         logMessage('Fehler beim Anlegen: ' + (err.message || err));

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -94,6 +94,7 @@
       <p id="success-script" hidden></p>
       <ul id="task-status" class="uk-list uk-text-left"></ul>
       <ul id="task-log" class="uk-list uk-text-left uk-margin-top"></ul>
+      <a id="success-link" class="uk-button uk-button-primary uk-margin-top" hidden>Zu Ihrem QuizRace</a>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show link to new container once onboarding finishes

## Testing
- `vendor/bin/phpunit --stop-on-failure`
- `node tests/test_competition_mode.js && node tests/test_results_rankings.js`
- `pytest -q`
- `vendor/bin/phpstan analyse --error-format=raw --no-progress --memory-limit=1G`


------
https://chatgpt.com/codex/tasks/task_e_688cfbfbfcd0832b9aab93b2a377e914