### PR TITLE
Replace testimonial section with invitation

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -61,19 +61,21 @@
   </div>
 </section>
 
-<!-- Trust / Weiterempfehlung -->
+<!-- Vision & Einladung -->
 <section class="uk-section uk-section-primary uk-light">
   <div class="uk-container">
-    <div class="uk-grid uk-flex-middle" uk-grid uk-scrollspy="target: > div; cls: uk-animation-fade; delay: 150">
+    <div class="uk-grid uk-flex-middle" uk-grid>
       <div class="uk-width-expand@m">
-        <h6 class="uk-h2 uk-heading-bullet" style="color:#fff;">Begeisterte Stimmen</h6>
-        <blockquote style="color:#fff; font-size:1.2rem; font-style:italic; margin:0;">
-          „Noch nie war ein Teamevent so unkompliziert, interaktiv und spaßig!“<br>
-          <span style="font-weight:bold;">&ndash; HR Managerin, Musterfirma GmbH</span>
-        </blockquote>
+        <h6 class="uk-h2 uk-heading-bullet" style="color:#fff;">Warum QuizRace?</h6>
+        <div style="color:#fff; font-size:1.1em;">
+          <strong>Wir bringen Spaß, Wettbewerb und Teamgeist in jedes Event.</strong><br><br>
+          Entwickelt aus über 20 Jahren Erfahrung in Event- und Softwareprojekten, 
+          ist QuizRace die datensichere Plattform für interaktive Veranstaltungen – 
+          live, vor Ort oder hybrid. Einfach starten, begeistern und verbinden.
+        </div>
       </div>
-      <div class="uk-width-expand@m uk-text-center">
-        <img loading="lazy" decoding="async" src="{{ basePath }}/img/provenexpert_quizrace.png" alt="Kundenbewertungen & Erfahrungen zu QuizRace" style="height:84px; border:0;">
+      <div class="uk-width-auto@m uk-text-center">
+        <a class="btn btn-black uk-button-large" href="{{ basePath }}/onboarding">Jetzt kostenlos ausprobieren</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Replace placeholder testimonial section with a vision-and-invitation block encouraging free trials

## Testing
- `composer test` *(fails: Database error: fail; PasswordControllerTest::testAcceptStrongPassword; PasswordResetFlowTest::testFullResetFlow)*

------
https://chatgpt.com/codex/tasks/task_e_6897fc25fdbc832badfef86bda1c0348