### PR TITLE
feat: add parameterized catalog and team QR endpoints

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -44,10 +44,34 @@ class QrController
         QrCodeService $qrService
     ) {
         $this->config = $config;
-        $this->teams = $teams;
-        $this->events = $events;
-        $this->catalogs = $catalogs;
-        $this->qrService = $qrService;
+       $this->teams = $teams;
+       $this->events = $events;
+       $this->catalogs = $catalogs;
+       $this->qrService = $qrService;
+    }
+
+    /**
+     * Generate a catalog QR code with default styling.
+     */
+    public function catalog(Request $request, Response $response): Response
+    {
+        $out = $this->qrService->generateCatalog($request->getQueryParams());
+        $response->getBody()->write($out['body']);
+        return $response
+            ->withHeader('Content-Type', $out['mime'])
+            ->withStatus(200);
+    }
+
+    /**
+     * Generate a team QR code with default styling.
+     */
+    public function team(Request $request, Response $response): Response
+    {
+        $out = $this->qrService->generateTeam($request->getQueryParams());
+        $response->getBody()->write($out['body']);
+        return $response
+            ->withHeader('Content-Type', $out['mime'])
+            ->withStatus(200);
     }
 
     /**

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -9,6 +9,7 @@ use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\ErrorCorrectionLevel;
 use Endroid\QrCode\Logo\Logo;
+use Endroid\QrCode\QrCode;
 use Endroid\QrCode\RoundBlockSizeMode;
 use Endroid\QrCode\Writer\PngWriter;
 use Endroid\QrCode\Writer\SvgWriter;
@@ -17,6 +18,10 @@ use Throwable;
 
 class QrCodeService
 {
+    private const QR_SIZE_DEF = 300;
+    private const QR_MARGIN_DEF = 10;
+    private const LOGO_WIDTH_DEF = 80;
+    private const FONT_SIZE_DEF = 20;
     /**
      * Generate a QR code with the project's default styling.
      *
@@ -133,5 +138,182 @@ class QrCodeService
             }
         }
         return null;
+    }
+
+    /**
+     * @return array{mime:string,body:string}
+     */
+    public function generateCatalog(array $q): array
+    {
+        return $this->buildQrWithCenterLogoParam($q, [
+            't' => 'https://quizrace.app/?katalog=station',
+            'fg' => 'dc0000',
+        ]);
+    }
+
+    /**
+     * @return array{mime:string,body:string}
+     */
+    public function generateTeam(array $q): array
+    {
+        return $this->buildQrWithCenterLogoParam($q, [
+            't' => 'Team 1',
+            'fg' => '004bc8',
+        ]);
+    }
+
+    /**
+     * @param array<string,mixed> $q
+     * @param array{t:string,fg:string} $defaults
+     * @return array{mime:string,body:string}
+     */
+    private function buildQrWithCenterLogoParam(array $q, array $defaults): array
+    {
+        $data = (string) ($q['t'] ?? $defaults['t']);
+        $format = strtolower((string) ($q['format'] ?? 'png'));
+        if (!in_array($format, ['png', 'svg'], true)) {
+            $format = 'png';
+        }
+
+        $size = $this->clampInt($q['size'] ?? null, 64, 2048, self::QR_SIZE_DEF);
+        $margin = $this->clampInt($q['margin'] ?? null, 0, 40, self::QR_MARGIN_DEF);
+
+        $fgRgb = $this->parseHex((string) ($q['fg'] ?? $defaults['fg']));
+        $bgRgb = $this->parseHex((string) ($q['bg'] ?? 'ffffff'), 'ffffff');
+
+        $logoW = $this->clampInt($q['logo_width'] ?? null, 20, 200, self::LOGO_WIDTH_DEF);
+        $fontSz = $this->clampInt($q['font_size'] ?? null, 8, 48, self::FONT_SIZE_DEF);
+        $text1 = (string) ($q['text1'] ?? 'QUIZ');
+        $text2 = (string) ($q['text2'] ?? 'RACE');
+
+        $rounded = $this->boolParam($q['rounded'] ?? null, true);
+        $ec = $this->ecFromParam($q['ec'] ?? null);
+
+        $roundMode = $rounded ? RoundBlockSizeMode::Margin : RoundBlockSizeMode::None;
+        $qr = new QrCode(
+            data: $data,
+            encoding: new Encoding('UTF-8'),
+            errorCorrectionLevel: $ec,
+            size: $size,
+            margin: $margin,
+            roundBlockSizeMode: $roundMode,
+            foregroundColor: new Color($fgRgb[0], $fgRgb[1], $fgRgb[2]),
+            backgroundColor: new Color($bgRgb[0], $bgRgb[1], $bgRgb[2])
+        );
+
+        $logoPath = null;
+        $fontFile = $this->getFontFile();
+        if ($fontFile !== null && extension_loaded('gd')) {
+            $logoPath = $this->createTextLogoPng($text1, $text2, $fontFile, $fontSz, [0, 0, 0]);
+        }
+        $logo = $logoPath !== null ? new Logo($logoPath, $logoW) : null;
+
+        try {
+            if ($format === 'svg') {
+                $body = (new SvgWriter())->write($qr, $logo)->getString();
+                $mime = 'image/svg+xml';
+            } else {
+                $body = (new PngWriter())->write($qr, $logo)->getString();
+                $mime = 'image/png';
+            }
+        } finally {
+            if ($logoPath !== null) {
+                @unlink($logoPath);
+            }
+        }
+
+        return ['mime' => $mime, 'body' => $body];
+    }
+
+    /**
+     * @return array{0:int,1:int,2:int}
+     */
+    private function parseHex(string $hex, string $fallback = '000000'): array
+    {
+        $h = preg_replace('/[^0-9a-f]/i', '', $hex);
+        if ($h === '') {
+            $h = $fallback;
+        }
+        if (strlen($h) === 3) {
+            $h = $h[0] . $h[0] . $h[1] . $h[1] . $h[2] . $h[2];
+        }
+        $h = str_pad(substr($h, 0, 6), 6, '0');
+        return [
+            hexdec(substr($h, 0, 2)),
+            hexdec(substr($h, 2, 2)),
+            hexdec(substr($h, 4, 2)),
+        ];
+    }
+
+    private function boolParam(mixed $v, bool $def = true): bool
+    {
+        if ($v === null) {
+            return $def;
+        }
+        return in_array(strtolower((string) $v), ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function ecFromParam(?string $v): ErrorCorrectionLevel
+    {
+        return match (strtolower((string) $v)) {
+            'low' => ErrorCorrectionLevel::Low,
+            'medium' => ErrorCorrectionLevel::Medium,
+            'quartile' => ErrorCorrectionLevel::Quartile,
+            default => ErrorCorrectionLevel::High,
+        };
+    }
+
+    private function clampInt(mixed $v, int $min, int $max, int $def): int
+    {
+        $i = filter_var($v, FILTER_VALIDATE_INT);
+        if ($i === false) {
+            $i = $def;
+        }
+        return max($min, min($max, $i));
+    }
+
+    /**
+     * Create PNG logo with two lines of centered text.
+     *
+     * @param array{0:int,1:int,2:int} $rgb
+     */
+    private function createTextLogoPng(
+        string $line1,
+        string $line2,
+        string $fontFile,
+        int $fontSize,
+        array $rgb
+    ): string {
+        $padding = 10;
+        $lineHeight = $fontSize + 6;
+        $measure = function (string $t) use ($fontFile, $fontSize): int {
+            $bb = imagettfbbox($fontSize, 0, $fontFile, $t);
+            return abs($bb[2] - $bb[0]);
+        };
+        $w1 = $measure($line1);
+        $w2 = $measure($line2);
+        $width = max($w1, $w2) + $padding * 2;
+        $height = 2 * $lineHeight + $padding * 2;
+
+        $im = imagecreatetruecolor($width, $height);
+        imagesavealpha($im, true);
+        imagefill($im, 0, 0, imagecolorallocatealpha($im, 0, 0, 0, 127));
+        $col = imagecolorallocate($im, $rgb[0], $rgb[1], $rgb[2]);
+
+        $draw = function (string $t, int $y) use ($im, $fontFile, $fontSize, $width, $col): void {
+            $bb = imagettfbbox($fontSize, 0, $fontFile, $t);
+            $tw = abs($bb[2] - $bb[0]);
+            $x = (int) (($width - $tw) / 2);
+            imagettftext($im, $fontSize, 0, $x, $y, $col, $fontFile, $t);
+        };
+        $y1 = $padding + $fontSize;
+        $y2 = $y1 + $lineHeight;
+        $draw($line1, $y1);
+        $draw($line2, $y2);
+
+        $tmp = tempnam(sys_get_temp_dir(), 'qrlogo_') . '.png';
+        imagepng($im, $tmp);
+        imagedestroy($im);
+        return $tmp;
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -590,6 +590,12 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/qr.pdf', function (Request $request, Response $response) {
         return $request->getAttribute('qrController')->pdf($request, $response);
     });
+    $app->get('/qr/catalog', function (Request $request, Response $response) {
+        return $request->getAttribute('qrController')->catalog($request, $response);
+    });
+    $app->get('/qr/team', function (Request $request, Response $response) {
+        return $request->getAttribute('qrController')->team($request, $response);
+    });
     $app->get('/invites.pdf', function (Request $request, Response $response) {
         return $request->getAttribute('qrController')->pdfAll($request, $response);
     })->add(new RoleAuthMiddleware('admin'));

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -62,6 +62,29 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
+    public function testCatalogQrDefaults(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/qr/catalog');
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/png', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
+    }
+
+    public function testTeamQrSvgFormat(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/qr/team')
+            ->withQueryParams(['format' => 'svg']);
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/svg+xml', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
+    }
+
     public function testQrPdfIsGenerated(): void
     {
         $app = $this->getAppInstance();


### PR DESCRIPTION
## Summary
- allow building QR codes with overridable styling and logo text
- add /qr/catalog and /qr/team routes with defaults
- cover new endpoints with controller tests

## Testing
- `composer test` *(fails: Database error: fail, Error creating tenant: boom, Failed asserting that 500 is identical to 200, etc.)*
- `vendor/bin/phpunit tests/Controller/QrControllerTest.php` *(fails: Intervention\Image\Exceptions\DecoderException: Unable to decode input)*

------
https://chatgpt.com/codex/tasks/task_e_6897fa6f04a4832b977bde406cf70736