### PR TITLE
Add placeholder logo images for missing config

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -125,7 +125,7 @@
                 <label class="uk-form-label" for="cfgLogoPreview">{{ t('label_logo_preview') }}</label>
                 <div class="uk-form-controls">
                   <div class="logo-frame uk-margin-small-top">
-                    <img id="cfgLogoPreview" src="{{ basePath ~ config.logoPath|default('') }}" alt="{{ t('label_logo_preview') }}" class="logo-placeholder">
+                    <img id="cfgLogoPreview" src="{{ basePath ~ config.logoPath|default('https://via.placeholder.com/160x240?text=Logo') }}" alt="{{ t('label_logo_preview') }}" class="logo-placeholder" width="160" height="240" loading="lazy">
                   </div>
                 </div>
               </div>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -36,7 +36,7 @@
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin" uk-scrollspy="cls: uk-animation-fade">
       <div id="quiz-header" class="uk-text-center uk-margin" uk-scrollspy="cls: uk-animation-scale-up; delay: 100">
-        <img id="quiz-logo" class="logo-placeholder" src="{{ basePath ~ config.logoPath|default('') }}" alt="Logo">
+        <img id="quiz-logo" class="logo-placeholder" src="{{ basePath ~ config.logoPath|default('https://via.placeholder.com/160x240?text=Logo') }}" alt="Logo" width="160" height="240" loading="lazy">
       </div>
       <progress id="progress" class="uk-progress" value="0" max="1" aria-label="{{ t('quiz_progress') }}" aria-valuenow="0" uk-scrollspy="cls: uk-animation-fade; delay: 200"></progress>
       <span id="question-announcer" class="uk-hidden-visually" aria-live="polite"></span>


### PR DESCRIPTION
## Summary
- Provide online placeholder logo on landing page when no logo configured
- Show same placeholder in admin preview and include lazy loading with intrinsic size

## Testing
- `composer test` *(fails: Slim Application Error, database error: fail; Error creating tenant: boom)*

------
https://chatgpt.com/codex/tasks/task_e_6898cde91abc832b8e0dbb5c95299091