### PR TITLE
Send set-password link in welcome email

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -94,17 +94,17 @@ class MailService
     }
 
     /**
-     * Send initial welcome mail with admin credentials.
+     * Send initial welcome mail with set-password link.
      *
      * Returns the rendered HTML (useful for logging/preview).
      *
      * @return string Rendered HTML content of the email
      */
-    public function sendWelcome(string $to, string $domain, string $password): string
+    public function sendWelcome(string $to, string $domain, string $link): string
     {
         $html = $this->twig->render('emails/welcome.twig', [
-            'domain'   => $domain,
-            'password' => $password,
+            'domain' => $domain,
+            'link'   => $link,
         ]);
 
         $email = (new Email())

--- a/templates/emails/welcome.twig
+++ b/templates/emails/welcome.twig
@@ -1,4 +1,5 @@
 <p>Hallo,</p>
 <p>Ihr QuizRace wurde unter <a href="https://{{ domain }}">{{ domain }}</a> eingerichtet.</p>
-<p>Admin-Login: <strong>admin</strong> / <strong>{{ password }}</strong></p>
+<p>Zum Setzen des Admin-Passworts klicken Sie bitte auf folgenden Link:</p>
+<p><a href="{{ link }}">{{ link }}</a></p>
 <p>Viel Erfolg!</p>

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -37,7 +37,7 @@
           <p>Passwort konnte nicht geändert werden.</p>
         </div>
         {% endif %}
-        <form method="post" action="/password/reset/confirm">
+        <form method="post" action="{{ action|default('/password/reset/confirm') }}">
           <input type="hidden" name="token" value="{{ token }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
           <div class="uk-margin">


### PR DESCRIPTION
## Summary
- include one-time set-password link in welcome email
- add `/password/set` route for token-based password setup
- adjust tenant onboarding to generate and send set-password link

## Testing
- `composer test` (fails: Tests: 156, Assertions: 307, Errors: 8, Failures: 3)
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_6897c2bb4fd8832baa9d0fedc2863eb1