### PR TITLE
chore: add ghostscript to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM php:8.2-alpine
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 RUN apk add --no-cache docker-cli docker-cli-compose \
-    libpng libjpeg-turbo freetype libwebp postgresql-client imagemagick && \
+    libpng libjpeg-turbo freetype libwebp postgresql-client imagemagick ghostscript && \
     apk add --no-cache --virtual .build-deps libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev postgresql-dev $PHPIZE_DEPS && \
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp && \
     docker-php-ext-install gd pdo_pgsql exif && \


### PR DESCRIPTION
## Summary
- include ghostscript in Dockerfile so the `gs` command is available in the container

## Testing
- `docker build -t sommerfest-quiz:test .` *(fails: Cannot connect to the Docker daemon)*
- `composer test` *(fails: Tests: 151, Assertions: 294, Errors: 8, Failures: 3, Warnings: 2, PHPUnit Deprecations: 1, Notices: 9.)*


------
https://chatgpt.com/codex/tasks/task_e_68956c649734832b99eef6ab20e214e1