### PR TITLE
Send welcome email after tenant onboarding

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1989,6 +1989,25 @@ document.addEventListener('DOMContentLoaded', function () {
               })
               .catch(err => notify(err.message || 'Fehler beim Erneuern', 'danger'));
           });
+          const welcomeBtn = document.createElement('button');
+          welcomeBtn.className = 'uk-button uk-button-default uk-button-small uk-margin-small-right';
+          welcomeBtn.textContent = 'Willkommensmail';
+          welcomeBtn.addEventListener('click', () => {
+            apiFetch('/tenants/' + encodeURIComponent(t.subdomain) + '/welcome')
+              .then(r => {
+                if (!r.ok) throw new Error('Fehler');
+                return r.text();
+              })
+              .then(html => {
+                const w = window.open('', '_blank');
+                if (w) {
+                  w.document.write(html);
+                  w.document.close();
+                }
+              })
+              .catch(() => notify('Willkommensmail nicht verfügbar', 'danger'));
+          });
+          actionTd.appendChild(welcomeBtn);
           actionTd.appendChild(renewBtn);
           actionTd.appendChild(delBtn);
           tr.appendChild(subTd);

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -394,6 +394,28 @@
         setTaskStatus('ssl', 'done');
         logMessage(boardJson.status || 'Container gestartet');
 
+        try {
+          logMessage('Sende Willkommensmail...');
+          const welcomeRes = await fetch(withBase('/tenant-welcome'), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({
+              schema: data.subdomain,
+              email: data.imprintEmail,
+              password: data.adminPass
+            })
+          });
+          if (!welcomeRes.ok) {
+            const text = await welcomeRes.text();
+            logMessage('Fehler Willkommensmail: ' + text);
+          } else {
+            logMessage('Willkommensmail gesendet');
+          }
+        } catch (e) {
+          logMessage('Fehler Willkommensmail');
+        }
+
         if (successDomain) {
           successDomain.textContent = data.subdomain + '.' + mainDomain;
           successDomain.hidden = false;

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -56,4 +56,27 @@ class MailService
 
         $this->mailer->send($email);
     }
+
+    /**
+     * Send initial welcome mail with admin credentials.
+     *
+     * @return string Rendered HTML content of the email
+     */
+    public function sendWelcome(string $to, string $domain, string $password): string
+    {
+        $html = $this->twig->render('emails/welcome.twig', [
+            'domain' => $domain,
+            'password' => $password,
+        ]);
+
+        $email = (new Email())
+            ->from($this->from)
+            ->to($to)
+            ->subject('Willkommen bei QuizRace')
+            ->html($html);
+
+        $this->mailer->send($email);
+
+        return $html;
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -28,6 +28,7 @@ use App\Service\NginxService;
 use App\Service\SettingsService;
 use App\Service\TranslationService;
 use App\Service\PasswordResetService;
+use App\Service\MailService;
 use App\Controller\Admin\ProfileController;
 use App\Application\Middleware\LanguageMiddleware;
 use App\Application\Middleware\CsrfMiddleware;
@@ -404,6 +405,20 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('tenantController')->list($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN));
 
+    $app->get('/tenants/{subdomain}/welcome', function (Request $request, Response $response, array $args) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(403);
+        }
+        $sub = preg_replace('/[^a-z0-9\-]/', '-', strtolower((string) ($args['subdomain'] ?? '')));
+        $base = dirname(__DIR__, 1);
+        $file = $base . '/data/' . $sub . '/welcome_email.html';
+        if (!is_readable($file)) {
+            return $response->withStatus(404);
+        }
+        $response->getBody()->write((string) file_get_contents($file));
+        return $response->withHeader('Content-Type', 'text/html');
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+
     $app->get('/teams.json', function (Request $request, Response $response) {
         return $request->getAttribute('teamController')->get($request, $response);
     });
@@ -451,6 +466,32 @@ return function (\Slim\App $app, TranslationService $translator) {
         } else {
             $userService->updatePassword((int)$existing['id'], (string)$data['password']);
         }
+
+        return $response->withStatus(204);
+    })->add(new RoleAuthMiddleware(Roles::SERVICE_ACCOUNT));
+
+    $app->post('/tenant-welcome', function (Request $request, Response $response) {
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data) || !isset($data['schema'], $data['email'], $data['password'])) {
+            return $response->withStatus(400);
+        }
+        $schema = preg_replace('/[^a-z0-9_\-]/i', '', strtolower((string) $data['schema']));
+        if ($schema === '' || $schema === 'public') {
+            return $response->withStatus(400);
+        }
+        $email = (string) $data['email'];
+        $password = (string) $data['password'];
+        $mainDomain = getenv('MAIN_DOMAIN') ?: getenv('DOMAIN') ?: $request->getUri()->getHost();
+        $twig = Twig::fromRequest($request);
+        $mailer = new MailService($twig);
+        $domain = sprintf('%s.%s', $schema, $mainDomain);
+        $html = $mailer->sendWelcome($email, $domain, $password);
+        $base = dirname(__DIR__, 1);
+        $dir = $base . '/data/' . $schema;
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents($dir . '/welcome_email.html', $html);
 
         return $response->withStatus(204);
     })->add(new RoleAuthMiddleware(Roles::SERVICE_ACCOUNT));

--- a/templates/emails/welcome.twig
+++ b/templates/emails/welcome.twig
@@ -1,0 +1,4 @@
+<p>Hallo,</p>
+<p>Ihr QuizRace wurde unter <a href="https://{{ domain }}">{{ domain }}</a> eingerichtet.</p>
+<p>Admin-Login: <strong>admin</strong> / <strong>{{ password }}</strong></p>
+<p>Viel Erfolg!</p>


### PR DESCRIPTION
## Summary
- send admin welcome email after tenant onboarding and store message
- allow main admins to view initial welcome email per tenant
- expose welcome email template

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_6897b1de8f04832bb08f71d162c50ce7