### PR TITLE
feat(admin): allow editing tenant profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 ### Ci
 
 - Add workflow for automatic changelog
+### Feat
+
+- Allow admins to edit tenant profile
 - Build tenant image during deploy
 
 ### Docs

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -31,6 +31,8 @@ document.addEventListener('DOMContentLoaded', function () {
     .map(tab => tab.getAttribute('data-route') || '');
   const settingsInitial = window.quizSettings || {};
   const pagesInitial = window.pagesContent || {};
+  const profileForm = document.getElementById('profileForm');
+  const profileSaveBtn = document.getElementById('profileSaveBtn');
 
   function slugify(text) {
     return text
@@ -2134,6 +2136,22 @@ document.addEventListener('DOMContentLoaded', function () {
       });
     });
   }
+
+  profileSaveBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    if (!profileForm) return;
+    const formData = new FormData(profileForm);
+    const data = {};
+    formData.forEach((value, key) => { data[key] = value; });
+    apiFetch('/admin/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    }).then(r => {
+      if (!r.ok) throw new Error(r.statusText);
+      notify('Profil gespeichert', 'success');
+    }).catch(() => notify('Fehler beim Speichern', 'danger'));
+  });
 
   // Page editors are handled in trumbowyg-pages.js
 

--- a/src/Controller/Admin/ProfileController.php
+++ b/src/Controller/Admin/ProfileController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Service\TenantService;
+use App\Infrastructure\Database;
+use PDO;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class ProfileController
+{
+    public function update(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $fields = [
+            'plan' => (string) ($data['plan'] ?? ''),
+            'billing_info' => (string) ($data['billing_info'] ?? ''),
+            'imprint_name' => (string) ($data['imprint_name'] ?? ''),
+            'imprint_street' => (string) ($data['imprint_street'] ?? ''),
+            'imprint_zip' => (string) ($data['imprint_zip'] ?? ''),
+            'imprint_city' => (string) ($data['imprint_city'] ?? ''),
+            'imprint_email' => (string) ($data['imprint_email'] ?? ''),
+        ];
+
+        $domainType = $request->getAttribute('domainType');
+        if ($domainType === 'main') {
+            $path = dirname(__DIR__, 3) . '/data/profile.json';
+            $current = [];
+            if (is_file($path)) {
+                $current = json_decode((string) file_get_contents($path), true) ?? [];
+            }
+            foreach ($fields as $k => $v) {
+                $current[$k] = $v;
+            }
+            file_put_contents($path, json_encode($current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        } else {
+            $pdo = $request->getAttribute('pdo');
+            if (!$pdo instanceof PDO) {
+                $pdo = Database::connectFromEnv();
+            }
+            $host = $request->getUri()->getHost();
+            $sub = explode('.', $host)[0];
+            $service = new TenantService($pdo);
+            $service->updateProfile($sub, $fields);
+        }
+
+        return $response->withStatus(204);
+    }
+}

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -294,6 +294,39 @@ class TenantService
     }
 
     /**
+     * Update profile information for a tenant identified by subdomain.
+     *
+     * @param array<string,string> $data
+     */
+    public function updateProfile(string $subdomain, array $data): void
+    {
+        $fields = [
+            'plan',
+            'billing_info',
+            'imprint_name',
+            'imprint_street',
+            'imprint_zip',
+            'imprint_city',
+            'imprint_email',
+        ];
+        $set = [];
+        $params = [];
+        foreach ($fields as $f) {
+            if (array_key_exists($f, $data)) {
+                $set[] = $f . ' = ?';
+                $params[] = $data[$f];
+            }
+        }
+        if ($set === []) {
+            return;
+        }
+        $params[] = $subdomain;
+        $sql = 'UPDATE tenants SET ' . implode(', ', $set) . ' WHERE subdomain = ?';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+    }
+
+    /**
      * Retrieve all tenants ordered by creation date.
      *
      * @return list<array{

--- a/src/routes.php
+++ b/src/routes.php
@@ -27,6 +27,7 @@ use App\Service\TenantService;
 use App\Service\NginxService;
 use App\Service\SettingsService;
 use App\Service\TranslationService;
+use App\Controller\Admin\ProfileController;
 use App\Application\Middleware\LanguageMiddleware;
 use App\Controller\ResultController;
 use App\Controller\TeamController;
@@ -235,6 +236,10 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/admin/pages', AdminController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
     $app->get('/admin/management', AdminController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
     $app->get('/admin/profile', AdminController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
+    $app->post('/admin/profile', function (Request $request, Response $response) {
+        $controller = new ProfileController();
+        return $controller->update($request, $response);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
     $app->get('/admin/tenants', function (Request $request, Response $response) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(404);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -649,21 +649,47 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_profile') }}</h2>
         {% if tenant %}
-        <div class="uk-overflow-auto">
-          <table class="uk-table uk-table-divider uk-table-small">
-            <tbody>
-              <tr><th>{{ t('column_subdomain') }}</th><td>{{ tenant.subdomain }}</td></tr>
-              <tr><th>{{ t('column_plan') }}</th><td>{{ tenant.plan|default('') }}</td></tr>
-              <tr><th>{{ t('column_billing') }}</th><td>{{ tenant.billing_info|default('') }}</td></tr>
-              <tr><th>{{ t('column_imprint_name') }}</th><td>{{ tenant.imprint_name|default('') }}</td></tr>
-              <tr><th>{{ t('column_imprint_street') }}</th><td>{{ tenant.imprint_street|default('') }}</td></tr>
-              <tr><th>{{ t('column_imprint_zip') }}</th><td>{{ tenant.imprint_zip|default('') }}</td></tr>
-              <tr><th>{{ t('column_imprint_city') }}</th><td>{{ tenant.imprint_city|default('') }}</td></tr>
-              <tr><th>{{ t('column_imprint_email') }}</th><td>{{ tenant.imprint_email|default('') }}</td></tr>
-              <tr><th>{{ t('column_created') }}</th><td>{{ tenant.created_at }}</td></tr>
-            </tbody>
-          </table>
-        </div>
+        <form id="profileForm" class="uk-form-stacked">
+          <div class="uk-grid-small" uk-grid>
+            <div class="uk-width-1-2@s">
+              <label class="uk-form-label">{{ t('column_subdomain') }}</label>
+              <input class="uk-input" type="text" name="subdomain" value="{{ tenant.subdomain }}" readonly>
+            </div>
+            <div class="uk-width-1-2@s">
+              <label class="uk-form-label">{{ t('column_plan') }}</label>
+              <input class="uk-input" type="text" name="plan" value="{{ tenant.plan|default('') }}">
+            </div>
+            <div class="uk-width-1-1">
+              <label class="uk-form-label">{{ t('column_billing') }}</label>
+              <input class="uk-input" type="text" name="billing_info" value="{{ tenant.billing_info|default('') }}">
+            </div>
+            <div class="uk-width-1-1">
+              <label class="uk-form-label">{{ t('column_imprint_name') }}</label>
+              <input class="uk-input" type="text" name="imprint_name" value="{{ tenant.imprint_name|default('') }}">
+            </div>
+            <div class="uk-width-1-2@s">
+              <label class="uk-form-label">{{ t('column_imprint_street') }}</label>
+              <input class="uk-input" type="text" name="imprint_street" value="{{ tenant.imprint_street|default('') }}">
+            </div>
+            <div class="uk-width-1-2@s">
+              <label class="uk-form-label">{{ t('column_imprint_zip') }}</label>
+              <input class="uk-input" type="text" name="imprint_zip" value="{{ tenant.imprint_zip|default('') }}">
+            </div>
+            <div class="uk-width-1-2@s">
+              <label class="uk-form-label">{{ t('column_imprint_city') }}</label>
+              <input class="uk-input" type="text" name="imprint_city" value="{{ tenant.imprint_city|default('') }}">
+            </div>
+            <div class="uk-width-1-2@s">
+              <label class="uk-form-label">{{ t('column_imprint_email') }}</label>
+              <input class="uk-input" type="email" name="imprint_email" value="{{ tenant.imprint_email|default('') }}">
+            </div>
+            <div class="uk-width-1-2@s">
+              <label class="uk-form-label">{{ t('column_created') }}</label>
+              <input class="uk-input" type="text" value="{{ tenant.created_at }}" readonly>
+            </div>
+          </div>
+          <button id="profileSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: {{ t('tip_save_changes') }}; pos: left"></button>
+        </form>
         {% else %}
         <p>{{ t('text_no_data') }}</p>
         {% endif %}

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Slim\Psr7\Uri;
+use Slim\Psr7\Factory\StreamFactory;
+use Tests\TestCase;
+use PDO;
+
+class ProfileControllerTest extends TestCase
+{
+    private function setupDb(): string
+    {
+        $db = tempnam(sys_get_temp_dir(), 'db');
+        putenv('POSTGRES_DSN=sqlite:' . $db);
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        $_ENV['POSTGRES_DSN'] = 'sqlite:' . $db;
+        $_ENV['POSTGRES_USER'] = '';
+        $_ENV['POSTGRES_PASSWORD'] = '';
+        return $db;
+    }
+
+    public function testUpdateProfileMainDomain(): void
+    {
+        $db = $this->setupDb();
+        $profilePath = dirname(__DIR__, 2) . '/data/profile.json';
+        $backup = file_get_contents($profilePath);
+        putenv('MAIN_DOMAIN=example.com');
+        $_ENV['MAIN_DOMAIN'] = 'example.com';
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $request = $this->createRequest('POST', '/admin/profile', ['HTTP_CONTENT_TYPE' => 'application/json']);
+        $stream = (new StreamFactory())->createStream(json_encode(['plan' => 'Pro']));
+        $request = $request->withBody($stream)
+            ->withUri(new Uri('http', 'example.com', 80, '/admin/profile'));
+        $response = $app->handle($request);
+        $this->assertEquals(204, $response->getStatusCode());
+        $data = json_decode(file_get_contents($profilePath), true);
+        $this->assertSame('Pro', $data['plan']);
+        file_put_contents($profilePath, $backup);
+        session_destroy();
+        unlink($db);
+        putenv('POSTGRES_DSN');
+        putenv('POSTGRES_USER');
+        putenv('POSTGRES_PASSWORD');
+        unset($_ENV['POSTGRES_DSN'], $_ENV['POSTGRES_USER'], $_ENV['POSTGRES_PASSWORD']);
+        putenv('MAIN_DOMAIN');
+        unset($_ENV['MAIN_DOMAIN']);
+    }
+
+}


### PR DESCRIPTION
## Summary
- enable admins to edit tenant profile and persist changes for main or sub domains
- add profile save UI and client script
- document feature

## Testing
- `composer test` *(fails: Tests\Controller\QrControllerTest::testQrPdfIsGenerated, Tests\Service\CatalogServiceTest::testWriteWithoutActiveEventUid)*


------
https://chatgpt.com/codex/tasks/task_e_6890295f8bc8832b886e6e1516c5adb4