### PR TITLE
Add onboarding email CSRF and rate limiting

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -30,6 +30,7 @@ use App\Service\TranslationService;
 use App\Service\PasswordResetService;
 use App\Service\MailService;
 use App\Service\InvitationService;
+use App\Service\EmailConfirmationService;
 use App\Controller\Admin\ProfileController;
 use App\Application\Middleware\LanguageMiddleware;
 use App\Application\Middleware\CsrfMiddleware;
@@ -243,7 +244,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/onboarding', OnboardingController::class);
     $app->post('/onboarding/email', function (Request $request, Response $response) {
         return $request->getAttribute('onboardingEmailController')->request($request, $response);
-    });
+    })->add(new RateLimitMiddleware(3, 3600))->add(new CsrfMiddleware());
     $app->get('/onboarding/email/confirm', function (Request $request, Response $response) {
         return $request->getAttribute('onboardingEmailController')->confirm($request, $response);
     });

--- a/tests/Controller/OnboardingEmailControllerTest.php
+++ b/tests/Controller/OnboardingEmailControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Infrastructure\Database;
+use App\Service\MailService;
+use Tests\TestCase;
+
+class OnboardingEmailControllerTest extends TestCase
+{
+    public function testPostRequiresCsrfToken(): void
+    {
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+
+        $request = $this->createRequest('POST', '/onboarding/email', ['Content-Type' => 'application/json']);
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, json_encode(['email' => 'alice@example.com']));
+        rewind($stream);
+        $request = $request->withBody((new \Slim\Psr7\Factory\StreamFactory())->createStreamFromResource($stream));
+        $request = $request->withAttribute(
+            'mailService',
+            new class extends MailService {
+                public function __construct()
+                {
+                }
+
+                public function sendDoubleOptIn(string $to, string $link): void
+                {
+                }
+            }
+        );
+
+        $response = $app->handle($request);
+        $this->assertSame(403, $response->getStatusCode());
+        session_destroy();
+    }
+
+    public function testPostRespectsRateLimitAndCsrf(): void
+    {
+        $app = $this->getAppInstance();
+        $pdo = Database::connectFromEnv();
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE IF NOT EXISTS email_confirmations (
+                email TEXT NOT NULL,
+                token TEXT NOT NULL,
+                confirmed INTEGER NOT NULL DEFAULT 0,
+                expires_at TEXT NOT NULL
+            );
+            SQL
+        );
+        $pdo->exec(
+            'CREATE UNIQUE INDEX IF NOT EXISTS idx_email_confirmations_token ON email_confirmations(token)'
+        );
+        $pdo->exec(
+            'CREATE UNIQUE INDEX IF NOT EXISTS idx_email_confirmations_email ON email_confirmations(email)'
+        );
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+
+        $mailer = new class extends MailService {
+            public array $sent = [];
+            public function __construct() {}
+            public function sendDoubleOptIn(string $to, string $link): void
+            {
+                $this->sent[] = [$to, $link];
+            }
+        };
+
+        for ($i = 0; $i < 4; $i++) {
+            $request = $this->createRequest('POST', '/onboarding/email', [
+                'Content-Type' => 'application/json',
+                'X-CSRF-Token' => 'tok',
+            ]);
+            $stream = fopen('php://temp', 'r+');
+            fwrite($stream, json_encode(['email' => 'user@example.com']));
+            rewind($stream);
+            $request = $request->withBody((new \Slim\Psr7\Factory\StreamFactory())->createStreamFromResource($stream));
+            $request = $request->withAttribute('mailService', $mailer);
+            $response = $app->handle($request);
+            if ($i < 3) {
+                $this->assertSame(204, $response->getStatusCode());
+            } else {
+                $this->assertSame(429, $response->getStatusCode());
+            }
+        }
+
+        $this->assertCount(3, $mailer->sent);
+        session_destroy();
+    }
+}


### PR DESCRIPTION
## Summary
- Protect `/onboarding/email` with CSRF and rate limit middleware
- Cover onboarding email endpoint with CSRF and rate limit tests

## Testing
- `vendor/bin/phpunit tests/Controller/OnboardingEmailControllerTest.php`
- `composer test` *(fails: Tests: 155, Assertions: 304, Errors: 8, Failures: 3, Warnings: 2, PHPUnit Deprecations: 1, Notices: 9)*

------
https://chatgpt.com/codex/tasks/task_e_6897bb0b52a4832baa2650f7541a1564