### PR TITLE
Add session service and invalidate user sessions

### DIFF
--- a/migrations/20241202_user_sessions.sql
+++ b/migrations/20241202_user_sessions.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS user_sessions (
+    user_id INTEGER NOT NULL,
+    session_id TEXT PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/Application/Middleware/SessionMiddleware.php
+++ b/src/Application/Middleware/SessionMiddleware.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Application\Middleware;
 
+use App\Service\SessionService;
+use App\Infrastructure\Database;
+use PDO;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface as Middleware;
@@ -20,6 +23,21 @@ class SessionMiddleware implements Middleware
             session_start();
         }
 
-        return $handler->handle($request);
+        $response = $handler->handle($request);
+
+        if (isset($_SESSION['user']['id'])) {
+            try {
+                $pdo = $request->getAttribute('pdo');
+                if (!$pdo instanceof PDO) {
+                    $pdo = Database::connectFromEnv();
+                }
+                $service = new SessionService($pdo);
+                $service->persistSession((int) $_SESSION['user']['id'], session_id());
+            } catch (\Throwable $e) {
+                // Ignore persistence errors to avoid breaking the request flow.
+            }
+        }
+
+        return $response;
     }
 }

--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Service\PasswordPolicy;
 use App\Service\UserService;
 use App\Service\AuditLogger;
+use App\Service\SessionService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -18,15 +19,17 @@ class PasswordController
     private UserService $service;
     private PasswordPolicy $policy;
     private AuditLogger $audit;
+    private SessionService $sessions;
 
     /**
      * Inject user service and password policy.
      */
-    public function __construct(UserService $service, PasswordPolicy $policy, AuditLogger $audit)
+    public function __construct(UserService $service, PasswordPolicy $policy, AuditLogger $audit, SessionService $sessions)
     {
         $this->service = $service;
         $this->policy = $policy;
         $this->audit = $audit;
+        $this->sessions = $sessions;
     }
 
     /**
@@ -58,6 +61,7 @@ class PasswordController
         }
 
         $this->service->updatePassword((int)$id, $pass);
+        $this->sessions->invalidateUserSessions((int)$id);
 
         $this->audit->log('password_change', ['userId' => $id]);
 

--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -8,6 +8,7 @@ use App\Service\MailService;
 use App\Service\PasswordPolicy;
 use App\Service\PasswordResetService;
 use App\Service\UserService;
+use App\Service\SessionService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
@@ -21,12 +22,18 @@ class PasswordResetController
     private UserService $users;
     private PasswordResetService $resets;
     private PasswordPolicy $policy;
+    private SessionService $sessions;
 
-    public function __construct(UserService $users, PasswordResetService $resets, PasswordPolicy $policy)
-    {
+    public function __construct(
+        UserService $users,
+        PasswordResetService $resets,
+        PasswordPolicy $policy,
+        SessionService $sessions
+    ) {
         $this->users = $users;
         $this->resets = $resets;
         $this->policy = $policy;
+        $this->sessions = $sessions;
     }
 
     /**
@@ -100,6 +107,7 @@ class PasswordResetController
         }
 
         $this->users->updatePassword($userId, $pass);
+        $this->sessions->invalidateUserSessions($userId);
 
         return $response->withStatus(204);
     }

--- a/src/Service/SessionService.php
+++ b/src/Service/SessionService.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use PDO;
+
+/**
+ * Manage persisted session identifiers for users.
+ */
+class SessionService
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * Store the current session id for the given user.
+     */
+    public function persistSession(int $userId, string $sessionId): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO user_sessions(user_id, session_id) VALUES(?, ?) ON CONFLICT DO NOTHING'
+        );
+        $stmt->execute([$userId, $sessionId]);
+    }
+
+    /**
+     * Invalidate all sessions associated with the given user id.
+     */
+    public function invalidateUserSessions(int $userId): void
+    {
+        $stmt = $this->pdo->prepare('SELECT session_id FROM user_sessions WHERE user_id=?');
+        $stmt->execute([$userId]);
+        $ids = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        $path = session_save_path();
+        if ($path === '') {
+            $path = sys_get_temp_dir();
+        }
+
+        foreach ($ids as $id) {
+            $file = $path . DIRECTORY_SEPARATOR . 'sess_' . $id;
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
+
+        $del = $this->pdo->prepare('DELETE FROM user_sessions WHERE user_id=?');
+        $del->execute([$userId]);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -34,6 +34,7 @@ use App\Service\EmailConfirmationService;
 use App\Service\InvitationService;
 use App\Service\AuditLogger;
 use App\Service\QrCodeService;
+use App\Service\SessionService;
 use App\Controller\Admin\ProfileController;
 use App\Application\Middleware\LanguageMiddleware;
 use App\Application\Middleware\CsrfMiddleware;
@@ -144,6 +145,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $passwordPolicy = new PasswordPolicy();
         $emailConfirmService = new EmailConfirmationService($pdo);
         $auditLogger = new AuditLogger($pdo);
+        $sessionService = new SessionService($pdo);
 
         $request = $request
             ->withAttribute('plan', $plan)
@@ -167,10 +169,10 @@ return function (\Slim\App $app, TranslationService $translator) {
                 )
             )
             ->withAttribute('auditLogger', $auditLogger)
-            ->withAttribute('passwordController', new PasswordController($userService, $passwordPolicy, $auditLogger))
+            ->withAttribute('passwordController', new PasswordController($userService, $passwordPolicy, $auditLogger, $sessionService))
             ->withAttribute(
                 'passwordResetController',
-                new PasswordResetController($userService, $passwordResetService, $passwordPolicy)
+                new PasswordResetController($userService, $passwordResetService, $passwordPolicy, $sessionService)
             )
             ->withAttribute('userController', new UserController($userService))
             ->withAttribute('settingsController', new SettingsController($settingsService))

--- a/tests/Service/SessionServiceTest.php
+++ b/tests/Service/SessionServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\SessionService;
+use Tests\TestCase;
+
+class SessionServiceTest extends TestCase
+{
+    public function testInvalidateRemovesSessions(): void
+    {
+        $pdo = $this->createDatabase();
+        $pdo->exec('CREATE TABLE user_sessions(user_id INTEGER NOT NULL, session_id TEXT PRIMARY KEY)');
+
+        $pdo->exec("INSERT INTO user_sessions(user_id, session_id) VALUES (1,'abc'),(1,'def'),(2,'zzz')");
+
+        $path = sys_get_temp_dir() . '/sess_' . uniqid();
+        mkdir($path);
+        $old = session_save_path();
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+        session_save_path($path);
+        file_put_contents($path . '/sess_abc', '');
+        file_put_contents($path . '/sess_def', '');
+        file_put_contents($path . '/sess_zzz', '');
+
+        $service = new SessionService($pdo);
+        $service->invalidateUserSessions(1);
+
+        $this->assertFileDoesNotExist($path . '/sess_abc');
+        $this->assertFileDoesNotExist($path . '/sess_def');
+        $this->assertFileExists($path . '/sess_zzz');
+
+        $count1 = $pdo->query('SELECT COUNT(*) FROM user_sessions WHERE user_id=1')->fetchColumn();
+        $count2 = $pdo->query('SELECT COUNT(*) FROM user_sessions WHERE user_id=2')->fetchColumn();
+        $this->assertSame('0', (string)$count1);
+        $this->assertSame('1', (string)$count2);
+
+        @unlink($path . '/sess_zzz');
+        @rmdir($path);
+        session_save_path($old);
+    }
+}


### PR DESCRIPTION
## Summary
- manage persisted user session IDs and add invalidation support
- persist sessions on login and clear them after password resets/changes
- add migration and unit test for session invalidation

## Testing
- `vendor/bin/phpunit tests/Service/SessionServiceTest.php`
- `vendor/bin/phpunit` *(fails: no such column: published, Intervention\Image\Exceptions\DecoderException, and others)*

------
https://chatgpt.com/codex/tasks/task_e_6897f7efc854832b94ac00d424abd612