### PR TITLE
feat: add publish toggle and copy link for events

### DIFF
--- a/migrations/20241014_add_published_flag_to_events.sql
+++ b/migrations/20241014_add_published_flag_to_events.sql
@@ -1,0 +1,2 @@
+ALTER TABLE events ADD COLUMN published BOOLEAN DEFAULT FALSE;
+UPDATE events SET published = TRUE;

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -1,0 +1,31 @@
+const currentScript = document.currentScript;
+const basePath = currentScript ? currentScript.dataset.base || '' : '';
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.toggle-publish').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const uid = btn.dataset.uid;
+      const published = btn.dataset.published === 'true';
+      fetch(`${basePath}/events/${uid}/publish`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ published: !published })
+      }).then((resp) => {
+        if (resp.ok) {
+          btn.dataset.published = (!published).toString();
+          btn.textContent = !published ? 'Nicht veröffentlichen' : 'Veröffentlichen';
+        }
+      });
+    });
+  });
+  document.querySelectorAll('.copy-link').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const link = btn.dataset.link;
+      navigator.clipboard.writeText(link).then(() => {
+        if (typeof UIkit !== 'undefined') {
+          UIkit.notification({ message: 'Link kopiert', status: 'success' });
+        }
+      });
+    });
+  });
+});

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -36,4 +36,19 @@ class EventController
         $this->service->saveAll($data);
         return $response->withStatus(204);
     }
+
+    /**
+     * Set the published state of an event.
+     */
+    public function publish(Request $request, Response $response, array $args): Response
+    {
+        $data = json_decode((string)$request->getBody(), true);
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $uid = (string)($args['uid'] ?? '');
+        $published = (bool)($data['published'] ?? false);
+        $this->service->setPublished($uid, $published);
+        return $response->withStatus(204);
+    }
 }

--- a/src/Controller/EventListController.php
+++ b/src/Controller/EventListController.php
@@ -26,18 +26,19 @@ class EventListController
         }
         $eventSvc = new EventService($pdo);
         $cfgSvc = new ConfigService($pdo);
-        $events = $eventSvc->getAll();
-        $cfg = $cfgSvc->getConfig();
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
         }
         $role = $_SESSION['user']['role'] ?? null;
+        $events = $eventSvc->getAll(!in_array($role, ['admin', 'event-manager'], true));
+        $cfg = $cfgSvc->getConfig();
         if ($role !== 'admin') {
             $cfg = ConfigService::removePuzzleInfo($cfg);
         }
         return $view->render($response, 'events_overview.twig', [
             'events' => $events,
             'config' => $cfg,
+            'role' => $role,
         ]);
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -349,6 +349,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/events.json', function (Request $request, Response $response) {
         return $request->getAttribute('eventController')->post($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
+    $app->post('/events/{uid}/publish', function (Request $request, Response $response, array $args) {
+        return $request->getAttribute('eventController')->publish($request, $response, $args);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
 
     $app->post('/tenants', function (Request $request, Response $response) {
         if ($request->getAttribute('domainType') !== 'main') {

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -33,10 +33,22 @@
     <div class="uk-grid-match uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m" uk-grid>
       {% for ev in events %}
       <div>
-        <a href="{{ basePath }}/?event={{ ev.uid }}" class="uk-card uk-card-default uk-card-hover uk-card-body uk-display-block uk-link-toggle">
-          <h3 class="uk-card-title">{{ ev.name }}</h3>
-          {% if ev.description %}<p>{{ ev.description }}</p>{% endif %}
-        </a>
+        <div class="uk-card uk-card-default uk-card-hover">
+          <div class="uk-card-body">
+            <a href="{{ basePath }}/?event={{ ev.uid }}" class="uk-link-toggle">
+              <h3 class="uk-card-title">{{ ev.name }}</h3>
+              {% if ev.description %}<p>{{ ev.description }}</p>{% endif %}
+            </a>
+          </div>
+          <div class="uk-card-footer">
+            {% if role in ['admin','event-manager'] %}
+            <button class="uk-button uk-button-primary toggle-publish" data-uid="{{ ev.uid }}" data-published="{{ ev.published ? 'true' : 'false' }}">
+              {{ ev.published ? 'Nicht veröffentlichen' : 'Veröffentlichen' }}
+            </button>
+            {% endif %}
+            <button class="uk-button uk-button-default copy-link" data-link="{{ basePath }}/?event={{ ev.uid }}">Link kopieren</button>
+          </div>
+        </div>
       </div>
       {% endfor %}
     </div>
@@ -46,4 +58,5 @@
 {% block scripts %}
   <script src="{{ basePath }}/js/custom-icons.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
+  <script src="{{ basePath }}/js/events.js" data-base="{{ basePath }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `published` flag for events with migration and service logic
- expose publish toggle and link copying on events overview page
- provide API endpoint and JS handlers for publishing events

## Testing
- `composer test` *(fails: Slim Application Error; Database error: fail; Error creating tenant: boom; Failed to reload nginx: reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_6890cef72258832b90a3e6341787c244