### PR TITLE
Fix mobile admin event selector layout

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -465,6 +465,11 @@ body.dark-mode .sticky-actions {
   .admin-page .topbar .uk-navbar-center {
     order: 3;
     width: 100%;
+    position: static;
+    transform: none;
+  }
+  .admin-page #eventSelect {
+    flex: 1;
   }
   .admin-page .nav-placeholder {
     height: 112px;


### PR DESCRIPTION
## Summary
- prevent admin topbar event selector from overlapping other controls on mobile

## Testing
- `composer test` *(fails: "Database error: fail" and phpunit errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894db50fdec832bbef0d94e30cfe548