### PR TITLE
Align topbar elements and slim footer

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -1,5 +1,5 @@
 <!-- HERO / HEADER -->
-<section class="hero-bg-quizrace uk-section uk-flex uk-flex-middle" style="min-height:70vh; position:relative;">
+<section class="hero-bg-quizrace uk-section uk-padding-remove-top uk-flex uk-flex-middle" style="min-height:70vh; position:relative;">
   <div class="hero-overlay"></div>
   <div class="uk-container hero-content">
     <div class="uk-grid uk-flex-middle" uk-grid>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -120,6 +120,7 @@ body.uk-padding {
   padding-bottom: 0;
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 .topbar .uk-navbar-center {
   flex: 1;
@@ -162,7 +163,7 @@ body.uk-padding {
 
 /* Footer item alignment */
 .bottombar .uk-navbar-item > a {
-  min-height: 38px;
+  min-height: 28px;
   padding-top: 0;
   padding-bottom: 0;
   display: flex;
@@ -171,13 +172,13 @@ body.uk-padding {
 
 /* Footer link height */
 .bottombar .uk-navbar-nav > li > a {
-  min-height: 38px;
+  min-height: 28px;
   padding-top: 0;
   padding-bottom: 0;
 }
 
 .footer-placeholder {
-  height: calc(38px + env(safe-area-inset-bottom));
+  height: calc(28px + env(safe-area-inset-bottom));
 }
 
 @keyframes fadeIn {
@@ -222,13 +223,13 @@ a.uk-accordion-title {
     padding-right: 8px;
   }
   .bottombar .uk-navbar-nav > li > a {
-    min-height: 38px;
+    min-height: 28px;
   }
   .bottombar .uk-navbar-item > a {
-    min-height: 38px;
+    min-height: 28px;
   }
   .footer-placeholder {
-    height: calc(38px + env(safe-area-inset-bottom));
+    height: calc(28px + env(safe-area-inset-bottom));
   }
 }
 

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -58,12 +58,12 @@
     .hero-subtext strong {
       font-weight: 700;
     }
-    .hero-buttons .btn {
-      font-size: 1.07rem;
+    .btn {
+      font-size: 1rem;
       font-weight: 500;
       letter-spacing: .04em;
-      padding: 0.8em 2em;
-      border-radius: 3px;
+      padding: 0.75rem 1.5rem;
+      border-radius: 8px;
       font-family: 'Poppins',sans-serif;
     }
     .btn-black {
@@ -147,6 +147,9 @@
     .topbar .uk-navbar-toggle {
       width: 44px;
       height: 56px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
     .topbar .uk-navbar-toggle-icon {
       width: 24px;
@@ -157,19 +160,29 @@
         display: none;
       }
     }
-    .top-cta {
-      position: absolute;
-      right: 1rem;
-      top: 1rem;
-      padding: 0.5rem 0.75rem;
-      font-size: 0.875rem;
+    .top-cta,
+    .cta-main {
+      background: #007bff;
+      color: #fff;
+      border-radius: 8px;
+      font-family: 'Poppins',sans-serif;
+      font-weight: 500;
+      text-align: center;
+      letter-spacing: .04em;
     }
-    @media (max-width: 480px) {
-      .top-cta {
-        position: static;
-        display: block;
-        margin: 1rem auto;
-      }
+    .top-cta {
+      padding: 0.4rem 0.75rem;
+      font-size: 0.875rem;
+      white-space: nowrap;
+      display: inline-block;
+    }
+    .cta-main {
+      display: block;
+      width: 100%;
+      max-width: 320px;
+      margin: 1rem auto 2rem;
+      font-size: 1rem;
+      padding: 0.75rem;
     }
 
     /* Hero text & buttons */
@@ -197,20 +210,9 @@
     .hero-overlay {
       z-index: 0;
     }
-    .cta-main {
-      display: block;
-      width: 100%;
-      max-width: 320px;
-      margin: 1rem auto 2rem;
-      font-size: 1rem;
-      padding: 0.75rem;
-      background: #007bff;
-      color: #fff;
-      border-radius: 8px;
-      text-align: center;
-    }
     .bottombar {
-      padding-top: 2rem;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
       font-size: 0.8rem;
       color: #aaa;
       background-color: #f9f9f9;
@@ -235,8 +237,9 @@
       </ul>
     {% endblock %}
     {% block right %}
-      <a class="uk-button uk-button-primary top-cta" href="{{ basePath }}/onboarding">Kostenlos testen</a>
+      <a class="top-cta" href="{{ basePath }}/onboarding">Kostenlos testen</a>
     {% endblock %}
+    {% block nav_placeholder %}{% endblock %}
     {% block offcanvas %}
     <div id="offcanvas-nav" uk-offcanvas="overlay: true">
       <div class="uk-offcanvas-bar">

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -33,4 +33,6 @@
 </div>
 {% endblock %}
 {% block headerbar %}{% endblock %}
+{% block nav_placeholder %}
 <div class="nav-placeholder"></div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- streamline topbar by centering menu toggle and making the call-to-action button share hero styling
- remove spacing between topbar and hero and tighten footer spacing

## Testing
- `composer test` *(fails: Tests: 133, Assertions: 247, Errors: 13, Failures: 3)*

------
https://chatgpt.com/codex/tasks/task_e_6892bb97d58c832bb9edb4a281fa73f4