### PR TITLE
Fix password reset link

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -52,6 +52,7 @@ use App\Controller\TenantController;
 use App\Controller\Marketing\LandingController;
 use App\Controller\RegisterController;
 use App\Controller\OnboardingController;
+use Slim\Views\Twig;
 use GuzzleHttp\Client;
 use Psr\Log\NullLogger;
 use App\Controller\BackupController;
@@ -230,6 +231,15 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/login', [LoginController::class, 'login']);
     $app->get('/register', [RegisterController::class, 'show']);
     $app->post('/register', [RegisterController::class, 'register']);
+    $app->get('/password/reset/request', function (Request $request, Response $response) {
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'password_request.twig');
+    });
+    $app->get('/password/reset', function (Request $request, Response $response) {
+        $view = Twig::fromRequest($request);
+        $token = (string) ($request->getQueryParams()['token'] ?? '');
+        return $view->render($response, 'password_confirm.twig', ['token' => $token]);
+    });
     $app->get('/logout', LogoutController::class);
     $app->get('/admin', function (Request $request, Response $response) {
         $base = \Slim\Routing\RouteContext::fromRequest($request)->getBasePath();

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -54,7 +54,7 @@
               <button class="uk-button uk-button-primary uk-button-large uk-width-1-1">Login</button>
             </div>
             <div class="uk-margin uk-text-center">
-              <a href="{{ basePath }}/password/request">Passwort vergessen?</a>
+              <a href="{{ basePath }}/password/reset/request">Passwort vergessen?</a>
             </div>
             {% if registration_allowed %}
             <div class="uk-margin uk-text-center">

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -37,7 +37,8 @@
           <p>Passwort konnte nicht geändert werden.</p>
         </div>
         {% endif %}
-        <form method="post" action="/password/confirm">
+        <form method="post" action="/password/reset/confirm">
+          <input type="hidden" name="token" value="{{ token }}">
           <div class="uk-margin">
             <div class="uk-inline uk-width-1-1">
               <span class="uk-form-icon" uk-icon="icon: lock"></span>

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -37,7 +37,7 @@
           <p>Anfrage fehlgeschlagen.</p>
         </div>
         {% endif %}
-        <form method="post" action="/password/request">
+        <form method="post" action="/password/reset/request">
           <div class="uk-margin">
             <div class="uk-inline uk-width-1-1">
               <span class="uk-form-icon" uk-icon="icon: mail"></span>


### PR DESCRIPTION
## Summary
- route password reset pages so the reset link no longer 404s
- update password reset templates to use correct routes and include token

## Testing
- `composer test` *(fails: Database error: fail, Failed asserting that two strings are identical)*

------
https://chatgpt.com/codex/tasks/task_e_6890cfc8c854832ba370e96e6eab938f