### PR TITLE
Fix QR code generation when GD missing and serve default logo

### DIFF
--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -31,16 +31,26 @@ class LogoController
     {
         $cfg = $this->config->getConfig();
         $relPath = $cfg['logoPath'] ?? '';
-        if ($relPath === '') {
-            return $response->withStatus(404);
+        $path = '';
+        $contentType = 'image/png';
+
+        if ($relPath !== '') {
+            $path = __DIR__ . '/../../data' . $relPath;
+            if (file_exists($path)) {
+                $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+                $contentType = $ext === 'webp' ? 'image/webp' : 'image/png';
+            } else {
+                $path = '';
+            }
         }
-        $path = __DIR__ . '/../../data' . $relPath;
-        if (!file_exists($path)) {
-            return $response->withStatus(404);
+
+        // Fallback to the public favicon when no custom logo is available.
+        if ($path === '') {
+            $path = __DIR__ . '/../../public/favicon.svg';
+            $contentType = 'image/svg+xml';
         }
-        $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-        $response->getBody()->write((string)file_get_contents($path));
-        $contentType = $ext === 'webp' ? 'image/webp' : 'image/png';
+
+        $response->getBody()->write((string) file_get_contents($path));
         return $response->withHeader('Content-Type', $contentType);
     }
 

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -79,11 +79,15 @@ class QrController
             return $response->withStatus(400);
         }
 
-        $writer = new PngWriter();
+        // Use PNG output when the GD extension is available, otherwise
+        // gracefully fall back to SVG to avoid runtime errors on systems
+        // without the required image libraries.
+        $writer = extension_loaded('gd') ? new PngWriter() : new SvgWriter();
         if ($demo === 'svg' || $demo === 'svg-clean') {
             $writer = new SvgWriter();
         } elseif ($demo === 'webp') {
-            $writer = new WebPWriter();
+            // Generating WebP also requires GD; use SVG when it is missing.
+            $writer = extension_loaded('gd') ? new WebPWriter() : new SvgWriter();
         }
 
         $writerOptions = [];

--- a/tests/Controller/LogoControllerTest.php
+++ b/tests/Controller/LogoControllerTest.php
@@ -13,7 +13,7 @@ use Slim\Psr7\Stream;
 
 class LogoControllerTest extends TestCase
 {
-    public function testGetNotFound(): void
+    public function testGetFallbackLogo(): void
     {
         $pdo = $this->createDatabase();
         $cfg = new ConfigService($pdo);
@@ -23,7 +23,9 @@ class LogoControllerTest extends TestCase
         $request = $this->createRequest('GET', '/logo.png');
         $response = $controller->get($request, new Response());
 
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('image/svg+xml', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
         @rename(dirname(__DIR__, 2) . '/data/logo.png.bak', dirname(__DIR__, 2) . '/data/logo.png');
         @rename(dirname(__DIR__, 2) . '/data/logo.webp.bak', dirname(__DIR__, 2) . '/data/logo.webp');
     }


### PR DESCRIPTION
## Summary
- Gracefully fall back to SVG QR codes when GD/WebP support is unavailable
- Serve favicon as default logo instead of 404
- Adjust LogoController tests for new fallback behavior

## Testing
- `composer test` *(fails: Slim Application Error, CatalogService assertions, etc.)*
- `vendor/bin/phpunit tests/Controller/LogoControllerTest.php tests/Controller/QrControllerTest.php` *(fails: Intervention\Image\Exceptions\DecoderException)*

------
https://chatgpt.com/codex/tasks/task_e_6890d27c3680832bac2970b6659e0613