### PR TITLE
Add responsive SVG logo images

### DIFF
--- a/public/logo-160.svg
+++ b/public/logo-160.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="240" viewBox="0 0 160 240">
+  <rect width="160" height="240" fill="#ffe17b" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="64" fill="#333">SF</text>
+</svg>

--- a/public/logo-320.svg
+++ b/public/logo-320.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="480" viewBox="0 0 320 480">
+  <rect width="320" height="480" fill="#ffe17b" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="128" fill="#333">SF</text>
+</svg>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -36,7 +36,11 @@
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin" uk-scrollspy="cls: uk-animation-fade">
       <div id="quiz-header" class="uk-text-center uk-margin" uk-scrollspy="cls: uk-animation-scale-up; delay: 100">
-        <img id="quiz-logo" class="logo-placeholder" src="{{ basePath ~ config.logoPath|default('https://via.placeholder.com/160x240?text=Logo') }}" alt="Logo" width="160" height="240" loading="lazy">
+        <img id="quiz-logo" class="logo-placeholder"
+             src="{{ basePath }}/logo-160.svg"
+             srcset="{{ basePath }}/logo-160.svg 160w, {{ basePath }}/logo-320.svg 320w"
+             sizes="(max-width: 600px) 160px, 320px"
+             alt="Logo" width="160" height="240" loading="lazy">
       </div>
       <progress id="progress" class="uk-progress" value="0" max="1" aria-label="{{ t('quiz_progress') }}" aria-valuenow="0" uk-scrollspy="cls: uk-animation-fade; delay: 200"></progress>
       <span id="question-announcer" class="uk-hidden-visually" aria-live="polite"></span>


### PR DESCRIPTION
## Summary
- replace binary PNG logos with text-based SVG versions
- keep responsive `srcset` and `sizes` for logo selection

## Testing
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d7afcf34832ba34efdae2fc7e685