### PR TITLE
style: modernize onboarding step boxes

### DIFF
--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -15,6 +15,10 @@ body.high-contrast .uk-card-default {
 body.high-contrast .modern-info-card {
   border-color: #000000;
 }
+body.high-contrast .onboarding-step {
+  border-color: #000000;
+  box-shadow: none;
+}
 body.high-contrast .uk-button-primary {
   background-color: #000000;
   border-color: #000000;
@@ -76,6 +80,10 @@ body.dark-mode.high-contrast .uk-card-default {
 }
 body.dark-mode.high-contrast .modern-info-card {
   border-color: #ffffff;
+}
+body.dark-mode.high-contrast .onboarding-step {
+  border-color: #ffffff;
+  box-shadow: none;
 }
 
 body.dark-mode.high-contrast .uk-button-primary {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -424,6 +424,20 @@ body.dark-mode .sticky-actions {
   font-style: italic;
 }
 
+/* Modern style for onboarding steps */
+.onboarding-step {
+  border-radius: 1rem;
+  box-shadow: 0 6px 30px rgba(0,0,0,0.08);
+  border: 1px solid #e5e5e5;
+  background: linear-gradient(135deg, #ffffff 0%, #fafafa 100%);
+}
+
+body.dark-mode .onboarding-step {
+  border-color: #444;
+  background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
+  box-shadow: 0 6px 30px rgba(0,0,0,0.5);
+}
+
 
 /* Wrapper for thumbnails with rotate button */
 .photo-wrapper {

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -23,7 +23,7 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-margin-large-top">
-    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="login"{% if logged_in %} hidden{% endif %}>
+    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="login"{% if logged_in %} hidden{% endif %}>
       <h3 class="uk-card-title">Login</h3>
       <div id="login-error" class="uk-alert-danger" uk-alert hidden>
         <p>Benutzername oder Passwort falsch.</p>
@@ -37,7 +37,7 @@
       <button class="uk-button uk-button-primary" id="login-btn">Login</button>
     </div>
 
-    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1"{% if not logged_in %} hidden{% endif %}>
+    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1"{% if not logged_in %} hidden{% endif %}>
       <h3 class="uk-card-title">1. Name der App/Domain</h3>
       <div class="uk-margin">
         <input id="customer-name" class="uk-input" type="text" placeholder="Name der App oder Domain" required>
@@ -52,7 +52,7 @@
       <button class="uk-button uk-button-primary" id="next1" disabled>Weiter</button>
     </div>
 
-    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step2" hidden>
+    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step2" hidden>
       <h3 class="uk-card-title">2. Abo wählen</h3>
       <div class="uk-margin">
         <select id="plan" class="uk-select">
@@ -64,7 +64,7 @@
       <button class="uk-button uk-button-primary" id="next2">Weiter</button>
     </div>
 
-    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step3" hidden>
+    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step3" hidden>
       <h3 class="uk-card-title">3. Zahlungsart</h3>
       <div class="uk-margin">
         <select id="payment" class="uk-select">
@@ -78,7 +78,7 @@
       <button class="uk-button uk-button-primary" id="next3">Weiter</button>
     </div>
 
-    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step4" hidden>
+    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step4" hidden>
       <h3 class="uk-card-title">4. Daten für Impressum/Datenschutz</h3>
       <div class="uk-margin">
         <input id="imprint-name" class="uk-input" type="text" placeholder="Name des Betreibers" required>
@@ -98,7 +98,7 @@
       <button class="uk-button uk-button-primary" id="next4">Weiter</button>
     </div>
 
-    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step5" hidden>
+    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step5" hidden>
       <h3 class="uk-card-title">5. Erstellung</h3>
       <ul class="uk-list">
         <li><strong>Name:</strong> <span id="summary-name"></span></li>
@@ -116,7 +116,7 @@
       <button class="uk-button uk-button-primary" id="create">Jetzt QuizRace-Umgebung erstellen</button>
     </div>
 
-    <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="success" hidden>
+    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="success" hidden>
       <h3 class="uk-card-title">Erstellung der Umgebung</h3>
       <p id="success-domain" hidden></p>
       <p id="success-pass" hidden></p>


### PR DESCRIPTION
## Summary
- add `onboarding-step` class to onboarding wizard cards
- give steps a modern gradient, rounded corners and subtle shadow
- ensure high contrast theme removes shadow for readability

## Testing
- `composer test` *(fails: Tests: 173, Assertions: 358, Errors: 8, Failures: 7, Warnings: 2, PHPUnit Deprecations: 2, Notices: 11)*

------
https://chatgpt.com/codex/tasks/task_e_6898fd630018832baee57e8b47aa27b1