### PR TITLE
Fix logo upload image manager initialization

### DIFF
--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Service\ConfigService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\ImageManager;
 
 /**
@@ -75,7 +76,7 @@ class LogoController
             return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
         }
 
-        $manager = ImageManager::gd();
+        $manager = new ImageManager(new Driver());
         $img = $manager->read($file->getStream());
         $img->scaleDown(512, 512);
         $img->save($target, 80);


### PR DESCRIPTION
## Summary
- instantiate ImageManager with GD driver for Intervention Image v3 compatibility

## Testing
- `composer test` *(fails: Database error: fail; 5 errors, 3 failures)*
- `vendor/bin/phpcs src/Controller/LogoController.php`


------
https://chatgpt.com/codex/tasks/task_e_68904b2f09b4832b9a95bfb814a9ef3e