### PR TITLE
Restrict tenant management to main domain

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1873,7 +1873,7 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   function loadTenants() {
-    if (!tenantTableBody) return;
+    if (!tenantTableBody || window.domainType !== 'main') return;
     const mainDomain = window.mainDomain || '';
     apiFetch('/tenants.json', { headers: { 'Accept': 'application/json' } })
       .then(r => r.json())
@@ -2061,30 +2061,34 @@ document.addEventListener('DOMContentLoaded', function () {
     if (initIdx >= 0) {
       tabControl.show(initIdx);
     }
-    UIkit.util.on(adminTabs, 'shown', (e, tab) => {
-      const index = Array.prototype.indexOf.call(adminTabs.children, tab);
-      const route = adminRoutes[index];
-      if (route) {
-        const url = basePath + '/admin/' + route;
-        if (window.history && window.history.replaceState) {
-          window.history.replaceState(null, '', url);
+      UIkit.util.on(adminTabs, 'shown', (e, tab) => {
+        const index = Array.prototype.indexOf.call(adminTabs.children, tab);
+        const route = adminRoutes[index];
+        if (route) {
+          const url = basePath + '/admin/' + route;
+          if (window.history && window.history.replaceState) {
+            window.history.replaceState(null, '', url);
+          }
         }
-      }
-      if (index === 5) {
+        if (index === summaryIdx) {
+          loadSummary();
+        }
+        if (index === tenantIdx) {
+          loadTenants();
+        }
+      });
+      const summaryIdx = adminRoutes.indexOf('summary');
+      const tenantIdx = adminRoutes.indexOf('tenants');
+    if (summaryIdx >= 0) {
+      adminTabs.children[summaryIdx]?.addEventListener('click', () => {
         loadSummary();
-      }
-      if (index === tenantIdx) {
+      });
+    }
+    if (tenantIdx >= 0) {
+      adminTabs.children[tenantIdx]?.addEventListener('click', () => {
         loadTenants();
-      }
-    });
-    const summaryIdx = 5;
-    const tenantIdx = 10;
-    adminTabs.children[summaryIdx]?.addEventListener('click', () => {
-      loadSummary();
-    });
-    adminTabs.children[tenantIdx]?.addEventListener('click', () => {
-      loadTenants();
-    });
+      });
+    }
     adminMenu.querySelectorAll('[data-tab]').forEach(item => {
       item.addEventListener('click', e => {
         e.preventDefault();
@@ -2110,5 +2114,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Page editors are handled in trumbowyg-pages.js
 
   loadBackups();
-  loadTenants();
+  if (adminRoutes.indexOf('tenants') >= 0) {
+    loadTenants();
+  }
 });

--- a/src/routes.php
+++ b/src/routes.php
@@ -111,7 +111,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $summaryService = new SummaryPhotoService($pdo, $configService);
         $eventService = new EventService($pdo);
         $nginxService = new NginxService();
-        $tenantService = new TenantService($pdo, null, $nginxService);
+        $tenantService = new TenantService($base, null, $nginxService);
         $userService = new \App\Service\UserService($pdo);
         $settingsService = new \App\Service\SettingsService($pdo);
 
@@ -504,6 +504,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     });
 
     $app->post('/api/tenants/{slug}/onboard', function (Request $request, Response $response, array $args) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(403);
+        }
         $slug = preg_replace('/[^a-z0-9\-]/', '-', strtolower((string) ($args['slug'] ?? '')));
         $script = realpath(__DIR__ . '/../scripts/onboard_tenant.sh');
 
@@ -533,6 +536,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware(Roles::SERVICE_ACCOUNT));
 
     $app->delete('/api/tenants/{slug}', function (Request $request, Response $response, array $args) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(403);
+        }
         $slug = preg_replace('/[^a-z0-9\-]/', '-', strtolower((string) ($args['slug'] ?? '')));
         $script = realpath(__DIR__ . '/../scripts/offboard_tenant.sh');
 
@@ -557,6 +563,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware('admin'));
 
     $app->post('/api/tenants/{slug}/renew-ssl', function (Request $request, Response $response, array $args) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(403);
+        }
         $slug = preg_replace('/[^a-z0-9\-]/', '-', strtolower((string) ($args['slug'] ?? '')));
         $script = realpath(__DIR__ . '/../scripts/renew_ssl.sh');
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -52,7 +52,9 @@
     {% if role == 'admin' %}
     <li data-route="pages" data-help="Statische Seiten bearbeiten."><a href="{{ basePath }}/admin/pages">{{ t('tab_pages') }}</a></li>
     <li data-route="management" data-help="Benutzer verwalten, Rollen zuweisen und Sicherungen erstellen. Rollen: admin – Administrator; catalog-editor – Fragenkataloge bearbeiten; event-manager – Veranstaltungen verwalten; analyst – Ergebnisse analysieren; team-manager – Teams verwalten."><a href="{{ basePath }}/admin/management">{{ t('tab_management') }}</a></li>
+    {% if domainType == 'main' %}
     <li data-route="tenants" data-help="Liste aller angelegten Subdomains."><a href="{{ basePath }}/admin/tenants">{{ t('tab_tenants') }}</a></li>
+    {% endif %}
     {% endif %}
   </ul>
   <ul id="adminSwitcher" class="uk-switcher uk-margin">
@@ -615,7 +617,7 @@
         </table>
       </div>
     </li>
-    {% if role == 'admin' %}
+    {% if domainType == 'main' %}
     <li>
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_tenants') }}</h2>
@@ -634,7 +636,7 @@
       </div>
     </li>
     {% endif %}
-      {% endif %}
+    {% endif %}
   </ul>
   <div id="helpSidebar" uk-offcanvas="flip: true; overlay: true">
     <div class="uk-offcanvas-bar uk-width-medium">
@@ -667,7 +669,9 @@
           {% if role == 'admin' %}
           <li class="uk-nav-header">{{ t('menu_admin') }}</li>
           <li><a href="{{ basePath }}/admin/management" data-tab="9">{{ t('tab_management') }}</a></li>
+          {% if domainType == 'main' %}
           <li><a href="{{ basePath }}/admin/tenants" data-tab="10">{{ t('tab_tenants') }}</a></li>
+          {% endif %}
           {% endif %}
 
           <li class="uk-nav-divider"></li>
@@ -685,6 +689,7 @@
     window.roles = {{ roles|json_encode|raw }};
     window.baseUrl = '{{ baseUrl }}';
     window.mainDomain = '{{ main_domain }}';
+    window.domainType = '{{ domainType }}';
     window.pagesContent = {{ pages|json_encode|raw }};
   </script>
   <script src="{{ basePath }}/js/admin.js"></script>


### PR DESCRIPTION
## Summary
- Hide tenant management tab and section unless running on main domain.
- Ensure tenant service always uses public schema and block tenant APIs on subdomains.
- Guard admin scripts and tab indices so tenant data loads only on main site.

## Testing
- `composer test`
- `vendor/bin/phpcs src/routes.php`


------
https://chatgpt.com/codex/tasks/task_e_688d64a25fdc832b98f77b2241788a1d