### PR TITLE
Handle invalid QR requests

### DIFF
--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -32,6 +32,16 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
+    public function testQrImageRejectsInvalidSize(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/qr.png')
+            ->withQueryParams(['t' => 'Demo', 's' => '0']);
+        $response = $app->handle($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+    }
+
     public function testQrPdfIsGenerated(): void
     {
         $app = $this->getAppInstance();


### PR DESCRIPTION
## Summary
- validate size and margin for QR images
- guard against builder failures when creating QR codes
- cover invalid size requests with a unit test

## Testing
- `vendor/bin/phpunit tests/Controller/QrControllerTest.php` (fails: Unable to decode input)
- `composer test` (fails: Errors and failures remain)
- `vendor/bin/phpcs src/Controller/QrController.php tests/Controller/QrControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6890cb5e00f4832b8437b68d6945b158