### PR TITLE
Darken About Us section background

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -10,7 +10,7 @@ body {
 
 /* Background for "Wer steckt hinter QuizRace?" section */
 .about-section {
-  background-color: #f3f3f3;
+  background-color: #e0e0e0;
 }
 
 body.uk-padding {


### PR DESCRIPTION
## Summary
- darken About Us section background on landing page for improved contrast

## Testing
- `composer test` (fails: Failed to reload nginx)

------
https://chatgpt.com/codex/tasks/task_e_68980c2bb0b0832bbd035000bc87eb85