### PR TITLE
feat: open selected event in frontend from admin

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1267,6 +1267,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const eventAddBtn = document.getElementById('eventAddBtn');
   const eventsSaveBtn = document.getElementById('eventsSaveBtn');
   const eventSelect = document.getElementById('eventSelect');
+  const eventOpenBtn = document.getElementById('eventOpenBtn');
   const langSelect = document.getElementById('langSelect');
   let activeEventUid = cfgInitial.event_uid || '';
 
@@ -1497,6 +1498,13 @@ document.addEventListener('DOMContentLoaded', function () {
     const name = eventSelect.options[eventSelect.selectedIndex]?.textContent || '';
     if (uid && uid !== activeEventUid) {
       setActiveEvent(uid, name);
+    }
+  });
+
+  eventOpenBtn?.addEventListener('click', () => {
+    const uid = eventSelect?.value;
+    if (uid) {
+      window.open(withBase('/?event=' + uid), '_blank');
     }
   });
 

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -64,6 +64,7 @@ return [
     'tip_sort_rows' => 'Zum Sortieren Zeile ziehen',
     'tip_event_remove' => 'Veranstaltung entfernen',
     'tip_event_add' => 'Neue Veranstaltung anlegen',
+    'tip_event_open' => 'Veranstaltung im Frontend öffnen',
     'tip_save_changes' => 'Änderungen speichern',
     'tip_slug' => 'Eindeutiger Name in der URL',
     'tip_cat_name' => 'Angezeigter Titel des Katalogs',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -64,6 +64,7 @@ return [
     'tip_sort_rows' => 'Drag row to sort',
     'tip_event_remove' => 'Remove event',
     'tip_event_add' => 'Add new event',
+    'tip_event_open' => 'Open event in frontend',
     'tip_save_changes' => 'Save changes',
     'tip_slug' => 'Unique name in the URL',
     'tip_cat_name' => 'Displayed catalog title',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -22,7 +22,10 @@
       <a id="adminMenuToggle" class="uk-icon-button" uk-icon="icon: menu; ratio: 2" aria-label="{{ t('menu') }}" uk-toggle="target: #adminNav"></a>
     {% endblock %}
     {% block center %}
-      <select id="eventSelect" class="uk-select"></select>
+      <div class="uk-flex uk-flex-middle">
+        <select id="eventSelect" class="uk-select"></select>
+        <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
+      </div>
     {% endblock %}
     {% block right %}
       <div class="theme-switch">


### PR DESCRIPTION
## Summary
- add "open event" button next to event selection in admin topbar
- support translations for new button
- wire up button to open selected event in a new tab

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688e58c129c0832b922c32944472b466