### PR TITLE
Fix boolean insertion during event import

### DIFF
--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -110,7 +110,7 @@ class EventService
                 $end = date('Y-m-d\TH:i');
             }
             $desc = $event['description'] ?? null;
-            $published = (bool)($event['published'] ?? false);
+            $published = filter_var($event['published'] ?? false, FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
 
             if (in_array($uid, $existing, true)) {
                 $updateStmt->execute([$name, $start, $end, $desc, $published, $uid]);


### PR DESCRIPTION
## Summary
- ensure imported events bind `published` flag as numeric boolean

## Testing
- `composer test` *(fails: Slim Application Error, Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68956f41eb78832bae5e73a6bf71b5c0