### PR TITLE
Send cookies with landing contact form fetch

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -377,6 +377,8 @@ window.addEventListener('load', () => {
       const data = new URLSearchParams(new FormData(form));
       fetch('{{ basePath }}/landing/contact', {
         method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        credentials: 'same-origin',
         body: data
       }).then(res => {
         if (res.ok) {


### PR DESCRIPTION
## Summary
- send contact form as URL-encoded request including session cookies

## Testing
- `composer test` *(fails: Tests: 173, Assertions: 358, Errors: 8, Failures: 7)*
- `curl -i -X POST http://127.0.0.1:8000/landing/contact ...` *(500 Internal Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_6899048119e8832bb8590c6ea25610eb