### PR TITLE
Preload admin profile and pages data

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -118,31 +118,27 @@ class AdminController
             $users = (new UserService($pdo))->getAll();
         }
 
-        if ($section === 'pages') {
-            $pageSlugs = ['landing', 'impressum', 'datenschutz', 'faq'];
-            foreach ($pageSlugs as $slug) {
-                $path       = dirname(__DIR__, 2) . '/content/' . $slug . '.html';
-                $pages[$slug] = is_file($path) ? file_get_contents($path) : '';
-            }
+        $pageSlugs = ['landing', 'impressum', 'datenschutz', 'faq'];
+        foreach ($pageSlugs as $slug) {
+            $path       = dirname(__DIR__, 2) . '/content/' . $slug . '.html';
+            $pages[$slug] = is_file($path) ? file_get_contents($path) : '';
         }
 
-        if (in_array($section, ['profile', 'pages'], true)) {
-            $domainType = $request->getAttribute('domainType');
-            if ($domainType === 'main') {
-                $path = dirname(__DIR__, 2) . '/data/profile.json';
-                if (is_file($path)) {
-                    $data = json_decode((string) file_get_contents($path), true);
-                    if (is_array($data)) {
-                        $tenant = $data;
-                    }
+        $domainType = $request->getAttribute('domainType');
+        if ($domainType === 'main') {
+            $path = dirname(__DIR__, 2) . '/data/profile.json';
+            if (is_file($path)) {
+                $data = json_decode((string) file_get_contents($path), true);
+                if (is_array($data)) {
+                    $tenant = $data;
                 }
-            } else {
-                $host = $request->getUri()->getHost();
-                $sub  = explode('.', $host)[0];
-                $base = Database::connectFromEnv();
-                $tenantSvc = new TenantService($base);
-                $tenant = $tenantSvc->getBySubdomain($sub);
             }
+        } else {
+            $host = $request->getUri()->getHost();
+            $sub  = explode('.', $host)[0];
+            $base = Database::connectFromEnv();
+            $tenantSvc = new TenantService($base);
+            $tenant = $tenantSvc->getBySubdomain($sub);
         }
 
         $uri    = $request->getUri();

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -79,4 +79,20 @@ class AdminControllerTest extends TestCase
         putenv('MAIN_DOMAIN');
         unset($_ENV['MAIN_DOMAIN']);
     }
+
+    public function testPagesAndProfileDataLoadedOnEvents(): void
+    {
+        $db = $this->setupDb();
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $request = $this->createRequest('GET', '/admin/events');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $html = (string) $response->getBody();
+        $this->assertStringContainsString('Example Org', $html);
+        $this->assertStringContainsString('Professionelles Quiz-Hosting', $html);
+        session_destroy();
+        unlink($db);
+    }
 }


### PR DESCRIPTION
## Summary
- Always load static page content and tenant profile in `AdminController` so Profile and Pages tabs show full data without a refresh
- Add regression test ensuring events dashboard includes profile and page data

## Testing
- `vendor/bin/phpunit tests/Controller/AdminControllerTest.php`
- `composer test` *(fails: Intervention\Image\Exceptions\DecoderException: Unable to decode input)*

------
https://chatgpt.com/codex/tasks/task_e_6890547f8494832b9971a90584df7701