### PR TITLE
Use catalog QR route in template

### DIFF
--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -22,7 +22,8 @@
                         </div>
                         <div class="uk-width-auto@s uk-width-1-1">
                             {% set link = baseUrl ? baseUrl ~ '/?event=' ~ event.uid ~ '&katalog=' ~ katalog.slug : '?event=' ~ event.uid ~ '&katalog=' ~ katalog.slug %}
-                            <img src="{{ basePath }}/qr.png?t={{ link|url_encode }}" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
+                            {% set qrQuery = { t: link }|merge(qrOptions|default({})) %}
+                            <img src="{{ basePath }}/qr/catalog?{{ qrQuery|url_encode }}" alt="QR" width="48" height="48" class="uk-margin-small-bottom">
                             <button class="uk-button uk-button-danger uk-button-small uk-width-1-1">Löschen</button>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- point catalog QR links to `/qr/catalog`
- allow passing optional QR parameters

## Testing
- `composer test` *(fails: Database error: fail ... QrControllerTest::testTeamQrSvgFormat)*

------
https://chatgpt.com/codex/tasks/task_e_6898d6b0b4d0832bb835e468e6b920a9