### PR TITLE
Use profile email for outgoing mail

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -35,12 +35,22 @@ class MailService
         $pass = (string) ($env['SMTP_PASS'] ?? getenv('SMTP_PASS') ?: '');
         $port = (string) ($env['SMTP_PORT'] ?? getenv('SMTP_PORT') ?: '587');
 
+        $profileFile = $root . '/data/profile.json';
+        $profile = [];
+        if (is_readable($profileFile)) {
+            $profile = json_decode((string) file_get_contents($profileFile), true) ?: [];
+        }
+
+        $fromEmail = (string) ($profile['imprint_email'] ?? $user);
+        $fromName  = (string) ($profile['imprint_name'] ?? '');
+        $from      = $fromName !== '' ? sprintf('%s <%s>', $fromName, $fromEmail) : $fromEmail;
+
         $dsn = sprintf('smtp://%s:%s@%s:%s', rawurlencode($user), rawurlencode($pass), $host, $port);
 
         $transport = Transport::fromDsn($dsn);
         $this->mailer = new Mailer($transport);
         $this->twig   = $twig;
-        $this->from   = $user;
+        $this->from   = $from;
         $this->audit  = $audit;
     }
 

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\MailService;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class MailServiceTest extends TestCase
+{
+    public function testUsesProfileEmailAsFrom(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $profile = $root . '/data/profile.json';
+        $backup = file_get_contents($profile);
+        file_put_contents($profile, json_encode([
+            'imprint_name' => 'Example Org',
+            'imprint_email' => 'admin@example.org',
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        putenv('SMTP_HOST=localhost');
+        putenv('SMTP_USER=user@example.org');
+        putenv('SMTP_PASS=secret');
+        putenv('SMTP_PORT=587');
+        $_ENV['SMTP_HOST'] = 'localhost';
+        $_ENV['SMTP_USER'] = 'user@example.org';
+        $_ENV['SMTP_PASS'] = 'secret';
+        $_ENV['SMTP_PORT'] = '587';
+
+        $twig = new Environment(new ArrayLoader());
+        $svc = new MailService($twig);
+
+        $ref = new \ReflectionClass($svc);
+        $prop = $ref->getProperty('from');
+        $prop->setAccessible(true);
+        $from = $prop->getValue($svc);
+
+        $this->assertSame('Example Org <admin@example.org>', $from);
+
+        file_put_contents($profile, $backup);
+    }
+}
+


### PR DESCRIPTION
## Summary
- use profile's `imprint_email` (and name) as default From address
- add regression test for MailService sender address

## Testing
- `vendor/bin/phpunit tests/Service/MailServiceTest.php`
- `composer test` *(fails: ExportControllerTest::testExportIncludesEvents; PasswordResetFlowTest::testFullResetFlow; QrControllerTest::testQrImageSvgFormat; QrControllerTest::testTeamQrSvgFormat; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68981b28fa44832b9bfc2db539a1aff7