### PR TITLE
Add password policy enforcement for password endpoints

### DIFF
--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Service\PasswordPolicy;
 use App\Service\UserService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -14,13 +15,15 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 class PasswordController
 {
     private UserService $service;
+    private PasswordPolicy $policy;
 
     /**
-     * Inject user service.
+     * Inject user service and password policy.
      */
-    public function __construct(UserService $service)
+    public function __construct(UserService $service, PasswordPolicy $policy)
     {
         $this->service = $service;
+        $this->policy = $policy;
     }
 
     /**
@@ -39,7 +42,7 @@ class PasswordController
         }
 
         $pass = $data['password'] ?? '';
-        if (!is_string($pass) || $pass === '') {
+        if (!is_string($pass) || $pass === '' || !$this->policy->validate($pass)) {
             return $response->withStatus(400);
         }
 

--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\MailService;
+use App\Service\PasswordPolicy;
 use App\Service\PasswordResetService;
 use App\Service\UserService;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -18,11 +19,13 @@ class PasswordResetController
 {
     private UserService $users;
     private PasswordResetService $resets;
+    private PasswordPolicy $policy;
 
-    public function __construct(UserService $users, PasswordResetService $resets)
+    public function __construct(UserService $users, PasswordResetService $resets, PasswordPolicy $policy)
     {
         $this->users = $users;
         $this->resets = $resets;
+        $this->policy = $policy;
     }
 
     /**
@@ -84,7 +87,7 @@ class PasswordResetController
 
         $token = (string) ($data['token'] ?? '');
         $pass = (string) ($data['password'] ?? '');
-        if ($token === '' || $pass === '') {
+        if ($token === '' || $pass === '' || !$this->policy->validate($pass)) {
             return $response->withStatus(400);
         }
 

--- a/src/Service/PasswordPolicy.php
+++ b/src/Service/PasswordPolicy.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class PasswordPolicy
+{
+    /**
+     * Validate the given password against security requirements.
+     */
+    public function validate(string $pass): bool
+    {
+        if (strlen($pass) < 8) {
+            return false;
+        }
+        if (!preg_match('/[a-z]/', $pass)) {
+            return false;
+        }
+        if (!preg_match('/[A-Z]/', $pass)) {
+            return false;
+        }
+        if (!preg_match('/\d/', $pass)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -28,6 +28,7 @@ use App\Service\NginxService;
 use App\Service\SettingsService;
 use App\Service\TranslationService;
 use App\Service\PasswordResetService;
+use App\Service\PasswordPolicy;
 use App\Service\MailService;
 use App\Service\EmailConfirmationService;
 use App\Service\InvitationService;
@@ -138,6 +139,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             3600,
             getenv('PASSWORD_RESET_SECRET') ?: ''
         );
+        $passwordPolicy = new PasswordPolicy();
         $emailConfirmService = new EmailConfirmationService($pdo);
 
         $request = $request
@@ -161,10 +163,10 @@ return function (\Slim\App $app, TranslationService $translator) {
                     filter_var(getenv('DISPLAY_ERROR_DETAILS'), FILTER_VALIDATE_BOOLEAN)
                 )
             )
-            ->withAttribute('passwordController', new PasswordController($userService))
+            ->withAttribute('passwordController', new PasswordController($userService, $passwordPolicy))
             ->withAttribute(
                 'passwordResetController',
-                new PasswordResetController($userService, $passwordResetService)
+                new PasswordResetController($userService, $passwordResetService, $passwordPolicy)
             )
             ->withAttribute('userController', new UserController($userService))
             ->withAttribute('settingsController', new SettingsController($settingsService))

--- a/tests/Controller/PasswordControllerTest.php
+++ b/tests/Controller/PasswordControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Domain\Roles;
+use App\Infrastructure\Database;
+use App\Infrastructure\Migrations\Migrator;
+use App\Service\UserService;
+use Tests\TestCase;
+
+class PasswordControllerTest extends TestCase
+{
+    private function createUser(): UserService
+    {
+        $pdo = Database::connectFromEnv();
+        Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        try {
+            $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
+        } catch (\PDOException $e) {
+        }
+        try {
+            $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
+        } catch (\PDOException $e) {
+        }
+        $service = new UserService($pdo);
+        $service->create('alice', 'OldPass1', null, Roles::ADMIN);
+        return $service;
+    }
+
+    public function testRejectWeakPassword(): void
+    {
+        putenv('POSTGRES_DSN=');
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        unset($_ENV['POSTGRES_DSN'], $_ENV['POSTGRES_USER'], $_ENV['POSTGRES_PASSWORD']);
+        $app = $this->getAppInstance();
+        $service = $this->createUser();
+
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => Roles::ADMIN];
+
+        $request = $this->createRequest('POST', '/password')
+            ->withParsedBody(['password' => 'weak']);
+        $response = $app->handle($request);
+        $this->assertSame(400, $response->getStatusCode());
+
+        $user = $service->getByUsername('alice');
+        $this->assertIsArray($user);
+        $this->assertTrue(password_verify('OldPass1', (string) $user['password']));
+        session_destroy();
+    }
+
+    public function testAcceptStrongPassword(): void
+    {
+        putenv('POSTGRES_DSN=');
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        unset($_ENV['POSTGRES_DSN'], $_ENV['POSTGRES_USER'], $_ENV['POSTGRES_PASSWORD']);
+        $app = $this->getAppInstance();
+        $service = $this->createUser();
+
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => Roles::ADMIN];
+
+        $request = $this->createRequest('POST', '/password')
+            ->withParsedBody(['password' => 'Str0ngPass1']);
+        $response = $app->handle($request);
+        $this->assertSame(204, $response->getStatusCode());
+
+        $user = $service->getByUsername('alice');
+        $this->assertIsArray($user);
+        $this->assertTrue(password_verify('Str0ngPass1', (string) $user['password']));
+        session_destroy();
+    }
+}

--- a/tests/Controller/PasswordResetFlowTest.php
+++ b/tests/Controller/PasswordResetFlowTest.php
@@ -17,12 +17,25 @@ class PasswordResetFlowTest extends TestCase
     {
         putenv('PASSWORD_RESET_SECRET=secret');
         $_ENV['PASSWORD_RESET_SECRET'] = 'secret';
+        putenv('POSTGRES_DSN=');
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        unset($_ENV['POSTGRES_DSN'], $_ENV['POSTGRES_USER'], $_ENV['POSTGRES_PASSWORD']);
         $app = $this->getAppInstance();
         $pdo = Database::connectFromEnv();
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
-        $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
-        $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)');
+        try {
+            $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
+        } catch (\PDOException $e) {
+        }
+        try {
+            $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
+        } catch (\PDOException $e) {
+        }
+        try {
+            $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)');
+        } catch (\PDOException $e) {
+        }
         $userService = new UserService($pdo);
         $userService->create('alice', 'oldpass', 'alice@example.com', Roles::ADMIN);
 
@@ -55,7 +68,7 @@ class PasswordResetFlowTest extends TestCase
         $confirm = $this->createRequest('POST', '/password/reset/confirm')
             ->withParsedBody([
                 'token' => $token,
-                'password' => 'newpass',
+                'password' => 'Str0ngPass1',
                 'csrf_token' => 'tok',
             ]);
         $resp2 = $app->handle($confirm);
@@ -63,6 +76,69 @@ class PasswordResetFlowTest extends TestCase
 
         $updated = $userService->getByUsername('alice');
         $this->assertIsArray($updated);
-        $this->assertTrue(password_verify('newpass', (string)$updated['password']));
+        $this->assertTrue(password_verify('Str0ngPass1', (string)$updated['password']));
+    }
+
+    public function testRejectWeakPassword(): void
+    {
+        putenv('PASSWORD_RESET_SECRET=secret');
+        $_ENV['PASSWORD_RESET_SECRET'] = 'secret';
+        putenv('POSTGRES_DSN=');
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        unset($_ENV['POSTGRES_DSN'], $_ENV['POSTGRES_USER'], $_ENV['POSTGRES_PASSWORD']);
+        $app = $this->getAppInstance();
+        $pdo = Database::connectFromEnv();
+        Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        try {
+            $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
+        } catch (\PDOException $e) {
+        }
+        try {
+            $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
+        } catch (\PDOException $e) {
+        }
+        try {
+            $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)');
+        } catch (\PDOException $e) {
+        }
+        $userService = new UserService($pdo);
+        $userService->create('alice', 'oldpass', 'alice@example.com', Roles::ADMIN);
+
+        $mailer = new class extends MailService {
+            public array $sent = [];
+            public function __construct() {}
+            public function sendPasswordReset(string $to, string $link): void
+            {
+                $this->sent[] = ['to' => $to, 'link' => $link];
+            }
+        };
+
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+        $request = $this->createRequest('POST', '/password/reset/request')
+            ->withAttribute('mailService', $mailer)
+            ->withParsedBody(['username' => 'alice', 'csrf_token' => 'tok']);
+        $response = $app->handle($request);
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertCount(1, $mailer->sent);
+
+        $link = $mailer->sent[0]['link'];
+        $pos = strrpos($link, 'token=');
+        $token = $pos === false ? '' : substr($link, $pos + 6);
+        $this->assertNotSame('', $token, 'Token not found in link: ' . $link);
+
+        $confirm = $this->createRequest('POST', '/password/reset/confirm')
+            ->withParsedBody([
+                'token' => $token,
+                'password' => 'weak',
+                'csrf_token' => 'tok',
+            ]);
+        $resp2 = $app->handle($confirm);
+        $this->assertSame(400, $resp2->getStatusCode());
+
+        $updated = $userService->getByUsername('alice');
+        $this->assertIsArray($updated);
+        $this->assertTrue(password_verify('oldpass', (string)$updated['password']));
     }
 }


### PR DESCRIPTION
## Summary
- introduce `PasswordPolicy` service checking minimum length and character classes
- validate passwords in `PasswordController` and `PasswordResetController`
- cover strong and weak password scenarios in new tests

## Testing
- `vendor/bin/phpunit tests/Controller/PasswordControllerTest.php tests/Controller/PasswordResetFlowTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6897e7bdb7f8832ba2c2dac01c740439