### PR TITLE
Fix duplicated footnotes on landing page pricing section

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -199,9 +199,6 @@
           <a href="#contact-us" class="btn btn-transparent uk-width-1-1 uk-button-large">Beratung anfragen</a>
         </div>
       </div>
-      <p class="uk-text-meta uk-margin-top">1 (Die Teamgröße ist nicht technisch limitiert und kann bedarfsgerecht festgelegt werden.)</p>
-      <p class="uk-text-meta uk-margin-top">2 (Im Starter-Paket mit Wasserzeichen oder ohne individuelles Layout/Logo)</p>
-      <p class="uk-text-meta uk-margin-top">3 (z.&nbsp;B. Datenschutz, AGB, Einladung, FAQ, Spielanleitung – alles eigenständig editierbar)</p>
     </div>
     <p class="uk-text-meta uk-text-center uk-margin-large-top">Alle Preise zzgl. MwSt. – individuelle Lösungen auf Anfrage.</p>
     <p class="uk-text-meta uk-margin-top">1 (Die Teamgröße ist nicht technisch limitiert und kann bedarfsgerecht festgelegt werden.)</p>


### PR DESCRIPTION
## Summary
- remove duplicate footnotes in landing page pricing section

## Testing
- `composer test` *(fails: 13 errors, 4 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6894d011aab4832b97d24636773696d1