### PR TITLE
Avoid failing QR code generation without FreeType

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -74,6 +74,9 @@ class QrController
         $demo   = (string)($params['demo'] ?? '');
         $label  = (string)($params['label'] ?? '1');
         $useLabel = !in_array(strtolower($label), ['0', 'false', 'no'], true);
+        if ($useLabel && !function_exists('imagettfbbox')) {
+            $useLabel = false;
+        }
 
         if ($size <= 0 || $margin < 0) {
             return $response->withStatus(400);

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -42,6 +42,18 @@ class QrControllerTest extends TestCase
         $this->assertSame(400, $response->getStatusCode());
     }
 
+    public function testQrImageWithoutLabel(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/qr.png')
+            ->withQueryParams(['t' => 'Demo', 'label' => '0']);
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/png', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
+    }
+
     public function testQrPdfIsGenerated(): void
     {
         $app = $this->getAppInstance();


### PR DESCRIPTION
## Summary
- Disable QR label rendering when FreeType functions are unavailable
- Cover label-off scenario with a regression test

## Testing
- `composer test` (fails: Slim Application Error, Database error: fail)
- `vendor/bin/phpcs src/Controller/QrController.php tests/Controller/QrControllerTest.php`
- `vendor/bin/phpstan analyse` (fails: Child process error: PHPStan process crashed because it reached configured PHP memory limit)


------
https://chatgpt.com/codex/tasks/task_e_68956f5af250832bbb87fd9ed789af1a