### PR TITLE
Fix CSRF handling for password reset forms

### DIFF
--- a/src/Application/Middleware/CsrfMiddleware.php
+++ b/src/Application/Middleware/CsrfMiddleware.php
@@ -28,7 +28,12 @@ class CsrfMiddleware implements MiddlewareInterface
 
         if ($request->getMethod() === 'POST') {
             $header = $request->getHeaderLine('X-CSRF-Token');
-            if ($token === null || $header !== $token) {
+            $bodyToken = '';
+            $data = $request->getParsedBody();
+            if (is_array($data)) {
+                $bodyToken = (string) ($data['csrf_token'] ?? '');
+            }
+            if ($token === null || ($header !== $token && $bodyToken !== $token)) {
                 return (new SlimResponse())->withStatus(403);
             }
         }

--- a/src/routes.php
+++ b/src/routes.php
@@ -235,12 +235,16 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/register', [RegisterController::class, 'register']);
     $app->get('/password/reset/request', function (Request $request, Response $response) {
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'password_request.twig');
+        $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
+        $_SESSION['csrf_token'] = $csrf;
+        return $view->render($response, 'password_request.twig', ['csrf_token' => $csrf]);
     });
     $app->get('/password/reset', function (Request $request, Response $response) {
         $view = Twig::fromRequest($request);
         $token = (string) ($request->getQueryParams()['token'] ?? '');
-        return $view->render($response, 'password_confirm.twig', ['token' => $token]);
+        $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
+        $_SESSION['csrf_token'] = $csrf;
+        return $view->render($response, 'password_confirm.twig', ['token' => $token, 'csrf_token' => $csrf]);
     });
     $app->get('/logout', LogoutController::class);
     $app->get('/admin', function (Request $request, Response $response) {

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -39,6 +39,7 @@
         {% endif %}
         <form method="post" action="/password/reset/confirm">
           <input type="hidden" name="token" value="{{ token }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
           <div class="uk-margin">
             <div class="uk-inline uk-width-1-1">
               <span class="uk-form-icon" uk-icon="icon: lock"></span>

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -38,6 +38,7 @@
         </div>
         {% endif %}
         <form method="post" action="/password/reset/request">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
           <div class="uk-margin">
             <div class="uk-inline uk-width-1-1">
               <span class="uk-form-icon" uk-icon="icon: mail"></span>

--- a/tests/Controller/PasswordResetFlowTest.php
+++ b/tests/Controller/PasswordResetFlowTest.php
@@ -35,11 +35,9 @@ class PasswordResetFlowTest extends TestCase
 
         session_start();
         $_SESSION['csrf_token'] = 'tok';
-        $request = $this->createRequest('POST', '/password/reset/request', [
-            'X-CSRF-Token' => 'tok',
-        ])
+        $request = $this->createRequest('POST', '/password/reset/request')
             ->withAttribute('mailService', $mailer)
-            ->withParsedBody(['username' => 'alice']);
+            ->withParsedBody(['username' => 'alice', 'csrf_token' => 'tok']);
         $response = $app->handle($request);
         $this->assertSame(204, $response->getStatusCode());
         $this->assertCount(1, $mailer->sent);
@@ -49,10 +47,12 @@ class PasswordResetFlowTest extends TestCase
         $this->assertIsString($token);
         $this->assertStringContainsString($token, $link);
 
-        $confirm = $this->createRequest('POST', '/password/reset/confirm', [
-            'X-CSRF-Token' => 'tok',
-        ])
-            ->withParsedBody(['token' => $token, 'password' => 'newpass']);
+        $confirm = $this->createRequest('POST', '/password/reset/confirm')
+            ->withParsedBody([
+                'token' => $token,
+                'password' => 'newpass',
+                'csrf_token' => 'tok',
+            ]);
         $resp2 = $app->handle($confirm);
         $this->assertSame(204, $resp2->getStatusCode());
 


### PR DESCRIPTION
## Summary
- accept CSRF tokens from request body
- include CSRF token in password reset forms
- adjust password reset flow test to use body token

## Testing
- `composer test` *(fails: Slim Application Error, Database error: fail, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68955f51c974832b9c386bb383e4c968