### PR TITLE
Fix main domain profile view

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -127,11 +127,22 @@ class AdminController
         }
 
         if (in_array($section, ['profile', 'pages'], true)) {
-            $host = $request->getUri()->getHost();
-            $sub  = explode('.', $host)[0];
-            $base = Database::connectFromEnv();
-            $tenantSvc = new TenantService($base);
-            $tenant = $tenantSvc->getBySubdomain($sub);
+            $domainType = $request->getAttribute('domainType');
+            if ($domainType === 'main') {
+                $path = dirname(__DIR__, 2) . '/data/profile.json';
+                if (is_file($path)) {
+                    $data = json_decode((string) file_get_contents($path), true);
+                    if (is_array($data)) {
+                        $tenant = $data;
+                    }
+                }
+            } else {
+                $host = $request->getUri()->getHost();
+                $sub  = explode('.', $host)[0];
+                $base = Database::connectFromEnv();
+                $tenantSvc = new TenantService($base);
+                $tenant = $tenantSvc->getBySubdomain($sub);
+            }
         }
 
         $uri    = $request->getUri();

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Controller;
 
+use Slim\Psr7\Uri;
 use Tests\TestCase;
 
 class AdminControllerTest extends TestCase
@@ -58,5 +59,24 @@ class AdminControllerTest extends TestCase
         $this->assertEquals('/login', $response->getHeaderLine('Location'));
         session_destroy();
         unlink($db);
+    }
+
+    public function testProfileShowsMainDomainData(): void
+    {
+        $db = $this->setupDb();
+        putenv('MAIN_DOMAIN=example.com');
+        $_ENV['MAIN_DOMAIN'] = 'example.com';
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $request = $this->createRequest('GET', '/admin/profile')
+            ->withUri(new Uri('http', 'example.com', 80, '/admin/profile'));
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('Example Org', (string) $response->getBody());
+        session_destroy();
+        unlink($db);
+        putenv('MAIN_DOMAIN');
+        unset($_ENV['MAIN_DOMAIN']);
     }
 }


### PR DESCRIPTION
## Summary
- load profile data from data/profile.json when admin views profile on main domain
- test that main-domain profile data is rendered

## Testing
- `vendor/bin/phpcs src/Controller/AdminController.php tests/Controller/AdminControllerTest.php`
- `vendor/bin/phpunit` *(fails: Failed asserting that 500 is identical to 200; Tests: 125, Assertions: 228, Errors: 9, Failures: 3, Warnings: 6)*


------
https://chatgpt.com/codex/tasks/task_e_6890272ed7d0832b8f2d51d3bbddb487