### PR TITLE
Show hamburger menu only on landing page

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -262,6 +262,11 @@
 {% block body %}
   <div class="landing-content">
     {% embed 'topbar.twig' %}
+      {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+      {% endblock %}
       {% block left %}
         <a class="uk-logo" href="{{ basePath }}/landing">QuizRace</a>
         {% endblock %}

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,10 +1,6 @@
 <nav class="uk-navbar-container uk-padding-small topbar" uk-navbar>
   <div class="uk-navbar-left">
-    {% block mobile_menu_toggle %}
-    <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-      <span uk-navbar-toggle-icon></span>
-    </a>
-    {% endblock %}
+    {% block mobile_menu_toggle %}{% endblock %}
     <div class="uk-navbar-item">
       {% block left %}{% endblock %}
     </div>
@@ -20,18 +16,7 @@
     </div>
   </div>
 </nav>
-{% block offcanvas %}
-<div id="offcanvas-nav" uk-offcanvas="overlay: true">
-  <div class="uk-offcanvas-bar">
-    <ul class="uk-nav uk-nav-primary">
-      <li><a href="#features">Features</a></li>
-      <li><a href="{{ basePath }}/pricing">Preise</a></li>
-      <li><a href="#contact">Kontakt</a></li>
-      <li><a href="{{ basePath }}/login">Login</a></li>
-    </ul>
-  </div>
-</div>
-{% endblock %}
+{% block offcanvas %}{% endblock %}
 {% block headerbar %}{% endblock %}
 {% block nav_placeholder %}
 <div class="nav-placeholder"></div>


### PR DESCRIPTION
## Summary
- Hide mobile hamburger menu and offcanvas by default in shared topbar template
- Restore hamburger toggle and offcanvas navigation for marketing landing page

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_6894d8a64b5c832ba1607bd569a371dc