### PR TITLE
Improve mobile layout of landing page hero

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -5,20 +5,18 @@
     <div class="uk-grid uk-flex-middle" uk-grid>
       <div class="uk-width-1-1 uk-width-3-4@m">
         <div class="hero-text">
-          <h2 class="hero-title">
+          <h2 class="hero-headline">
             Professionelles Quiz-Hosting für<br class="uk-hidden@s"> Unternehmen & Teams
           </h2>
-          <blockquote class="hero-blockquote uk-width-large@m uk-margin-remove-top">
+          <p class="hero-subtext">
             Das einzige deutschsprachige Event-Quiz mit<br>
-            <b>datensicherem Hosting, Live-Auswertung & flexiblen Einsatzmöglichkeiten</b> – sofort starten!
-            <footer class="el-footer" style="color:#fff; font-size:1.05rem; font-weight:400; margin-top:10px;">
-              by René Buske
-            </footer>
-          </blockquote>
+            <strong>datensicherem Hosting, Live-Auswertung</strong><br>
+            &amp; <strong>flexiblen Einsatzmöglichkeiten</strong> – sofort starten!
+          </p>
         </div>
         <div class="separator width-100 bottom-border border-2px border-color-gray-light margin-top-bottom-30px uk-width-1-2@s"></div>
         <div class="hero-buttons uk-margin-top">
-          <a class="btn btn-transparent" href="{{ basePath }}/onboarding">Zugang sichern</a>
+          <a class="cta-main" href="{{ basePath }}/onboarding">Zugang sichern</a>
           <a class="btn btn-black" href="{{ basePath }}/kataloge">Beispiel ansehen</a>
         </div>
       </div>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -38,28 +38,25 @@
     }
     @media (max-width: 640px) {
       .hero-content { padding: 40px 0 30px 0; }
-      .hero-title { font-size: 2.2rem !important; }
-      .hero-blockquote { font-size: 1.1rem !important; }
     }
-    .hero-title {
+    .hero-headline {
+      font-size: clamp(1.4rem, 5vw, 2rem);
+      line-height: 1.3;
+      text-align: center;
+      margin-bottom: 0.75rem;
       color: #fff;
       font-family: 'Poppins',sans-serif;
       font-weight: 800;
-      font-size: 2.6rem;
-      line-height: 1.3;
-      margin-bottom: 18px;
-      letter-spacing: -1.5px;
     }
-    .hero-blockquote {
+    .hero-subtext {
       color: #fff;
-      font-size: 1.2rem;
+      font-size: 1.1rem;
       font-weight: 400;
-      font-family: 'Roboto',sans-serif;
-      border-left: 4px solid #fff3;
-      margin-bottom: 32px;
-      margin-left: 0;
-      padding-left: 18px;
       line-height: 1.4;
+      margin-bottom: 2rem;
+    }
+    .hero-subtext strong {
+      font-weight: 700;
     }
     .hero-buttons .btn {
       font-size: 1.07rem;
@@ -68,16 +65,6 @@
       padding: 0.8em 2em;
       border-radius: 3px;
       font-family: 'Poppins',sans-serif;
-    }
-    .btn-transparent {
-      background: rgba(255,255,255,0.12) !important;
-      color: #fff !important;
-      border: 2px solid #fff;
-      transition: all 0.18s;
-    }
-    .btn-transparent:hover {
-      background: #fff !important;
-      color: #0c86d0 !important;
     }
     .btn-black {
       background: #232323 !important;
@@ -148,6 +135,7 @@
     .topbar {
       padding: 0.75rem 1rem;
       flex-wrap: nowrap;
+      position: relative;
     }
     .topbar .uk-navbar-left {
       padding-left: 0.5rem;
@@ -168,16 +156,18 @@
         display: none;
       }
     }
-    .topbar .uk-button-primary {
-      font-size: 0.875rem;
+    .top-cta {
+      position: absolute;
+      right: 1rem;
+      top: 1rem;
       padding: 0.5rem 0.75rem;
-      border-radius: 6px;
-      white-space: nowrap;
+      font-size: 0.875rem;
     }
     @media (max-width: 480px) {
-      .topbar .uk-button-primary {
-        font-size: 0.7rem;
-        padding: 0.4rem 0.5rem;
+      .top-cta {
+        position: static;
+        display: block;
+        margin: 1rem auto;
       }
     }
 
@@ -187,11 +177,6 @@
       max-width: 90%;
       margin: 0 auto;
       text-align: center;
-    }
-    @media (max-width: 480px) {
-      .hero-text .hero-title {
-        font-size: 1.8rem;
-      }
     }
     .hero-buttons {
       display: flex;
@@ -211,6 +196,27 @@
     .hero-overlay {
       z-index: 0;
     }
+    .cta-main {
+      display: block;
+      width: 100%;
+      max-width: 320px;
+      margin: 1rem auto 2rem;
+      font-size: 1rem;
+      padding: 0.75rem;
+      background: #007bff;
+      color: #fff;
+      border-radius: 8px;
+      text-align: center;
+    }
+    .bottombar {
+      padding-top: 2rem;
+      font-size: 0.8rem;
+      color: #aaa;
+      background-color: #f9f9f9;
+    }
+    .bottombar a {
+      color: #aaa;
+    }
   </style>
 {% endblock %}
 
@@ -228,7 +234,7 @@
       </ul>
     {% endblock %}
     {% block right %}
-      <a class="uk-button uk-button-primary" href="{{ basePath }}/onboarding">Kostenlos testen</a>
+      <a class="uk-button uk-button-primary top-cta" href="{{ basePath }}/onboarding">Kostenlos testen</a>
     {% endblock %}
     {% block offcanvas %}
     <div id="offcanvas-nav" uk-offcanvas="overlay: true">


### PR DESCRIPTION
## Summary
- Add responsive hero headline and simplified subtext
- Center "Kostenlos testen" button on mobile and style primary CTA
- Lighten footer nav styling for clearer separation

## Testing
- `composer test` *(fails: Tests: 133, Assertions: 247, Errors: 13, Failures: 3)*

------
https://chatgpt.com/codex/tasks/task_e_68925d62c710832b8af70df5935eb165