### PR TITLE
fix: ensure logo uploads work across image versions

### DIFF
--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -7,7 +7,6 @@ namespace App\Controller;
 use App\Service\ConfigService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\ImageManager;
 
 /**
@@ -76,7 +75,12 @@ class LogoController
             return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
         }
 
-        $manager = new ImageManager(new Driver());
+        if (method_exists(ImageManager::class, 'gd')) {
+            $manager = ImageManager::gd();
+        } else {
+            // Fallback for intervention/image version 2
+            $manager = new ImageManager(['driver' => 'gd']);
+        }
         $img = $manager->read($file->getStream());
         $img->scaleDown(512, 512);
         $img->save($target, 80);


### PR DESCRIPTION
## Summary
- support Intervention Image v2 and v3 when resizing uploaded logos

## Testing
- `composer test` *(fails: Database error; PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890ccef96a4832b868e104273b2060e