### PR TITLE
chore: test against php 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1]
+                php: [8.2]
                 experimental: [false]
                 include:
-                    - php: 8.1
+                    - php: 8.2
                       analysis: true
 
         steps:


### PR DESCRIPTION
## Summary
- test GitHub Actions workflow against PHP 8.2

## Testing
- `mise exec php@8.2 -- vendor/bin/phpcs` *(fails: multiple coding standard errors and warnings)*
- `mise exec php@8.2 -- vendor/bin/phpstan --memory-limit=512M` *(fails: 9 errors)*
- `mise exec php@8.2 -- composer test` *(fails: Script vendor/bin/phpunit returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_6897b80ee328832bbdf8feb77f42a578