### PR TITLE
Rename onboarding quiz link and target

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -402,7 +402,8 @@
         }
 
         if (successLink) {
-          successLink.href = 'https://' + data.subdomain + '.' + mainDomain;
+          successLink.href =
+            'https://' + data.subdomain + '.' + mainDomain + '/admin';
           successLink.textContent = 'Warte auf Start...';
           successLink.classList.add('uk-disabled');
           successLink.hidden = false;
@@ -427,7 +428,7 @@
         if (ready) {
           logMessage('Subdomain erreichbar');
           successLink.classList.remove('uk-disabled');
-          successLink.textContent = 'Zu Ihrem QuizRace';
+          successLink.textContent = 'Zu deinem Quiz';
           if (successInfo) {
             successInfo.textContent = 'Die Subdomain ist jetzt erreichbar.';
           }

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -122,7 +122,7 @@
         <summary>Logmeldungen anzeigen</summary>
         <ul id="task-log" class="uk-list uk-text-left uk-margin-top"></ul>
       </details>
-      <a id="success-link" class="uk-button uk-button-primary uk-margin-top" hidden>Zu Ihrem QuizRace</a>
+      <a id="success-link" class="uk-button uk-button-primary uk-margin-top" hidden>Zu deinem Quiz</a>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Rename onboarding success link to "Zu deinem Quiz"
- Open newly created quiz subdomain directly to its `/admin` page

## Testing
- `composer test` *(fails: Slim Application Error; Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_6897b0a78be8832b8284aa2e232bd5e9