### PR TITLE
Downgrade QR code library for PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "slim/twig-view": "^3.3",
         "setasign/fpdf": "^1.8",
         "setasign/fpdi": "^2.6",
-        "endroid/qr-code": "^6.0",
+        "endroid/qr-code": "^5.1",
         "intervention/image": "^3.0",
         "ext-exif": "*",
         "guzzlehttp/guzzle": "^7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63b6a64bd31ae448521588a8618ee0ac",
+    "content-hash": "d174971995d8acf906ef6105a7dce4fc",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -112,21 +112,21 @@
         },
         {
             "name": "endroid/qr-code",
-            "version": "6.0.9",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/endroid/qr-code.git",
-                "reference": "21e888e8597440b2205e2e5c484b6c8e556bcd1a"
+                "reference": "393fec6c4cbdc1bd65570ac9d245704428010122"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/endroid/qr-code/zipball/21e888e8597440b2205e2e5c484b6c8e556bcd1a",
-                "reference": "21e888e8597440b2205e2e5c484b6c8e556bcd1a",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/393fec6c4cbdc1bd65570ac9d245704428010122",
+                "reference": "393fec6c4cbdc1bd65570ac9d245704428010122",
                 "shasum": ""
             },
             "require": {
                 "bacon/bacon-qr-code": "^3.0",
-                "php": "^8.2"
+                "php": "^8.1"
             },
             "require-dev": {
                 "endroid/quality": "dev-main",
@@ -143,7 +143,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.x-dev"
+                    "dev-main": "5.x-dev"
                 }
             },
             "autoload": {
@@ -172,7 +172,7 @@
             ],
             "support": {
                 "issues": "https://github.com/endroid/qr-code/issues",
-                "source": "https://github.com/endroid/qr-code/tree/6.0.9"
+                "source": "https://github.com/endroid/qr-code/tree/5.1.0"
             },
             "funding": [
                 {
@@ -180,7 +180,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-13T19:59:45+00:00"
+            "time": "2024-09-08T08:52:55+00:00"
         },
         {
             "name": "fig/http-message-util",


### PR DESCRIPTION
## Summary
- use endroid/qr-code ^5.1 to support PHP 8.1
- update lockfile accordingly

## Testing
- `composer test` *(fails: Tests: 120, Assertions: 217, Errors: 9, Failures: 3, Warnings: 6, Deprecations: 7, PHPUnit Deprecations: 1, Notices: 6)*

------
https://chatgpt.com/codex/tasks/task_e_688f75c1f408832badd3a71e0aa244bf