### PR TITLE
Align landing page pricing cards

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -200,7 +200,7 @@ window.addEventListener('load', () => {
     <div class="uk-container">
       <h2 class="uk-heading-medium uk-text-center text-black" uk-scrollspy="cls: uk-animation-slide-top-small">Abomodelle für jedes Event</h2>
       <p class="uk-text-center uk-text-lead uk-margin-large-bottom" uk-scrollspy="cls: uk-animation-fade; delay: 150">Einfacher Start – faire Preise – alle Funktionen jederzeit testen!</p>
-      <div class="uk-grid-large uk-child-width-1-3@m uk-flex-center" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
+      <div class="uk-grid-large uk-child-width-1-3@m uk-flex-center uk-grid-match pricing-grid" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
       <!-- Starter -->
       <div>
         <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -121,6 +121,9 @@
       border: 2px solid #232323;
       background: #0c86d0;
       color: #fff;
+      transform: scale(1.05);
+      z-index: 1;
+      position: relative;
     }
     .uk-card-popular .uk-label {
       background: #232323;
@@ -134,6 +137,14 @@
       background: #fff !important;
       color: #0c86d0 !important;
       border: 2px solid #fff;
+    }
+    .pricing-grid .uk-card-quizrace {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+    .pricing-grid .uk-card-quizrace .btn {
+      margin-top: auto;
     }
     .uk-step-circle {
       background: #0c86d0;


### PR DESCRIPTION
## Summary
- Ensure pricing section cards share equal height via UIkit grid match and flex styling
- Emphasize "Meist gewählt" plan with subtle scaling and layering

## Testing
- `composer test` *(fails: Slim Application Error, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_6898cea6c528832b95972bd1173f655b