### PR TITLE
Always show admin profile tab

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -57,9 +57,8 @@
     <li data-route="management" data-help="Benutzer verwalten, Rollen zuweisen und Sicherungen erstellen. Rollen: admin – Administrator; catalog-editor – Fragenkataloge bearbeiten; event-manager – Veranstaltungen verwalten; analyst – Ergebnisse analysieren; team-manager – Teams verwalten."><a href="{{ basePath }}/admin/management">{{ t('tab_management') }}</a></li>
     {% if domainType == 'main' %}
     <li data-route="tenants" data-help="Liste aller angelegten Subdomains."><a href="{{ basePath }}/admin/tenants">{{ t('tab_tenants') }}</a></li>
-    {% else %}
-    <li data-route="profile" data-help="Informationen zum eigenen Mandanten."><a href="{{ basePath }}/admin/profile">{{ t('tab_profile') }}</a></li>
     {% endif %}
+    <li data-route="profile" data-help="Informationen zum eigenen Mandanten."><a href="{{ basePath }}/admin/profile">{{ t('tab_profile') }}</a></li>
     {% endif %}
   </ul>
   <ul id="adminSwitcher" class="uk-switcher uk-margin">
@@ -642,7 +641,7 @@
         </div>
       </div>
     </li>
-    {% else %}
+    {% endif %}
     <li>
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_profile') }}</h2>
@@ -662,7 +661,6 @@
         {% endif %}
       </div>
     </li>
-    {% endif %}
     {% endif %}
   </ul>
   <div id="helpSidebar" uk-offcanvas="flip: true; overlay: true">
@@ -698,6 +696,7 @@
           <li><a href="{{ basePath }}/admin/management" data-tab="9">{{ t('tab_management') }}</a></li>
           {% if domainType == 'main' %}
           <li><a href="{{ basePath }}/admin/tenants" data-tab="10">{{ t('tab_tenants') }}</a></li>
+          <li><a href="{{ basePath }}/admin/profile" data-tab="11">{{ t('tab_profile') }}</a></li>
           {% else %}
           <li><a href="{{ basePath }}/admin/profile" data-tab="10">{{ t('tab_profile') }}</a></li>
           {% endif %}


### PR DESCRIPTION
## Summary
- Always include the admin profile tab and keep tenants link for main domain

## Testing
- `composer test` *(fails: Database error: fail; Tests: 120, Assertions: 232, Errors: 5, Failures: 1)*

------
https://chatgpt.com/codex/tasks/task_e_688eacaa471c832b9b5bcab61d722c96