### PR TITLE
Show Stripe payment terms during onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -135,6 +135,7 @@
       const planSelect = document.getElementById('plan');
       const paymentSelect = document.getElementById('payment');
       const payBtn = document.getElementById('payBtn');
+      const paymentInfo = document.getElementById('payment-info');
     const imprintNameInput = document.getElementById('imprint-name');
     const imprintStreetInput = document.getElementById('imprint-street');
     const imprintZipInput = document.getElementById('imprint-zip');
@@ -210,6 +211,13 @@
 
       const allowedPlans = ['starter', 'standard', 'professional'];
       const allowedPayments = ['invoice', 'credit', 'paypal'];
+
+      paymentSelect?.addEventListener('change', () => {
+        const credit = paymentSelect.value === 'credit';
+        if (payBtn) payBtn.hidden = !credit;
+        if (paymentInfo) paymentInfo.hidden = !credit;
+      });
+      paymentSelect?.dispatchEvent(new Event('change'));
 
       next2.addEventListener('click', () => {
         const planValue = planSelect?.value || '';

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -166,6 +166,7 @@ return [
       'billing_invoice' => 'Rechnung',
       'billing_credit' => 'Kreditkarte',
       'billing_paypal' => 'PayPal',
+      'stripe_payment_terms' => 'Die Zahlung wird über Stripe abgewickelt. Es gelten die <a href="https://stripe.com/payment-terms/legal" target="_blank" rel="noopener">Stripe-Zahlungsbedingungen</a>.',
       'action_delete' => 'Löschen',
       'action_cancel' => 'Abbrechen',
     'label_registration_enabled' => 'Registrierung zulassen',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -166,6 +166,7 @@ return [
       'billing_invoice' => 'Invoice',
       'billing_credit' => 'Credit card',
       'billing_paypal' => 'PayPal',
+      'stripe_payment_terms' => 'Payment is processed via Stripe. The <a href="https://stripe.com/payment-terms/legal" target="_blank" rel="noopener">Stripe payment terms</a> apply.',
       'action_delete' => 'Delete',
       'action_cancel' => 'Cancel',
     'label_registration_enabled' => 'Allow registration',

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -69,6 +69,7 @@
           <option value="paypal">{{ t('billing_paypal') }}</option>
         </select>
       </div>
+      <p id="payment-info" class="uk-text-meta" hidden>{{ t('stripe_payment_terms')|raw }}</p>
       <button class="uk-button uk-button-secondary uk-margin-small-right" id="payBtn">Jetzt bezahlen</button>
       <button class="uk-button uk-button-primary" id="next3">Weiter</button>
     </div>


### PR DESCRIPTION
## Summary
- add Stripe payment terms note in onboarding step 3
- toggle payment button and info based on credit card selection
- localize Stripe payment terms in English and German

## Testing
- `composer test` *(fails: Slim Application Error; Tests: 153, Assertions: 298, Errors: 8, Failures: 3, Warnings: 2)*

------
https://chatgpt.com/codex/tasks/task_e_6897afd5f17c832b8e0ca1c8f0e36aff