### PR TITLE
Ignore config ID when seeding data

### DIFF
--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -162,6 +162,7 @@ class TenantService
                 if (is_readable($cfgFile)) {
                     $cfg = json_decode(file_get_contents($cfgFile), true) ?? [];
                 }
+                unset($cfg['id']);
                 $cfg['event_uid'] = $activeUid;
                 $cols = array_keys($cfg);
                 if ($cols !== []) {


### PR DESCRIPTION
## Summary
- prevent seeding of identity `id` field in config to avoid database error when creating tenants

## Testing
- `composer test`
- `vendor/bin/phpcs src/Service/TenantService.php`


------
https://chatgpt.com/codex/tasks/task_e_688d96205f48832baa5304a7bbce54b8