### PR TITLE
Secure password reset tokens

### DIFF
--- a/migrations/20241007_password_resets.sql
+++ b/migrations/20241007_password_resets.sql
@@ -1,8 +1,8 @@
 CREATE TABLE IF NOT EXISTS password_resets (
     user_id INTEGER NOT NULL,
-    token TEXT NOT NULL,
+    token_hash TEXT NOT NULL,
     expires_at TIMESTAMP NOT NULL,
     CONSTRAINT fk_password_resets_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_password_resets_token ON password_resets(token);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_password_resets_token ON password_resets(token_hash);

--- a/sample.env
+++ b/sample.env
@@ -50,6 +50,9 @@ SMTP_USER=user@example.com
 SMTP_PASS=secret
 SMTP_PORT=587
 
+# Geheimnis zum Hashen von Passwort-Reset-Token
+PASSWORD_RESET_SECRET=changeme
+
 # Stripe-Zahlungsanbieter
 STRIPE_SECRET_KEY=
 STRIPE_PRICE_STARTER=

--- a/src/Service/PasswordResetService.php
+++ b/src/Service/PasswordResetService.php
@@ -23,10 +23,17 @@ class PasswordResetService
 
     private LoggerInterface $logger;
 
-    public function __construct(PDO $pdo, int $ttlSeconds = 3600, ?LoggerInterface $logger = null)
-    {
+    private string $secret;
+
+    public function __construct(
+        PDO $pdo,
+        int $ttlSeconds = 3600,
+        ?string $secret = null,
+        ?LoggerInterface $logger = null
+    ) {
         $this->pdo = $pdo;
         $this->ttl = $ttlSeconds;
+        $this->secret = $secret ?? (string) getenv('PASSWORD_RESET_SECRET');
         $this->logger = $logger ?? new NullLogger();
     }
 
@@ -37,15 +44,19 @@ class PasswordResetService
     {
         $this->cleanupExpired();
 
+        $stmt = $this->pdo->prepare('DELETE FROM password_resets WHERE user_id=?');
+        $stmt->execute([$userId]);
+
         $token = bin2hex(random_bytes(16));
+        $hash = hash_hmac('sha256', $token, $this->secret);
         $expires = (new DateTimeImmutable())
             ->modify('+' . $this->ttl . ' seconds')
             ->format('Y-m-d H:i:s');
 
         $stmt = $this->pdo->prepare(
-            'INSERT INTO password_resets(user_id, token, expires_at) VALUES(?,?,?)'
+            'INSERT INTO password_resets(user_id, token_hash, expires_at) VALUES(?,?,?)'
         );
-        $stmt->execute([$userId, $token, $expires]);
+        $stmt->execute([$userId, $hash, $expires]);
 
         $this->logger->info('Password reset token created', ['userId' => $userId]);
 
@@ -61,8 +72,9 @@ class PasswordResetService
     {
         $this->cleanupExpired();
 
-        $stmt = $this->pdo->prepare('SELECT user_id, expires_at FROM password_resets WHERE token=?');
-        $stmt->execute([$token]);
+        $hash = hash_hmac('sha256', $token, $this->secret);
+        $stmt = $this->pdo->prepare('SELECT user_id, expires_at FROM password_resets WHERE token_hash=?');
+        $stmt->execute([$hash]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
         if ($row === false) {
@@ -90,8 +102,9 @@ class PasswordResetService
      */
     public function deleteToken(int $userId, string $token): void
     {
-        $stmt = $this->pdo->prepare('DELETE FROM password_resets WHERE user_id=? AND token=?');
-        $stmt->execute([$userId, $token]);
+        $hash = hash_hmac('sha256', $token, $this->secret);
+        $stmt = $this->pdo->prepare('DELETE FROM password_resets WHERE user_id=? AND token_hash=?');
+        $stmt->execute([$userId, $hash]);
     }
 
     /**

--- a/src/routes.php
+++ b/src/routes.php
@@ -31,7 +31,6 @@ use App\Service\PasswordResetService;
 use App\Service\MailService;
 use App\Service\EmailConfirmationService;
 use App\Service\InvitationService;
-use App\Service\EmailConfirmationService;
 use App\Controller\Admin\ProfileController;
 use App\Application\Middleware\LanguageMiddleware;
 use App\Application\Middleware\CsrfMiddleware;
@@ -134,7 +133,11 @@ return function (\Slim\App $app, TranslationService $translator) {
         $plan = $tenantService->getPlanBySubdomain($sub);
         $userService = new \App\Service\UserService($pdo);
         $settingsService = new \App\Service\SettingsService($pdo);
-        $passwordResetService = new PasswordResetService($pdo);
+        $passwordResetService = new PasswordResetService(
+            $pdo,
+            3600,
+            getenv('PASSWORD_RESET_SECRET') ?: ''
+        );
         $emailConfirmService = new EmailConfirmationService($pdo);
 
         $request = $request

--- a/tests/Service/PasswordResetServiceTest.php
+++ b/tests/Service/PasswordResetServiceTest.php
@@ -37,14 +37,16 @@ class PasswordResetServiceTest extends TestCase
         $pdo = $this->createDatabase();
         $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
         $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token TEXT NOT NULL, expires_at TEXT NOT NULL)');
+        $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)');
         $users = new UserService($pdo);
         $users->create('alice', 'secret', 'alice@example.com');
 
         $logger = new ArrayLogger();
-        $svc = new PasswordResetService($pdo, 3600, $logger);
+        $svc = new PasswordResetService($pdo, 3600, 'secret', $logger);
         $token = $svc->createToken(1);
         $this->assertNotEmpty($token);
+        $hash = $pdo->query('SELECT token_hash FROM password_resets')->fetchColumn();
+        $this->assertSame(hash_hmac('sha256', $token, 'secret'), $hash);
         $this->assertTrue($logger->has('info', 'Password reset token created'));
 
         $userId = $svc->consumeToken($token);
@@ -60,12 +62,12 @@ class PasswordResetServiceTest extends TestCase
         $pdo = $this->createDatabase();
         $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
         $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token TEXT NOT NULL, expires_at TEXT NOT NULL)');
+        $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)');
         $users = new UserService($pdo);
         $users->create('bob', 'secret', 'bob@example.com');
 
         $logger = new ArrayLogger();
-        $svc = new PasswordResetService($pdo, 3600, $logger);
+        $svc = new PasswordResetService($pdo, 3600, 'secret', $logger);
         $token = $svc->createToken(1);
         $pdo->exec("UPDATE password_resets SET expires_at = '2000-01-01 00:00:00'");
 
@@ -74,5 +76,22 @@ class PasswordResetServiceTest extends TestCase
             $logger->has('warning', 'expired') ||
             $logger->has('warning', 'token not found')
         );
+    }
+
+    public function testOldTokenInvalidated(): void
+    {
+        $pdo = $this->createDatabase();
+        $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
+        $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
+        $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)');
+        $users = new UserService($pdo);
+        $users->create('carol', 'secret', 'carol@example.com');
+
+        $svc = new PasswordResetService($pdo, 3600, 'secret');
+        $first = $svc->createToken(1);
+        $second = $svc->createToken(1);
+
+        $this->assertNull($svc->consumeToken($first));
+        $this->assertSame(1, $svc->consumeToken($second));
     }
 }


### PR DESCRIPTION
## Summary
- hash password reset tokens before storing and clean up old tokens
- allow PasswordResetService to use secret and update schema accordingly
- verify hashed token storage and token invalidation through new tests

## Testing
- `vendor/bin/phpunit tests/Service/PasswordResetServiceTest.php tests/Controller/PasswordResetFlowTest.php`
- `vendor/bin/phpstan analyse src/Service/PasswordResetService.php tests/Service/PasswordResetServiceTest.php tests/Controller/PasswordResetFlowTest.php` *(fails: Found 26 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897be348544832b9bbaef53d48b0c04