### PR TITLE
Enable landing contact form email and confirmation modal

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -24,6 +24,37 @@
   </div>
 </section>
 
+<div id="contact-modal" uk-modal>
+  <div class="uk-modal-dialog uk-modal-body">
+    <p id="contact-modal-message"></p>
+    <button class="uk-button uk-button-primary uk-modal-close" type="button">OK</button>
+  </div>
+</div>
+
+<script>
+  const form = document.getElementById('contact-form');
+  const modal = UIkit.modal('#contact-modal');
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = new URLSearchParams(new FormData(form));
+    fetch('{{ basePath }}/landing/contact', {
+      method: 'POST',
+      body: data
+    }).then(res => {
+      if (res.ok) {
+        document.getElementById('contact-modal-message').textContent = 'Vielen Dank für Ihre Nachricht!';
+        form.reset();
+      } else {
+        document.getElementById('contact-modal-message').textContent = 'Fehler beim Versenden. Bitte versuchen Sie es erneut.';
+      }
+      modal.show();
+    }).catch(() => {
+      document.getElementById('contact-modal-message').textContent = 'Fehler beim Versenden. Bitte versuchen Sie es erneut.';
+      modal.show();
+    });
+  });
+</script>
+
 <script>
 const words = ["unvergesslich", "spannend", "interaktiv", "einzigartig", "unterhaltsam"]; // Wörterliste
 const changeInterval = 5500; // Wechselintervall in Millisekunden
@@ -305,22 +336,23 @@ window.addEventListener('load', () => {
     Schreiben Sie uns – wir melden uns garantiert persönlich zurück!</p>
     <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-middle" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
       <div>
-        <form class="uk-form-stacked uk-width-large uk-margin-auto">
+        <form id="contact-form" class="uk-form-stacked uk-width-large uk-margin-auto">
           <div class="uk-margin">
             <label class="uk-form-label" for="form-name">Ihr Name</label>
-            <input class="uk-input" id="form-name" type="text" required>
+            <input class="uk-input" id="form-name" name="name" type="text" required>
           </div>
           <div class="uk-margin">
             <label class="uk-form-label" for="form-email">E-Mail</label>
-            <input class="uk-input" id="form-email" type="email" required>
+            <input class="uk-input" id="form-email" name="email" type="email" required>
           </div>
           <div class="uk-margin">
             <label class="uk-form-label" for="form-msg">Nachricht</label>
-            <textarea class="uk-textarea" id="form-msg" rows="5" required></textarea>
+            <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
           </div>
           <div class="uk-margin">
-            <label><input class="uk-checkbox" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
+            <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
           </div>
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
           <button class="btn btn-black uk-button-large uk-width-1-1" type="submit">Senden</button>
         </form>
       </div>
@@ -349,3 +381,34 @@ window.addEventListener('load', () => {
     </div>
   </div>
 </section>
+
+<div id="contact-modal" uk-modal>
+  <div class="uk-modal-dialog uk-modal-body">
+    <p id="contact-modal-message"></p>
+    <button class="uk-button uk-button-primary uk-modal-close" type="button">OK</button>
+  </div>
+</div>
+
+<script>
+  const form = document.getElementById('contact-form');
+  const modal = UIkit.modal('#contact-modal');
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = new URLSearchParams(new FormData(form));
+    fetch('{{ basePath }}/landing/contact', {
+      method: 'POST',
+      body: data
+    }).then(res => {
+      if (res.ok) {
+        document.getElementById('contact-modal-message').textContent = 'Vielen Dank für Ihre Nachricht!';
+        form.reset();
+      } else {
+        document.getElementById('contact-modal-message').textContent = 'Fehler beim Versenden. Bitte versuchen Sie es erneut.';
+      }
+      modal.show();
+    }).catch(() => {
+      document.getElementById('contact-modal-message').textContent = 'Fehler beim Versenden. Bitte versuchen Sie es erneut.';
+      modal.show();
+    });
+  });
+</script>

--- a/src/Controller/Marketing/ContactController.php
+++ b/src/Controller/Marketing/ContactController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Marketing;
+
+use App\Service\MailService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
+
+/**
+ * Handles contact form submissions from the landing page.
+ */
+class ContactController
+{
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            $data = $request->getParsedBody();
+        }
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+
+        $name = trim((string) ($data['name'] ?? ''));
+        $email = trim((string) ($data['email'] ?? ''));
+        $message = trim((string) ($data['message'] ?? ''));
+        if ($name === '' || $email === '' || $message === '') {
+            return $response->withStatus(400);
+        }
+
+        $profileFile = dirname(__DIR__, 3) . '/data/profile.json';
+        $profile = [];
+        if (is_readable($profileFile)) {
+            $profile = json_decode((string) file_get_contents($profileFile), true) ?: [];
+        }
+        $to = (string) ($profile['imprint_email'] ?? '');
+        if ($to === '') {
+            return $response->withStatus(500);
+        }
+
+        $mailer = $request->getAttribute('mailService');
+        if (!$mailer instanceof MailService) {
+            $twig = Twig::fromRequest($request)->getEnvironment();
+            $mailer = new MailService($twig);
+        }
+        $mailer->sendContact($to, $name, $email, $message);
+
+        return $response->withStatus(204);
+    }
+}

--- a/src/Controller/Marketing/LandingController.php
+++ b/src/Controller/Marketing/LandingController.php
@@ -24,6 +24,13 @@ class LandingController
         $basePath = RouteContext::fromRequest($request)->getBasePath();
         $html = str_replace('{{ basePath }}', $basePath, $html);
 
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
+        $_SESSION['csrf_token'] = $csrf;
+        $html = str_replace('{{ csrf_token }}', $csrf, $html);
+
         $view = Twig::fromRequest($request);
         return $view->render($response, 'marketing/landing.twig', [
             'content' => $html,

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -133,4 +133,27 @@ class MailService
 
         return $html;
     }
+
+    /**
+     * Send contact form message to given recipient.
+     */
+    public function sendContact(string $to, string $name, string $replyTo, string $message): void
+    {
+        $html = $this->twig->render('emails/contact.twig', [
+            'name'    => $name,
+            'email'   => $replyTo,
+            'message' => $message,
+        ]);
+
+        $email = (new Email())
+            ->from($this->from)
+            ->to($to)
+            ->replyTo($replyTo)
+            ->subject('Kontaktanfrage')
+            ->html($html);
+
+        $this->mailer->send($email);
+
+        $this->audit?->log('contact_mail', ['from' => $replyTo]);
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -57,6 +57,7 @@ use App\Controller\SettingsController;
 use App\Controller\Admin\PageController;
 use App\Controller\TenantController;
 use App\Controller\Marketing\LandingController;
+use App\Controller\Marketing\ContactController;
 use App\Controller\RegisterController;
 use App\Controller\OnboardingController;
 use App\Controller\OnboardingEmailController;
@@ -99,6 +100,7 @@ require_once __DIR__ . '/Controller/BackupController.php';
 require_once __DIR__ . '/Controller/UserController.php';
 require_once __DIR__ . '/Controller/TenantController.php';
 require_once __DIR__ . '/Controller/Marketing/LandingController.php';
+require_once __DIR__ . '/Controller/Marketing/ContactController.php';
 require_once __DIR__ . '/Controller/RegisterController.php';
 require_once __DIR__ . '/Controller/OnboardingController.php';
 require_once __DIR__ . '/Controller/OnboardingEmailController.php';
@@ -254,6 +256,9 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = new LandingController();
         return $controller($request, $response);
     });
+    $app->post('/landing/contact', ContactController::class)
+        ->add(new RateLimitMiddleware(3, 3600))
+        ->add(new CsrfMiddleware());
     $app->get('/onboarding', OnboardingController::class);
     $app->post('/onboarding/email', function (Request $request, Response $response) {
         return $request->getAttribute('onboardingEmailController')->request($request, $response);

--- a/templates/emails/contact.twig
+++ b/templates/emails/contact.twig
@@ -1,0 +1,2 @@
+<p>Kontaktanfrage von {{ name }} ({{ email }}):</p>
+<p>{{ message|nl2br }}</p>


### PR DESCRIPTION
## Summary
- add ContactController and route for landing page submissions
- extend MailService with contact email support and template
- enhance landing content with CSRF token, modal and JS feedback

## Testing
- `composer test` *(fails: Slim Application Error, database error, PHPUnit failures)*

------
https://chatgpt.com/codex/tasks/task_e_68982a1c8260832b9cdf5c3ae75e524b