### PR TITLE
Add SMTP encryption setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Für Funktionen wie das Zurücksetzen von Passwörtern nutzt die Anwendung SMTP.
 - `SMTP_USER` – Benutzername und Absenderadresse
 - `SMTP_PASS` – Passwort
 - `SMTP_PORT` – Port (z. B. 587)
+- `SMTP_ENCRYPTION` – Verschlüsselung (`none`, `tls` oder `ssl`)
 
 Diese Variablen können in `.env` gesetzt werden.
 
@@ -492,7 +493,7 @@ Die API unterstützt ein zweistufiges Verfahren zum Zurücksetzen vergessener Pa
 1. `POST /password/reset/request` nimmt einen Benutzernamen oder eine E‑Mail-Adresse entgegen und verschickt einen Link mit einem Reset-Token.
 2. `POST /password/reset/confirm` setzt nach Validierung des Tokens das neue Passwort.
 
-Für den Versand der E-Mails müssen `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS` und `SMTP_PORT` konfiguriert sein. Das Token ist aus Sicherheitsgründen nur eine Stunde gültig.
+Für den Versand der E-Mails müssen `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `SMTP_PORT` und `SMTP_ENCRYPTION` konfiguriert sein. Das Token ist aus Sicherheitsgründen nur eine Stunde gültig.
 
 ### Administrationsoberfläche
 Unter `/admin` stehen folgende Tabs zur Verfügung:

--- a/sample.env
+++ b/sample.env
@@ -49,6 +49,7 @@ SMTP_HOST=smtp.example.com
 SMTP_USER=user@example.com
 SMTP_PASS=secret
 SMTP_PORT=587
+SMTP_ENCRYPTION=none # none|tls|ssl
 
 # Geheimnis zum Hashen von Passwort-Reset-Token
 PASSWORD_RESET_SECRET=changeme


### PR DESCRIPTION
## Summary
- support optional SMTP_ENCRYPTION for mail transport
- document SMTP_ENCRYPTION in README and sample.env
- test DSN generation with encryption value

## Testing
- `vendor/bin/phpunit` *(fails: Tests: 171, Assertions: 352, Errors: 8, Failures: 7, Warnings: 2)*

------
https://chatgpt.com/codex/tasks/task_e_6898b8158ff4832bbae7ff5f30f0087e