### PR TITLE
Skip landing page for catalog links

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -59,12 +59,15 @@ class HomeController
                 $ctrl = new HelpController();
                 return $ctrl($request, $response);
             } elseif ($home === 'landing') {
-                $domainType = $request->getAttribute('domainType');
-                $host = $request->getUri()->getHost();
-                $mainDomain = getenv('MAIN_DOMAIN') ?: '';
-                if ($domainType === null || $domainType === 'main' || $host === $mainDomain) {
-                    $ctrl = new \App\Controller\Marketing\LandingController();
-                    return $ctrl($request, $response);
+                $params = $request->getQueryParams();
+                if (($params['katalog'] ?? '') === '') {
+                    $domainType = $request->getAttribute('domainType');
+                    $host = $request->getUri()->getHost();
+                    $mainDomain = getenv('MAIN_DOMAIN') ?: '';
+                    if ($domainType === null || $domainType === 'main' || $host === $mainDomain) {
+                        $ctrl = new \App\Controller\Marketing\LandingController();
+                        return $ctrl($request, $response);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Avoid showing marketing landing page when `katalog` parameter is present
- Add regression test ensuring catalog link bypasses landing page

## Testing
- `vendor/bin/phpcs src/Controller/HomeController.php tests/Controller/HomeControllerTest.php`
- `composer test` *(fails: Failed asserting that 500 is identical to 200; Failed asserting that two strings are identical; more details in log)*
- `vendor/bin/phpstan analyse` *(fails: PHPStan process crashed because it reached configured PHP memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_68904ef226bc832bae0c65570f76976e