### PR TITLE
Fix evidence photo uploads by handling missing ImageManager::gd method

### DIFF
--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -92,7 +92,11 @@ class EvidenceController
         $tmpPath = tempnam(sys_get_temp_dir(), 'upload_');
         $file->moveTo($tmpPath);
 
-        $manager = ImageManager::gd();
+        if (method_exists(ImageManager::class, 'gd')) {
+            $manager = ImageManager::gd();
+        } else {
+            $manager = new ImageManager(['driver' => 'gd']);
+        }
         $img = $manager->read($tmpPath);
         $orientationHandled = false;
         if (function_exists('exif_read_data')) {

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -339,7 +339,11 @@ class ResultController
                 if (is_readable($file)) {
                     $tmp = null;
                     if (str_ends_with(strtolower($file), '.webp')) {
-                        $manager = ImageManager::gd();
+                        if (method_exists(ImageManager::class, 'gd')) {
+                            $manager = ImageManager::gd();
+                        } else {
+                            $manager = new ImageManager(['driver' => 'gd']);
+                        }
                         $img = $manager->read($file);
                         $tmp = tempnam(sys_get_temp_dir(), 'photo') . '.png';
                         $img->save($tmp, 80);

--- a/src/Service/Pdf.php
+++ b/src/Service/Pdf.php
@@ -39,7 +39,11 @@ class Pdf extends Fpdi
 
         if (is_file($logoFile) && is_readable($logoFile)) {
             if (str_ends_with(strtolower($logoFile), '.webp')) {
-                $manager = ImageManager::gd();
+                if (method_exists(ImageManager::class, 'gd')) {
+                    $manager = ImageManager::gd();
+                } else {
+                    $manager = new ImageManager(['driver' => 'gd']);
+                }
                 $img = $manager->read($logoFile);
                 $logoTemp = tempnam(sys_get_temp_dir(), 'logo') . '.png';
                 $img->save($logoTemp, 80);


### PR DESCRIPTION
## Summary
- ensure evidence upload supports older Intervention\Image versions by checking for missing `gd` method
- apply same fallback in PDF generation and result export when converting WebP images

## Testing
- `composer test` *(fails: Database error: fail; Error creating tenant: boom; Failed to reload nginx; Tests: 133, Assertions: 245, Errors: 13, Failures: 3, Warnings: 2, PHPUnit Deprecations: 1, Notices: 7)*
- `vendor/bin/phpcs src/Controller/EvidenceController.php src/Service/Pdf.php src/Controller/ResultController.php`


------
https://chatgpt.com/codex/tasks/task_e_6890d45a4368832b86562c099408a655