### PR TITLE
Preserve landing page during tests

### DIFF
--- a/tests/Controller/DomainAccessTest.php
+++ b/tests/Controller/DomainAccessTest.php
@@ -29,13 +29,17 @@ class DomainAccessTest extends TestCase
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
-        session_start();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
         $request = $this->createRequest('POST', '/tenants');
         $request = $request->withUri($request->getUri()->withHost('tenant.test'));
         $response = $app->handle($request);
         $this->assertEquals(403, $response->getStatusCode());
-        session_destroy();
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
         if ($old === false) {
             putenv('MAIN_DOMAIN');
         } else {
@@ -48,13 +52,17 @@ class DomainAccessTest extends TestCase
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
-        session_start();
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
         $req = $this->createRequest('GET', '/tenants/foo');
         $req = $req->withUri($req->getUri()->withHost('tenant.test'));
         $res = $app->handle($req);
         $this->assertEquals(403, $res->getStatusCode());
-        session_destroy();
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
         if ($old === false) {
             putenv('MAIN_DOMAIN');
         } else {

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -15,6 +15,7 @@ class PageControllerTest extends TestCase
             mkdir($dir);
         }
         $file = $dir . '/landing.html';
+        $backup = is_file($file) ? file_get_contents($file) : null;
         file_put_contents($file, '<p>old</p>');
 
         $app = $this->getAppInstance();
@@ -31,7 +32,11 @@ class PageControllerTest extends TestCase
         $this->assertStringEqualsFile($file, '<p>new</p>');
 
         session_destroy();
-        unlink($file);
+        if ($backup === null) {
+            unlink($file);
+        } else {
+            file_put_contents($file, $backup);
+        }
     }
 
     public function testInvalidSlug(): void


### PR DESCRIPTION
## Summary
- avoid deleting tracked `landing.html` during page controller tests
- guard session handling in domain access tests

## Testing
- `vendor/bin/phpunit tests/Controller/DomainAccessTest.php`
- `vendor/bin/phpunit`
- `vendor/bin/phpcs tests/Controller/DomainAccessTest.php tests/Controller/PageControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_688e5922361c832b97a6aea3fb2d0877