### PR TITLE
Show upgrade modal when hitting subscription limits

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2,10 +2,34 @@
 
 const basePath = window.basePath || '';
 const withBase = path => basePath + path;
+function showUpgradeModal() {
+  if (document.getElementById('upgrade-modal')) return;
+  const modal = document.createElement('div');
+  modal.id = 'upgrade-modal';
+  modal.setAttribute('uk-modal', '');
+  modal.innerHTML = '<div class="uk-modal-dialog uk-modal-body">' +
+    '<h3 class="uk-modal-title">' + (window.transUpgradeTitle || 'Limit erreicht') + '</h3>' +
+    '<p>' + (window.transUpgradeText || '') + '</p>' +
+    '<p class="uk-text-center"><a class="uk-button uk-button-primary" href="' +
+    (window.upgradeUrl || withBase('/admin/subscription')) + '">' +
+    (window.transUpgradeAction || 'Upgrade') + '</a></p>' +
+    '</div>';
+  document.body.appendChild(modal);
+  const ui = UIkit.modal(modal);
+  UIkit.util.on(modal, 'hidden', () => { modal.remove(); });
+  ui.show();
+}
+
 window.apiFetch = (path, options = {}) => {
   return fetch(withBase(path), {
     credentials: 'same-origin',
     ...options
+  }).then(res => {
+    if (res.status === 402) {
+      showUpgradeModal();
+      throw new Error('upgrade-required');
+    }
+    return res;
   });
 };
 window.notify = (msg, status = 'primary') => {

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -193,4 +193,7 @@ return [
     'text_password_reset_error' => 'Passwort konnte nicht geändert werden.',
     'action_send_link' => 'Link senden',
     'action_set_password' => 'Passwort setzen',
+    'heading_limit_reached' => 'Limit erreicht',
+    'text_upgrade_required' => 'Abo-Limit erreicht. Bitte upgraden, um mehr Ressourcen anzulegen.',
+    'action_upgrade' => 'Jetzt upgraden',
 ];

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -193,4 +193,7 @@ return [
     'text_password_reset_error' => 'Password could not be changed.',
     'action_send_link' => 'Send link',
     'action_set_password' => 'Set password',
+    'heading_limit_reached' => 'Limit reached',
+    'text_upgrade_required' => 'Subscription limit reached. Please upgrade to add more resources.',
+    'action_upgrade' => 'Upgrade now',
 ];

--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -53,6 +53,21 @@ class HttpErrorHandler extends SlimErrorHandler
             }
         }
 
+        if ($exception instanceof \RuntimeException) {
+            $msg = $exception->getMessage();
+            $limitErrors = [
+                'max-events-exceeded',
+                'max-teams-exceeded',
+                'max-catalogs-exceeded',
+                'max-questions-exceeded',
+            ];
+            if (in_array($msg, $limitErrors, true)) {
+                $statusCode = 402;
+                $error->setType(ActionError::BAD_REQUEST);
+                $error->setDescription($msg);
+            }
+        }
+
         if (
             !($exception instanceof HttpException)
             && $this->displayErrorDetails

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -770,6 +770,10 @@
     window.mainDomain = '{{ main_domain }}';
     window.domainType = '{{ domainType }}';
     window.pagesContent = {{ pages|json_encode|raw }};
+    window.transUpgradeTitle = '{{ t('heading_limit_reached') }}';
+    window.transUpgradeText = '{{ t('text_upgrade_required') }}';
+    window.transUpgradeAction = '{{ t('action_upgrade') }}';
+    window.upgradeUrl = '{{ basePath }}/admin/subscription';
   </script>
   <script src="{{ basePath }}/js/admin.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>


### PR DESCRIPTION
## Summary
- add error handler and frontend modal to prompt subscription upgrade when resource limits are exceeded
- translate new upgrade prompt text in German and English

## Testing
- `composer test` *(fails: ERRORS! Tests: 153, Assertions: 298, Errors: 8, Failures: 3, Warnings: 2, PHPUnit Deprecations: 1, Notices: 9.)*

------
https://chatgpt.com/codex/tasks/task_e_6895f0cb14fc832bb61e8d2c6168c467