### PR TITLE
Add password reset logging, rate limiting and tests

### DIFF
--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -58,8 +58,11 @@ class PasswordResetController
             ->withPath('/password/reset')
             ->withQuery('token=' . urlencode($token));
 
-        $twig = Twig::fromRequest($request)->getEnvironment();
-        $mailer = new MailService($twig);
+        $mailer = $request->getAttribute('mailService');
+        if (!$mailer instanceof MailService) {
+            $twig = Twig::fromRequest($request)->getEnvironment();
+            $mailer = new MailService($twig);
+        }
         $mailer->sendPasswordReset((string) $user['email'], (string) $uri);
 
         return $response->withStatus(204);

--- a/src/routes.php
+++ b/src/routes.php
@@ -395,10 +395,10 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->post('/password/reset/request', function (Request $request, Response $response) {
         return $request->getAttribute('passwordResetController')->request($request, $response);
-    })->add(new RateLimitMiddleware())->add(new CsrfMiddleware());
+    })->add(new RateLimitMiddleware(3, 3600))->add(new CsrfMiddleware());
     $app->post('/password/reset/confirm', function (Request $request, Response $response) {
         return $request->getAttribute('passwordResetController')->confirm($request, $response);
-    })->add(new RateLimitMiddleware())->add(new CsrfMiddleware());
+    })->add(new RateLimitMiddleware(3, 3600))->add(new CsrfMiddleware());
     $app->post('/import', function (Request $request, Response $response) {
         return $request->getAttribute('importController')->post($request, $response);
     })->add(new RoleAuthMiddleware('admin'));

--- a/tests/Controller/PasswordResetFlowTest.php
+++ b/tests/Controller/PasswordResetFlowTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Domain\Roles;
+use App\Infrastructure\Database;
+use App\Infrastructure\Migrations\Migrator;
+use App\Service\UserService;
+use App\Service\MailService;
+use Tests\TestCase;
+
+class PasswordResetFlowTest extends TestCase
+{
+    public function testFullResetFlow(): void
+    {
+        $app = $this->getAppInstance();
+        $pdo = Database::connectFromEnv();
+        Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
+        $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
+        $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token TEXT NOT NULL, expires_at TEXT NOT NULL)');
+        $userService = new UserService($pdo);
+        $userService->create('alice', 'oldpass', 'alice@example.com', Roles::ADMIN);
+
+        $mailer = new class extends MailService {
+            public array $sent = [];
+            public function __construct() {}
+            public function sendPasswordReset(string $to, string $link): void
+            {
+                $this->sent[] = ['to' => $to, 'link' => $link];
+            }
+        };
+
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+        $request = $this->createRequest('POST', '/password/reset/request', [
+            'X-CSRF-Token' => 'tok',
+        ])
+            ->withAttribute('mailService', $mailer)
+            ->withParsedBody(['username' => 'alice']);
+        $response = $app->handle($request);
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertCount(1, $mailer->sent);
+
+        $link = $mailer->sent[0]['link'];
+        $token = $pdo->query('SELECT token FROM password_resets')->fetchColumn();
+        $this->assertIsString($token);
+        $this->assertStringContainsString($token, $link);
+
+        $confirm = $this->createRequest('POST', '/password/reset/confirm', [
+            'X-CSRF-Token' => 'tok',
+        ])
+            ->withParsedBody(['token' => $token, 'password' => 'newpass']);
+        $resp2 = $app->handle($confirm);
+        $this->assertSame(204, $resp2->getStatusCode());
+
+        $updated = $userService->getByUsername('alice');
+        $this->assertIsArray($updated);
+        $this->assertTrue(password_verify('newpass', (string)$updated['password']));
+    }
+}

--- a/tests/Service/PasswordResetServiceTest.php
+++ b/tests/Service/PasswordResetServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\PasswordResetService;
+use App\Service\UserService;
+use Psr\Log\AbstractLogger;
+use Tests\TestCase;
+
+class ArrayLogger extends AbstractLogger
+{
+    /** @var list<array{level:string,message:string}> */
+    public array $records = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->records[] = ['level' => (string)$level, 'message' => (string)$message];
+    }
+
+    public function has(string $level, string $fragment): bool
+    {
+        foreach ($this->records as $r) {
+            if ($r['level'] === $level && str_contains($r['message'], $fragment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+class PasswordResetServiceTest extends TestCase
+{
+    public function testCreateAndConsumeToken(): void
+    {
+        $pdo = $this->createDatabase();
+        $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
+        $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
+        $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token TEXT NOT NULL, expires_at TEXT NOT NULL)');
+        $users = new UserService($pdo);
+        $users->create('alice', 'secret', 'alice@example.com');
+
+        $logger = new ArrayLogger();
+        $svc = new PasswordResetService($pdo, 3600, $logger);
+        $token = $svc->createToken(1);
+        $this->assertNotEmpty($token);
+        $this->assertTrue($logger->has('info', 'Password reset token created'));
+
+        $userId = $svc->consumeToken($token);
+        $this->assertSame(1, $userId);
+        $this->assertTrue($logger->has('info', 'Password reset token consumed'));
+
+        $this->assertNull($svc->consumeToken($token));
+        $this->assertTrue($logger->has('warning', 'Password reset token not found'));
+    }
+
+    public function testTokenExpires(): void
+    {
+        $pdo = $this->createDatabase();
+        $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
+        $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
+        $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token TEXT NOT NULL, expires_at TEXT NOT NULL)');
+        $users = new UserService($pdo);
+        $users->create('bob', 'secret', 'bob@example.com');
+
+        $logger = new ArrayLogger();
+        $svc = new PasswordResetService($pdo, 3600, $logger);
+        $token = $svc->createToken(1);
+        $pdo->exec("UPDATE password_resets SET expires_at = '2000-01-01 00:00:00'");
+
+        $this->assertNull($svc->consumeToken($token));
+        $this->assertTrue(
+            $logger->has('warning', 'expired') ||
+            $logger->has('warning', 'token not found')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- log password reset token creation/consumption and handle expiry
- tighten rate limiting on password reset endpoints
- cover password reset service and full reset flow with tests

## Testing
- `vendor/bin/phpunit tests/Service/PasswordResetServiceTest.php tests/Controller/PasswordResetFlowTest.php`
- `composer test` *(fails: see log for missing environment and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6890c14c9344832b897d9ff367eac2be