### PR TITLE
fix: apply dark mode styles to page editor

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -116,6 +116,30 @@ body.dark-mode .uk-icon-button {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
+/* Styles for Trumbowyg editor in Dark Mode */
+body.dark-mode .trumbowyg-box,
+body.dark-mode .trumbowyg-editor {
+  background-color: #1e1e1e !important;
+  color: #f5f5f5 !important;
+}
+
+body.dark-mode .trumbowyg-button-pane {
+  background-color: #2a2a2a;
+  border-color: #444;
+}
+
+body.dark-mode .trumbowyg-button-pane button {
+  color: #f5f5f5;
+}
+
+body.dark-mode .trumbowyg-button-pane button svg {
+  fill: #f5f5f5;
+}
+
+body.dark-mode .trumbowyg-button-pane button:hover {
+  background-color: #333;
+}
+
 /* Styles fuer QR-Scan-Popup im Dunkelmodus */
 body.dark-mode .uk-modal-dialog {
   background-color: #1e1e1e;


### PR DESCRIPTION
## Summary
- ensure Trumbowyg page editor reflects dark mode colors

## Testing
- `composer test` *(fails: Slim Application Error / Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68902473c784832b907c9e5861752a3c