### PR TITLE
Restart tenant container and ensure certificate load in onboarding script

### DIFF
--- a/scripts/onboard_tenant.sh
+++ b/scripts/onboard_tenant.sh
@@ -118,5 +118,15 @@ if ! curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null; th
   error_exit "Konnte Nginx-Reload nicht auslösen; kein Zertifikat beantragt"
 fi
 
+# restart the tenant container to pick up the certificate
+if ! $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" restart >/dev/null; then
+  error_exit "Konnte Tenant-Container nicht neu starten"
+fi
+
+# trigger a second reload so nginx picks up the certificate
+if ! curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null; then
+  echo "Warnung: Konnte zweiten Nginx-Reload nicht auslösen" >&2
+fi
+
 echo "Tenant '$SLUG' deployed under https://${SLUG}.${DOMAIN_SUFFIX}"
 echo "{\"status\": \"success\", \"slug\": \"${SLUG}\", \"url\": \"https://${SLUG}.${DOMAIN_SUFFIX}\"}"


### PR DESCRIPTION
## Summary
- Restart tenant container after triggering initial nginx reload
- Trigger a second nginx reload to ensure the certificate loads after restart

## Testing
- `scripts/run_tests.sh` *(fails: Tests: 120, Assertions: 217, Errors: 9, Failures: 3)*

------
https://chatgpt.com/codex/tasks/task_e_688fadb28d98832b97d0a167b98374f5