### PR TITLE
Fix page editor initialization

### DIFF
--- a/public/js/trumbowyg-pages.js
+++ b/public/js/trumbowyg-pages.js
@@ -112,5 +112,8 @@ export function showPreview() {
 }
 
 window.showPreview = showPreview;
-
-document.addEventListener('DOMContentLoaded', initPageEditors);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initPageEditors);
+} else {
+  initPageEditors();
+}


### PR DESCRIPTION
## Summary
- initialize page editor immediately when DOM is ready

## Testing
- `composer test` *(fails: Unable to decode input in LogoControllerTest, Unknown named parameter $writer, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68902ae5314c832b9028884e5a29c84d