### PR TITLE
feat: collapse onboarding logs and track availability

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -54,6 +54,7 @@
       tasks.push({ key: 'reload', label: 'Proxy neu laden' });
     }
     tasks.push({ key: 'ssl', label: 'Container starten (SSL)' });
+    tasks.push({ key: 'wait', label: 'Auf Verfügbarkeit warten' });
 
     function initTaskList() {
       if (!taskStatusEl || taskStatusEl.children.length > 0) return;
@@ -329,6 +330,7 @@
           });
         }
 
+        setTaskStatus('wait', 'pending');
         logMessage('Warte bis die Seite aktiv ist...');
         if (successInfo) {
           successInfo.textContent = 'Die Subdomain wird gestartet. Bitte warten...';
@@ -344,11 +346,13 @@
           if (successInfo) {
             successInfo.textContent = 'Die Subdomain ist jetzt erreichbar.';
           }
+          setTaskStatus('wait', 'done');
           if (typeof UIkit !== 'undefined') {
             UIkit.notification({ message: 'Instanz ist bereit', status: 'success' });
           }
         } else {
           logMessage('Subdomain nach Wartezeit nicht erreichbar');
+          setTaskStatus('wait', 'failed');
           if (typeof UIkit !== 'undefined') {
             UIkit.notification({ message: 'Instanz ist noch nicht erreichbar', status: 'warning' });
           }

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -93,7 +93,10 @@
       <p id="success-info">Die Subdomain ist in wenigen Minuten erreichbar, sobald das SSL-Zertifikat erstellt wurde.</p>
       <p id="success-script" hidden></p>
       <ul id="task-status" class="uk-list uk-text-left"></ul>
-      <ul id="task-log" class="uk-list uk-text-left uk-margin-top"></ul>
+      <details class="uk-margin-top">
+        <summary>Logmeldungen anzeigen</summary>
+        <ul id="task-log" class="uk-list uk-text-left uk-margin-top"></ul>
+      </details>
       <a id="success-link" class="uk-button uk-button-primary uk-margin-top" hidden>Zu Ihrem QuizRace</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- hide onboarding logs behind a collapsible details section
- show new task for waiting on instance availability
- update status indicator when instance becomes reachable

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688e11a574a0832b9dc3c25def333ca5