### PR TITLE
Handle missing baseUrl for QR codes

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2008,8 +2008,8 @@ document.addEventListener('DOMContentLoaded', function () {
       nameEl.textContent = ev.name || '';
       if (descEl) descEl.textContent = ev.description || '';
       if (qrImg) {
-        const link = window.baseUrl || '';
-                qrImg.src = withBase('/qr.png?t=' + encodeURIComponent(link) + '&fg=000000&label=0');
+        const link = window.baseUrl ? window.baseUrl : withBase('/?event=' + encodeURIComponent(ev.uid || ''));
+        qrImg.src = withBase('/qr.png?t=' + encodeURIComponent(link) + '&fg=000000&label=0');
       }
       if (qrLabel) qrLabel.textContent = ev.name || '';
       catalogsEl.innerHTML = '';

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -63,7 +63,7 @@ class QrController
         $params = $request->getQueryParams();
         $text   = (string)($params['t'] ?? '');
         if ($text === '') {
-            return $response->withStatus(400);
+            $text = '?';
         }
 
         $fg     = (string)($params['fg'] ?? '23b45a');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -368,7 +368,7 @@
             <p id="summaryEventDesc">{{ event.description }}</p>
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
-            <img id="summaryEventQr" src="{{ basePath }}/qr.png?t={{ baseUrl|url_encode }}&fg=000000&label=0" alt="QR" width="96" height="96">
+            <img id="summaryEventQr" src="{{ basePath }}/qr.png?t={{ (baseUrl ? baseUrl : '?event=' ~ event.uid)|url_encode }}&fg=000000&label=0" alt="QR" width="96" height="96">
             <div id="summaryEventLabel">{{ event.name }}</div>
           </div>
         </div>

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -21,6 +21,17 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
+    public function testQrImageFallbackWhenTextMissing(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/qr.png');
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/png', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
+    }
+
     public function testQrPdfIsGenerated(): void
     {
         $app = $this->getAppInstance();


### PR DESCRIPTION
## Summary
- Fallback to event-specific link when no base URL is configured
- Build summary QR links client-side using baseUrl or event UID
- Ensure `/qr.png` always produces a QR code even without `t` parameter and test the behavior

## Testing
- `composer test` *(fails: Intervention\Image\Exceptions\DecoderException: Unable to decode input)*

------
https://chatgpt.com/codex/tasks/task_e_6890447fc914832ba246ce8a19d97e3a