### PR TITLE
refactor: centralise qr-code option constants

### DIFF
--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -71,13 +71,13 @@ class QrCodeService
                 data: $data,
                 encoding: new Encoding('UTF-8'),
                 errorCorrectionLevel: ErrorCorrectionLevel::High,
-                size: 300,
-                margin: 10,
+                size: self::QR_SIZE_DEF,
+                margin: self::QR_MARGIN_DEF,
                 roundBlockSizeMode: RoundBlockSizeMode::Margin,
                 foregroundColor: $fg,
                 backgroundColor: $bg,
                 logoPath: $logoPath ?? '',
-                logoResizeToWidth: $logoPath !== null ? 80 : null,
+                logoResizeToWidth: $logoPath !== null ? self::LOGO_WIDTH_DEF : null,
                 logoPunchoutBackground: $logoPath !== null,
             ))->build();
         } finally {


### PR DESCRIPTION
## Summary
- use predefined constants for QR size, margin and logo width when building QR codes

## Testing
- `vendor/bin/phpunit` *(fails: Failed asserting that 500 is identical to 204)*

------
https://chatgpt.com/codex/tasks/task_e_68981bd7ec40832baf5b1352458aa198