### PR TITLE
chore: pin PHP base images to patch release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-alpine
+FROM php:8.2.29-alpine
 
 # allow Composer to run as root inside the container
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM php:8.2-alpine
+FROM php:8.2.29-alpine
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
 


### PR DESCRIPTION
## Summary
- pin PHP Dockerfile bases to `php:8.2.29-alpine`
- ensure Docker Compose builds from updated base image

## Testing
- `docker-compose ps` *(fails: ConnectionRefusedError - cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6897c272f78c832ba71f57fc22ccf7e7