### PR TITLE
Validate email for Stripe checkout

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -301,7 +301,7 @@
         const res = await fetch(withBase('/onboarding/checkout'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ plan: data.plan })
+          body: JSON.stringify({ plan: data.plan, email: data.email })
         });
         const json = await res.json().catch(() => ({}));
         if (json.url) {

--- a/src/Controller/StripeCheckoutController.php
+++ b/src/Controller/StripeCheckoutController.php
@@ -17,7 +17,7 @@ class StripeCheckoutController
     {
         $data = (array) $request->getParsedBody();
         $plan = (string) ($data['plan'] ?? '');
-        $email = isset($data['email']) ? (string) $data['email'] : null;
+        $email = filter_var($data['email'] ?? null, FILTER_VALIDATE_EMAIL) ? (string) $data['email'] : null;
 
         $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
         $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';


### PR DESCRIPTION
## Summary
- Send onboarding email along with plan when starting Stripe checkout
- Validate incoming email before creating Stripe session

## Testing
- `composer test` *(fails: Tests\Controller\PasswordControllerTest::testPasswordResetForm, Tests\Controller\PasswordControllerTest::testPasswordResetHashExpired, Tests\Controller\PasswordResetFlowTest::testFullResetFlow, Tests\Controller\QrControllerTest::testQrImageSvgFormat, Tests\Controller\QrControllerTest::testTeamQrSvgFormat)*

------
https://chatgpt.com/codex/tasks/task_e_6898fab3af98832bb0c38a42c243acf5