### PR TITLE
Normalize base path handling to avoid 404s

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -34,13 +34,17 @@ use App\Service\TranslationService;
 $settings = require __DIR__ . '/../config/settings.php';
 $app = \Slim\Factory\AppFactory::create();
 $basePath = getenv('BASE_PATH') ?: '';
+$basePath = '/' . trim($basePath, '/');
+if ($basePath === '/') {
+    $basePath = '';
+}
 $app->setBasePath($basePath);
 
 $translator = new TranslationService();
 $twig = Twig::create(__DIR__ . '/../templates', ['cache' => false]);
 $twig->addExtension(new UikitExtension());
 $twig->addExtension(new TranslationExtension($translator));
-$twig->getEnvironment()->addGlobal('basePath', rtrim($basePath, '/'));
+$twig->getEnvironment()->addGlobal('basePath', $basePath);
 $app->add(TwigMiddleware::create($app, $twig));
 $app->add(new SessionMiddleware());
 $app->add(new DomainMiddleware());

--- a/tests/Controller/PasswordResetRequestTest.php
+++ b/tests/Controller/PasswordResetRequestTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class PasswordResetRequestTest extends TestCase
+{
+    public function testRenderResetRequestForm(): void
+    {
+        $app = $this->getAppInstance();
+        session_start();
+        $response = $app->handle($this->createRequest('GET', '/password/reset/request'));
+        $this->assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('<form', $body);
+        $this->assertStringContainsString('csrf_token', $body);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -52,7 +52,11 @@ class TestCase extends PHPUnit_TestCase
         $twig->addExtension(new \App\Twig\UikitExtension());
         $twig->addExtension(new \App\Twig\TranslationExtension($translator));
         $basePath = getenv('BASE_PATH') ?: '';
-        $twig->getEnvironment()->addGlobal('basePath', rtrim($basePath, '/'));
+        $basePath = '/' . trim($basePath, '/');
+        if ($basePath === '/') {
+            $basePath = '';
+        }
+        $twig->getEnvironment()->addGlobal('basePath', $basePath);
         $app->setBasePath($basePath);
         $app->add(TwigMiddleware::create($app, $twig));
         $app->add(new SessionMiddleware());


### PR DESCRIPTION
## Summary
- normalize BASE_PATH so `/` behaves like an empty base path
- cover password reset page with a regression test

## Testing
- `composer test` *(fails: Slim Application Error; Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_689565eff860832b9ba9158c52d5c4ff