### PR TITLE
Enforce tenant event limits

### DIFF
--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -6,6 +6,8 @@ namespace App\Service;
 
 use PDO;
 use App\Service\ConfigService;
+use App\Service\TenantService;
+use App\Domain\Plan;
 
 /**
  * Service for managing quiz events.
@@ -14,11 +16,19 @@ class EventService
 {
     private PDO $pdo;
     private ConfigService $config;
+    private ?TenantService $tenants;
+    private string $subdomain;
 
-    public function __construct(PDO $pdo, ?ConfigService $config = null)
-    {
+    public function __construct(
+        PDO $pdo,
+        ?ConfigService $config = null,
+        ?TenantService $tenants = null,
+        string $subdomain = ''
+    ) {
         $this->pdo = $pdo;
         $this->config = $config ?? new ConfigService($pdo);
+        $this->tenants = $tenants;
+        $this->subdomain = $subdomain;
     }
 
     /**
@@ -58,10 +68,31 @@ class EventService
      */
     public function saveAll(array $events): void
     {
-        $this->pdo->beginTransaction();
-
         $existingStmt = $this->pdo->query('SELECT uid FROM events');
         $existing = $existingStmt->fetchAll(PDO::FETCH_COLUMN);
+
+        if ($this->tenants !== null && $this->subdomain !== '') {
+            $plan = $this->tenants->getPlanBySubdomain($this->subdomain);
+            if ($plan !== null) {
+                $limits = Plan::limits($plan);
+                $max = $limits['maxEvents'] ?? null;
+                if ($max !== null) {
+                    $currentCount = count($existing);
+                    $newCount = 0;
+                    foreach ($events as $event) {
+                        $uid = $event['uid'] ?? null;
+                        if ($uid === null || !in_array($uid, $existing, true)) {
+                            $newCount++;
+                        }
+                    }
+                    if ($currentCount + $newCount > $max) {
+                        throw new \RuntimeException('max-events-exceeded');
+                    }
+                }
+            }
+        }
+
+        $this->pdo->beginTransaction();
 
         $updateStmt = $this->pdo->prepare(
             'UPDATE events SET name = ?, start_date = ?, end_date = ?, description = ?, published = ? WHERE uid = ?'


### PR DESCRIPTION
## Summary
- enforce plan-based event count limits using TenantService and Plan definitions
- test event limit enforcement for starter and standard plans

## Testing
- `vendor/bin/phpunit tests/Service/EventServiceTest.php`
- `composer phpunit` *(fails: ERROR Tests: 138, Assertions: 267, Errors: 8)*

------
https://chatgpt.com/codex/tasks/task_e_6894d0ee96b8832b9b7d5da796eb4092