### PR TITLE
Use chalk underline for landing page rotating word

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -6,7 +6,7 @@
       <div class="uk-width-1-1 uk-width-3-4@m">
         <div class="hero-text">
           <h2 class="hero-headline" uk-scrollspy="cls: uk-animation-slide-right-small">
-            Das Team-Quiz, das Ihr Event <span id="rotating-word" class="marker">unvergesslich</span> macht.
+            Das Team-Quiz, das Ihr Event <span id="rotating-word" class="marker-text">unvergesslich</span> macht.
           </h2>
           <p class="hero-subtext" uk-scrollspy="cls: uk-animation-fade; delay: 150">
             Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams.<br>
@@ -28,112 +28,66 @@
 const words = ["unvergesslich", "spannend", "interaktiv", "einzigartig", "unterhaltsam"]; // Wörterliste
 const changeInterval = 5500; // Wechselintervall in Millisekunden
 const fadeDuration = 1000; // Dauer der Ein-/Ausblendung
-const markerDelay = 300; // Verzögerung des Marker-Starts
-const markerColor = "#ffde59"; // Markerfarbe
 
 const el = document.getElementById("rotating-word");
-document.documentElement.style.setProperty("--marker-color", markerColor);
 let i = 0;
 
 setInterval(() => {
-  el.classList.remove("marker-animate");
   el.style.opacity = 0;
 
   setTimeout(() => {
     i = (i + 1) % words.length;
     el.textContent = words[i];
     el.style.opacity = 1;
-
-    setTimeout(() => {
-      void el.offsetWidth;
-      el.classList.add("marker-animate");
-    }, markerDelay);
   }, fadeDuration);
 }, changeInterval);
 </script>
 
 <style>
-:root {
-  --marker-color: #ffde59;
-}
-
 #rotating-word {
   transition: opacity 1s ease;
-  font-weight: bold;
-  position: relative;
-  display: inline-block;
 }
 
-/* Kreide-/Marker-Strich als ::after */
-.marker::after {
+.marker-text {
+  display: inline-block;
+  font-size: 2em;
+  font-weight: bold;
+  position: relative;
+  padding-bottom: 0.3em;
+}
+
+/* Kreidestrich */
+.marker-text::after {
   content: "";
   position: absolute;
   left: 0;
-  bottom: -0.12em;
-  height: 0.42em;
-  width: 0%;
-  --marker: var(--marker-color);
-
-  background:
-    linear-gradient(115deg, rgba(0,0,0,0.08) 0 2%, transparent 2% 6%) repeat,
-    linear-gradient(295deg, rgba(0,0,0,0.05) 0 3%, transparent 3% 7%) repeat,
-    linear-gradient(var(--marker), var(--marker));
-  background-size:
-    10px 10px,
-    14px 14px,
-    100% 100%;
-  background-blend-mode: multiply, multiply, normal;
-
-  -webkit-mask:
-      radial-gradient(10px 8px at 6% 0, transparent 52%, #000 53%) repeat-x,
-      radial-gradient(12px 8px at 18% 0, transparent 50%, #000 51%) repeat-x,
-      radial-gradient(12px 8px at 10% 100%, transparent 51%, #000 52%) repeat-x,
-      radial-gradient(10px 8px at 24% 100%, transparent 53%, #000 54%) repeat-x,
-      linear-gradient(#000, #000);
-  -webkit-mask-size:
-      22px 9px,
-      28px 9px,
-      26px 9px,
-      18px 9px,
-      100% 100%;
-  -webkit-mask-position:
-      0 0,
-      0 0,
-      0 100%,
-      0 100%,
-      0 0;
-  -webkit-mask-composite: source-over, source-over, source-over, source-over, source-in;
-
-  mask:
-      radial-gradient(10px 8px at 6% 0, transparent 52%, #000 53%) repeat-x,
-      radial-gradient(12px 8px at 18% 0, transparent 50%, #000 51%) repeat-x,
-      radial-gradient(12px 8px at 10% 100%, transparent 51%, #000 52%) repeat-x,
-      radial-gradient(10px 8px at 24% 100%, transparent 53%, #000 54%) repeat-x,
-      linear-gradient(#000, #000);
-  mask-size:
-      22px 9px,
-      28px 9px,
-      26px 9px,
-      18px 9px,
-      100% 100%;
-  mask-position:
-      0 0,
-      0 0,
-      0 100%,
-      0 100%,
-      0 0;
-
-  filter: blur(0.4px);
-  transform: rotate(-0.3deg);
-  transform-origin: left center;
-
-  transition: width 0.55s cubic-bezier(.2,.9,.2,1);
-  z-index: -1;
-}
-
-/* Aktivierung: wird per JS-Klasse gesetzt */
-.marker-animate::after {
+  bottom: -0.2em;
   width: 100%;
+  height: 0.5em;
+  --chalk: #f8f6f0; /* Kreidefarbe */
+
+  /* Basisfarbe */
+  background-color: var(--chalk);
+  opacity: 0.9;
+
+  /* Unregelmäßige Dicke */
+  clip-path: polygon(
+    0% 65%, 5% 50%, 10% 70%, 15% 55%, 20% 75%, 25% 60%,
+    30% 68%, 35% 50%, 40% 72%, 45% 58%, 50% 76%, 55% 54%,
+    60% 73%, 65% 57%, 70% 70%, 75% 55%, 80% 72%, 85% 60%,
+    90% 68%, 95% 53%, 100% 65%
+  );
+
+  /* Kreidekörnung */
+  background-image:
+    radial-gradient(circle at 1px 1px, rgba(0,0,0,0.1) 1px, transparent 0),
+    radial-gradient(circle at 3px 2px, rgba(0,0,0,0.08) 1px, transparent 0),
+    radial-gradient(circle at 2px 4px, rgba(0,0,0,0.06) 1px, transparent 0);
+  background-size: 5px 5px;
+
+  /* Leicht weich und kontrastreich */
+  filter: blur(0.6px) contrast(1.05);
+  z-index: -1;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- style the landing page's rotating word with a chalk-like underline
- simplify rotating word script to only fade between words

## Testing
- `composer test` *(fails: Tests: 166, Assertions: 346, Errors: 8, Failures: 5)*

------
https://chatgpt.com/codex/tasks/task_e_689813cc99f8832ba194930a77dd2a04