### PR TITLE
feat: update admin QR codes to new design

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2059,7 +2059,7 @@ document.addEventListener('DOMContentLoaded', function () {
       if (descEl) descEl.textContent = ev.description || '';
       if (qrImg) {
         const link = window.baseUrl ? window.baseUrl : withBase('/?event=' + encodeURIComponent(ev.uid || ''));
-        qrImg.src = withBase('/qr.png?t=' + encodeURIComponent(link) + '&fg=000000&label=0');
+        qrImg.src = withBase('/qr.png?t=' + encodeURIComponent(link));
       }
       if (qrLabel) qrLabel.textContent = ev.name || '';
       catalogsEl.innerHTML = '';
@@ -2083,7 +2083,7 @@ document.addEventListener('DOMContentLoaded', function () {
         p.textContent = c.description || '';
         const img = document.createElement('img');
         const qrLink = (window.baseUrl ? window.baseUrl + href : href);
-                img.src = withBase('/qr.png?t=' + encodeURIComponent(qrLink) + '&fg=dc0000&label=0');
+                img.src = withBase('/qr.png?t=' + encodeURIComponent(qrLink));
         img.alt = 'QR';
         img.width = 96;
         img.height = 96;
@@ -2108,7 +2108,7 @@ document.addEventListener('DOMContentLoaded', function () {
         h4.className = 'uk-card-title';
         h4.textContent = t;
         const img = document.createElement('img');
-        img.src = withBase('/qr.png?t=' + encodeURIComponent(t) + '&fg=004bc8');
+        img.src = withBase('/qr.png?t=' + encodeURIComponent(t));
         img.alt = 'QR';
         img.width = 96;
         img.height = 96;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -369,7 +369,7 @@
             <p id="summaryEventDesc">{{ event.description }}</p>
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
-            <img id="summaryEventQr" src="{{ basePath }}/qr.png?t={{ (baseUrl ? baseUrl : '?event=' ~ event.uid)|url_encode }}&fg=000000&label=0" alt="QR" width="96" height="96">
+            <img id="summaryEventQr" src="{{ basePath }}/qr.png?t={{ (baseUrl ? baseUrl : '?event=' ~ event.uid)|url_encode }}" alt="QR" width="96" height="96">
             <div id="summaryEventLabel">{{ event.name }}</div>
           </div>
         </div>
@@ -386,7 +386,7 @@
               {% endif %}
               <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
               <p>{{ c.description }}</p>
-              <img src="{{ basePath }}/qr.png?t={{ link|url_encode }}&fg=dc0000&label=0" alt="QR" width="96" height="96">
+              <img src="{{ basePath }}/qr.png?t={{ link|url_encode }}" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}
@@ -403,7 +403,7 @@
             <div class="export-card uk-card uk-card-default uk-card-body uk-position-relative">
               <button class="qr-print-btn uk-icon-button uk-position-top-right" data-team="{{ t }}" uk-icon="icon: print" aria-label="QR-Code drucken"></button>
               <h4 class="uk-card-title">{{ t }}</h4>
-              <img src="{{ basePath }}/qr.png?t={{ t|url_encode }}&fg=004bc8" alt="QR" width="96" height="96">
+              <img src="{{ basePath }}/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -22,7 +22,7 @@
                         </div>
                         <div class="uk-width-auto@s uk-width-1-1">
                             {% set link = baseUrl ? baseUrl ~ '/?event=' ~ event.uid ~ '&katalog=' ~ katalog.slug : '?event=' ~ event.uid ~ '&katalog=' ~ katalog.slug %}
-                            <img src="{{ basePath }}/qr.png?t={{ link|url_encode }}&fg=dc0000" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
+                            <img src="{{ basePath }}/qr.png?t={{ link|url_encode }}" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
                             <button class="uk-button uk-button-danger uk-button-small uk-width-1-1">Löschen</button>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- drop legacy QR color/label params in admin summary templates
- streamline QR code rendering in admin JS
- remove old QR color usage in kataloge template

## Testing
- `composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_6897f72bea64832b89eccf61f2134197