### PR TITLE
Add onboarding email with double opt-in

### DIFF
--- a/migrations/20241019_email_confirmations.sql
+++ b/migrations/20241019_email_confirmations.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS email_confirmations (
+    email TEXT NOT NULL,
+    token TEXT NOT NULL,
+    confirmed INTEGER NOT NULL DEFAULT 0,
+    expires_at TIMESTAMP NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_email_confirmations_token ON email_confirmations(token);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_email_confirmations_email ON email_confirmations(email);

--- a/src/Controller/OnboardingEmailController.php
+++ b/src/Controller/OnboardingEmailController.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\EmailConfirmationService;
+use App\Service\MailService;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+use Slim\Views\Twig;
+
+/**
+ * Handle email confirmation during onboarding.
+ */
+class OnboardingEmailController
+{
+    private EmailConfirmationService $service;
+
+    public function __construct(EmailConfirmationService $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * Accept email and send confirmation link.
+     */
+    public function request(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $email = trim((string) ($data['email'] ?? ''));
+        if ($email === '') {
+            return $response->withStatus(400);
+        }
+
+        $token = $this->service->createToken($email);
+        $uri = $request->getUri()
+            ->withPath('/onboarding/email/confirm')
+            ->withQuery('token=' . urlencode($token));
+
+        $mailer = $request->getAttribute('mailService');
+        if (!$mailer instanceof MailService) {
+            $twig = Twig::fromRequest($request)->getEnvironment();
+            $mailer = new MailService($twig);
+        }
+        $mailer->sendDoubleOptIn($email, (string) $uri);
+
+        return $response->withStatus(204);
+    }
+
+    /**
+     * Confirm email via token and redirect back to onboarding.
+     */
+    public function confirm(Request $request, Response $response): Response
+    {
+        $token = (string) ($request->getQueryParams()['token'] ?? '');
+        if ($token === '') {
+            return $response->withStatus(400);
+        }
+
+        $email = $this->service->confirmToken($token);
+        if ($email === null) {
+            return $response->withStatus(400);
+        }
+
+        $uri = $request->getUri()
+            ->withPath('/onboarding')
+            ->withQuery(http_build_query(['email' => $email, 'verified' => 1]));
+
+        return $response->withHeader('Location', (string) $uri)->withStatus(302);
+    }
+
+    /**
+     * Return 204 if email is confirmed, 404 otherwise.
+     */
+    public function status(Request $request, Response $response): Response
+    {
+        $email = (string) ($request->getQueryParams()['email'] ?? '');
+        if ($email === '') {
+            return $response->withStatus(400);
+        }
+
+        return $this->service->isConfirmed($email)
+            ? $response->withStatus(204)
+            : $response->withStatus(404);
+    }
+}

--- a/src/Service/EmailConfirmationService.php
+++ b/src/Service/EmailConfirmationService.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use DateTimeImmutable;
+use PDO;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Manage email confirmation tokens for double opt-in.
+ */
+class EmailConfirmationService
+{
+    private PDO $pdo;
+    private int $ttl;
+    private LoggerInterface $logger;
+
+    public function __construct(PDO $pdo, int $ttlSeconds = 86400, ?LoggerInterface $logger = null)
+    {
+        $this->pdo = $pdo;
+        $this->ttl = $ttlSeconds;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Generate token for email and store it.
+     */
+    public function createToken(string $email): string
+    {
+        $this->cleanupExpired();
+
+        $token = bin2hex(random_bytes(16));
+        $expires = (new DateTimeImmutable())
+            ->modify('+' . $this->ttl . ' seconds')
+            ->format('Y-m-d H:i:s');
+
+        $stmt = $this->pdo->prepare('DELETE FROM email_confirmations WHERE email = ?');
+        $stmt->execute([$email]);
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO email_confirmations(email, token, confirmed, expires_at) VALUES(?,?,0,?)'
+        );
+        $stmt->execute([$email, $token, $expires]);
+
+        $this->logger->info('Email confirmation token created', ['email' => $email]);
+
+        return $token;
+    }
+
+    /**
+     * Verify token and mark email as confirmed.
+     */
+    public function confirmToken(string $token): ?string
+    {
+        $this->cleanupExpired();
+
+        $stmt = $this->pdo->prepare('SELECT email, expires_at FROM email_confirmations WHERE token = ?');
+        $stmt->execute([$token]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            $this->logger->warning('Email confirmation token not found', ['token' => $token]);
+            return null;
+        }
+
+        $email = (string) $row['email'];
+        $expires = new DateTimeImmutable((string) $row['expires_at']);
+
+        if ($expires < new DateTimeImmutable()) {
+            $this->logger->warning('Email confirmation token expired', ['email' => $email]);
+            $this->deleteToken($email);
+            return null;
+        }
+
+        $stmt = $this->pdo->prepare('UPDATE email_confirmations SET confirmed = 1 WHERE email = ?');
+        $stmt->execute([$email]);
+
+        $this->logger->info('Email confirmed', ['email' => $email]);
+
+        return $email;
+    }
+
+    /**
+     * Check whether given email is confirmed.
+     */
+    public function isConfirmed(string $email): bool
+    {
+        $this->cleanupExpired();
+
+        $stmt = $this->pdo->prepare('SELECT confirmed FROM email_confirmations WHERE email = ?');
+        $stmt->execute([$email]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row !== false && (int) $row['confirmed'] === 1;
+    }
+
+    private function deleteToken(string $email): void
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM email_confirmations WHERE email = ?');
+        $stmt->execute([$email]);
+    }
+
+    /**
+     * Remove expired tokens.
+     */
+    public function cleanupExpired(): void
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM email_confirmations WHERE expires_at <= ?');
+        $stmt->execute([(new DateTimeImmutable())->format('Y-m-d H:i:s')]);
+    }
+}

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -56,4 +56,20 @@ class MailService
 
         $this->mailer->send($email);
     }
+
+    /**
+     * Send double opt-in email with confirmation link.
+     */
+    public function sendDoubleOptIn(string $to, string $link): void
+    {
+        $html = $this->twig->render('emails/double_optin.twig', ['link' => $link]);
+
+        $email = (new Email())
+            ->from($this->from)
+            ->to($to)
+            ->subject('E-Mail-Adresse bestätigen')
+            ->html($html);
+
+        $this->mailer->send($email);
+    }
 }

--- a/templates/emails/double_optin.twig
+++ b/templates/emails/double_optin.twig
@@ -1,0 +1,4 @@
+<p>Hallo,</p>
+<p>bitte bestätige deine E-Mail-Adresse durch Klick auf den folgenden Link:</p>
+<p><a href="{{ link }}">{{ link }}</a></p>
+<p>Wenn du diese Anfrage nicht gestellt hast, kannst du diese E-Mail ignorieren.</p>

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -43,6 +43,10 @@
         <input id="customer-name" class="uk-input" type="text" placeholder="Name der App oder Domain" required>
       </div>
       <div class="uk-margin">
+        <input id="customer-email" class="uk-input" type="email" placeholder="E-Mail-Adresse" required>
+        <div id="email-hint" class="uk-text-meta uk-margin-small-top" hidden></div>
+      </div>
+      <div class="uk-margin">
         <label>Subdomain: <span id="subdomain-preview">-</span>.{{ main_domain }}</label>
       </div>
       <button class="uk-button uk-button-primary" id="next1" disabled>Weiter</button>


### PR DESCRIPTION
## Summary
- collect user email in onboarding's first step
- send double opt-in confirmation link and persist verification tokens

## Testing
- `composer test` *(fails: Slim Application Error: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_6897b2a78fc4832bace8a41342ec526f