### PR TITLE
Set neutral background for founder section

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -218,7 +218,7 @@
 </section>
 
 <!-- Über uns / Founder -->
-<section class="uk-section uk-section-muted">
+<section class="uk-section about-section">
   <div class="uk-container">
     <h2 class="uk-text-center uk-heading-medium" uk-scrollspy="cls: uk-animation-slide-top-small">Wer steckt hinter QuizRace?</h2>
     <div class="uk-width-2xlarge uk-margin-auto uk-text-center uk-text-lead" uk-scrollspy="cls: uk-animation-fade; delay: 150">

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -8,6 +8,11 @@ body {
   overflow-x: hidden;
 }
 
+/* Background for "Wer steckt hinter QuizRace?" section */
+.about-section {
+  background-color: #f3f3f3;
+}
+
 body.uk-padding {
   padding-top: 56px;
 }


### PR DESCRIPTION
## Summary
- make "Wer steckt hinter QuizRace?" section use a neutral grey background
- add `.about-section` style to main stylesheet

## Testing
- `composer test` *(fails: Slim Application Error, database errors)*
- `vendor/bin/phpcs` *(fails: existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_689804084738832b9a9e7aa53eec28c5