### PR TITLE
docs: add PHP 8.2 stable support note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Optimize landing page images
 - Add ghostscript to Docker image
 - Require PHP 8.2
+- Support for PHP 8.2 stable
 - Test against php 8.2
 - Update dependencies
 - Pin php base images to patch release


### PR DESCRIPTION
## Summary
- document support for PHP 8.2 stable in changelog

## Testing
- `composer test` *(fails: Script vendor/bin/phpunit handling the phpunit event returned with error code 2)*
- `vendor/bin/phpstan analyse` *(incomplete: Result is incomplete because of severe errors)*
- `vendor/bin/phpcs` *(fails: coding standard violations)*

## Release Notes
- Support for PHP 8.2 stable. Upgrade requires PHP 8.2 runtime and running `composer install` to pull updated dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6897f88b62b0832b902a869f85fc0180