### PR TITLE
feat: add password reset endpoints

### DIFF
--- a/src/Application/Middleware/CsrfMiddleware.php
+++ b/src/Application/Middleware/CsrfMiddleware.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Middleware;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
+use Slim\Psr7\Response as SlimResponse;
+
+/**
+ * Very basic CSRF protection middleware.
+ */
+class CsrfMiddleware implements MiddlewareInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(Request $request, RequestHandler $handler): Response
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        $token = $_SESSION['csrf_token'] ?? null;
+
+        if ($request->getMethod() === 'POST') {
+            $header = $request->getHeaderLine('X-CSRF-Token');
+            if ($token === null || $header !== $token) {
+                return (new SlimResponse())->withStatus(403);
+            }
+        }
+
+        if ($token === null) {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(16));
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Application/Middleware/RateLimitMiddleware.php
+++ b/src/Application/Middleware/RateLimitMiddleware.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Middleware;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
+use Slim\Psr7\Response as SlimResponse;
+
+/**
+ * Simple session-based rate limiter.
+ */
+class RateLimitMiddleware implements MiddlewareInterface
+{
+    private int $maxRequests;
+    private int $windowSeconds;
+
+    public function __construct(int $maxRequests = 5, int $windowSeconds = 60)
+    {
+        $this->maxRequests = $maxRequests;
+        $this->windowSeconds = $windowSeconds;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(Request $request, RequestHandler $handler): Response
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        $key = 'rate:' . $request->getUri()->getPath();
+        $entry = $_SESSION[$key] ?? ['count' => 0, 'start' => time()];
+
+        if (time() - $entry['start'] > $this->windowSeconds) {
+            $entry = ['count' => 0, 'start' => time()];
+        }
+
+        $entry['count']++;
+        $_SESSION[$key] = $entry;
+
+        if ($entry['count'] > $this->maxRequests) {
+            return (new SlimResponse())->withStatus(429);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\MailService;
+use App\Service\PasswordResetService;
+use App\Service\UserService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
+
+/**
+ * Handle password reset requests and confirmations.
+ */
+class PasswordResetController
+{
+    private UserService $users;
+    private PasswordResetService $resets;
+
+    public function __construct(UserService $users, PasswordResetService $resets)
+    {
+        $this->users = $users;
+        $this->resets = $resets;
+    }
+
+    /**
+     * Accept username or email, generate token and send reset link.
+     */
+    public function request(Request $request, Response $response): Response
+    {
+        $data = $request->getParsedBody();
+        if ($request->getHeaderLine('Content-Type') === 'application/json') {
+            $data = json_decode((string) $request->getBody(), true);
+        }
+
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+
+        $username = trim((string) ($data['username'] ?? ''));
+        $email = trim((string) ($data['email'] ?? ''));
+        if ($username === '' && $email === '') {
+            return $response->withStatus(400);
+        }
+
+        $user = $username !== ''
+            ? $this->users->getByUsername($username)
+            : $this->users->getByEmail($email);
+
+        if ($user === null || $user['email'] === null) {
+            return $response->withStatus(404);
+        }
+
+        $token = $this->resets->createToken((int) $user['id']);
+        $uri = $request->getUri()
+            ->withPath('/password/reset')
+            ->withQuery('token=' . urlencode($token));
+
+        $twig = Twig::fromRequest($request)->getEnvironment();
+        $mailer = new MailService($twig);
+        $mailer->sendPasswordReset((string) $user['email'], (string) $uri);
+
+        return $response->withStatus(204);
+    }
+
+    /**
+     * Verify token and set new password.
+     */
+    public function confirm(Request $request, Response $response): Response
+    {
+        $data = $request->getParsedBody();
+        if ($request->getHeaderLine('Content-Type') === 'application/json') {
+            $data = json_decode((string) $request->getBody(), true);
+        }
+
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+
+        $token = (string) ($data['token'] ?? '');
+        $pass = (string) ($data['password'] ?? '');
+        if ($token === '' || $pass === '') {
+            return $response->withStatus(400);
+        }
+
+        $userId = $this->resets->consumeToken($token);
+        if ($userId === null) {
+            return $response->withStatus(400);
+        }
+
+        $this->users->updatePassword($userId, $pass);
+
+        return $response->withStatus(204);
+    }
+}

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -34,6 +34,20 @@ class UserService
     }
 
     /**
+     * Find a user by email.
+     *
+     * @return array{id:int,username:string,password:string,email:?
+     *     string,role:string,active:bool}|null
+     */
+    public function getByEmail(string $email): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT id,username,password,email,role,active FROM users WHERE email=?');
+        $stmt->execute([strtolower($email)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false ? $row : null;
+    }
+
+    /**
      * Create a new user with the given role.
      */
     public function create(


### PR DESCRIPTION
## Summary
- implement `PasswordResetController` with token request and confirmation
- expose `/password/reset/request` and `/password/reset/confirm` routes with CSRF and rate limiting
- support lookup by email and add basic CSRF/RateLimit middleware

## Testing
- `composer test` *(fails: Slim Application Error... Tests: 128, Assertions: 247, Errors: 5, Failures: 4, Warnings: 6, Deprecations: 7, PHPUnit Deprecations: 1, Notices: 6)*

------
https://chatgpt.com/codex/tasks/task_e_68905378ebec832b86e36c1bebb0edf6