### PR TITLE
Fix dark background for landing page about section

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -9,7 +9,7 @@
   <link href="https://fonts.googleapis.com/css?family=Noto+Sans:700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Rock+Salt&display=swap" rel="stylesheet">
   <style>
-    body, .uk-section, .uk-card-default {
+    body, .uk-card-default {
       font-family: 'Roboto', Arial, sans-serif;
       color: #232323;
       background: #fff;
@@ -28,6 +28,13 @@
     }
     .uk-section-primary {
       background: #0c86d0 !important;
+      color: #fff;
+    }
+    .uk-section.about-section {
+      background: #000;
+      color: #fff;
+    }
+    .uk-section.about-section a {
       color: #fff;
     }
     .hero-bg-quizrace {


### PR DESCRIPTION
## Summary
- ensure marketing landing page no longer forces white background on uk-section elements
- style about section with explicit dark background and white text

## Testing
- `node check_style.js` *(fails: Cannot find module '/workspace/sommerfest-quiz/check_style.js')*
- `composer test` *(fails: vendor/bin/phpunit not found)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_6898caee90f0832b8c354fa59d65a33b