### PR TITLE
Handle email sending failures in onboarding flow

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -243,7 +243,7 @@
     emailInput.addEventListener('blur', async () => {
       if (data.email === '') return;
       try {
-        await fetch(withBase('/onboarding/email'), {
+        const res = await fetch(withBase('/onboarding/email'), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -251,6 +251,16 @@
           },
           body: JSON.stringify({ email: data.email })
         });
+        if (!res.ok) {
+          if (emailHint) {
+            emailHint.textContent = 'Bestätigungs-E-Mail konnte nicht gesendet werden.';
+            emailHint.hidden = false;
+          }
+          if (typeof UIkit !== 'undefined') {
+            UIkit.notification({ message: 'Bestätigungs-E-Mail konnte nicht gesendet werden', status: 'danger' });
+          }
+          return;
+        }
         if (emailHint) {
           emailHint.textContent = 'Bestätigungs-E-Mail gesendet.';
           emailHint.hidden = false;
@@ -259,7 +269,13 @@
           UIkit.notification({ message: 'Bestätigungs-E-Mail gesendet', status: 'primary' });
         }
       } catch (e) {
-        // ignore
+        if (emailHint) {
+          emailHint.textContent = 'Bestätigungs-E-Mail konnte nicht gesendet werden.';
+          emailHint.hidden = false;
+        }
+        if (typeof UIkit !== 'undefined') {
+          UIkit.notification({ message: 'Bestätigungs-E-Mail konnte nicht gesendet werden', status: 'danger' });
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- check response after onboarding email send
- show error message when confirmation email fails

## Testing
- `composer test` *(fails: Tests: 173, Assertions: 358, Errors: 8, Failures: 7, Warnings: 2, PHPUnit Deprecations: 2, Notices: 11)*

------
https://chatgpt.com/codex/tasks/task_e_68990222a578832b891338958b0abd62