### PR TITLE
Add terms and privacy checkboxes to onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -13,7 +13,9 @@
     imprintZip: '',
     imprintCity: '',
     imprintEmail: '',
-    adminPass: ''
+    adminPass: '',
+    acceptTerms: false,
+    acceptPrivacy: false
   };
 
   function show(step) {
@@ -145,6 +147,8 @@
     const imprintZipInput = document.getElementById('imprint-zip');
     const imprintCityInput = document.getElementById('imprint-city');
     const imprintEmailInput = document.getElementById('imprint-email');
+    const acceptTerms = document.getElementById('accept-terms');
+    const acceptPrivacy = document.getElementById('accept-privacy');
     const createBtn = document.getElementById('create');
     const adminPassInput = document.getElementById('admin-pass');
     const successDomain = document.getElementById('success-domain');
@@ -159,6 +163,10 @@
         RESERVED_SUBDOMAINS.has(data.subdomain) ||
         data.email === '' ||
         !data.emailConfirmed;
+    }
+
+    function updateNext4() {
+      next4.disabled = !acceptTerms.checked || !acceptPrivacy.checked;
     }
 
     const params = new URLSearchParams(window.location.search);
@@ -176,6 +184,7 @@
       }
     }
     updateNext1();
+    updateNext4();
 
     const paidParam = params.get('paid');
     const canceledParam = params.get('canceled');
@@ -192,6 +201,9 @@
         UIkit.notification({ message: 'Zahlung abgebrochen', status: 'warning' });
       }
     }
+
+    acceptTerms?.addEventListener('change', updateNext4);
+    acceptPrivacy?.addEventListener('change', updateNext4);
 
     async function waitForHttps(url, onProgress) {
       const maxAttempts = 30;
@@ -334,6 +346,8 @@
       data.imprintZip = imprintZipInput.value.trim();
       data.imprintCity = imprintCityInput.value.trim();
       data.imprintEmail = imprintEmailInput.value.trim();
+      data.acceptTerms = acceptTerms.checked;
+      data.acceptPrivacy = acceptPrivacy.checked;
       document.getElementById('summary-imprint-name').textContent = data.imprintName;
       document.getElementById('summary-imprint-street').textContent = data.imprintStreet;
       document.getElementById('summary-imprint-zip').textContent = data.imprintZip;
@@ -422,7 +436,14 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({ uid: data.subdomain, schema: data.subdomain, plan: data.plan || null, billing: data.payment || null })
+          body: JSON.stringify({
+            uid: data.subdomain,
+            schema: data.subdomain,
+            plan: data.plan || null,
+            billing: data.payment || null,
+            acceptTerms: data.acceptTerms,
+            acceptPrivacy: data.acceptPrivacy
+          })
         });
         if (!tenantRes.ok) {
           const text = await tenantRes.text();

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -95,7 +95,19 @@
       <div class="uk-margin">
         <input id="imprint-email" class="uk-input" type="email" placeholder="E-Mail-Adresse" required>
       </div>
-      <button class="uk-button uk-button-primary" id="next4">Weiter</button>
+      <div class="uk-margin">
+        <label>
+          <input id="accept-terms" class="uk-checkbox" type="checkbox">
+          Ich akzeptiere die <a href="{{ basePath }}/lizenz" target="_blank">AGB</a>
+        </label>
+      </div>
+      <div class="uk-margin">
+        <label>
+          <input id="accept-privacy" class="uk-checkbox" type="checkbox">
+          Ich habe die <a href="{{ basePath }}/datenschutz" target="_blank">Datenschutzerklärung</a> gelesen
+        </label>
+      </div>
+      <button class="uk-button uk-button-primary" id="next4" disabled>Weiter</button>
     </div>
 
     <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step5" hidden>


### PR DESCRIPTION
## Summary
- require acceptance of AGB and privacy policy during onboarding
- validate term/privacy checkboxes before proceeding and send acceptance to server

## Testing
- `composer test` *(fails: Slim Application Error, reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_68990446cfd4832b8d2a45cb5eee87c3