### PR TITLE
fix: render footer menu at page bottom

### DIFF
--- a/public/Impressum.html
+++ b/public/Impressum.html
@@ -9,48 +9,43 @@
   <link rel="stylesheet" href="/css/dark.css">
 </head>
 <body class="uk-padding uk-background-muted">
-  <h1>Impressum</h1>
-  <p>Angaben gemäß § 5 TMG</p>
-  <p>[NAME]<br>
-  [STREET]<br>
-  [ZIP] [CITY]<br>
-  Deutschland</p>
-  <p>E-Mail: <a href="mailto:[EMAIL]">[EMAIL]</a></p>
+  <div class="wrapper">
+    <main class="content">
+      <h1>Impressum</h1>
+      <p>Angaben gemäß § 5 TMG</p>
+      <p>[NAME]<br>
+      [STREET]<br>
+      [ZIP] [CITY]<br>
+      Deutschland</p>
+      <p>E-Mail: <a href="mailto:[EMAIL]">[EMAIL]</a></p>
 
-  <p><strong>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:</strong><br>
-  [NAME]<br>
-  [STREET]<br>
-  [ZIP] [CITY]</p>
+      <p><strong>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:</strong><br>
+      [NAME]<br>
+      [STREET]<br>
+      [ZIP] [CITY]</p>
 
-  <p>Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz: DE 259645623</p>
+      <p>Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz: DE 259645623</p>
 
-  <h2>Haftungsausschluss</h2>
-  <p>Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung für die Inhalte externer Links. Für den Inhalt der verlinkten Seiten sind ausschließlich deren Betreiber verantwortlich.</p>
+      <h2>Haftungsausschluss</h2>
+      <p>Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung für die Inhalte externer Links. Für den Inhalt der verlinkten Seiten sind ausschließlich deren Betreiber verantwortlich.</p>
 
-  <h2>Urheberrecht</h2>
-  <p>Die durch den Seitenbetreiber erstellten Inhalte und Werke auf dieser Website unterliegen dem deutschen Urheberrecht. Beiträge Dritter sind als solche gekennzeichnet.</p>
+      <h2>Urheberrecht</h2>
+      <p>Die durch den Seitenbetreiber erstellten Inhalte und Werke auf dieser Website unterliegen dem deutschen Urheberrecht. Beiträge Dritter sind als solche gekennzeichnet.</p>
 
-  <h2>Quellcode</h2>
-  <p>Der Quellcode dieser Anwendung ist unter der MIT-Lizenz auf GitHub verfügbar:<br>
-  <a href="https://github.com/bastelix/sommerfest-quiz">https://github.com/bastelix/sommerfest-quiz</a></p>
-
-  <div class="footer-placeholder"></div>
-  <nav class="uk-navbar-container bottombar" uk-navbar>
-    <div class="uk-navbar-left">
-      <ul class="uk-navbar-nav">
-        <li>
-          <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="book" uk-tooltip="title: Handbuch öffnen" aria-label="Handbuch"></a>
-        </li>
-      </ul>
-    </div>
-    <div class="uk-navbar-center">
-      <ul class="uk-navbar-nav">
-        <li><a href="Datenschutz.html">Datenschutz</a></li>
-        <li><a href="Impressum.html">Impressum</a></li>
-        <li><a href="Lizenz.html">Lizenz</a></li>
-      </ul>
-    </div>
-  </nav>
+      <h2>Quellcode</h2>
+      <p>Der Quellcode dieser Anwendung ist unter der MIT-Lizenz auf GitHub verfügbar:<br>
+      <a href="https://github.com/bastelix/sommerfest-quiz">https://github.com/bastelix/sommerfest-quiz</a></p>
+    </main>
+    <footer class="site-footer">
+      <nav class="footer-menu">
+        <ul>
+          <li><a href="Datenschutz.html">Datenschutz</a></li>
+          <li><a href="Impressum.html">Impressum</a></li>
+          <li><a href="Lizenz.html">Lizenz</a></li>
+        </ul>
+      </nav>
+    </footer>
+  </div>
   <script src="/js/uikit.min.js"></script>
 </body>
 </html>

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -105,7 +105,7 @@ body.dark-mode .uk-icon-button {
   color: #f5f5f5;
 }
 
-body.dark-mode .bottombar {
+body.dark-mode .site-footer {
   background-color: #1e1e1e;
   border-color: #444;
   padding-bottom: env(safe-area-inset-bottom);

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,3 +1,8 @@
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
 body {
   min-height: 100vh;
   overflow-x: hidden;
@@ -9,6 +14,37 @@ body.uk-padding {
 
 .index-page {
   padding-top: 56px;
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.content {
+  flex: 1;
+}
+
+.site-footer {
+  background-color: #222;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+
+.footer-menu ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+}
+
+.footer-menu a {
+  color: #fff;
+  text-decoration: none;
 }
 
 .sortable-list li,
@@ -151,57 +187,6 @@ body.uk-padding {
   line-height: 1.2;
 }
 
-.bottombar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  padding-bottom: env(safe-area-inset-bottom);
-  z-index: 1000;
-}
-
-.footer-placeholder {
-  height: 56px;
-}
-
-body.landing-page .bottombar {
-  position: static;
-  padding-bottom: 0;
-}
-
-body.landing-page .footer-placeholder {
-  display: none;
-}
-
-body.landing-page .bottombar .uk-navbar-item {
-  margin-left: 0;
-  margin-right: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-  display: flex;
-  align-items: center;
-}
-
-/* Footer item alignment */
-body.landing-page .bottombar .uk-navbar-item > a {
-  min-height: 28px;
-  padding-top: 0;
-  padding-bottom: 0;
-  display: flex;
-  align-items: center;
-}
-
-/* Footer link height */
-body.landing-page .bottombar .uk-navbar-nav > li > a {
-  min-height: 28px;
-  padding-top: 0;
-  padding-bottom: 0;
-}
-
-body.landing-page .bottombar a {
-  color: inherit;
-}
-
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }
@@ -242,12 +227,6 @@ a.uk-accordion-title {
   .legal-container {
     padding-left: 8px;
     padding-right: 8px;
-  }
-  body.landing-page .bottombar .uk-navbar-nav > li > a {
-    min-height: 28px;
-  }
-  body.landing-page .bottombar .uk-navbar-item > a {
-    min-height: 28px;
   }
 }
 
@@ -298,11 +277,11 @@ body.dark-mode .sticky-actions {
 }
 @media print {
   .topbar,
-  .bottombar,
   .sticky-tabs,
   .nav-placeholder,
   #adminTabs,
-  .footer-placeholder,
+  .site-footer,
+  .footer-menu,
   .uk-footer,
   .uk-navbar-container,
   .uk-navbar,

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -14,22 +14,20 @@
   {% block head %}{% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}">
-{% block body %}{% endblock %}
-  <div class="footer-placeholder"></div>
-  <nav class="uk-navbar-container bottombar" uk-navbar>
-    <div class="uk-navbar-left">
-      <div class="uk-navbar-item uk-margin-small-left">
-        <a href="https://bastelix.github.io/sommerfest-quiz/" target="_blank" rel="noopener" class="uk-icon-button" uk-icon="icon: handbook; ratio: 2" uk-tooltip="title: {{ t('manual_open') }}" aria-label="{{ t('manual_open') }}"></a>
-      </div>
-    </div>
-    <div class="uk-navbar-center">
-      <ul class="uk-navbar-nav">
-        <li><a href="{{ basePath }}/datenschutz">{{ t('privacy') }}</a></li>
-        <li><a href="{{ basePath }}/impressum">{{ t('imprint') }}</a></li>
-        <li><a href="{{ basePath }}/lizenz">{{ t('license') }}</a></li>
-      </ul>
-    </div>
-  </nav>
+  <div class="wrapper">
+    <main class="content">
+      {% block body %}{% endblock %}
+    </main>
+    <footer class="site-footer">
+      <nav class="footer-menu">
+        <ul>
+          <li><a href="{{ basePath }}/impressum">{{ t('imprint') }}</a></li>
+          <li><a href="{{ basePath }}/datenschutz">{{ t('privacy') }}</a></li>
+          <li><a href="{{ basePath }}/lizenz">{{ t('license') }}</a></li>
+        </ul>
+      </nav>
+    </footer>
+  </div>
   <script src="{{ basePath }}/js/uikit.min.js"></script>
   <script src="{{ basePath }}/js/uikit-icons.min.js"></script>
   <script>window.basePath = '{{ basePath }}';</script>


### PR DESCRIPTION
## Summary
- replace sticky bottom bar with semantic footer menu
- style footer to sit at end of page using flex layout
- update static Impressum page and dark mode styles

## Testing
- `node -e "const fs=require('fs');const {JSDOM}=require('jsdom');const html=fs.readFileSync('templates/layout.twig','utf8');const dom=new JSDOM(html);const footerMenus=dom.window.document.querySelectorAll('.footer-menu');console.assert(footerMenus.length===1,'⚠️ Footer-Menü wurde mehrfach eingebunden.');console.log('Footer menu count:',footerMenus.length);"`
- `node -e "const fs=require('fs');const {JSDOM}=require('jsdom');const html=fs.readFileSync('public/Impressum.html','utf8');const dom=new JSDOM(html);const footerMenus=dom.window.document.querySelectorAll('.footer-menu');console.assert(footerMenus.length===1,'⚠️ Footer-Menü wurde mehrfach eingebunden.');console.log('Footer menu count (Impressum):',footerMenus.length);"`
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68940b27a040832b965190ec20e708ae