### PR TITLE
feat: align subscription templates with new plan details

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -157,9 +157,11 @@
           <div class="uk-text-meta uk-margin-small-bottom">Für kleine Events & Einsteiger</div>
           <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom">
             <li><b>1 Event gleichzeitig</b></li>
-            <li>Max. 5 Teams</li>
-            <li>Bis zu 5 Fragenkataloge (je 5 Fragen)</li>
-            <li>Alle Basisfunktionen</li>
+            <li>5 Teams &amp; 5 Kataloge à 5 Fragen</li>
+            <li>Unbegrenzte Teilnehmende pro Team¹</li>
+            <li>Live-Ranking &amp; Basis-PDF-Export²</li>
+            <li>Alle Fragetypen &amp; QR-Codes</li>
+            <li>Backup &amp; editierbare Texte³</li>
           </ul>
           <a href="{{ basePath }}/login" class="btn btn-transparent uk-width-1-1 uk-button-large uk-margin-small-top">Jetzt kostenlos starten</a>
         </div>
@@ -173,10 +175,11 @@
           <div class="uk-text-meta uk-margin-small-bottom" style="color:#fff;">Beliebt bei Schulen & Teams</div>
           <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom" style="color:#fff;">
             <li><b>Bis zu 3 Events gleichzeitig</b></li>
-            <li>Max. 10 Teams & 10 Fragenkataloge pro Event</li>
-            <li>Je 10 Fragen pro Katalog</li>
-            <li>Auswertung & Urkunden</li>
-            <li>E-Mail-Support</li>
+            <li>10 Teams &amp; 10 Kataloge à 10 Fragen</li>
+            <li>Unbegrenzte Teilnehmende pro Team¹</li>
+            <li>Eigene Subdomain &amp; PDF-Export</li>
+            <li>Alle Fragetypen &amp; QR-Codes</li>
+            <li>Backup &amp; editierbare Texte³</li>
           </ul>
           <a href="#contact-us" class="btn btn-black uk-width-1-1 uk-button-large">Jetzt upgraden</a>
         </div>
@@ -186,19 +189,24 @@
         <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
           <span class="uk-label uk-label-primary uk-label-large">Professional</span>
           <h3 class="uk-card-title uk-text-primary uk-margin-small-top">Professional</h3>
-          <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">auf Anfrage</div>
+          <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">79&nbsp;€/Monat</div>
           <div class="uk-text-meta uk-margin-small-bottom">Für Agenturen & Unternehmen</div>
           <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom">
-            <li>Beliebige Events, Teams & Fragen</li>
-            <li>White-Label & API-Integration</li>
-            <li>Eigene Server & Branding möglich</li>
-            <li>Premium-Support & persönliche Beratung</li>
+            <li><b>20 Events gleichzeitig</b> (mehr auf Anfrage)</li>
+            <li>100 Teams &amp; 50 Kataloge à 50 Fragen</li>
+            <li>Unbegrenzte Teilnehmende pro Team¹</li>
+            <li>White-Label, Rollenverwaltung &amp; eigene Subdomain</li>
+            <li>PDF-Export, alle Fragetypen &amp; QR-Codes</li>
+            <li>Backup &amp; editierbare Texte³</li>
           </ul>
           <a href="#contact-us" class="btn btn-transparent uk-width-1-1 uk-button-large">Beratung anfragen</a>
         </div>
       </div>
     </div>
     <p class="uk-text-meta uk-text-center uk-margin-large-top">Alle Preise zzgl. MwSt. – individuelle Lösungen auf Anfrage.</p>
+    <p class="uk-text-meta uk-margin-top">1 (Die Teamgröße ist nicht technisch limitiert und kann bedarfsgerecht festgelegt werden.)</p>
+    <p class="uk-text-meta uk-margin-top">2 (Im Starter-Paket mit Wasserzeichen oder ohne individuelles Layout/Logo)</p>
+    <p class="uk-text-meta uk-margin-top">3 (z.&nbsp;B. Datenschutz, AGB, Einladung, FAQ, Spielanleitung – alles eigenständig editierbar)</p>
   </div>
 </section>
 

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -51,9 +51,9 @@
       <h3 class="uk-card-title">2. Abo wählen</h3>
       <div class="uk-margin">
         <select id="plan" class="uk-select">
-          <option value="demo">Demo</option>
+          <option value="starter">Starter</option>
           <option value="standard">Standard</option>
-          <option value="premium">Premium</option>
+          <option value="professional">Professional</option>
         </select>
       </div>
       <button class="uk-button uk-button-primary" id="next2">Weiter</button>


### PR DESCRIPTION
## Summary
- update landing page subscription cards with new plan limits, features, and pricing, including footnotes
- rename onboarding plan options to Starter, Standard, and Professional

## Testing
- `composer test` *(fails: Tests: 133, Assertions: 247, Errors: 13, Failures: 4, Warnings: 2, PHPUnit Deprecations: 1, Notices: 8.)*

------
https://chatgpt.com/codex/tasks/task_e_689422ab2ef8832ba91b3ff0e56b183a