### PR TITLE
Enable punchout logos and round mode selection for QR codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Statistik-Tab beschrieben
 
+### Feat
+
+- Enable punch-out logos and custom round modes for QR codes
+
 ### Chore
 
 - Cascade delete events


### PR DESCRIPTION
## Summary
- expose new RoundBlockSizeMode options and logo punch-out support in QR code service
- document QR code enhancements in changelog

## Testing
- `composer test` *(fails: Slim Application Error, Database error: fail, see log)*

------
https://chatgpt.com/codex/tasks/task_e_689814a7d434832ba23a9f4e3484c1bf