### PR TITLE
Remove Intervention Image fallbacks

### DIFF
--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -85,12 +85,7 @@ class LogoController
             return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
         }
 
-        if (method_exists(ImageManager::class, 'gd')) {
-            $manager = ImageManager::gd();
-        } else {
-            // Fallback for intervention/image version 2
-            $manager = new ImageManager(['driver' => 'gd']);
-        }
+        $manager = ImageManager::gd();
         $img = $manager->read($file->getStream());
         $img->scaleDown(512, 512);
         $img->save($target, 80);

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -339,11 +339,7 @@ class ResultController
                 if (is_readable($file)) {
                     $tmp = null;
                     if (str_ends_with(strtolower($file), '.webp')) {
-                        if (method_exists(ImageManager::class, 'gd')) {
-                            $manager = ImageManager::gd();
-                        } else {
-                            $manager = new ImageManager(['driver' => 'gd']);
-                        }
+                        $manager = ImageManager::gd();
                         $img = $manager->read($file);
                         $tmp = tempnam(sys_get_temp_dir(), 'photo') . '.png';
                         $img->save($tmp, 80);

--- a/src/Service/Pdf.php
+++ b/src/Service/Pdf.php
@@ -39,11 +39,7 @@ class Pdf extends Fpdi
 
         if (is_file($logoFile) && is_readable($logoFile)) {
             if (str_ends_with(strtolower($logoFile), '.webp')) {
-                if (method_exists(ImageManager::class, 'gd')) {
-                    $manager = ImageManager::gd();
-                } else {
-                    $manager = new ImageManager(['driver' => 'gd']);
-                }
+                $manager = ImageManager::gd();
                 $img = $manager->read($logoFile);
                 $logoTemp = tempnam(sys_get_temp_dir(), 'logo') . '.png';
                 $img->save($logoTemp, 80);


### PR DESCRIPTION
## Summary
- drop legacy Intervention Image fallbacks and rely on ImageManager::gd()
- use modern read()/orient()/scaleDown() API when processing images

## Testing
- `php -d display_errors=1 vendor/bin/phpunit` *(fails: Errors: 8, Failures: 3)*
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `vendor/bin/phpcs` *(fails: 1 error, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6897c472d6cc832baa09842b9ff5dff3