### PR TITLE
Render marketing landing page by default

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -58,9 +58,14 @@ class HomeController
             } elseif ($home === 'help') {
                 $ctrl = new HelpController();
                 return $ctrl($request, $response);
-            } elseif ($home === 'landing' && $request->getAttribute('domainType') === 'main') {
-                $ctrl = new \App\Controller\Marketing\LandingController();
-                return $ctrl($request, $response);
+            } elseif ($home === 'landing') {
+                $domainType = $request->getAttribute('domainType');
+                $host = $request->getUri()->getHost();
+                $mainDomain = getenv('MAIN_DOMAIN') ?: '';
+                if ($domainType === null || $domainType === 'main' || $host === $mainDomain) {
+                    $ctrl = new \App\Controller\Marketing\LandingController();
+                    return $ctrl($request, $response);
+                }
             }
         }
         if (session_status() === PHP_SESSION_NONE) {

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -27,6 +27,9 @@
       <a class="uk-button uk-button-primary" href="{{ basePath }}/login">Kostenlos testen</a>
     {% endblock %}
   {% endembed %}
+  {% if 'Willkommen beim QuizRace' not in content %}
+    <h1 class="uk-heading-medium">Willkommen beim QuizRace</h1>
+  {% endif %}
   {{ content|raw }}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Render marketing landing page when `home_page` is set to `landing` even without `domainType` or when host matches main domain
- Ensure landing template always displays “Willkommen beim QuizRace”

## Testing
- `vendor/bin/phpcs src/Controller/HomeController.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688e710e1100832b911fb747413790ae