### PR TITLE
feat: add password reset templates

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -175,4 +175,13 @@ return [
     'action_delete_tenant' => 'Mandant löschen',
     'action_renew_ssl' => 'SSL erneuern',
     'help_admin_pass' => 'Definiert das Admin-Passwort des neuen Mandanten. Bleibt das Feld leer, wird ein zufälliges Passwort erzeugt',
+    'link_forgot_password' => 'Passwort vergessen?',
+    'heading_password_request' => 'Passwort zurücksetzen',
+    'text_password_request_success' => 'Falls die E-Mail existiert, wurde ein Link gesendet.',
+    'text_password_request_error' => 'Anfrage fehlgeschlagen.',
+    'heading_password_confirm' => 'Passwort setzen',
+    'text_password_reset_success' => 'Passwort erfolgreich geändert.',
+    'text_password_reset_error' => 'Passwort konnte nicht geändert werden.',
+    'action_send_link' => 'Link senden',
+    'action_set_password' => 'Passwort setzen',
 ];

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -175,4 +175,13 @@ return [
     'action_delete_tenant' => 'Delete tenant',
     'action_renew_ssl' => 'Renew SSL',
     'help_admin_pass' => 'Defines the admin password for the new tenant. Leave empty to generate a random one',
+    'link_forgot_password' => 'Forgot password?',
+    'heading_password_request' => 'Reset password',
+    'text_password_request_success' => 'If the email exists, a link was sent.',
+    'text_password_request_error' => 'Request failed.',
+    'heading_password_confirm' => 'Set password',
+    'text_password_reset_success' => 'Password changed successfully.',
+    'text_password_reset_error' => 'Password could not be changed.',
+    'action_send_link' => 'Send link',
+    'action_set_password' => 'Set password',
 ];

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -53,6 +53,9 @@
             <div class="uk-margin">
               <button class="uk-button uk-button-primary uk-button-large uk-width-1-1">Login</button>
             </div>
+            <div class="uk-margin uk-text-center">
+              <a href="{{ basePath }}/password/request">Passwort vergessen?</a>
+            </div>
             {% if registration_allowed %}
             <div class="uk-margin uk-text-center">
               <a href="{{ basePath }}/register">Registrieren</a>

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -1,0 +1,65 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Neues Passwort{% endblock %}
+
+{% block head %}
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+{% endblock %}
+
+{% block body_class %}uk-padding{% endblock %}
+
+{% block body %}
+  {% embed 'topbar.twig' %}
+    {% block left %}
+      <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+    {% endblock %}
+    {% block right %}
+      <div class="theme-switch">
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
+      </div>
+    {% endblock %}
+  {% endembed %}
+  <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
+    <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
+      <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+        <h3 class="uk-card-title uk-text-center">Neues Passwort</h3>
+        {% if success %}
+        <div class="uk-alert-success" uk-alert>
+          <p>Passwort erfolgreich geändert.</p>
+        </div>
+        {% elseif error %}
+        <div class="uk-alert-danger" uk-alert>
+          <p>Passwort konnte nicht geändert werden.</p>
+        </div>
+        {% endif %}
+        <form method="post" action="/password/confirm">
+          <div class="uk-margin">
+            <div class="uk-inline uk-width-1-1">
+              <span class="uk-form-icon" uk-icon="icon: lock"></span>
+              <input class="uk-input uk-form-large" type="password" name="password" placeholder="Passwort" required>
+            </div>
+          </div>
+          <div class="uk-margin">
+            <div class="uk-inline uk-width-1-1">
+              <span class="uk-form-icon" uk-icon="icon: lock"></span>
+              <input class="uk-input uk-form-large" type="password" name="password_repeat" placeholder="Passwort wiederholen" required>
+            </div>
+          </div>
+          <div class="uk-margin">
+            <button class="uk-button uk-button-primary uk-button-large uk-width-1-1">Passwort setzen</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ basePath }}/js/app.js"></script>
+  <script src="{{ basePath }}/js/custom-icons.js"></script>
+{% endblock %}

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -1,0 +1,59 @@
+{% extends 'layout.twig' %}
+
+{% block title %}Passwort zurücksetzen{% endblock %}
+
+{% block head %}
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+{% endblock %}
+
+{% block body_class %}uk-padding{% endblock %}
+
+{% block body %}
+  {% embed 'topbar.twig' %}
+    {% block left %}
+      <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+    {% endblock %}
+    {% block right %}
+      <div class="theme-switch">
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
+      </div>
+    {% endblock %}
+  {% endembed %}
+  <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
+    <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
+      <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+        <h3 class="uk-card-title uk-text-center">Passwort zurücksetzen</h3>
+        {% if success %}
+        <div class="uk-alert-success" uk-alert>
+          <p>Falls die E-Mail existiert, wurde ein Link gesendet.</p>
+        </div>
+        {% elseif error %}
+        <div class="uk-alert-danger" uk-alert>
+          <p>Anfrage fehlgeschlagen.</p>
+        </div>
+        {% endif %}
+        <form method="post" action="/password/request">
+          <div class="uk-margin">
+            <div class="uk-inline uk-width-1-1">
+              <span class="uk-form-icon" uk-icon="icon: mail"></span>
+              <input class="uk-input uk-form-large" type="email" name="email" id="email" placeholder="E-Mail" required>
+            </div>
+          </div>
+          <div class="uk-margin">
+            <button class="uk-button uk-button-primary uk-button-large uk-width-1-1">Link senden</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ basePath }}/js/app.js"></script>
+  <script src="{{ basePath }}/js/custom-icons.js"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add password reset request and confirmation pages
- link login page to password reset flow and expose translations

## Testing
- `composer test` *(fails: Database error fail; CatalogServiceTest::testWriteWithoutActiveEventUid etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6890b8a3e994832b8d7733f5b8078dab