### PR TITLE
fix: ensure landing route sets domain type

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -201,7 +201,14 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/impressum', ImpressumController::class);
     $app->get('/lizenz', LizenzController::class);
     $app->get('/landing', function (Request $request, Response $response) {
-        if ($request->getAttribute('domainType') !== 'main') {
+        $domainType = $request->getAttribute('domainType');
+        if ($domainType === null) {
+            $host = $request->getUri()->getHost();
+            $mainDomain = getenv('MAIN_DOMAIN') ?: '';
+            $domainType = $host === $mainDomain || $mainDomain === '' ? 'main' : 'tenant';
+            $request = $request->withAttribute('domainType', $domainType);
+        }
+        if ($domainType !== 'main') {
             return $response->withStatus(404);
         }
         $controller = new LandingController();


### PR DESCRIPTION
## Summary
- ensure domainType attribute is set for landing route and defaults to main when not provided

## Testing
- `composer install`
- `composer test`
- `vendor/bin/phpcs src/routes.php`


------
https://chatgpt.com/codex/tasks/task_e_688e711bab8c832bb52e8d3e0865335f