### PR TITLE
Add text label to event settings save button

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -139,6 +139,7 @@ return [
     'heading_catalog_comment' => 'Kommentar zum Katalog',
     'placeholder_catalog_comment' => 'Kommentar eingeben...',
     'label_catalog_select' => 'Fragenkatalog',
+    'action_save' => 'Speichern',
     'action_reset' => 'Zurücksetzen',
     'action_preview' => 'Vorschau',
     'action_invite_text' => 'Einladungstext eingeben',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -139,6 +139,7 @@ return [
     'heading_catalog_comment' => 'Catalog comment',
     'placeholder_catalog_comment' => 'Enter comment...',
     'label_catalog_select' => 'Question catalog',
+    'action_save' => 'Save',
     'action_reset' => 'Reset',
     'action_preview' => 'Preview',
     'action_invite_text' => 'Enter invitation text',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -231,7 +231,7 @@
         <div class="uk-margin uk-flex uk-flex-between">
           <button id="cfgResetBtn" class="uk-button uk-button-default" uk-tooltip="title: {{ t('tip_form_reset') }}; pos: right">{{ t('action_reset') }}</button>
           <div>
-            <button id="cfgSaveBtn" class="uk-icon-button uk-button-primary" uk-icon="check" uk-tooltip="title: {{ t('tip_save_settings') }}; pos: right"></button>
+            <button id="cfgSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: {{ t('tip_save_settings') }}; pos: right"><span uk-icon="check"></span> {{ t('action_save') }}</button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- show explicit **Speichern** text on event settings save button
- add reusable `action_save` translation in German and English

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68903cddb540832b884647328ea54ffd