### PR TITLE
Add rounded styling to admin QR images

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -701,4 +701,8 @@ body.dark-mode .sticky-actions {
   height: auto !important;
 }
 
+.qr-img {
+  border-radius: 8px;
+}
+
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -369,7 +369,7 @@
             <p id="summaryEventDesc">{{ event.description }}</p>
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
-            <img id="summaryEventQr" src="{{ basePath }}/qr.png?t={{ (baseUrl ? baseUrl : '?event=' ~ event.uid)|url_encode }}" alt="QR" width="96" height="96">
+            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr.png?t={{ (baseUrl ? baseUrl : '?event=' ~ event.uid)|url_encode }}" alt="QR" width="96" height="96">
             <div id="summaryEventLabel">{{ event.name }}</div>
           </div>
         </div>
@@ -386,7 +386,7 @@
               {% endif %}
               <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
               <p>{{ c.description }}</p>
-              <img src="{{ basePath }}/qr.png?t={{ link|url_encode }}" alt="QR" width="96" height="96">
+              <img class="qr-img" src="{{ basePath }}/qr.png?t={{ link|url_encode }}" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}
@@ -403,7 +403,7 @@
             <div class="export-card uk-card uk-card-default uk-card-body uk-position-relative">
               <button class="qr-print-btn uk-icon-button uk-position-top-right" data-team="{{ t }}" uk-icon="icon: print" aria-label="QR-Code drucken"></button>
               <h4 class="uk-card-title">{{ t }}</h4>
-              <img src="{{ basePath }}/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
+              <img class="qr-img" src="{{ basePath }}/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}


### PR DESCRIPTION
## Summary
- add `qr-img` class for rounded QR images
- apply rounded styling to admin QR code images

## Testing
- `composer test` *(fails: 166 tests, 8 errors, 5 failures)*

------
https://chatgpt.com/codex/tasks/task_e_689808579ab8832b860c093ab7137cb6