### PR TITLE
feat: add variable placeholders for legal pages

### DIFF
--- a/content/datenschutz.html
+++ b/content/datenschutz.html
@@ -3,10 +3,10 @@
 
     <h2 class="uk-heading-bullet">1. Verantwortlicher</h2>
     <p>Verantwortlich für die Datenverarbeitung im Rahmen dieser Anwendung ist:<br>
-    René Buske<br>
-    Weidenbusch 8<br>
-    14532 Kleinmachnow<br>
-    E-Mail: <a href="mailto:info@calhelp.de">info@calhelp.de</a></p>
+    [NAME]<br>
+    [STREET]<br>
+    [ZIP] [CITY]<br>
+    E-Mail: <a href="mailto:[EMAIL]">[EMAIL]</a></p>
 
     <h2 class="uk-heading-bullet">2. Zweck der Datenverarbeitung</h2>
     <p>Die Quiz-App dient der Durchführung eines digitalen Quiz im Rahmen der Sommerfeier 2025. Die Erhebung und Verarbeitung von Daten erfolgt ausschließlich zur Bereitstellung und Verbesserung des Quiz-Angebots.</p>
@@ -31,7 +31,7 @@
     <p>Da keine personenbezogenen Daten verarbeitet werden, bestehen keine Betroffenenrechte im Sinne der DSGVO bezüglich Auskunft, Berichtigung, Löschung oder Übertragbarkeit.</p>
 
     <h2 class="uk-heading-bullet">8. Kontakt</h2>
-    <p>Für Fragen zum Datenschutz oder zur Anwendung wenden Sie sich bitte an: <a href="mailto:info@calhelp.de">info@calhelp.de</a></p>
+    <p>Für Fragen zum Datenschutz oder zur Anwendung wenden Sie sich bitte an: <a href="mailto:[EMAIL]">[EMAIL]</a></p>
 
     <p class="uk-text-small"><strong>Hinweis:</strong> Diese Datenschutzerklärung basiert auf dem aktuellen Stand der Technik und des Projekts. <strong>CalHelp übernimmt keine Verantwortung</strong> für bereits durch Administrator:innen eingegebene personenbezogene Daten. Sollte sich der Funktionsumfang ändern oder die App personenbezogene Daten erheben, ist eine Anpassung dieser Datenschutzerklärung erforderlich.</p>
   </div>

--- a/content/impressum.html
+++ b/content/impressum.html
@@ -2,16 +2,16 @@
     <h1 class="uk-heading-divider uk-hidden">Impressum</h1>
 
     <p>Angaben gemäß § 5 TMG</p>
-    <p>René Buske<br>
-    Weidenbusch 8<br>
-    14532 Kleinmachnow<br>
+    <p>[NAME]<br>
+    [STREET]<br>
+    [ZIP] [CITY]<br>
     Deutschland</p>
-    <p>E-Mail: <a href="mailto:office@calhelp.de">office@calhelp.de</a></p>
+    <p>E-Mail: <a href="mailto:[EMAIL]">[EMAIL]</a></p>
 
     <p><strong>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:</strong><br>
-    René Buske<br>
-    Weidenbusch 8<br>
-    14532 Kleinmachnow</p>
+    [NAME]<br>
+    [STREET]<br>
+    [ZIP] [CITY]</p>
 
     <p>Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz: DE 259645623</p>
 

--- a/public/Impressum.html
+++ b/public/Impressum.html
@@ -11,16 +11,16 @@
 <body class="uk-padding uk-background-muted">
   <h1>Impressum</h1>
   <p>Angaben gemäß § 5 TMG</p>
-  <p>René Buske<br>
-  Weidenbusch 8<br>
-  14532 Kleinmachnow<br>
+  <p>[NAME]<br>
+  [STREET]<br>
+  [ZIP] [CITY]<br>
   Deutschland</p>
-  <p>E-Mail: <a href="mailto:office@calhelp.de">office@calhelp.de</a></p>
+  <p>E-Mail: <a href="mailto:[EMAIL]">[EMAIL]</a></p>
 
   <p><strong>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:</strong><br>
-  René Buske<br>
-  Weidenbusch 8<br>
-  14532 Kleinmachnow</p>
+  [NAME]<br>
+  [STREET]<br>
+  [ZIP] [CITY]</p>
 
   <p>Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz: DE 259645623</p>
 

--- a/public/js/trumbowyg-pages.js
+++ b/public/js/trumbowyg-pages.js
@@ -2,7 +2,7 @@
 
 // Define custom UIkit templates for Trumbowyg
 $.extend(true, $.trumbowyg, {
-  langs: { de: { template: 'Vorlage' } },
+  langs: { de: { template: 'Vorlage', variable: 'Variable' } },
   plugins: {
     template: {
       init: function (trumbowyg) {
@@ -35,6 +35,26 @@ $.extend(true, $.trumbowyg, {
           title: 'UIkit Card'
         });
       }
+    },
+    variable: {
+      init: function (trumbowyg) {
+        const vars = window.profileVars || {};
+        const keys = Object.keys(vars);
+        if (!keys.length) return;
+        const dropdown = keys.map(k => `var-${k}`);
+        trumbowyg.addBtnDef('variable', {
+          dropdown: dropdown,
+          ico: 'insertTemplate'
+        });
+        keys.forEach(k => {
+          trumbowyg.addBtnDef(`var-${k}`, {
+            fn: function () {
+              trumbowyg.execCmd('insertText', `[${k}]`);
+            },
+            title: `${k}${vars[k] ? ' (' + vars[k] + ')' : ''}`
+          });
+        });
+      }
     }
   }
 });
@@ -57,10 +77,11 @@ export function initPageEditors() {
         ['link'],
         ['insertImage'],
         ['unorderedList', 'orderedList'],
+        ['variable'],
         ['template'],
         ['fullscreen']
       ],
-      plugins: { template: true }
+      plugins: { template: true, variable: true }
     });
     const saveBtn = form.querySelector('.save-page-btn');
     saveBtn?.addEventListener('click', e => {

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -126,7 +126,7 @@ class AdminController
             }
         }
 
-        if ($section === 'profile') {
+        if (in_array($section, ['profile', 'pages'], true)) {
             $host = $request->getUri()->getHost();
             $sub  = explode('.', $host)[0];
             $base = Database::connectFromEnv();

--- a/src/Controller/DatenschutzController.php
+++ b/src/Controller/DatenschutzController.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
 use Slim\Routing\RouteContext;
+use App\Service\PageVariableService;
 
 /**
  * Renders the privacy policy page.
@@ -23,6 +24,7 @@ class DatenschutzController
         $html = (string) file_get_contents($path);
         $basePath = RouteContext::fromRequest($request)->getBasePath();
         $html = str_replace('{{ basePath }}', $basePath, $html);
+        $html = PageVariableService::apply($html);
 
         $view = Twig::fromRequest($request);
         return $view->render($response, 'datenschutz.twig', [

--- a/src/Controller/ImpressumController.php
+++ b/src/Controller/ImpressumController.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
 use Slim\Routing\RouteContext;
+use App\Service\PageVariableService;
 
 /**
  * Displays the legal notice page.
@@ -23,6 +24,7 @@ class ImpressumController
         $html = (string) file_get_contents($path);
         $basePath = RouteContext::fromRequest($request)->getBasePath();
         $html = str_replace('{{ basePath }}', $basePath, $html);
+        $html = PageVariableService::apply($html);
 
         $view = Twig::fromRequest($request);
         return $view->render($response, 'impressum.twig', [

--- a/src/Service/PageVariableService.php
+++ b/src/Service/PageVariableService.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Replaces placeholder variables in HTML content with profile data.
+ */
+class PageVariableService
+{
+    /**
+     * Apply profile-based replacements on the given HTML.
+     */
+    public static function apply(string $html): string
+    {
+        $path = dirname(__DIR__, 2) . '/data/profile.json';
+        $profile = [];
+        if (is_file($path)) {
+            $data = json_decode((string) file_get_contents($path), true);
+            if (is_array($data)) {
+                $profile = $data;
+            }
+        }
+
+        $replacements = [
+            '[NAME]' => $profile['imprint_name'] ?? '',
+            '[STREET]' => $profile['imprint_street'] ?? '',
+            '[ZIP]' => $profile['imprint_zip'] ?? '',
+            '[CITY]' => $profile['imprint_city'] ?? '',
+            '[EMAIL]' => $profile['imprint_email'] ?? '',
+        ];
+
+        return str_replace(array_keys($replacements), array_values($replacements), $html);
+    }
+}

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -9,6 +9,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/ui/trumbowyg.min.css">
   <script src="https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/trumbowyg.min.js"></script>
+  <script>
+    window.profileVars = {
+      NAME: '{{ tenant.imprint_name|default('')|e('js') }}',
+      STREET: '{{ tenant.imprint_street|default('')|e('js') }}',
+      ZIP: '{{ tenant.imprint_zip|default('')|e('js') }}',
+      CITY: '{{ tenant.imprint_city|default('')|e('js') }}',
+      EMAIL: '{{ tenant.imprint_email|default('')|e('js') }}'
+    };
+  </script>
   <script type="module" src="{{ basePath }}/js/trumbowyg-pages.js"></script>
 {% endblock %}
 

--- a/tests/Service/PageVariableServiceTest.php
+++ b/tests/Service/PageVariableServiceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use App\Service\PageVariableService;
+
+class PageVariableServiceTest extends TestCase
+{
+    public function testApplyReplacesPlaceholders(): void
+    {
+        $html = '<p>[NAME], [STREET], [ZIP] [CITY], [EMAIL]</p>';
+        $result = PageVariableService::apply($html);
+        $this->assertStringNotContainsString('[NAME]', $result);
+        $this->assertStringNotContainsString('[STREET]', $result);
+        $this->assertStringNotContainsString('[ZIP]', $result);
+        $this->assertStringNotContainsString('[CITY]', $result);
+        $this->assertStringNotContainsString('[EMAIL]', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- allow profile-based variables like `[NAME]` in Impressum and Datenschutz
- pass profile data to page editor and add variable insertion menu
- provide service for replacing placeholders with profile defaults

## Testing
- `composer test` *(fails: Database error: fail, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688fc575e610832ba6f78f5e66fdff09