### PR TITLE
Fix SSL renewal by starting tenant container

### DIFF
--- a/scripts/renew_ssl.sh
+++ b/scripts/renew_ssl.sh
@@ -8,8 +8,24 @@ if [ "$#" -lt 1 ]; then
 fi
 
 SLUG="$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')"
+TENANT_DIR="$(dirname "$0")/../tenants/$SLUG"
+COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
 RELOADER_URL="${NGINX_RELOADER_URL:-http://nginx-reloader:8080/reload}"
 RELOAD_TOKEN="${NGINX_RELOAD_TOKEN:-changeme}"
+
+# start tenant container if compose file exists
+if [ -f "$COMPOSE_FILE" ]; then
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    DOCKER_COMPOSE="docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    DOCKER_COMPOSE="docker-compose"
+  else
+    DOCKER_COMPOSE=""
+  fi
+  if [ -n "$DOCKER_COMPOSE" ]; then
+    $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" up -d >/dev/null 2>&1 || true
+  fi
+fi
 
 curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null
 


### PR DESCRIPTION
## Summary
- start tenant container when renewing SSL

## Testing
- `composer install --no-interaction`
- `scripts/run_tests.sh`
- `vendor/bin/phpstan --memory-limit=512M --error-format=table`

------
https://chatgpt.com/codex/tasks/task_e_688d3dd84964832b9035c8c5cdad0a05