### PR TITLE
Validate SMTP configuration in MailService

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use RuntimeException;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mailer\Transport;
@@ -34,6 +35,21 @@ class MailService
         $user = (string) ($env['SMTP_USER'] ?? getenv('SMTP_USER') ?: '');
         $pass = (string) ($env['SMTP_PASS'] ?? getenv('SMTP_PASS') ?: '');
         $port = (string) ($env['SMTP_PORT'] ?? getenv('SMTP_PORT') ?: '587');
+
+        if ($host === '' || $user === '' || $pass === '') {
+            $missing = [];
+            if ($host === '') {
+                $missing[] = 'SMTP_HOST';
+            }
+            if ($user === '') {
+                $missing[] = 'SMTP_USER';
+            }
+            if ($pass === '') {
+                $missing[] = 'SMTP_PASS';
+            }
+
+            throw new RuntimeException('Missing SMTP configuration: ' . implode(', ', $missing));
+        }
 
         $profileFile = $root . '/data/profile.json';
         $profile = [];

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -42,5 +42,41 @@ class MailServiceTest extends TestCase
 
         file_put_contents($profile, $backup);
     }
-}
 
+    /**
+     * @dataProvider missingEnvProvider
+     */
+    public function testMissingEnvThrows(string $var): void
+    {
+        putenv('SMTP_HOST=localhost');
+        putenv('SMTP_USER=user@example.org');
+        putenv('SMTP_PASS=secret');
+        putenv('SMTP_PORT=587');
+        $_ENV['SMTP_HOST'] = 'localhost';
+        $_ENV['SMTP_USER'] = 'user@example.org';
+        $_ENV['SMTP_PASS'] = 'secret';
+        $_ENV['SMTP_PORT'] = '587';
+
+        putenv($var);
+        unset($_ENV[$var]);
+
+        $twig = new Environment(new ArrayLoader());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Missing SMTP configuration: ' . $var);
+
+        new MailService($twig);
+    }
+
+    /**
+     * @return array<string[]>
+     */
+    public function missingEnvProvider(): array
+    {
+        return [
+            ['SMTP_HOST'],
+            ['SMTP_USER'],
+            ['SMTP_PASS'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- ensure SMTP host, user, and password are provided before building DSN
- add unit test covering missing SMTP config cases

## Testing
- `vendor/bin/phpunit tests/Service/MailServiceTest.php`
- `vendor/bin/phpstan analyse src/Service/MailService.php tests/Service/MailServiceTest.php`
- `vendor/bin/phpcs src/Service/MailService.php tests/Service/MailServiceTest.php`
- `composer test` *(fails: Tests: 170, Assertions: 351, Errors: 8, Failures: 7, Warnings: 2, PHPUnit Deprecations: 2, Notices: 11)*

------
https://chatgpt.com/codex/tasks/task_e_6898b2487520832b882568d416558349