### PR TITLE
Seed tenant demo data and use tenant schema for DB access

### DIFF
--- a/src/Controller/AdminCatalogController.php
+++ b/src/Controller/AdminCatalogController.php
@@ -11,6 +11,7 @@ use App\Service\CatalogService;
 use App\Service\ConfigService;
 use App\Service\EventService;
 use App\Infrastructure\Database;
+use PDO;
 
 /**
  * Displays the catalog administration overview page.
@@ -33,7 +34,10 @@ class AdminCatalogController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $cfgSvc = new ConfigService($pdo);
         $eventSvc = new EventService($pdo);
 

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -16,6 +16,7 @@ use App\Service\SettingsService;
 use App\Service\UserService;
 use App\Domain\Roles;
 use App\Infrastructure\Database;
+use PDO;
 
 /**
  * Shows the main administration dashboard.
@@ -32,7 +33,10 @@ class AdminController
             session_start();
         }
         $role = $_SESSION['user']['role'] ?? null;
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $cfgSvc = new ConfigService($pdo);
         $eventSvc = new EventService($pdo);
         $settingsSvc = new SettingsService($pdo);

--- a/src/Controller/EventListController.php
+++ b/src/Controller/EventListController.php
@@ -10,6 +10,7 @@ use Slim\Views\Twig;
 use App\Service\EventService;
 use App\Service\ConfigService;
 use App\Infrastructure\Database;
+use PDO;
 
 /**
  * Displays a list of all events for selection.
@@ -19,7 +20,10 @@ class EventListController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $eventSvc = new EventService($pdo);
         $cfgSvc = new ConfigService($pdo);
         $events = $eventSvc->getAll();

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -10,6 +10,7 @@ use Slim\Views\Twig;
 use App\Service\ConfigService;
 use App\Service\EventService;
 use App\Infrastructure\Database;
+use PDO;
 
 /**
  * Presents the help page with configuration settings.
@@ -22,7 +23,10 @@ class HelpController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $cfgSvc = new ConfigService($pdo);
         $eventSvc = new EventService($pdo);
 

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -12,6 +12,7 @@ use App\Service\EventService;
 use App\Service\SettingsService;
 use App\Infrastructure\Database;
 use Slim\Views\Twig;
+use PDO;
 
 /**
  * Entry point for the quiz application home page.
@@ -24,7 +25,10 @@ class HomeController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $cfgSvc = new ConfigService($pdo);
         $eventSvc = new EventService($pdo);
         $settingsSvc = new SettingsService($pdo);

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -9,6 +9,7 @@ use App\Infrastructure\Database;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use PDO;
 
 /**
  * Handles administrator authentication.
@@ -20,7 +21,10 @@ class LoginController
      */
     public function show(Request $request, Response $response): Response
     {
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $settings = new \App\Service\SettingsService($pdo);
         $allowed = $settings->get('registration_enabled', '0') === '1';
         $view = Twig::fromRequest($request);
@@ -37,7 +41,10 @@ class LoginController
             $data = json_decode((string) $request->getBody(), true);
         }
 
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $service = new UserService($pdo);
 
         $record = $service->getByUsername((string)($data['username'] ?? ''));

--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 use App\Service\UserService;
 use App\Infrastructure\Database;
+use PDO;
 
 /**
  * Display the onboarding wizard for creating a new tenant.
@@ -25,7 +26,10 @@ class OnboardingController
         $serviceUser = getenv('SERVICE_USER') ?: '';
         $servicePass = getenv('SERVICE_PASS') ?: '';
         if ($serviceUser !== '' && $servicePass !== '' && !isset($_SESSION['user'])) {
-            $pdo = Database::connectFromEnv();
+            $pdo = $request->getAttribute('pdo');
+            if (!$pdo instanceof PDO) {
+                $pdo = Database::connectFromEnv();
+            }
             $service = new UserService($pdo);
             $record = $service->getByUsername($serviceUser);
             if ($record !== null && (bool)$record['active']) {

--- a/src/Controller/RegisterController.php
+++ b/src/Controller/RegisterController.php
@@ -11,6 +11,7 @@ use App\Infrastructure\Database;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 use Slim\Views\Twig;
+use PDO;
 
 /**
  * Handles self-registration of backend users.
@@ -22,7 +23,10 @@ class RegisterController
      */
     public function show(Request $request, Response $response): Response
     {
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $settings = new SettingsService($pdo);
         $allowed = $settings->get('registration_enabled', '0') === '1';
         $view = Twig::fromRequest($request);
@@ -34,7 +38,10 @@ class RegisterController
      */
     public function register(Request $request, Response $response): Response
     {
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $settings = new SettingsService($pdo);
         if ($settings->get('registration_enabled', '0') !== '1') {
             return $response->withStatus(403);

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -17,6 +17,7 @@ use Intervention\Image\ImageManagerStatic as Image;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use PDO;
 
 /**
  * Provides CRUD endpoints for quiz results and exposes a results page.
@@ -39,14 +40,14 @@ class ResultController
         TeamService $teams,
         CatalogService $catalogs,
         string $photoDir,
-        ?EventService $events = null
+        EventService $events
     ) {
         $this->service = $service;
         $this->config = $config;
         $this->teams = $teams;
         $this->catalogs = $catalogs;
         $this->photoDir = rtrim($photoDir, '/');
-        $this->events = $events ?? new EventService(Database::connectFromEnv());
+        $this->events = $events;
     }
 
     /**
@@ -143,7 +144,10 @@ class ResultController
         $view = Twig::fromRequest($request);
         $results = $this->service->getAll();
 
-        $pdo = Database::connectFromEnv();
+        $pdo = $request->getAttribute('pdo');
+        if (!$pdo instanceof PDO) {
+            $pdo = Database::connectFromEnv();
+        }
         $configSvc = new ConfigService($pdo);
         $catalogSvc = new CatalogService($pdo, $configSvc);
         $json = $catalogSvc->read('catalogs.json');

--- a/src/Controller/SummaryController.php
+++ b/src/Controller/SummaryController.php
@@ -21,10 +21,10 @@ class SummaryController
     /**
      * Inject configuration service dependency.
      */
-    public function __construct(ConfigService $config)
+    public function __construct(ConfigService $config, EventService $events)
     {
         $this->config = $config;
-        $this->events = new EventService(\App\Infrastructure\Database::connectFromEnv());
+        $this->events = $events;
     }
 
     /**

--- a/src/routes.php
+++ b/src/routes.php
@@ -146,7 +146,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             ))
             ->withAttribute('catalogDesignController', new CatalogDesignController($catalogService))
             ->withAttribute('logoController', new LogoController($configService))
-            ->withAttribute('summaryController', new SummaryController($configService))
+            ->withAttribute('summaryController', new SummaryController($configService, $eventService))
             ->withAttribute('importController', new ImportController(
                 $catalogService,
                 $configService,


### PR DESCRIPTION
## Summary
- seed default events, config, catalogs and questions when creating a tenant
- use schema-bound PDO from the request so controllers read/write tenant data

## Testing
- `vendor/bin/phpunit` *(fails: Database error: fail; Error creating tenant: boom; Failed to reload nginx: reload failed; OK, but there were issues! Tests: 119, Assertions: 239, Warnings: 9, Deprecations: 16, PHPUnit Deprecations: 1, Notices: 7)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_688d645f73ec832ba750c54babe2869d