### PR TITLE
fix: prevent landing page header overlap on mobile

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -136,7 +136,6 @@
       height: 56px;
       padding: 0 1rem;
       flex-wrap: nowrap;
-      position: relative;
     }
     .topbar .uk-navbar-left {
       padding-left: 0.5rem;
@@ -239,7 +238,6 @@
     {% block right %}
       <a class="top-cta" href="{{ basePath }}/onboarding">Kostenlos testen</a>
     {% endblock %}
-    {% block nav_placeholder %}{% endblock %}
     {% block offcanvas %}
     <div id="offcanvas-nav" uk-offcanvas="overlay: true">
       <div class="uk-offcanvas-bar">


### PR DESCRIPTION
## Summary
- ensure landing navbar uses fixed positioning
- rely on default nav placeholder to keep content from slipping under the header

## Testing
- `composer test` *(fails: Database error)*

------
https://chatgpt.com/codex/tasks/task_e_6892bef78b80832b82a91b772c4b8d8e