### PR TITLE
Reduce landing page footer height

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -225,6 +225,14 @@
     .bottombar {
       padding-top: 0;
       padding-bottom: 0;
+      min-height: 24px;
+    }
+    .bottombar .uk-navbar-item > a,
+    .bottombar .uk-navbar-nav > li > a {
+      min-height: 24px;
+    }
+    .footer-placeholder {
+      height: calc(24px + env(safe-area-inset-bottom));
     }
     .bottombar a {
       color: inherit;


### PR DESCRIPTION
## Summary
- lower footer height on marketing landing page to 24px and adjust placeholder spacing

## Testing
- `composer test` *(fails: Slim Application Error, Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_6892c3666d20832ba738375681eafc1c