### PR TITLE
Fix default content import during onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -303,7 +303,9 @@
         logMessage('Importiere Standardinhalte...');
         const importRes = await fetch(withBase('/restore-default'), {
           method: 'POST',
-          credentials: 'include'
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ schema: data.subdomain })
         });
         if (!importRes.ok) {
           const text = await importRes.text();


### PR DESCRIPTION
## Summary
- ensure onboarding sends schema when importing default data
- add schema-aware restoreDefaults handler

## Testing
- `composer test` *(fails: Database error etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689411135928832bbc34979a3fe176d2