### PR TITLE
Add configurable SMTP encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Für Funktionen wie das Zurücksetzen von Passwörtern nutzt die Anwendung SMTP.
 - `SMTP_USER` – Benutzername und Absenderadresse
 - `SMTP_PASS` – Passwort
 - `SMTP_PORT` – Port (z. B. 587)
+- `SMTP_ENCRYPTION` – Verschlüsselung (`none`, `tls` oder `ssl`)
 
 Diese Variablen können in `.env` gesetzt werden.
 
@@ -492,7 +493,7 @@ Die API unterstützt ein zweistufiges Verfahren zum Zurücksetzen vergessener Pa
 1. `POST /password/reset/request` nimmt einen Benutzernamen oder eine E‑Mail-Adresse entgegen und verschickt einen Link mit einem Reset-Token.
 2. `POST /password/reset/confirm` setzt nach Validierung des Tokens das neue Passwort.
 
-Für den Versand der E-Mails müssen `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS` und `SMTP_PORT` konfiguriert sein. Das Token ist aus Sicherheitsgründen nur eine Stunde gültig.
+Für den Versand der E-Mails müssen `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS` und `SMTP_PORT` konfiguriert sein. Optional kann `SMTP_ENCRYPTION` auf `tls` oder `ssl` gesetzt werden. Das Token ist aus Sicherheitsgründen nur eine Stunde gültig.
 
 ### Administrationsoberfläche
 Unter `/admin` stehen folgende Tabs zur Verfügung:

--- a/sample.env
+++ b/sample.env
@@ -49,6 +49,7 @@ SMTP_HOST=smtp.example.com
 SMTP_USER=user@example.com
 SMTP_PASS=secret
 SMTP_PORT=587
+SMTP_ENCRYPTION=tls           # none, tls oder ssl
 
 # Geheimnis zum Hashen von Passwort-Reset-Token
 PASSWORD_RESET_SECRET=changeme

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -42,5 +42,27 @@ class MailServiceTest extends TestCase
 
         file_put_contents($profile, $backup);
     }
-}
 
+    public function testBuildsDsnWithEncryption(): void
+    {
+        putenv('SMTP_HOST=localhost');
+        putenv('SMTP_USER=user@example.org');
+        putenv('SMTP_PASS=secret');
+        putenv('SMTP_PORT=587');
+        putenv('SMTP_ENCRYPTION=tls');
+        $_ENV['SMTP_HOST'] = 'localhost';
+        $_ENV['SMTP_USER'] = 'user@example.org';
+        $_ENV['SMTP_PASS'] = 'secret';
+        $_ENV['SMTP_PORT'] = '587';
+        $_ENV['SMTP_ENCRYPTION'] = 'tls';
+
+        $twig = new Environment(new ArrayLoader());
+        $svc = new MailService($twig);
+        $dsn = $svc->getDsn();
+
+        $this->assertSame(
+            'smtp://user%40example.org:secret@localhost:587?encryption=tls',
+            $dsn
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring mail transport encryption via new `SMTP_ENCRYPTION` env var
- document SMTP encryption options in README and sample env
- test DSN generation with encryption parameter

## Testing
- `./vendor/bin/phpunit tests/Service/MailServiceTest.php`
- `./vendor/bin/phpstan analyse src/Service/MailService.php tests/Service/MailServiceTest.php --no-progress`
- `./vendor/bin/phpcs src/Service/MailService.php tests/Service/MailServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6898b26b94d8832bb98bd865d0491731