### PR TITLE
Reduce mobile spacing between hero buttons

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -199,7 +199,7 @@
       display: block;
       width: 100%;
       max-width: 320px;
-      margin: 1rem auto 2rem;
+      margin: 0;
       font-size: 1rem;
       padding: 0.75rem;
     }
@@ -208,7 +208,7 @@
       display: block;
       width: 100%;
       max-width: 320px;
-      margin: 1rem auto 2rem;
+      margin: 0;
       font-size: 1rem;
       padding: 0.75rem;
       text-align: center;
@@ -224,9 +224,10 @@
     .hero-buttons {
       display: flex;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.25rem;
       align-items: center;
       margin-top: 1rem;
+      margin-bottom: 2rem;
       position: relative;
       z-index: 1;
     }
@@ -234,6 +235,12 @@
       .hero-buttons {
         flex-direction: row;
         justify-content: center;
+        gap: 0.5rem;
+        margin-bottom: 0;
+      }
+      .cta-main,
+      .hero-buttons .btn {
+        margin: 1rem auto 2rem;
       }
     }
     .hero-overlay {


### PR DESCRIPTION
## Summary
- Tighten spacing between "Zugang sichern" and "Beispiel ansehen" buttons for mobile screens
- Preserve original desktop layout via media query adjustments

## Testing
- `composer test` *(fails: Tests: 133, Assertions: 247, Errors: 13, Failures: 3)*

------
https://chatgpt.com/codex/tasks/task_e_6892cb53e238832bb47215dbafef02d2