### PR TITLE
Allow PNG, JPG and SVG logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ beschreibbar sein.
 Neben Mandanten-Zertifikaten kann das SSL-Zertifikat der Admin-Domain über einen POST auf `/api/renew-ssl` erneuert werden. Der Aufruf startet den Hauptcontainer neu.
 
 ### Logo hochladen
-Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue PNG- oder WebP-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert. Die Datei landet im Verzeichnis `data/`, damit auch PDFs das Logo einbinden können.
+Das aktuelle Logo wird unter `/logo.png`, `/logo.jpg` oder `/logo.svg` bereitgestellt. Über einen POST auf `/logo` lässt sich eine neue PNG-, JPG- oder SVG-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert. Die Datei landet im Verzeichnis `data/`, damit auch PDFs das Logo einbinden können.
 
 ### Sicherheit und Haftung
 Die Software wird ohne Gewähr bereitgestellt. Alle Rechte liegen bei René Buske. Eine Haftung für Schäden, die aus der Nutzung entstehen, ist ausgeschlossen. Die integrierten Maßnahmen zur Barrierefreiheit verbessern die Zugänglichkeit, sie ersetzen jedoch keine individuelle Prüfung.

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ beschreibbar sein.
 Neben Mandanten-Zertifikaten kann das SSL-Zertifikat der Admin-Domain über einen POST auf `/api/renew-ssl` erneuert werden. Der Aufruf startet den Hauptcontainer neu.
 
 ### Logo hochladen
-Das aktuelle Logo wird unter `/logo.png`, `/logo.jpg` oder `/logo.svg` bereitgestellt. Über einen POST auf `/logo` lässt sich eine neue PNG-, JPG- oder SVG-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert. Die Datei landet im Verzeichnis `data/`, damit auch PDFs das Logo einbinden können.
+Das aktuelle Logo wird unter `/logo.png`, `/logo.jpg`, `/logo.svg` oder `/logo.webp` bereitgestellt. Über einen POST auf `/logo` lässt sich eine neue PNG-, JPG-, SVG- oder WEBP-Datei hochladen. Nach dem Upload wird der Pfad automatisch in `config.json` gespeichert. Die Datei landet im Verzeichnis `data/`, damit auch PDFs das Logo einbinden können.
 
 ### Sicherheit und Haftung
 Die Software wird ohne Gewähr bereitgestellt. Alle Rechte liegen bei René Buske. Eine Haftung für Schäden, die aus der Nutzung entstehen, ist ausgeschlossen. Die integrierten Maßnahmen zur Barrierefreiheit verbessern die Zugänglichkeit, sie ersetzen jedoch keine individuelle Prüfung.

--- a/docs-jtd/konfiguration.md
+++ b/docs-jtd/konfiguration.md
@@ -35,7 +35,7 @@ Alle wesentlichen Optionen stehen in `data/config.json` und werden beim ersten I
 
 Alternativ kann die Variable `DISPLAY_ERROR_DETAILS` in `.env` gesetzt werden.
 
-Das hochgeladene Logo wird in `data/` gespeichert und über `logoPath` referenziert, typischerweise als `/logo.png`, `/logo.jpg` oder `/logo.svg`.
+Das hochgeladene Logo wird in `data/` gespeichert und über `logoPath` referenziert, typischerweise als `/logo.png`, `/logo.jpg`, `/logo.svg` oder `/logo.webp`.
 
 Optional kann `baseUrl` gesetzt werden, um in QR-Codes komplette Links zu erzeugen. `QRRemember` merkt sich gescannte Namen und zeigt den Anmeldedialog nicht erneut an. Der Parameter `competitionMode` verhindert Wiederholungen bereits gelöster Kataloge. Über `teamResults` wird gesteuert, ob Teams ihre Ergebnisse einsehen dürfen, und `photoUpload` aktiviert den Upload von Beweisfotos. `puzzleWordEnabled` schaltet das Rätselwort frei und `puzzleFeedback` definiert den Erfolgshinweis nach der Lösung.
 

--- a/docs-jtd/konfiguration.md
+++ b/docs-jtd/konfiguration.md
@@ -35,7 +35,7 @@ Alle wesentlichen Optionen stehen in `data/config.json` und werden beim ersten I
 
 Alternativ kann die Variable `DISPLAY_ERROR_DETAILS` in `.env` gesetzt werden.
 
-Das hochgeladene Logo wird in `data/` gespeichert und über `logoPath` referenziert, typischerweise als `/logo.png`.
+Das hochgeladene Logo wird in `data/` gespeichert und über `logoPath` referenziert, typischerweise als `/logo.png`, `/logo.jpg` oder `/logo.svg`.
 
 Optional kann `baseUrl` gesetzt werden, um in QR-Codes komplette Links zu erzeugen. `QRRemember` merkt sich gescannte Namen und zeigt den Anmeldedialog nicht erneut an. Der Parameter `competitionMode` verhindert Wiederholungen bereits gelöster Kataloge. Über `teamResults` wird gesteuert, ob Teams ihre Ergebnisse einsehen dürfen, und `photoUpload` aktiviert den Upload von Beweisfotos. `puzzleWordEnabled` schaltet das Rätselwort frei und `puzzleFeedback` definiert den Erfolgshinweis nach der Lösung.
 

--- a/docs-jtd/verwaltung.md
+++ b/docs-jtd/verwaltung.md
@@ -32,7 +32,7 @@ Der Statistik-Tab listet jede Antwort mit Name, Versuch, Katalog, Frage, Antwort
 
 - **Administration:** Über `/export` kann ein JSON-Backup erstellt werden. Eine Wiederherstellung ist per `/import` oder `/backups/{name}/restore` möglich.
   Die Route `/backups` listet vorhandene Sicherungen.
-- **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png`, `/logo.jpg` oder `/logo.svg` bereitgestellt. Über einen POST auf `/logo` lässt sich eine neue Datei hochladen. Das Bild wird dabei im Ordner `data/` gespeichert, sodass PDFs es einbinden können.
+- **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png`, `/logo.jpg`, `/logo.svg` oder `/logo.webp` bereitgestellt. Über einen POST auf `/logo` lässt sich eine neue Datei hochladen. Das Bild wird dabei im Ordner `data/` gespeichert, sodass PDFs es einbinden können.
 - **Ergebnisse exportieren:** Alle Resultate können als CSV-Datei heruntergeladen werden.
 Die API ermöglicht so die komplette Verwaltung eines Quizsystems und ist sowohl lokal als auch im Netzwerk schnell einsatzbereit.
 

--- a/docs-jtd/verwaltung.md
+++ b/docs-jtd/verwaltung.md
@@ -32,7 +32,7 @@ Der Statistik-Tab listet jede Antwort mit Name, Versuch, Katalog, Frage, Antwort
 
 - **Administration:** Über `/export` kann ein JSON-Backup erstellt werden. Eine Wiederherstellung ist per `/import` oder `/backups/{name}/restore` möglich.
   Die Route `/backups` listet vorhandene Sicherungen.
-- **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png` oder `/logo.webp` bereitgestellt. Über einen POST auf diese URLs lässt sich eine neue Datei hochladen. Das Bild wird dabei im Ordner `data/` gespeichert, sodass PDFs es einbinden können.
+- **Logo hochladen:** Das aktuelle Logo wird unter `/logo.png`, `/logo.jpg` oder `/logo.svg` bereitgestellt. Über einen POST auf `/logo` lässt sich eine neue Datei hochladen. Das Bild wird dabei im Ordner `data/` gespeichert, sodass PDFs es einbinden können.
 - **Ergebnisse exportieren:** Alle Resultate können als CSV-Datei heruntergeladen werden.
 Die API ermöglicht so die komplette Verwaltung eines Quizsystems und ist sowohl lokal als auch im Netzwerk schnell einsatzbereit.
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -144,7 +144,7 @@ document.addEventListener('DOMContentLoaded', function () {
     return Object.assign({}, cfgInitial, {
       logoPath: (function () {
         if (cfgFields.logoPreview && cfgFields.logoPreview.src) {
-          const m = cfgFields.logoPreview.src.match(/\/logo(?:-[\w-]+)?\.(png|webp)/);
+          const m = cfgFields.logoPreview.src.match(/\/logo(?:-[\w-]+)?\.(png|jpe?g|svg)/);
           if (m) return m[0];
         }
         return cfgInitial.logoPath;
@@ -273,7 +273,7 @@ document.addEventListener('DOMContentLoaded', function () {
   if (cfgFields.logoFile && cfgFields.logoPreview) {
     const bar = document.getElementById('cfgLogoProgress');
     UIkit.upload('.js-upload', {
-              url: withBase('/logo.png'),
+      url: withBase('/logo'),
       name: 'file',
       multiple: false,
       error: function (e) {
@@ -298,7 +298,11 @@ document.addEventListener('DOMContentLoaded', function () {
           bar.setAttribute('hidden', 'hidden');
         }, 1000);
         const file = cfgFields.logoFile.files && cfgFields.logoFile.files[0];
-        const ext = file && file.name.toLowerCase().endsWith('.webp') ? 'webp' : 'png';
+        let ext = 'png';
+        if (file && file.name) {
+          const m = file.name.toLowerCase().match(/\.([a-z0-9]+)$/);
+          if (m) ext = m[1];
+        }
         cfgInitial.logoPath = '/logo-' + activeEventUid + '.' + ext;
         cfgFields.logoPreview.src = withBase(cfgInitial.logoPath) + '?' + Date.now();
         notify('Logo hochgeladen', 'success');

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -144,7 +144,7 @@ document.addEventListener('DOMContentLoaded', function () {
     return Object.assign({}, cfgInitial, {
       logoPath: (function () {
         if (cfgFields.logoPreview && cfgFields.logoPreview.src) {
-          const m = cfgFields.logoPreview.src.match(/\/logo(?:-[\w-]+)?\.(png|jpe?g|svg)/);
+          const m = cfgFields.logoPreview.src.match(/\/logo(?:-[\w-]+)?\.(png|jpe?g|svg|webp)/);
           if (m) return m[0];
         }
         return cfgInitial.logoPath;
@@ -301,7 +301,7 @@ document.addEventListener('DOMContentLoaded', function () {
         let ext = 'png';
         if (file && file.name) {
           const m = file.name.toLowerCase().match(/\.([a-z0-9]+)$/);
-          if (m) ext = m[1];
+          if (m && ['png', 'jpg', 'jpeg', 'svg', 'webp'].includes(m[1])) ext = m[1];
         }
         cfgInitial.logoPath = '/logo-' + activeEventUid + '.' + ext;
         cfgFields.logoPreview.src = withBase(cfgInitial.logoPath) + '?' + Date.now();

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -49,7 +49,7 @@ return [
     'menu_evaluation' => 'Auswertung',
     'menu_admin' => 'Administration',
     'logout' => 'Abmelden',
-    'tip_logo_upload' => 'PNG-Datei als Logo für die Startseite hochladen.',
+    'tip_logo_upload' => 'PNG-, JPG- oder SVG-Datei als Logo für die Startseite hochladen.',
     'tip_page_title' => 'Text, der im Browser-Tab angezeigt wird.',
     'tip_background_color' => 'CSS-Farbwert für die Seite.',
     'tip_button_color' => 'CSS-Farbwert für alle Buttons.',

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     'help' => 'Hilfe',
     'design_toggle' => 'Design wechseln',
@@ -49,7 +50,7 @@ return [
     'menu_evaluation' => 'Auswertung',
     'menu_admin' => 'Administration',
     'logout' => 'Abmelden',
-    'tip_logo_upload' => 'PNG-, JPG- oder SVG-Datei als Logo für die Startseite hochladen.',
+    'tip_logo_upload' => 'PNG-, JPG-, SVG- oder WEBP-Datei als Logo für die Startseite hochladen.',
     'tip_page_title' => 'Text, der im Browser-Tab angezeigt wird.',
     'tip_background_color' => 'CSS-Farbwert für die Seite.',
     'tip_button_color' => 'CSS-Farbwert für alle Buttons.',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -49,7 +49,7 @@ return [
     'menu_evaluation' => 'Evaluation',
     'menu_admin' => 'Administration',
     'logout' => 'Logout',
-    'tip_logo_upload' => 'Upload PNG logo for start page.',
+    'tip_logo_upload' => 'Upload PNG, JPG or SVG logo for start page.',
     'tip_page_title' => 'Text displayed in the browser tab.',
     'tip_background_color' => 'CSS color for the page.',
     'tip_button_color' => 'CSS color for all buttons.',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     'help' => 'Help',
     'design_toggle' => 'Toggle theme',
@@ -49,7 +50,7 @@ return [
     'menu_evaluation' => 'Evaluation',
     'menu_admin' => 'Administration',
     'logout' => 'Logout',
-    'tip_logo_upload' => 'Upload PNG, JPG or SVG logo for start page.',
+    'tip_logo_upload' => 'Upload PNG, JPG, SVG or WEBP logo for start page.',
     'tip_page_title' => 'Text displayed in the browser tab.',
     'tip_background_color' => 'CSS color for the page.',
     'tip_button_color' => 'CSS color for all buttons.',

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -44,6 +44,7 @@ class LogoController
         $contentType = match ($ext) {
             'jpg', 'jpeg' => 'image/jpeg',
             'svg' => 'image/svg+xml',
+            'webp' => 'image/webp',
             default => 'image/png',
         };
         return $response->withHeader('Content-Type', $contentType);
@@ -67,7 +68,7 @@ class LogoController
         }
 
         $extension = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
-        if (!in_array($extension, ['png', 'jpg', 'jpeg', 'svg'], true)) {
+        if (!in_array($extension, ['png', 'jpg', 'jpeg', 'svg', 'webp'], true)) {
             $response->getBody()->write('unsupported file type');
             return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }

--- a/src/Service/Pdf.php
+++ b/src/Service/Pdf.php
@@ -38,14 +38,18 @@ class Pdf extends Fpdi
         $headerHeight = max(25.0, $qrSize + 5.0);
 
         if (is_file($logoFile) && is_readable($logoFile)) {
-            if (str_ends_with(strtolower($logoFile), '.webp')) {
+            $type = 'PNG';
+            $lower = strtolower($logoFile);
+            if (str_ends_with($lower, '.webp') || str_ends_with($lower, '.svg')) {
                 $manager = ImageManager::gd();
                 $img = $manager->read($logoFile);
                 $logoTemp = tempnam(sys_get_temp_dir(), 'logo') . '.png';
                 $img->save($logoTemp, 80);
                 $logoFile = $logoTemp;
+            } elseif (str_ends_with($lower, '.jpg') || str_ends_with($lower, '.jpeg')) {
+                $type = 'JPG';
             }
-            $this->Image($logoFile, 10, 10, $qrSize, $qrSize, 'PNG');
+            $this->Image($logoFile, 10, 10, $qrSize, $qrSize, $type);
         }
 
         $this->SetXY(10, 10);

--- a/src/routes.php
+++ b/src/routes.php
@@ -460,16 +460,10 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/invites.pdf', function (Request $request, Response $response) {
         return $request->getAttribute('qrController')->pdfAll($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
-    $app->get('/{file:logo(?:-[\w-]+)?\.png}', function (Request $request, Response $response) {
-        return $request->getAttribute('logoController')->get($request->withAttribute('ext', 'png'), $response);
+    $app->get('/{file:logo(?:-[\w-]+)?\.(png|jpe?g|svg)}', function (Request $request, Response $response) {
+        return $request->getAttribute('logoController')->get($request, $response);
     });
-    $app->post('/logo.png', function (Request $request, Response $response) {
-        return $request->getAttribute('logoController')->post($request, $response);
-    })->add(new RoleAuthMiddleware('admin'));
-    $app->get('/{file:logo(?:-[\w-]+)?\.webp}', function (Request $request, Response $response) {
-        return $request->getAttribute('logoController')->get($request->withAttribute('ext', 'webp'), $response);
-    });
-    $app->post('/logo.webp', function (Request $request, Response $response) {
+    $app->post('/logo', function (Request $request, Response $response) {
         return $request->getAttribute('logoController')->post($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -114,7 +114,7 @@
                     <span uk-icon="icon: cloud-upload"></span>
                     <span class="uk-text-middle">{{ t('label_drag_file') }}&nbsp;</span>
                     <div uk-form-custom>
-                      <input type="file" id="cfgLogoFile" accept="image/png,image/jpeg,image/svg+xml">
+                      <input type="file" id="cfgLogoFile" accept="image/png,image/jpeg,image/svg+xml,image/webp">
                       <span class="uk-link">{{ t('action_select') }}</span>
                     </div>
                   </div>

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -114,7 +114,7 @@
                     <span uk-icon="icon: cloud-upload"></span>
                     <span class="uk-text-middle">{{ t('label_drag_file') }}&nbsp;</span>
                     <div uk-form-custom>
-                      <input type="file" id="cfgLogoFile" accept="image/png,image/webp">
+                      <input type="file" id="cfgLogoFile" accept="image/png,image/jpeg,image/svg+xml">
                       <span class="uk-link">{{ t('action_select') }}</span>
                     </div>
                   </div>

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -99,7 +99,7 @@ class QrControllerTest extends TestCase
             filesize($logoFile),
             UPLOAD_ERR_OK
         );
-        $upReq = $this->createRequest('POST', '/logo.png')->withUploadedFiles(['file' => $uploaded]);
+        $upReq = $this->createRequest('POST', '/logo')->withUploadedFiles(['file' => $uploaded]);
         $logo->post($upReq, new Response());
 
         $updated = $qr->pdf($req, new Response());


### PR DESCRIPTION
## Summary
- support PNG, JPG and SVG logo uploads and serve them with proper MIME types
- let admins pick the logo from only the supported formats and update docs/translations
- handle new formats in PDF generation and simplify logo routes

## Testing
- `vendor/bin/phpcs src/Controller/LogoController.php src/Service/Pdf.php src/routes.php tests/Controller/LogoControllerTest.php tests/Controller/QrControllerTest.php`
- `vendor/bin/phpunit tests/Controller/LogoControllerTest.php` *(pass: warnings about configuration)*
- `composer test` *(fails: many Slim Application Errors / test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6890cd6bd8ec832b9c3df448e0b9909f