### PR TITLE
Fail onboarding when reload fails

### DIFF
--- a/scripts/onboard_tenant.sh
+++ b/scripts/onboard_tenant.sh
@@ -111,9 +111,12 @@ if ! compose_out=$($DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" up -d 2>&1); th
 fi
 
 # optional reload to speed up certificate issuance
+# Without a successful reload no certificate will be requested, so abort on failure
 RELOADER_URL="${NGINX_RELOADER_URL:-http://nginx-reloader:8080/reload}"
 RELOAD_TOKEN="${NGINX_RELOAD_TOKEN:-changeme}"
-curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null || true
+if ! curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null; then
+  error_exit "Konnte Nginx-Reload nicht auslösen; kein Zertifikat beantragt"
+fi
 
 echo "Tenant '$SLUG' deployed under https://${SLUG}.${DOMAIN_SUFFIX}"
 echo "{\"status\": \"success\", \"slug\": \"${SLUG}\", \"url\": \"https://${SLUG}.${DOMAIN_SUFFIX}\"}"

--- a/tests/OnboardingScriptTest.php
+++ b/tests/OnboardingScriptTest.php
@@ -21,6 +21,8 @@ class OnboardingScriptTest extends TestCase
         mkdir($stubDir);
         file_put_contents($stubDir . '/docker', "#!/bin/sh\nexit 0\n");
         chmod($stubDir . '/docker', 0755);
+        file_put_contents($stubDir . '/curl', "#!/bin/sh\nexit 0\n");
+        chmod($stubDir . '/curl', 0755);
 
         $envPath = $stubDir . ':' . getenv('PATH');
         $cmd = sprintf(


### PR DESCRIPTION
## Summary
- abort tenant onboarding if nginx reload cannot be triggered and document that the certificate won't be requested
- stub curl in OnboardingScriptTest so onboarding succeeds during tests

## Testing
- `./scripts/run_tests.sh` *(fails: Tests: 119, Assertions: 239, Failures: 3)*

------
https://chatgpt.com/codex/tasks/task_e_688d67ff61b0832b9cc1ad517245094c