### PR TITLE
Validate tenant plan and expose plan context

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -119,11 +119,13 @@ return function (\Slim\App $app, TranslationService $translator) {
         $eventService = new EventService($pdo);
         $nginxService = new NginxService();
         $tenantService = new TenantService($base, null, $nginxService);
+        $plan = $tenantService->getPlanBySubdomain($sub);
         $userService = new \App\Service\UserService($pdo);
         $settingsService = new \App\Service\SettingsService($pdo);
         $passwordResetService = new PasswordResetService($pdo);
 
         $request = $request
+            ->withAttribute('plan', $plan)
             ->withAttribute('configController', new ConfigController($configService))
             ->withAttribute('catalogController', new CatalogController($catalogService))
             ->withAttribute('resultController', new ResultController(


### PR DESCRIPTION
## Summary
- ensure tenant plan is valid in create and update operations
- provide cached plan lookup per subdomain
- expose tenant plan in request context

## Testing
- `vendor/bin/phpunit tests/Service/TenantServiceTest.php`
- `composer test` *(fails: Errors: 13, Failures: 4)*

------
https://chatgpt.com/codex/tasks/task_e_6894cf521668832b800431262e09c5be