### PR TITLE
Add tenant-specific custom limits and enforce across services

### DIFF
--- a/migrations/20241015_add_custom_limits_to_tenants.sql
+++ b/migrations/20241015_add_custom_limits_to_tenants.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS custom_limits TEXT;

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -8,7 +8,6 @@ use PDO;
 use PDOException;
 use App\Service\ConfigService;
 use App\Service\TenantService;
-use App\Domain\Plan;
 
 /**
  * Service layer for managing quiz teams.
@@ -63,13 +62,10 @@ class TeamService
 
         $teamCount = count($teams);
         if ($this->tenants !== null && $this->subdomain !== '') {
-            $plan = $this->tenants->getPlanBySubdomain($this->subdomain);
-            if ($plan !== null) {
-                $limits = Plan::limits($plan);
-                $max = $limits['maxTeamsPerEvent'] ?? null;
-                if ($max !== null && $teamCount > $max) {
-                    throw new \RuntimeException('max-teams-exceeded');
-                }
+            $limits = $this->tenants->getLimitsBySubdomain($this->subdomain);
+            $max = $limits['maxTeamsPerEvent'] ?? null;
+            if ($max !== null && $teamCount > $max) {
+                throw new \RuntimeException('max-teams-exceeded');
             }
         }
 

--- a/tests/Controller/TenantControllerTest.php
+++ b/tests/Controller/TenantControllerTest.php
@@ -32,7 +32,13 @@ class TenantControllerTest extends TestCase
             {
             }
 
-            public function createTenant(string $uid, string $schema, ?string $plan = null, ?string $billing = null): void
+            public function createTenant(
+                string $uid,
+                string $schema,
+                ?string $plan = null,
+                ?string $billing = null,
+                ?array $customLimits = null
+            ): void
             {
             }
 
@@ -55,7 +61,13 @@ class TenantControllerTest extends TestCase
             {
             }
 
-            public function createTenant(string $uid, string $schema, ?string $plan = null, ?string $billing = null): void
+            public function createTenant(
+                string $uid,
+                string $schema,
+                ?string $plan = null,
+                ?string $billing = null,
+                ?array $customLimits = null
+            ): void
             {
             }
 
@@ -140,7 +152,7 @@ class TenantControllerTest extends TestCase
     public function testExistsReturns404ForUnknown(): void
     {
         $pdo = new PDO('sqlite::memory:');
-        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT, plan TEXT, billing_info TEXT, imprint_name TEXT, imprint_street TEXT, imprint_zip TEXT, imprint_city TEXT, imprint_email TEXT, created_at TEXT);');
+        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT, plan TEXT, billing_info TEXT, imprint_name TEXT, imprint_street TEXT, imprint_zip TEXT, imprint_city TEXT, imprint_email TEXT, custom_limits TEXT, created_at TEXT);');
         $controller = new TenantController(new TenantService($pdo));
         $req = $this->createRequest('GET', '/tenants/foo');
         $res = $controller->exists($req, new Response(), ['subdomain' => 'foo']);
@@ -150,7 +162,7 @@ class TenantControllerTest extends TestCase
     public function testExistsReturns200ForExisting(): void
     {
         $pdo = new PDO('sqlite::memory:');
-        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT, plan TEXT, billing_info TEXT, imprint_name TEXT, imprint_street TEXT, imprint_zip TEXT, imprint_city TEXT, imprint_email TEXT, created_at TEXT);');
+        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT, plan TEXT, billing_info TEXT, imprint_name TEXT, imprint_street TEXT, imprint_zip TEXT, imprint_city TEXT, imprint_email TEXT, custom_limits TEXT, created_at TEXT);');
         $pdo->exec("INSERT INTO tenants(uid, subdomain, plan, billing_info, imprint_name, imprint_street, imprint_zip, imprint_city, imprint_email, created_at) VALUES('u1', 'bar', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '')");
         $controller = new TenantController(new TenantService($pdo));
         $req = $this->createRequest('GET', '/tenants/bar');
@@ -161,7 +173,7 @@ class TenantControllerTest extends TestCase
     public function testExistsReturns200ForReserved(): void
     {
         $pdo = new PDO('sqlite::memory:');
-        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT, plan TEXT, billing_info TEXT, imprint_name TEXT, imprint_street TEXT, imprint_zip TEXT, imprint_city TEXT, imprint_email TEXT, created_at TEXT);');
+        $pdo->exec('CREATE TABLE tenants(uid TEXT PRIMARY KEY, subdomain TEXT, plan TEXT, billing_info TEXT, imprint_name TEXT, imprint_street TEXT, imprint_zip TEXT, imprint_city TEXT, imprint_email TEXT, custom_limits TEXT, created_at TEXT);');
         $controller = new TenantController(new TenantService($pdo));
         $req = $this->createRequest('GET', '/tenants/www');
         $res = $controller->exists($req, new Response(), ['subdomain' => 'www']);
@@ -175,7 +187,13 @@ class TenantControllerTest extends TestCase
             {
             }
 
-            public function createTenant(string $uid, string $schema, ?string $plan = null, ?string $billing = null): void
+            public function createTenant(
+                string $uid,
+                string $schema,
+                ?string $plan = null,
+                ?string $billing = null,
+                ?array $customLimits = null
+            ): void
             {
                 throw new \PDOException('fail');
             }
@@ -201,7 +219,13 @@ class TenantControllerTest extends TestCase
             {
             }
 
-            public function createTenant(string $uid, string $schema, ?string $plan = null, ?string $billing = null): void
+            public function createTenant(
+                string $uid,
+                string $schema,
+                ?string $plan = null,
+                ?string $billing = null,
+                ?array $customLimits = null
+            ): void
             {
                 throw new \Exception('boom');
             }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -115,6 +115,7 @@ class TestCase extends PHPUnit_TestCase
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         \App\Infrastructure\Migrations\Migrator::migrate($pdo, __DIR__ . '/../migrations');
+        $pdo->exec('ALTER TABLE tenants ADD COLUMN custom_limits TEXT');
         return $pdo;
     }
 


### PR DESCRIPTION
## Summary
- allow storing custom usage limits per tenant
- default service limits now prefer tenant overrides before plan defaults
- cover custom limit behavior with new service tests

## Testing
- `composer test` *(fails: Slim Application Error, Database error, Error creating tenant, Failed to reload nginx)*
- `vendor/bin/phpunit tests/Service/TenantServiceTest.php`
- `vendor/bin/phpunit tests/Service/EventServiceTest.php`
- `vendor/bin/phpunit tests/Service/TeamServiceTest.php`
- `vendor/bin/phpunit tests/Service/CatalogServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6894d832fbf4832bb2103c3575b5bd1b