### PR TITLE
Restart tenant services after SSL renewal

### DIFF
--- a/scripts/renew_ssl.sh
+++ b/scripts/renew_ssl.sh
@@ -27,6 +27,14 @@ if [ -f "$COMPOSE_FILE" ]; then
   fi
 fi
 
-curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null
+if ! curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null; then
+  echo "Failed to trigger nginx reload" >&2
+  exit 1
+fi
+
+if ! docker compose -f "$COMPOSE_FILE" -p "$SLUG" restart >/dev/null; then
+  echo "Failed to restart tenant services" >&2
+  exit 1
+fi
 
 printf '{"status":"renewed","slug":"%s"}\n' "$SLUG"


### PR DESCRIPTION
## Summary
- restart tenant containers after triggering nginx reload
- add error handling for reload and restart steps

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_688fc5a049cc832babd70694dd4ad69c