### PR TITLE
Move admin event selector to second header row on mobile

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -449,6 +449,26 @@ body.dark-mode .sticky-actions {
   .nav-placeholder {
     height: 56px;
   }
+  body.admin-page {
+    padding-top: 112px;
+  }
+  .admin-page .topbar {
+    height: auto;
+    flex-wrap: wrap;
+  }
+  .admin-page .topbar .uk-navbar-left {
+    order: 1;
+  }
+  .admin-page .topbar .uk-navbar-right {
+    order: 2;
+  }
+  .admin-page .topbar .uk-navbar-center {
+    order: 3;
+    width: 100%;
+  }
+  .admin-page .nav-placeholder {
+    height: 112px;
+  }
 }
 
 /* Floating action buttons */

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -21,7 +21,7 @@
   <script type="module" src="{{ basePath }}/js/trumbowyg-pages.js"></script>
 {% endblock %}
 
-{% block body_class %}uk-background-muted uk-padding{% endblock %}
+{% block body_class %}uk-background-muted uk-padding admin-page{% endblock %}
 
 {% block body %}
   {% embed 'topbar.twig' %}


### PR DESCRIPTION
## Summary
- allow admin header to wrap and push event selector into second row on mobile
- add admin-page body class for targeted mobile styling

## Testing
- `composer test` *(fails: Slim Application Error – Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_6894d8faec34832b9b12944f089dcfc4