### PR TITLE
Adjust chalk underline on landing page

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -82,7 +82,7 @@ window.addEventListener('load', () => {
   color: #f8f6f0;
   position: absolute;
   left: 0;
-  bottom: -2px;
+  bottom: -6px;
   width: 0;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Move chalk-style underline slightly lower for clearer spacing

## Testing
- `composer test` *(fails: Database error, Error creating tenant, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb58cab8832ba8ec4e987b2e2e4a