### PR TITLE
Use SMTP_USER as mail sender

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -41,7 +41,7 @@ class MailService
             $profile = json_decode((string) file_get_contents($profileFile), true) ?: [];
         }
 
-        $fromEmail = (string) ($profile['imprint_email'] ?? $user);
+        $fromEmail = $user;
         $fromName  = (string) ($profile['imprint_name'] ?? '');
         $from      = $fromName !== '' ? sprintf('%s <%s>', $fromName, $fromEmail) : $fromEmail;
 

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -11,7 +11,7 @@ use Twig\Loader\ArrayLoader;
 
 class MailServiceTest extends TestCase
 {
-    public function testUsesProfileEmailAsFrom(): void
+    public function testUsesSmtpUserAsFrom(): void
     {
         $root = dirname(__DIR__, 2);
         $profile = $root . '/data/profile.json';
@@ -38,7 +38,7 @@ class MailServiceTest extends TestCase
         $prop->setAccessible(true);
         $from = $prop->getValue($svc);
 
-        $this->assertSame('Example Org <admin@example.org>', $from);
+        $this->assertSame('Example Org <user@example.org>', $from);
 
         file_put_contents($profile, $backup);
     }


### PR DESCRIPTION
## Summary
- always use SMTP_USER from `.env` as email sender
- adjust MailService test to expect SMTP_USER as sender

## Testing
- `composer test` *(fails: Failed asserting that 500 is identical to 204.)*
- `vendor/bin/phpunit tests/Service/MailServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689826bd3004832b822971f68038b4fc