### PR TITLE
fix: use base path for QR images

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -368,7 +368,7 @@
             <p id="summaryEventDesc">{{ event.description }}</p>
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
-            <img id="summaryEventQr" src="/qr.png?t={{ baseUrl|url_encode }}&fg=000000&label=0" alt="QR" width="96" height="96">
+            <img id="summaryEventQr" src="{{ basePath }}/qr.png?t={{ baseUrl|url_encode }}&fg=000000&label=0" alt="QR" width="96" height="96">
             <div id="summaryEventLabel">{{ event.name }}</div>
           </div>
         </div>
@@ -385,7 +385,7 @@
               {% endif %}
               <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
               <p>{{ c.description }}</p>
-              <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000&label=0" alt="QR" width="96" height="96">
+              <img src="{{ basePath }}/qr.png?t={{ link|url_encode }}&fg=dc0000&label=0" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}
@@ -402,7 +402,7 @@
             <div class="export-card uk-card uk-card-default uk-card-body uk-position-relative">
               <button class="qr-print-btn uk-icon-button uk-position-top-right" data-team="{{ t }}" uk-icon="icon: print" aria-label="QR-Code drucken"></button>
               <h4 class="uk-card-title">{{ t }}</h4>
-              <img src="/qr.png?t={{ t|url_encode }}&fg=004bc8" alt="QR" width="96" height="96">
+              <img src="{{ basePath }}/qr.png?t={{ t|url_encode }}&fg=004bc8" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -22,7 +22,7 @@
                         </div>
                         <div class="uk-width-auto@s uk-width-1-1">
                             {% set link = baseUrl ? baseUrl ~ '/?event=' ~ event.uid ~ '&katalog=' ~ katalog.slug : '?event=' ~ event.uid ~ '&katalog=' ~ katalog.slug %}
-                            <img src="/qr.png?t={{ link|url_encode }}&fg=dc0000" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
+                            <img src="{{ basePath }}/qr.png?t={{ link|url_encode }}&fg=dc0000" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
                             <button class="uk-button uk-button-danger uk-button-small uk-width-1-1">Löschen</button>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- use `{{ basePath }}` for admin QR images
- use `{{ basePath }}` for catalog QR images

## Testing
- `composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68902746f104832b9a89f9687c2fc8f2