### PR TITLE
Add imprint data step to onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -1,11 +1,16 @@
 /* global UIkit */
 (function () {
-  const steps = ['login', 'step1', 'step2', 'step3', 'step4', 'success'];
+  const steps = ['login', 'step1', 'step2', 'step3', 'step4', 'step5', 'success'];
   const data = {
     name: '',
     subdomain: '',
     plan: '',
     payment: '',
+    imprintName: '',
+    imprintStreet: '',
+    imprintZip: '',
+    imprintCity: '',
+    imprintEmail: '',
     adminPass: ''
   };
 
@@ -108,6 +113,12 @@
     const next1 = document.getElementById('next1');
     const next2 = document.getElementById('next2');
     const next3 = document.getElementById('next3');
+    const next4 = document.getElementById('next4');
+    const imprintNameInput = document.getElementById('imprint-name');
+    const imprintStreetInput = document.getElementById('imprint-street');
+    const imprintZipInput = document.getElementById('imprint-zip');
+    const imprintCityInput = document.getElementById('imprint-city');
+    const imprintEmailInput = document.getElementById('imprint-email');
     const createBtn = document.getElementById('create');
     const adminPassInput = document.getElementById('admin-pass');
     const successDomain = document.getElementById('success-domain');
@@ -190,6 +201,20 @@
       show('step4');
     });
 
+    next4.addEventListener('click', () => {
+      data.imprintName = imprintNameInput.value.trim();
+      data.imprintStreet = imprintStreetInput.value.trim();
+      data.imprintZip = imprintZipInput.value.trim();
+      data.imprintCity = imprintCityInput.value.trim();
+      data.imprintEmail = imprintEmailInput.value.trim();
+      document.getElementById('summary-imprint-name').textContent = data.imprintName;
+      document.getElementById('summary-imprint-street').textContent = data.imprintStreet;
+      document.getElementById('summary-imprint-zip').textContent = data.imprintZip;
+      document.getElementById('summary-imprint-city').textContent = data.imprintCity;
+      document.getElementById('summary-imprint-email').textContent = data.imprintEmail;
+      show('step5');
+    });
+
     createBtn.addEventListener('click', async () => {
       if (!adminPassInput) {
         return;
@@ -239,7 +264,7 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({ uid: data.subdomain, schema: data.subdomain, plan: data.plan || null, billing: data.billing || null })
+          body: JSON.stringify({ uid: data.subdomain, schema: data.subdomain, plan: data.plan || null, billing: data.payment || null })
         });
         if (!tenantRes.ok) {
           const text = await tenantRes.text();

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -37,9 +37,9 @@
     </div>
 
     <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1"{% if not logged_in %} hidden{% endif %}>
-      <h3 class="uk-card-title">1. Kundendaten</h3>
+      <h3 class="uk-card-title">1. Name der App/Domain</h3>
       <div class="uk-margin">
-        <input id="customer-name" class="uk-input" type="text" placeholder="Kundenname" required>
+        <input id="customer-name" class="uk-input" type="text" placeholder="Name der App oder Domain" required>
       </div>
       <div class="uk-margin">
         <label>Subdomain: <span id="subdomain-preview">-</span>.{{ main_domain }}</label>
@@ -72,12 +72,35 @@
     </div>
 
     <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step4" hidden>
-      <h3 class="uk-card-title">4. Erstellung</h3>
+      <h3 class="uk-card-title">4. Daten für Impressum/Datenschutz</h3>
+      <div class="uk-margin">
+        <input id="imprint-name" class="uk-input" type="text" placeholder="Name des Betreibers" required>
+      </div>
+      <div class="uk-margin">
+        <input id="imprint-street" class="uk-input" type="text" placeholder="Straße und Hausnummer" required>
+      </div>
+      <div class="uk-margin">
+        <input id="imprint-zip" class="uk-input" type="text" placeholder="PLZ" required>
+      </div>
+      <div class="uk-margin">
+        <input id="imprint-city" class="uk-input" type="text" placeholder="Ort" required>
+      </div>
+      <div class="uk-margin">
+        <input id="imprint-email" class="uk-input" type="email" placeholder="E-Mail-Adresse" required>
+      </div>
+      <button class="uk-button uk-button-primary" id="next4">Weiter</button>
+    </div>
+
+    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step5" hidden>
+      <h3 class="uk-card-title">5. Erstellung</h3>
       <ul class="uk-list">
-        <li><strong>Kunde:</strong> <span id="summary-name"></span></li>
+        <li><strong>Name:</strong> <span id="summary-name"></span></li>
         <li><strong>Subdomain:</strong> <span id="summary-subdomain"></span>.{{ main_domain }}</li>
         <li><strong>Abo:</strong> <span id="summary-plan"></span></li>
         <li><strong>Zahlung:</strong> <span id="summary-payment"></span></li>
+        <li><strong>Betreiber:</strong> <span id="summary-imprint-name"></span></li>
+        <li><strong>Adresse:</strong> <span id="summary-imprint-street"></span>, <span id="summary-imprint-zip"></span> <span id="summary-imprint-city"></span></li>
+        <li><strong>E-Mail:</strong> <span id="summary-imprint-email"></span></li>
       </ul>
       <div class="uk-margin">
         <input id="admin-pass" class="uk-input" type="password" placeholder="Admin-Passwort">


### PR DESCRIPTION
## Summary
- Update onboarding's first step to focus on naming the app/domain
- Introduce new step for collecting imprint/privacy details
- Expand onboarding script to handle additional step and data

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688e6ede2a0c832bb0ba229e7e6df6f0