### PR TITLE
feat: style founder section

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -289,7 +289,7 @@ window.addEventListener('load', () => {
     <div class="uk-width-2xlarge uk-margin-auto uk-text-center uk-text-lead" uk-scrollspy="cls: uk-animation-fade; delay: 150">
       <b>QuizRace wurde von René Buske entwickelt – einem erfahrenen Softwarearchitekten und Digital-Event-Profi mit über 20 Jahren Erfahrung.</b>
       <br>
-      <span class="uk-text-muted">
+      <span>
         Nach langjähriger Tätigkeit als IT-Berater, Dozent und Entwickler von Individualsoftware bringt René fundiertes Wissen rund um Online-Events, Gamification und Datenschutz in QuizRace ein.<br>
         Sein Ziel: <b>Quiz-Events für alle sicher, einfach und modern machen</b> – mit einer Lösung, die jeden begeistert und stets zuverlässig funktioniert.
       </span>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -10,7 +10,8 @@ body {
 
 /* Background for "Wer steckt hinter QuizRace?" section */
 .about-section {
-  background-color: #e0e0e0;
+  background-color: #000;
+  color: #fff;
 }
 
 body.uk-padding {


### PR DESCRIPTION
## Summary
- make "Wer steckt hinter QuizRace?" section black with white text
- drop muted styling so founder description renders in white

## Testing
- `./scripts/run_tests.sh` *(fails: 8 errors, 7 failures)*


------
https://chatgpt.com/codex/tasks/task_e_68982b923588832b957ce88cd3f3394e