### PR TITLE
Show feedback after password reset request

### DIFF
--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -31,10 +31,12 @@
         {% if success %}
         <div class="uk-alert-success" uk-alert>
           <p>Falls die E-Mail existiert, wurde ein Link gesendet.</p>
+          <p><a href="{{ basePath }}/login">Zurück zum Login</a></p>
         </div>
         {% elseif error %}
         <div class="uk-alert-danger" uk-alert>
           <p>Anfrage fehlgeschlagen.</p>
+          <p><a href="{{ basePath }}/login">Zurück zum Login</a></p>
         </div>
         {% endif %}
         <form method="post" action="/password/reset/request">

--- a/tests/Controller/PasswordResetFlowTest.php
+++ b/tests/Controller/PasswordResetFlowTest.php
@@ -33,15 +33,23 @@ class PasswordResetFlowTest extends TestCase
         } catch (\PDOException $e) {
         }
         try {
-            $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)');
+            $pdo->exec(
+                'CREATE TABLE password_resets(' .
+                'user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)'
+            );
         } catch (\PDOException $e) {
         }
         $userService = new UserService($pdo);
         $userService->create('alice', 'oldpass', 'alice@example.com', Roles::ADMIN);
 
-        $mailer = new class extends MailService {
+        $mailer = new class extends MailService
+        {
             public array $sent = [];
-            public function __construct() {}
+
+            public function __construct()
+            {
+            }
+
             public function sendPasswordReset(string $to, string $link): void
             {
                 $this->sent[] = ['to' => $to, 'link' => $link];
@@ -54,7 +62,10 @@ class PasswordResetFlowTest extends TestCase
             ->withAttribute('mailService', $mailer)
             ->withParsedBody(['username' => 'alice', 'csrf_token' => 'tok']);
         $response = $app->handle($request);
-        $this->assertSame(204, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('Link gesendet', $body);
+        $this->assertStringContainsString('/login', $body);
         $this->assertCount(1, $mailer->sent);
 
         $link = $mailer->sent[0]['link'];
@@ -99,15 +110,23 @@ class PasswordResetFlowTest extends TestCase
         } catch (\PDOException $e) {
         }
         try {
-            $pdo->exec('CREATE TABLE password_resets(user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)');
+            $pdo->exec(
+                'CREATE TABLE password_resets(' .
+                'user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)'
+            );
         } catch (\PDOException $e) {
         }
         $userService = new UserService($pdo);
         $userService->create('alice', 'oldpass', 'alice@example.com', Roles::ADMIN);
 
-        $mailer = new class extends MailService {
+        $mailer = new class extends MailService
+        {
             public array $sent = [];
-            public function __construct() {}
+
+            public function __construct()
+            {
+            }
+
             public function sendPasswordReset(string $to, string $link): void
             {
                 $this->sent[] = ['to' => $to, 'link' => $link];
@@ -120,7 +139,7 @@ class PasswordResetFlowTest extends TestCase
             ->withAttribute('mailService', $mailer)
             ->withParsedBody(['username' => 'alice', 'csrf_token' => 'tok']);
         $response = $app->handle($request);
-        $this->assertSame(204, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $this->assertCount(1, $mailer->sent);
 
         $link = $mailer->sent[0]['link'];


### PR DESCRIPTION
## Summary
- Render password reset request page with success/error feedback and login link
- Add UI link back to login after requesting a password reset
- Update password reset flow tests for new HTML response

## Testing
- `vendor/bin/phpunit` *(fails: Failed asserting that 500 is identical to 204.)*
- `composer test` *(fails: Failed asserting that 500 is identical to 204.)*

------
https://chatgpt.com/codex/tasks/task_e_68981cf96ff4832ba47a04966232736b