### PR TITLE
Unify fonts on landing page

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -4,13 +4,10 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link href="https://fonts.googleapis.com/css?family=Poppins:400,500,700,800,900&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,500,700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Noto+Sans:700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Rock+Salt&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
   <style>
     body, .uk-card-default {
-      font-family: 'Roboto', Arial, sans-serif;
+      font-family: 'Poppins', Arial, sans-serif;
       color: #232323;
       background: #fff;
     }
@@ -207,7 +204,7 @@
     .topbar .uk-logo {
       font-size: 1.25rem;
       padding: 0;
-      font-family: 'Noto Sans', sans-serif;
+      font-family: 'Poppins', sans-serif;
       font-weight: 700;
     }
     @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- Serve the Poppins font via Google Fonts instead of a local copy
- Remove the GitHub Actions workflow and local font assets

## Testing
- `composer test` *(fails: Tests: 173, Assertions: 358, Errors: 8, Failures: 7, Warnings: 2, PHPUnit Deprecations: 2, Notices: 11)*

------
https://chatgpt.com/codex/tasks/task_e_6898fa761e8c832b9347fc20a8541abb