### PR TITLE
Link marketing CTAs to onboarding and catalog view

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -16,8 +16,8 @@
         </blockquote>
         <div class="separator width-100 bottom-border border-2px border-color-gray-light margin-top-bottom-30px uk-width-1-2@s"></div>
         <div class="hero-buttons uk-margin-top">
-          <a class="btn btn-transparent" href="{{ basePath }}/login">Zugang sichern</a>
-          <a class="btn btn-black" href="#contact-us" uk-scroll>Beispiel ansehen</a>
+          <a class="btn btn-transparent" href="{{ basePath }}/onboarding">Zugang sichern</a>
+          <a class="btn btn-black" href="{{ basePath }}/kataloge">Beispiel ansehen</a>
         </div>
       </div>
     </div>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -162,7 +162,7 @@
       </ul>
     {% endblock %}
     {% block right %}
-      <a class="uk-button uk-button-primary" href="{{ basePath }}/login">Kostenlos testen</a>
+      <a class="uk-button uk-button-primary" href="{{ basePath }}/onboarding">Kostenlos testen</a>
     {% endblock %}
     {% block offcanvas %}
     <div id="offcanvas-nav" uk-offcanvas="overlay: true">


### PR DESCRIPTION
## Summary
- Route header "Kostenlos testen" CTA to `/onboarding`
- Update hero buttons: "Zugang sichern" → `/onboarding`, "Beispiel ansehen" → catalog view

## Testing
- `composer test` *(fails: Failed to reload nginx; CatalogServiceTest errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890ce77172c832bb38fb7abede59432