### PR TITLE
Fix landing page section colors for better contrast

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -25,7 +25,7 @@
 </section>
 
 <!-- Warum QuizRace? -->
-<section class="uk-section uk-section-primary uk-light">
+<section class="uk-section uk-section-default">
   <div class="uk-container">
     <div class="uk-grid uk-flex-middle" uk-grid>
       <div class="uk-width-expand@m">
@@ -262,21 +262,21 @@
       <div>
         <div class="uk-grid uk-child-width-1-1 uk-grid-small">
           <div>
-            <div class="uk-card uk-card-default uk-card-body bg-blue uk-text-left padding-30px uk-light">
+            <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px">
               <p class="uk-margin-small-bottom uk-text-large">E-Mail</p>
-              <a href="mailto:office@quizrace.app" class="uk-text-lead uk-link-reset uk-text-light">office@quizrace.app</a>
+              <a href="mailto:office@quizrace.app" class="uk-text-lead uk-link-reset">office@quizrace.app</a>
             </div>
           </div>
           <div>
-            <div class="uk-card uk-card-default uk-card-body bg-blue uk-text-left padding-30px uk-light">
+            <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px">
               <p class="uk-margin-small-bottom uk-text-large">Telefon</p>
-              <a href="tel:+4933203609080" class="uk-text-lead uk-link-reset uk-text-light">+49 33203 609080</a>
+              <a href="tel:+4933203609080" class="uk-text-lead uk-link-reset">+49 33203 609080</a>
             </div>
           </div>
           <div>
-            <div class="uk-card uk-card-default uk-card-body bg-blue uk-text-left padding-30px uk-light">
+            <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px">
               <p class="uk-margin-small-bottom uk-text-large">Adresse</p>
-              <span class="uk-text-lead uk-text-light">Weidenbusch 8, 14532 Kleinmachnow</span>
+              <span class="uk-text-lead">Weidenbusch 8, 14532 Kleinmachnow</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- use neutral background for "Warum QuizRace?" section to avoid consecutive blue blocks
- show contact information on white cards for better contrast

## Testing
- `composer test` *(fails: Tests: 166, Assertions: 346, Errors: 8, Failures: 5)*

------
https://chatgpt.com/codex/tasks/task_e_6898029533a0832ba3a26a2f0a0ee3c9