### PR TITLE
Pass CSRF token to onboarding view and JS

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -245,7 +245,10 @@
       try {
         await fetch(withBase('/onboarding/email'), {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': window.csrfToken
+          },
           body: JSON.stringify({ email: data.email })
         });
         if (emailHint) {

--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -46,9 +46,16 @@ class OnboardingController
             }
         }
 
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
         $loggedIn = isset($_SESSION['user']);
 
         $reloadToken = getenv('NGINX_RELOAD_TOKEN') ?: '';
+
+        $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
+        $_SESSION['csrf_token'] = $csrf;
 
         return $view->render(
             $response,
@@ -57,6 +64,7 @@ class OnboardingController
                 'main_domain' => $mainDomain,
                 'logged_in' => $loggedIn,
                 'reload_token' => $reloadToken,
+                'csrf_token' => $csrf,
             ]
         );
     }

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -138,6 +138,7 @@
     window.mainDomain = '{{ main_domain }}';
     window.loggedIn = {{ logged_in ? 'true' : 'false' }};
     window.reloadToken = '{{ reload_token|e('js') }}';
+    window.csrfToken = '{{ csrf_token|e('js') }}';
   </script>
   <script src="{{ basePath }}/js/onboarding.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>


### PR DESCRIPTION
## Summary
- pass CSRF token from session to `onboarding.twig` and expose via `window.csrfToken`
- include CSRF token header in email verification request

## Testing
- `composer test` *(fails: Slim Application Error, database/QR controller failures)*
- `vendor/bin/phpcs src/Controller/OnboardingController.php`


------
https://chatgpt.com/codex/tasks/task_e_689900c33fb0832ba0ec9a56fb18927f