### PR TITLE
feat: add blacklist for sensitive subdomains

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -31,7 +31,22 @@
       .replace(/^-+|-+$/g, '');
   }
 
-  const RESERVED_SUBDOMAINS = new Set(['public']);
+  const RESERVED_SUBDOMAINS = new Set([
+    'public',
+    'www',
+    'so',
+    'sa',
+    'ss',
+    'ns',
+    'nsdap',
+    'nazi',
+    'nazis',
+    'hitler',
+    'adolf',
+    'hj',
+    'bdm',
+    'kz'
+  ]);
 
   document.addEventListener('DOMContentLoaded', () => {
     const loginBtn = document.getElementById('login-btn');

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -16,6 +16,23 @@ class TenantService
     private string $migrationsDir;
     private ?NginxService $nginxService;
 
+    private const RESERVED_SUBDOMAINS = [
+        'public',
+        'www',
+        'so',
+        'sa',
+        'ss',
+        'ns',
+        'nsdap',
+        'nazi',
+        'nazis',
+        'hitler',
+        'adolf',
+        'hj',
+        'bdm',
+        'kz',
+    ];
+
     public function __construct(PDO $pdo, ?string $migrationsDir = null, ?NginxService $nginxService = null)
     {
         $this->pdo = $pdo;
@@ -81,6 +98,9 @@ class TenantService
      */
     public function exists(string $subdomain): bool
     {
+        if ($this->isReserved($subdomain)) {
+            return true;
+        }
         $stmt = $this->pdo->prepare('SELECT 1 FROM tenants WHERE subdomain = ?');
         $stmt->execute([$subdomain]);
         if ($stmt->fetchColumn() !== false) {
@@ -96,6 +116,11 @@ class TenantService
         }
 
         return false;
+    }
+
+    private function isReserved(string $subdomain): bool
+    {
+        return in_array(strtolower($subdomain), self::RESERVED_SUBDOMAINS, true);
     }
 
     private function hasTable(string $name): bool

--- a/tests/Controller/TenantControllerTest.php
+++ b/tests/Controller/TenantControllerTest.php
@@ -158,6 +158,16 @@ class TenantControllerTest extends TestCase
         $this->assertEquals(200, $res->getStatusCode());
     }
 
+    public function testExistsReturns200ForReserved(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT, plan TEXT, billing_info TEXT, imprint_name TEXT, imprint_street TEXT, imprint_zip TEXT, imprint_city TEXT, imprint_email TEXT, created_at TEXT);');
+        $controller = new TenantController(new TenantService($pdo));
+        $req = $this->createRequest('GET', '/tenants/www');
+        $res = $controller->exists($req, new Response(), ['subdomain' => 'www']);
+        $this->assertEquals(200, $res->getStatusCode());
+    }
+
     public function testCreateHandlesPdoException(): void
     {
         $service = new class extends TenantService {

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -128,6 +128,26 @@ SQL;
         $service->createTenant('u5b', 'dup');
     }
 
+    public function testExistsReturnsTrueForReserved(): void
+    {
+        $dir = sys_get_temp_dir() . '/mig' . uniqid();
+        $pdo = new PDO('sqlite::memory:');
+        $service = $this->createService($dir, $pdo);
+        $this->assertTrue($service->exists('www'));
+    }
+
+    public function testCreateTenantFailsOnReserved(): void
+    {
+        $dir = sys_get_temp_dir() . '/mig' . uniqid();
+        $pdo = new PDO('sqlite::memory:');
+        $service = $this->createService($dir, $pdo);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('tenant-exists');
+
+        $service->createTenant('uid', 'www');
+    }
+
     public function testGetBySubdomainReturnsTenant(): void
     {
         $dir = sys_get_temp_dir() . '/mig' . uniqid();


### PR DESCRIPTION
## Summary
- forbid common and Nazi-related shortcuts as subdomains
- validate reserved subdomains server-side and in onboarding UI
- test that reserved names are rejected

## Testing
- `composer test` (failed: QrControllerTest errors)
- `vendor/bin/phpunit tests/Service/TenantServiceTest.php tests/Controller/TenantControllerTest.php`
- `vendor/bin/phpcs src/Service/TenantService.php tests/Controller/TenantControllerTest.php tests/Service/TenantServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_688fc639876c832bb96d2ca6687ad474