### PR TITLE
Enlarge hamburger menu link size

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -277,7 +277,7 @@
     {% block offcanvas %}
     <div id="offcanvas-nav" uk-offcanvas="overlay: true">
       <div class="uk-offcanvas-bar">
-        <ul class="uk-nav uk-nav-default">
+        <ul class="uk-nav uk-nav-primary">
           <li><a href="#features">Features</a></li>
           <li><a href="#pricing">Preise</a></li>
           <li><a href="#contact-us">Kontakt</a></li>

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -23,7 +23,7 @@
 {% block offcanvas %}
 <div id="offcanvas-nav" uk-offcanvas="overlay: true">
   <div class="uk-offcanvas-bar">
-    <ul class="uk-nav uk-nav-default">
+    <ul class="uk-nav uk-nav-primary">
       <li><a href="#features">Features</a></li>
       <li><a href="{{ basePath }}/pricing">Preise</a></li>
       <li><a href="#contact">Kontakt</a></li>


### PR DESCRIPTION
## Summary
- Use UIkit's primary nav style for offcanvas menus to make hamburger links larger

## Testing
- `composer test` *(fails: Errors: 13, Failures: 3)*

------
https://chatgpt.com/codex/tasks/task_e_6892ca983404832b91d4cf4451fee9ec