### PR TITLE
Split landing hero into two columns with video placeholder

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -2,8 +2,8 @@
 <section class="hero-bg-quizrace uk-section uk-padding-remove-top uk-flex uk-flex-middle" style="min-height:100vh; position:relative;">
   <div class="hero-overlay"></div>
   <div class="uk-container hero-content">
-    <div class="uk-grid uk-flex-middle" uk-grid>
-      <div class="uk-width-1-1 uk-width-3-4@m">
+    <div class="uk-grid uk-flex-middle uk-child-width-1-1 uk-child-width-1-2@m" uk-grid>
+      <div>
         <div class="hero-text">
           <h2 class="hero-headline" uk-scrollspy="cls: uk-animation-slide-right-small">
             Das Team-Quiz, das Ihr Event <span id="rotating-word" class="marker-text">unvergesslich</span> macht.
@@ -18,6 +18,13 @@
         <div class="hero-buttons uk-margin-top" uk-scrollspy="cls: uk-animation-scale-up; delay: 300">
           <a class="cta-main" href="{{ basePath }}/onboarding">Event kostenlos starten</a>
           <a class="btn btn-black" href="{{ basePath }}/kataloge">Demo anschauen</a>
+        </div>
+      </div>
+      <div>
+        <div class="hero-video" uk-scrollspy="cls: uk-animation-slide-left-small; delay: 300">
+          <div class="video-placeholder uk-flex uk-flex-middle uk-flex-center uk-border-rounded">
+            <span>Video Placeholder</span>
+          </div>
         </div>
       </div>
     </div>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -69,6 +69,17 @@
     .hero-subtext strong {
       font-weight: 700;
     }
+    .video-placeholder {
+      width: 100%;
+      aspect-ratio: 16/9;
+      background: rgba(255, 255, 255, 0.15);
+      border: 2px dashed #fff;
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+    }
     .btn {
       font-size: 1rem;
       font-weight: 500;


### PR DESCRIPTION
## Summary
- Restructured landing hero into a two-column layout, dedicating the right side to a video placeholder
- Styled new video placeholder with dashed border and 16:9 aspect ratio

## Testing
- `composer test` *(failed: Database error: fail; Failed asserting that 500 is identical to 204, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689829cdb4f4832b9ce1ea07f8eabe00