### PR TITLE
Ensure QR codes include logo and rounded styling

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -497,7 +497,7 @@ document.addEventListener('DOMContentLoaded', function () {
       e.preventDefault();
       const team = btn.getAttribute('data-team');
       if (team) {
-        window.open(withBase('/qr.pdf?t=' + encodeURIComponent(team)), '_blank');
+        window.open(withBase('/qr.pdf?t=' + encodeURIComponent(team) + '&logoText=QUIZ%0ARACE&rounded=1'), '_blank');
       }
     });
   });
@@ -2059,7 +2059,7 @@ document.addEventListener('DOMContentLoaded', function () {
       if (descEl) descEl.textContent = ev.description || '';
       if (qrImg) {
         const link = window.baseUrl ? window.baseUrl : withBase('/?event=' + encodeURIComponent(ev.uid || ''));
-        qrImg.src = withBase('/qr.png?t=' + encodeURIComponent(link));
+        qrImg.src = withBase('/qr.png?t=' + encodeURIComponent(link) + '&text1=QUIZ&text2=RACE&rounded=1');
       }
       if (qrLabel) qrLabel.textContent = ev.name || '';
       catalogsEl.innerHTML = '';
@@ -2083,7 +2083,7 @@ document.addEventListener('DOMContentLoaded', function () {
         p.textContent = c.description || '';
         const img = document.createElement('img');
         const qrLink = (window.baseUrl ? window.baseUrl + href : href);
-                img.src = withBase('/qr.png?t=' + encodeURIComponent(qrLink));
+                img.src = withBase('/qr/catalog?t=' + encodeURIComponent(qrLink));
         img.alt = 'QR';
         img.width = 96;
         img.height = 96;
@@ -2108,7 +2108,7 @@ document.addEventListener('DOMContentLoaded', function () {
         h4.className = 'uk-card-title';
         h4.textContent = t;
         const img = document.createElement('img');
-        img.src = withBase('/qr.png?t=' + encodeURIComponent(t));
+        img.src = withBase('/qr/team?t=' + encodeURIComponent(t));
         img.alt = 'QR';
         img.width = 96;
         img.height = 96;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -369,7 +369,7 @@
             <p id="summaryEventDesc">{{ event.description }}</p>
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
-            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr.png?t={{ (baseUrl ? baseUrl : '?event=' ~ event.uid)|url_encode }}" alt="QR" width="96" height="96">
+            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr.png?t={{ (baseUrl ? baseUrl : '?event=' ~ event.uid)|url_encode }}&text1=QUIZ&text2=RACE&rounded=1" alt="QR" width="96" height="96">
             <div id="summaryEventLabel">{{ event.name }}</div>
           </div>
         </div>
@@ -386,7 +386,7 @@
               {% endif %}
               <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
               <p>{{ c.description }}</p>
-              <img class="qr-img" src="{{ basePath }}/qr.png?t={{ link|url_encode }}" alt="QR" width="96" height="96">
+              <img class="qr-img" src="{{ basePath }}/qr/catalog?t={{ link|url_encode }}" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}
@@ -403,7 +403,7 @@
             <div class="export-card uk-card uk-card-default uk-card-body uk-position-relative">
               <button class="qr-print-btn uk-icon-button uk-position-top-right" data-team="{{ t }}" uk-icon="icon: print" aria-label="QR-Code drucken"></button>
               <h4 class="uk-card-title">{{ t }}</h4>
-              <img class="qr-img" src="{{ basePath }}/qr.png?t={{ t|url_encode }}" alt="QR" width="96" height="96">
+              <img class="qr-img" src="{{ basePath }}/qr/team?t={{ t|url_encode }}" alt="QR" width="96" height="96">
             </div>
           </div>
           {% else %}


### PR DESCRIPTION
## Summary
- Add explicit logo text and rounding parameters to event QR codes.
- Use `/qr/catalog` and `/qr/team` endpoints for catalog and team QR generation.
- Pass logo options when printing team QR PDFs.

## Testing
- `composer test` *(fails: 8 errors, 5 failures)*

------
https://chatgpt.com/codex/tasks/task_e_689809e80124832b9cdfe7f73b061977