### PR TITLE
Fix logo overflow on landing page

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -158,6 +158,15 @@
       width: 24px;
       height: 24px;
     }
+    .topbar .uk-logo {
+      font-size: 1.25rem;
+      padding: 0;
+    }
+    @media (max-width: 640px) {
+      .topbar .uk-logo {
+        font-size: 1rem;
+      }
+    }
     @media (max-width: 959px) {
       .topbar .uk-navbar-center {
         display: none;
@@ -226,8 +235,8 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a class="uk-navbar-item uk-logo" href="{{ basePath }}/landing">QuizRace</a>
-    {% endblock %}
+      <a class="uk-logo" href="{{ basePath }}/landing">QuizRace</a>
+      {% endblock %}
     {% block center %}
       <ul class="uk-navbar-nav uk-visible@m">
         <li><a href="#features">Features</a></li>


### PR DESCRIPTION
## Summary
- shrink landing page logo in top bar to prevent overflow on mobile
- remove redundant navbar item class from logo link

## Testing
- `composer test` *(fails: SQLSTATE[HY000] no such column: published)*

------
https://chatgpt.com/codex/tasks/task_e_6892c185f2d4832b8dfce9ab57abeb41