### PR TITLE
Fix landing contact card background

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -9,7 +9,7 @@
   <link href="https://fonts.googleapis.com/css?family=Noto+Sans:700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Rock+Salt&display=swap" rel="stylesheet">
   <style>
-    body, .uk-section, .uk-card {
+    body, .uk-section, .uk-card-default {
       font-family: 'Roboto', Arial, sans-serif;
       color: #232323;
       background: #fff;


### PR DESCRIPTION
## Summary
- Ensure primary cards on marketing landing page keep their blue background by limiting global white background styling to default cards

## Testing
- `composer test` *(fails: Failed asserting 500 is identical to 204; 500 for QR controllers; nginx reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_68982ec4b32c832b9407129ac814f8b4