### PR TITLE
Add event QR code generation and route

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -75,6 +75,18 @@ class QrController
     }
 
     /**
+     * Generate an event QR code with default styling.
+     */
+    public function event(Request $request, Response $response): Response
+    {
+        $out = $this->qrService->generateEvent($request->getQueryParams());
+        $response->getBody()->write($out['body']);
+        return $response
+            ->withHeader('Content-Type', $out['mime'])
+            ->withStatus(200);
+    }
+
+    /**
      * Render a QR code image based on query parameters.
      */
     public function image(Request $request, Response $response): Response

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -185,6 +185,17 @@ class QrCodeService
     }
 
     /**
+     * @return array{mime:string,body:string}
+     */
+    public function generateEvent(array $q): array
+    {
+        return $this->buildQrWithCenterLogoParam($q, [
+            't' => 'https://quizrace.app/?event=station',
+            'fg' => '00a65a',
+        ]);
+    }
+
+    /**
      * @param array<string,mixed> $q
      * @param array{t:string,fg:string} $defaults
      * @return array{mime:string,body:string}

--- a/src/routes.php
+++ b/src/routes.php
@@ -603,6 +603,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/qr/team', function (Request $request, Response $response) {
         return $request->getAttribute('qrController')->team($request, $response);
     });
+    $app->get('/qr/event', function (Request $request, Response $response) {
+        return $request->getAttribute('qrController')->event($request, $response);
+    });
     $app->get('/invites.pdf', function (Request $request, Response $response) {
         return $request->getAttribute('qrController')->pdfAll($request, $response);
     })->add(new RoleAuthMiddleware('admin'));

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -366,7 +366,7 @@
             <p id="summaryEventDesc">{{ event.description }}</p>
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
-            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr.png?t={{ (baseUrl ? baseUrl : '?event=' ~ event.uid)|url_encode }}&text1=QUIZ&text2=RACE&rounded=1" alt="QR" width="96" height="96">
+            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr/event?t={{ (baseUrl ? baseUrl : '?event=' ~ event.uid)|url_encode }}" alt="QR" width="96" height="96">
             <div id="summaryEventLabel">{{ event.name }}</div>
           </div>
         </div>

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -73,6 +73,17 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
+    public function testEventQrDefaults(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/qr/event');
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/png', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
+    }
+
     public function testTeamQrSvgFormat(): void
     {
         $app = $this->getAppInstance();


### PR DESCRIPTION
## Summary
- support event-specific QR code generation in `QrCodeService`
- expose `/qr/event` endpoint via controller and routes
- load event QR in admin template and cover with tests

## Testing
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit tests/Controller/QrControllerTest.php` *(fails: Intervention\Image\Exceptions\DecoderException and two status code assertions)*
- `vendor/bin/phpunit tests/Controller/QrControllerTest.php --filter testEventQrDefaults`

------
https://chatgpt.com/codex/tasks/task_e_6898d89f9320832b97fcec323eb6ddca