### PR TITLE
Handle payment status on onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -177,6 +177,21 @@
     }
     updateNext1();
 
+    const paidParam = params.get('paid');
+    const canceledParam = params.get('canceled');
+    if (next3 && (paidParam !== null || canceledParam !== null)) {
+      next3.disabled = paidParam !== '1';
+    }
+    if (paidParam === '1') {
+      if (typeof UIkit !== 'undefined') {
+        UIkit.notification({ message: 'Zahlung erfolgreich', status: 'success' });
+      }
+    } else if (canceledParam === '1') {
+      if (typeof UIkit !== 'undefined') {
+        UIkit.notification({ message: 'Zahlung abgebrochen', status: 'warning' });
+      }
+    }
+
     async function waitForHttps(url, onProgress) {
       const maxAttempts = 30;
       for (let i = 0; i < maxAttempts; i++) {


### PR DESCRIPTION
## Summary
- Read `paid` and `canceled` URL parameters in the onboarding flow.
- Display success or cancellation notifications and gate the next step based on payment status.

## Testing
- `composer test` *(fails: Tests: 173, Assertions: 358, Errors: 8, Failures: 7, Warnings: 2)*

------
https://chatgpt.com/codex/tasks/task_e_6898fc8e3cdc832b956bc3cd5c13aa74