### PR TITLE
Add copy button for admin password

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -399,7 +399,25 @@
           successDomain.hidden = false;
         }
         if (successPass) {
-          successPass.textContent = 'Ihr Admin-Login lautet: admin / ' + data.adminPass;
+          successPass.textContent =
+            'Ihr Admin-Login lautet: admin / ' + data.adminPass + ' ';
+          const passCopyBtn = document.createElement('button');
+          passCopyBtn.type = 'button';
+          passCopyBtn.className = 'uk-icon-button';
+          passCopyBtn.setAttribute('uk-icon', 'copy');
+          passCopyBtn.setAttribute('aria-label', 'Passwort kopieren');
+          passCopyBtn.setAttribute('title', 'Passwort kopieren');
+          passCopyBtn.addEventListener('click', () => {
+            navigator.clipboard.writeText(data.adminPass).then(() => {
+              if (typeof UIkit !== 'undefined') {
+                UIkit.notification({
+                  message: 'Passwort kopiert',
+                  status: 'success'
+                });
+              }
+            });
+          });
+          successPass.appendChild(passCopyBtn);
           successPass.hidden = false;
         }
 


### PR DESCRIPTION
## Summary
- allow onboarding success message to copy admin password via icon-only button

## Testing
- `composer test` *(fails: vendor/bin/phpunit not found, script returned with error code 127)*

------
https://chatgpt.com/codex/tasks/task_e_6897b23c784c832ba881397ea255ca91