### PR TITLE
Fix tenant management scripts to use uid

### DIFF
--- a/scripts/create_tenant.sh
+++ b/scripts/create_tenant.sh
@@ -44,7 +44,7 @@ fi
 
 curl -s -X POST \
   -H 'Content-Type: application/json' \
-  -d "{\"subdomain\":\"$SUBDOMAIN\"}" \
+  -d "{\"uid\":\"$SUBDOMAIN\",\"schema\":\"$SUBDOMAIN\"}" \
   "http://$DOMAIN/tenants"
 
 mkdir -p "$BASE_DIR/vhost.d"

--- a/scripts/delete_tenant.sh
+++ b/scripts/delete_tenant.sh
@@ -38,7 +38,7 @@ fi
 
 curl -s -X DELETE \
   -H 'Content-Type: application/json' \
-  -d "{\"subdomain\":\"$SUBDOMAIN\"}" \
+  -d "{\"uid\":\"$SUBDOMAIN\"}" \
   "http://$DOMAIN/tenants"
 
 rm -f "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"


### PR DESCRIPTION
## Summary
- send `uid` instead of `subdomain` when deleting tenants
- include `uid` and `schema` when creating tenants

## Testing
- `composer install`
- `composer test` *(fails: Tests: 127, Assertions: 244, Errors: 5, Failures: 3, Warnings: 6, Deprecations: 7, PHPUnit Deprecations: 1, Notices: 6.)*

------
https://chatgpt.com/codex/tasks/task_e_68904c107120832b91530a66220be832