### PR TITLE
Reduce landing page steps to four

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -262,9 +262,9 @@ window.addEventListener('load', () => {
 <!-- Steps / Ablauf -->
 <section class="uk-section uk-section-default">
   <div class="uk-container">
-      <h3 class="uk-text-center uk-heading-medium poppins text-black" uk-scrollspy="cls: uk-animation-slide-top-small">In 5 Schritten zum Erlebnis-Quiz mit QuizRace</h3>
+      <h3 class="uk-text-center uk-heading-medium poppins text-black" uk-scrollspy="cls: uk-animation-slide-top-small">In 4 Schritten zum Erlebnis-Quiz mit QuizRace</h3>
       <p class="uk-text-lead uk-text-center" uk-scrollspy="cls: uk-animation-fade; delay: 150"><strong>QuizRace bringt Action ins Event: Erstelle Fragenkataloge, drucke QR-Codes aus, klebe sie an spannende Stationen – und lass die Teams live gegeneinander antreten. Jedes Team erlebt das Quiz direkt vor Ort, beantwortet Fragen oder erhält Info-Karten und sammelt am Ende die Lösung fürs große Rätselwort!</strong></p>
-      <div class="uk-grid uk-child-width-1-5@m uk-child-width-1-2@s uk-flex-center uk-margin-large-top uk-margin-large-bottom" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-left-small; delay: 150">
+        <div class="uk-grid uk-child-width-1-4@m uk-child-width-1-2@s uk-flex-center uk-margin-large-top uk-margin-large-bottom" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-left-small; delay: 150">
         <div class="uk-text-center">
           <div class="uk-step-circle">1</div>
           <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">Event anlegen</p>
@@ -284,11 +284,6 @@ window.addEventListener('load', () => {
           <div class="uk-step-circle">4</div>
           <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">Teams per QR-Code starten lassen</p>
           <p class="uk-text-small uk-text-muted">Die Teams melden sich eigenständig per Team-QR-Code an. Jeder Stationen-QR-Code führt direkt zu den passenden Aufgaben oder Info-Karten – kein Suchen, keine Verwirrung.</p>
-        </div>
-        <div class="uk-text-center">
-          <div class="uk-step-circle">5</div>
-          <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">Rätselwort und Auswertung erleben</p>
-          <p class="uk-text-small uk-text-muted">Nach jedem Katalog gibt es z.&nbsp;B. einen Buchstaben fürs große Lösungswort oder einen Code für den Hauptpreis. Am Ende stehen Live-Rankings, PDF-Urkunden und begeisterte Teilnehmende!</p>
         </div>
       </div>
   </div>


### PR DESCRIPTION
## Summary
- Remove fifth step from landing page tutorial
- Update heading and grid to show four steps

## Testing
- `composer test` *(fails: Tests: 173, Assertions: 358, Errors: 8, Failures: 7, Warnings: 2)*

------
https://chatgpt.com/codex/tasks/task_e_6898dd30984c832bb7edf1c92e05799a