### PR TITLE
Remove welcome heading from landing page

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -1,6 +1,5 @@
   <section class="uk-section uk-section-primary uk-flex uk-flex-middle" uk-height-viewport="offset-top: true">
     <div class="uk-container">
-      <h1 class="uk-heading-medium">Willkommen beim QuizRace</h1>
       <p class="uk-text-lead">Trete gegen Freunde und Kollegen an und finde heraus, wer das meiste Wissen hat.</p>
       <p class="uk-margin-large-top">
         <a class="uk-button uk-button-secondary uk-button-large" href="{{ basePath }}/login">Jetzt starten</a>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -27,11 +27,9 @@
       <a class="uk-button uk-button-primary" href="{{ basePath }}/login">Kostenlos testen</a>
     {% endblock %}
   {% endembed %}
-  {% if 'Willkommen beim QuizRace' not in content %}
-    <h1 class="uk-heading-medium">Willkommen beim QuizRace</h1>
-  {% endif %}
+
   {{ content|raw }}
-{% endblock %}
+  {% endblock %}
 
 {% block scripts %}
   <script src="{{ basePath }}/js/app.js"></script>

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -110,7 +110,7 @@ class HomeControllerTest extends TestCase
             $request = $this->createRequest('GET', '/');
             $response = $app->handle($request);
             $this->assertEquals(200, $response->getStatusCode());
-            $this->assertStringContainsString('Willkommen beim QuizRace', (string)$response->getBody());
+            $this->assertStringContainsString('Trete gegen Freunde und Kollegen an', (string)$response->getBody());
         } finally {
             unlink($db);
         }


### PR DESCRIPTION
## Summary
- remove hard-coded welcome heading from landing content
- drop fallback heading from landing template
- adjust home page test to new landing content

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68903c313780832bb802182e4c8c5729