### PR TITLE
Use Noto Sans Bold for landing page logo

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
   <link href="https://fonts.googleapis.com/css?family=Poppins:400,500,700,800,900&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,500,700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Noto+Sans:700&display=swap" rel="stylesheet">
   <style>
     body, .uk-section, .uk-card {
       font-family: 'Roboto', Arial, sans-serif;
@@ -176,6 +177,8 @@
     .topbar .uk-logo {
       font-size: 1.25rem;
       padding: 0;
+      font-family: 'Noto Sans', sans-serif;
+      font-weight: 700;
     }
     @media (max-width: 640px) {
       .topbar .uk-logo {


### PR DESCRIPTION
## Summary
- Load Noto Sans Bold from Google Fonts on the landing page
- Style landing page logo with Noto Sans Bold

## Testing
- `composer test` *(fails: SQL column missing and image decode errors)*

------
https://chatgpt.com/codex/tasks/task_e_68980368fc14832b8e9b1013ea65ffed