### PR TITLE
Make landing page footer non-sticky

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -152,12 +152,9 @@ body.uk-padding {
 }
 
 .bottombar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
+  position: static;
   width: 100%;
-  z-index: 1000;
-  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: 0;
 }
 
 .bottombar .uk-navbar-item {
@@ -186,7 +183,11 @@ body.uk-padding {
 }
 
 .footer-placeholder {
-  height: calc(28px + env(safe-area-inset-bottom));
+  display: none;
+}
+
+.bottombar a {
+  color: inherit;
 }
 
 @keyframes fadeIn {
@@ -237,7 +238,7 @@ a.uk-accordion-title {
     min-height: 28px;
   }
   .footer-placeholder {
-    height: calc(28px + env(safe-area-inset-bottom));
+    display: none;
   }
 }
 

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -238,21 +238,6 @@
     .hero-overlay {
       z-index: 0;
     }
-    .bottombar {
-      padding-top: 0;
-      padding-bottom: 0;
-      min-height: 24px;
-    }
-    .bottombar .uk-navbar-item > a,
-    .bottombar .uk-navbar-nav > li > a {
-      min-height: 24px;
-    }
-    .footer-placeholder {
-      height: calc(24px + env(safe-area-inset-bottom));
-    }
-    .bottombar a {
-      color: inherit;
-    }
   </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Move bottom bar to normal document flow so footer appears after page content
- Remove unused footer placeholder and landing page overrides

## Testing
- `composer test` (fails: Database error: fail; Error creating tenant: boom; Failed to reload nginx; Tests: 133, Assertions: 247, Errors: 13, Failures: 3, Warnings: 2)


------
https://chatgpt.com/codex/tasks/task_e_6892c763b350832b834bd27f87f68d3c