### PR TITLE
Remove manual save for events

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1314,7 +1314,6 @@ document.addEventListener('DOMContentLoaded', function () {
   // --------- Veranstaltungen ---------
   const eventsListEl = document.getElementById('eventsList');
   const eventAddBtn = document.getElementById('eventAddBtn');
-  const eventsSaveBtn = document.getElementById('eventsSaveBtn');
   const eventSelect = document.getElementById('eventSelect');
   const eventOpenBtn = document.getElementById('eventOpenBtn');
   const langSelect = document.getElementById('langSelect');
@@ -1330,13 +1329,13 @@ document.addEventListener('DOMContentLoaded', function () {
     })).filter(e => e.name);
   }
 
-  function saveEventOrder() {
+  function saveEvents() {
     const list = collectEvents();
     apiFetch('/events.json', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(list)
-    }).catch(() => {});
+    }).catch(() => notify('Fehler beim Speichern', 'danger'));
     updateEventRowNumbers();
   }
 
@@ -1441,10 +1440,13 @@ document.addEventListener('DOMContentLoaded', function () {
     del.setAttribute('uk-icon', 'trash');
     del.setAttribute('aria-label', 'Löschen');
     del.addEventListener('click', () => {
-      if (confirm('Veranstaltung wirklich löschen? Dabei werden auch alle angelegten Kataloge, Fragen und Teams entfernt.')) {
-        row.remove();
-        updateEventRowNumbers();
-      }
+      UIkit.modal
+        .confirm('Veranstaltung wirklich löschen? Dabei werden auch alle angelegten Kataloge, Fragen und Teams entfernt.')
+        .then(() => {
+          row.remove();
+          saveEvents();
+        })
+        .catch(() => {});
     });
     delCell.appendChild(del);
 
@@ -1506,8 +1508,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   if (eventsListEl && window.UIkit && UIkit.util) {
     UIkit.util.on(eventsListEl, 'moved', () => {
-      saveEventOrder();
-      updateEventRowNumbers();
+      saveEvents();
     });
   }
 
@@ -1527,19 +1528,8 @@ document.addEventListener('DOMContentLoaded', function () {
     updateEventRowNumbers();
   });
 
-  eventsSaveBtn?.addEventListener('click', e => {
-    e.preventDefault();
-    const list = collectEvents();
-    apiFetch('/events.json', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(list)
-    })
-      .then(r => {
-        if (!r.ok) throw new Error(r.statusText);
-        notify('Liste gespeichert', 'success');
-      })
-      .catch(() => notify('Fehler beim Speichern', 'danger'));
+  eventsListEl?.addEventListener('change', () => {
+    saveEvents();
   });
 
   eventSelect?.addEventListener('change', () => {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -53,7 +53,7 @@
     {% endblock %}
   {% endembed %}
   <ul id="adminTabs" uk-tab="connect: #adminSwitcher">
-    <li class="uk-active" data-route="events" data-help="Veranstaltungen anlegen oder bearbeiten. Jede Zeile enthält Name, Beginn, Ende und Beschreibung. 'Hinzufügen' erstellt einen neuen Eintrag. Speichern übernimmt die Änderungen."><a href="#" data-route-url="{{ basePath }}/admin/events">{{ t('tab_events') }}</a></li>
+    <li class="uk-active" data-route="events" data-help="Veranstaltungen anlegen oder bearbeiten. Jede Zeile enthält Name, Beginn, Ende und Beschreibung. 'Hinzufügen' erstellt einen neuen Eintrag. Änderungen werden automatisch gespeichert."><a href="#" data-route-url="{{ basePath }}/admin/events">{{ t('tab_events') }}</a></li>
     <li data-route="event/settings" data-help="Logo hochladen und Vorschau ansehen. Seitentitel, Überschrift und Untertitel festlegen. Hintergrund- und Buttonfarbe wählen. Optional den Button 'Antwort prüfen' und den QR-Code-Login aktivieren. 'Zurücksetzen' lädt gespeicherte Werte, 'Speichern' übernimmt Änderungen."><a href="#" data-route-url="{{ basePath }}/admin/event/settings">{{ t('tab_event_settings') }}</a></li>
     <li data-route="catalogs" data-help="Fragenkataloge anlegen oder bearbeiten. Jede Zeile enthält einen Slug, Name, Beschreibung und optional einen Buchstaben für das Rätselwort. Der Slug kann angepasst werden. 'Hinzufügen' erstellt einen neuen Katalog, das rote × entfernt einen Eintrag. Speichern übernimmt die Änderungen."><a href="#" data-route-url="{{ basePath }}/admin/catalogs">{{ t('tab_catalogs') }}</a></li>
     <li data-route="questions" data-help="Nach Auswahl eines Katalogs einzelne Fragen bearbeiten oder neue anlegen. Das Plus-Symbol legt eine weitere Frage an, 'Zurücksetzen' verwirft Änderungen, 'Speichern' sichert den gesamten Katalog."><a href="#" data-route-url="{{ basePath }}/admin/questions">{{ t('tab_questions') }}</a></li>
@@ -94,9 +94,6 @@
         </div>
         <div class="uk-margin">
           <button id="eventAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_event_add') }}; pos: left"></button>
-        </div>
-        <div class="uk-margin uk-flex uk-flex-right">
-          <button id="eventsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: {{ t('tip_save_changes') }}; pos: left"></button>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- auto-save event list edits
- drop save button from event admin tab
- show modal confirmation before deleting an event

## Testing
- `composer test` *(fails: Tests: 166, Assertions: 342, Errors: 8, Failures: 7)*

------
https://chatgpt.com/codex/tasks/task_e_68981e8249f8832b9f9c5d8d144b2287