### PR TITLE
feat: style landing page with calhelp design

### DIFF
--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -1,0 +1,42 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap');
+
+body {
+  font-family: 'Roboto', sans-serif;
+  background-color: #f5f7fa;
+  color: #333;
+}
+
+/* Top navigation bar styling */
+.topbar {
+  background-color: #1e87f0;
+  border-bottom: 2px solid #e5e5e5;
+}
+
+.topbar .uk-navbar-item,
+.topbar .uk-navbar-nav > li > a,
+.topbar .uk-navbar-nav > li > a:focus,
+.topbar .uk-navbar-nav > li > a:hover {
+  color: #fff;
+}
+
+/* Card appearance */
+.uk-card-default {
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+/* Primary buttons */
+.uk-button-primary {
+  background-color: #1e87f0;
+  border: none;
+}
+
+.uk-button-primary:hover {
+  background-color: #0f6fbf;
+}
+
+#quiz-header .logo-placeholder {
+  max-width: 280px;
+  margin-bottom: 1rem;
+}
+

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
 {% endblock %}
 
 {% block body_class %}index-page uk-padding{% endblock %}


### PR DESCRIPTION
## Summary
- add dedicated calhelp stylesheet and load it on the landing page
- style navbar, buttons and cards with Roboto font and blue accent

## Testing
- `composer test` *(fails: Tests\Controller\QrControllerTest::testQrImageIsGenerated, Tests\Service\CatalogServiceTest::testWriteWithoutActiveEventUid)*

------
https://chatgpt.com/codex/tasks/task_e_6890391f4640832baf8865353c8e6ec0