### PR TITLE
docs: document PHP 8.2 requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Docs
 
+- Document PHP 8.2 minimum requirement
 - Add postgres instructions
 - Document running psql via Docker
 - Add frontend word-break guidelines

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 
 ## Schnellstart
 
+Stelle sicher, dass PHP 8.2 oder höher installiert ist:
+
+```bash
+php -v
+```
+
 1. Abhängigkeiten installieren:
   ```bash
   composer install

--- a/docs-jtd/changelog.md
+++ b/docs-jtd/changelog.md
@@ -9,6 +9,12 @@ toc: true
 # Versionsverlauf
 
 Dieses Dokument listet Änderungen und Updates des Projekts.
+
+## Version 0.2.1 - 10.08.2025
+### Geändert
+- Mindestanforderung auf PHP 8.2 aktualisiert
+- Installationsbeispiele angepasst
+
 ## Version 0.2.0 - 23.06.2025
 ### Hinzugefügt
 - Hierarchische Navigation im Handbuch

--- a/docs-jtd/installation.md
+++ b/docs-jtd/installation.md
@@ -8,6 +8,12 @@ toc: true
 
 # Installation & Schnellstart
 
+Stelle sicher, dass PHP 8.2 oder höher installiert ist:
+
+```bash
+php -v
+```
+
 1. **Abhängigkeiten installieren**
    ```bash
    composer install

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ auf dem Slim Framework und nutzt UIkit3 für ein responsives Design. Fragenkatal
 Teilnehmer und Ergebnisse werden in einer PostgreSQL-Datenbank gespeichert und
 können per JSON importiert oder exportiert werden.
 
+Die Anwendung benötigt PHP 8.2 oder höher.
+
 Die Entwicklung entstand als Machbarkeitsstudie, um das Potenzial moderner
 Code-Assistenten in der Praxis zu testen. Barrierefreiheit, Datenschutz und eine
 hohe Performance standen dabei im Mittelpunkt.


### PR DESCRIPTION
## Summary
- mention PHP 8.2 as minimum PHP version in README and docs
- update installation guide examples for PHP 8.2
- record PHP 8.2 requirement in changelogs

## Testing
- `composer test` *(fails: Slim Application Error, database error)*

------
https://chatgpt.com/codex/tasks/task_e_6897e7d73098832ba854edc23783bce2