### PR TITLE
feat: add invitation handling

### DIFF
--- a/migrations/20241130_invitations.sql
+++ b/migrations/20241130_invitations.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS invitations (
+    email TEXT NOT NULL,
+    token TEXT NOT NULL,
+    expires_at TIMESTAMP NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invitations_token ON invitations(token);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invitations_email ON invitations(email);

--- a/src/Controller/InvitationController.php
+++ b/src/Controller/InvitationController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\InvitationService;
+use App\Service\MailService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Handle sending invitation mails.
+ */
+class InvitationController
+{
+    private InvitationService $service;
+    private MailService $mailer;
+
+    public function __construct(InvitationService $service, MailService $mailer)
+    {
+        $this->service = $service;
+        $this->mailer = $mailer;
+    }
+
+    /**
+     * Accept email and name, send invitation link.
+     */
+    public function send(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $email = trim((string) ($data['email'] ?? ''));
+        $name  = trim((string) ($data['name'] ?? ''));
+        if ($email === '' || $name === '') {
+            return $response->withStatus(400);
+        }
+
+        $token = $this->service->createToken($email);
+        $uri = $request->getUri()
+            ->withPath('/register')
+            ->withQuery(http_build_query(['token' => $token]));
+
+        $this->mailer->sendInvitation($email, $name, (string) $uri);
+
+        return $response->withStatus(204);
+    }
+}

--- a/src/Service/InvitationService.php
+++ b/src/Service/InvitationService.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use DateTimeImmutable;
+use PDO;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Manage invitation tokens.
+ */
+class InvitationService
+{
+    private PDO $pdo;
+    private int $ttl;
+    private LoggerInterface $logger;
+
+    public function __construct(PDO $pdo, int $ttlSeconds = 86400, ?LoggerInterface $logger = null)
+    {
+        $this->pdo = $pdo;
+        $this->ttl = $ttlSeconds;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Generate and store a token for the given email.
+     */
+    public function createToken(string $email): string
+    {
+        $this->cleanupExpired();
+
+        $token = bin2hex(random_bytes(16));
+        $expires = (new DateTimeImmutable())
+            ->modify('+' . $this->ttl . ' seconds')
+            ->format('Y-m-d H:i:s');
+
+        $stmt = $this->pdo->prepare('INSERT INTO invitations(email, token, expires_at) VALUES(?,?,?)');
+        $stmt->execute([$email, $token, $expires]);
+
+        $this->logger->info('Invitation token created', ['email' => $email]);
+
+        return $token;
+    }
+
+    /**
+     * Verify token and return associated email. Token is removed.
+     */
+    public function consumeToken(string $token): ?string
+    {
+        $this->cleanupExpired();
+
+        $stmt = $this->pdo->prepare('SELECT email, expires_at FROM invitations WHERE token = ?');
+        $stmt->execute([$token]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            $this->logger->warning('Invitation token not found', ['token' => $token]);
+            return null;
+        }
+
+        $email = (string) $row['email'];
+        $expires = new DateTimeImmutable((string) $row['expires_at']);
+
+        $this->deleteToken($email);
+
+        if ($expires < new DateTimeImmutable()) {
+            $this->logger->warning('Invitation token expired', ['email' => $email]);
+            return null;
+        }
+
+        $this->logger->info('Invitation token consumed', ['email' => $email]);
+
+        return $email;
+    }
+
+    private function deleteToken(string $email): void
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM invitations WHERE email = ?');
+        $stmt->execute([$email]);
+    }
+
+    /**
+     * Remove expired tokens.
+     */
+    public function cleanupExpired(): void
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM invitations WHERE expires_at <= ?');
+        $stmt->execute([(new DateTimeImmutable())->format('Y-m-d H:i:s')]);
+    }
+}

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -75,6 +75,25 @@ class MailService
     }
 
     /**
+     * Send invitation email with registration link.
+     */
+    public function sendInvitation(string $to, string $name, string $link): void
+    {
+        $html = $this->twig->render('emails/invitation.twig', [
+            'name' => $name,
+            'link' => $link,
+        ]);
+
+        $email = (new Email())
+            ->from($this->from)
+            ->to($to)
+            ->subject('Einladung zu QuizRace')
+            ->html($html);
+
+        $this->mailer->send($email);
+    }
+
+    /**
      * Send initial welcome mail with admin credentials.
      *
      * Returns the rendered HTML (useful for logging/preview).

--- a/templates/emails/invitation.twig
+++ b/templates/emails/invitation.twig
@@ -1,0 +1,4 @@
+<p>Hallo {{ name }},</p>
+<p>du bist eingeladen, bei QuizRace mitzumachen. Klicke auf den folgenden Link, um dich zu registrieren:</p>
+<p><a href="{{ link }}">{{ link }}</a></p>
+<p>Viel Erfolg!</p>


### PR DESCRIPTION
## Summary
- implement InvitationService and InvitationController for token-based invitation emails
- add MailService method and invitation template
- register /invite admin route and migration

## Testing
- `composer test` (fails: Database error: fail)


------
https://chatgpt.com/codex/tasks/task_e_6897b9906514832b83181370ef70b79a