### PR TITLE
feat: add sidebar navigation for admin

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -195,6 +195,16 @@ body.uk-padding {
   line-height: 1.2;
 }
 
+/* Admin sidebar navigation */
+.qr-sidebar { min-height: calc(100vh - 56px); }
+.qr-sidebar-card { height: 100%; overflow-y: auto; }
+.qr-nav-text { margin-left: 8px; }
+.uk-nav > li.uk-active > a {
+  background: var(--uk-background-muted, #f8f8f8);
+  border-radius: 6px;
+  font-weight: 600;
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -161,21 +161,22 @@ class AdminController
             ?: getenv('DOMAIN')
             ?: $uri->getHost();
 
-        return $view->render($response, 'admin.twig', [
-            'config' => $cfg,
-            'settings' => $settings,
-            'results' => $results,
-            'catalogs' => $catalogs,
-            'teams' => $teams,
-            'users' => $users,
-            'roles' => Roles::ALL,
-            'baseUrl' => $baseUrl,
-            'main_domain' => $mainDomain,
-            'event' => $event,
-            'role' => $role,
-            'pages' => $pages,
-            'domainType' => $request->getAttribute('domainType'),
-            'tenant' => $tenant,
-        ]);
-    }
-}
+          return $view->render($response, 'admin.twig', [
+              'config' => $cfg,
+              'settings' => $settings,
+              'results' => $results,
+              'catalogs' => $catalogs,
+              'teams' => $teams,
+              'users' => $users,
+              'roles' => Roles::ALL,
+              'baseUrl' => $baseUrl,
+              'main_domain' => $mainDomain,
+              'event' => $event,
+              'role' => $role,
+              'pages' => $pages,
+              'domainType' => $request->getAttribute('domainType'),
+              'tenant' => $tenant,
+              'currentPath' => $request->getUri()->getPath(),
+          ]);
+      }
+  }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -25,10 +25,12 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}{% endblock %}
-    {% block offcanvas %}{% endblock %}
     {% block left %}
-      <a id="adminMenuToggle" class="uk-icon-button" uk-icon="icon: menu; ratio: 2" aria-label="{{ t('menu') }}" uk-toggle="target: #adminNav"></a>
+      <a class="uk-navbar-toggle uk-hidden@m" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+        <span uk-navbar-toggle-icon></span>
+        <span class="uk-margin-small-left">{{ t('menu') }}</span>
+      </a>
+      <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left">QuizRace Admin</a>
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
@@ -52,27 +54,14 @@
       <button id="helpBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" aria-label="Hilfe"></button>
     {% endblock %}
   {% endembed %}
-  <ul id="adminTabs" uk-tab="connect: #adminSwitcher">
-    <li class="uk-active" data-route="dashboard" data-help="Startseite mit Übersicht."><a href="#" data-route-url="{{ basePath }}/admin/dashboard">{{ t('tab_dashboard') }}</a></li>
-    <li data-route="events" data-help="Veranstaltungen anlegen oder bearbeiten. Jede Zeile enthält Name, Beginn, Ende und Beschreibung. 'Hinzufügen' erstellt einen neuen Eintrag. Änderungen werden automatisch gespeichert."><a href="#" data-route-url="{{ basePath }}/admin/events">{{ t('tab_events') }}</a></li>
-    <li data-route="event/settings" data-help="Logo hochladen und Vorschau ansehen. Seitentitel, Überschrift und Untertitel festlegen. Hintergrund- und Buttonfarbe wählen. Optional den Button 'Antwort prüfen' und den QR-Code-Login aktivieren. 'Zurücksetzen' lädt gespeicherte Werte, 'Speichern' übernimmt Änderungen."><a href="#" data-route-url="{{ basePath }}/admin/event/settings">{{ t('tab_event_settings') }}</a></li>
-    <li data-route="catalogs" data-help="Fragenkataloge anlegen oder bearbeiten. Jede Zeile enthält einen Slug, Name, Beschreibung und optional einen Buchstaben für das Rätselwort. Der Slug kann angepasst werden. 'Hinzufügen' erstellt einen neuen Katalog, das rote × entfernt einen Eintrag. Speichern übernimmt die Änderungen."><a href="#" data-route-url="{{ basePath }}/admin/catalogs">{{ t('tab_catalogs') }}</a></li>
-    <li data-route="questions" data-help="Nach Auswahl eines Katalogs einzelne Fragen bearbeiten oder neue anlegen. Das Plus-Symbol legt eine weitere Frage an, 'Zurücksetzen' verwirft Änderungen, 'Speichern' sichert den gesamten Katalog."><a href="#" data-route-url="{{ basePath }}/admin/questions">{{ t('tab_questions') }}</a></li>
-    <li data-route="teams" data-help="Teilnehmerliste pflegen. Über 'Hinzufügen' Teams oder Personen ergänzen. Die Checkbox beschränkt die Teilnahme auf gelistete Namen. Speichern aktualisiert die Liste."><a href="#" data-route-url="{{ basePath }}/admin/teams">{{ t('tab_teams') }}</a></li>
-    <li data-route="summary" data-help="QR-Codes für alle Kataloge und Teams anzeigen, um Quizlinks oder Anmeldungen weiterzugeben. 'Drucken' erstellt eine übersichtliche Liste."><a href="#" data-route-url="{{ basePath }}/admin/summary">{{ t('tab_summary') }}</a></li>
-    <li data-route="results" data-help="Gespeicherte Ergebnisse mit richtigen Antworten und Zeit einsehen. 'Zurücksetzen' löscht alle Daten, 'Herunterladen' exportiert sie als CSV."><a href="#" data-route-url="{{ basePath }}/admin/results">{{ t('tab_results') }}</a></li>
-    <li data-route="statistics" data-help="Einzelne Antworten analysieren. Tabelle filtert nach Teams/Personen."><a href="#" data-route-url="{{ basePath }}/admin/statistics">{{ t('tab_statistics') }}</a></li>
-    {% if role == 'admin' %}
-    <li data-route="pages" data-help="Statische Seiten bearbeiten."><a href="#" data-route-url="{{ basePath }}/admin/pages">{{ t('tab_pages') }}</a></li>
-    <li data-route="management" data-help="Benutzer verwalten, Rollen zuweisen und Sicherungen erstellen. Rollen: admin – Administrator; catalog-editor – Fragenkataloge bearbeiten; event-manager – Veranstaltungen verwalten; analyst – Ergebnisse analysieren; team-manager – Teams verwalten."><a href="#" data-route-url="{{ basePath }}/admin/management">{{ t('tab_management') }}</a></li>
-    {% if domainType == 'main' %}
-    <li data-route="tenants" data-help="Liste aller angelegten Subdomains."><a href="#" data-route-url="{{ basePath }}/admin/tenants">{{ t('tab_tenants') }}</a></li>
-    {% endif %}
-    <li data-route="profile" data-help="Informationen zum eigenen Mandanten."><a href="#" data-route-url="{{ basePath }}/admin/profile">{{ t('tab_profile') }}</a></li>
-    <li data-route="subscription" data-help="Abo verwalten."><a href="#" data-route-url="{{ basePath }}/admin/subscription">{{ t('tab_subscription') }}</a></li>
-    {% endif %}
-  </ul>
-  <ul id="adminSwitcher" class="uk-switcher uk-margin">
+  <div class="uk-grid-collapse" uk-grid>
+    <aside class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
+      <div class="uk-card uk-card-default uk-card-body qr-sidebar-card">
+        {% include 'admin/_nav.twig' %}
+      </div>
+    </aside>
+    <main class="uk-width-expand uk-padding-small@xs uk-padding">
+      <ul id="adminSwitcher" class="uk-switcher uk-margin">
     <li>
       <div class="uk-container uk-container-large">
         <div id="dashboard" class="uk-margin-large-top">
@@ -768,52 +757,20 @@
       </div>
     </li>
     {% endif %}
-  </ul>
+      </ul>
+    </main>
+  </div>
   <div id="helpSidebar" uk-offcanvas="flip: true; overlay: true">
     <div class="uk-offcanvas-bar uk-width-medium">
       <h3 class="uk-margin-remove-top">Hilfe</h3>
       <div id="helpContent"></div>
     </div>
   </div>
-  <div id="adminNav" uk-offcanvas="overlay: true">
+  <div id="qr-offcanvas" uk-offcanvas="overlay: true">
     <div class="uk-offcanvas-bar">
-        <ul class="uk-nav uk-nav-default" id="adminMenu">
-          <li><a href="{{ basePath }}/admin/dashboard" data-tab="0">{{ t('tab_dashboard') }}</a></li>
-          <li class="uk-nav-header">{{ t('menu_event') }}</li>
-          <li><a href="{{ basePath }}/admin/events" data-tab="1">{{ t('tab_events') }}</a></li>
-          <li><a href="{{ basePath }}/admin/event/settings" data-tab="2">{{ t('tab_event_settings') }}</a></li>
-
-          <li class="uk-nav-header">{{ t('menu_content') }}</li>
-          <li><a href="{{ basePath }}/admin/catalogs" data-tab="3">{{ t('tab_catalogs') }}</a></li>
-          <li><a href="{{ basePath }}/admin/questions" data-tab="4">{{ t('tab_questions') }}</a></li>
-          {% if role == 'admin' %}
-          <li><a href="{{ basePath }}/admin/pages" data-tab="9">{{ t('tab_pages') }}</a></li>
-          {% endif %}
-
-          <li class="uk-nav-header">{{ t('menu_teams') }}</li>
-          <li><a href="{{ basePath }}/admin/teams" data-tab="5">{{ t('tab_teams') }}</a></li>
-
-          <li class="uk-nav-header">{{ t('menu_evaluation') }}</li>
-          <li><a href="{{ basePath }}/admin/summary" data-tab="6">{{ t('tab_summary') }}</a></li>
-          <li><a href="{{ basePath }}/admin/results" data-tab="7">{{ t('tab_results') }}</a></li>
-          <li><a href="{{ basePath }}/admin/statistics" data-tab="8">{{ t('tab_statistics') }}</a></li>
-
-          {% if role == 'admin' %}
-          <li class="uk-nav-header">{{ t('menu_admin') }}</li>
-          <li><a href="{{ basePath }}/admin/management" data-tab="10">{{ t('tab_management') }}</a></li>
-          {% if domainType == 'main' %}
-          <li><a href="{{ basePath }}/admin/tenants" data-tab="11">{{ t('tab_tenants') }}</a></li>
-          <li><a href="{{ basePath }}/admin/profile" data-tab="12">{{ t('tab_profile') }}</a></li>
-          <li><a href="{{ basePath }}/admin/subscription" data-tab="13">{{ t('tab_subscription') }}</a></li>
-          {% else %}
-          <li><a href="{{ basePath }}/admin/profile" data-tab="11">{{ t('tab_profile') }}</a></li>
-          <li><a href="{{ basePath }}/admin/subscription" data-tab="12">{{ t('tab_subscription') }}</a></li>
-          {% endif %}
-          {% endif %}
-
-          <li class="uk-nav-divider"></li>
-          <li><a href="{{ basePath }}/logout">{{ t('logout') }}</a></li>
-        </ul>
+      <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
+      <h3 class="uk-margin-small">QuizRace</h3>
+      {% include 'admin/_nav.twig' %}
     </div>
   </div>
 {% endblock %}

--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -1,0 +1,118 @@
+{% set current = currentPath %}
+<ul class="uk-nav uk-nav-default">
+  <li class="{{ current starts with (basePath ~ '/admin/dashboard') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/dashboard">
+      <span uk-icon="icon: home; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_dashboard') }}</span>
+    </a>
+  </li>
+  <li class="uk-nav-header">{{ t('menu_event') }}</li>
+  <li class="{{ current starts with (basePath ~ '/admin/events') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/events">
+      <span uk-icon="icon: calendar; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_events') }}</span>
+    </a>
+  </li>
+  <li class="{{ current starts with (basePath ~ '/admin/event/settings') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/event/settings">
+      <span uk-icon="icon: cog; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_event_settings') }}</span>
+    </a>
+  </li>
+  <li class="uk-nav-header">{{ t('menu_content') }}</li>
+  <li class="{{ current starts with (basePath ~ '/admin/catalogs') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/catalogs">
+      <span uk-icon="icon: folder; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_catalogs') }}</span>
+    </a>
+  </li>
+  <li class="{{ current starts with (basePath ~ '/admin/questions') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/questions">
+      <span uk-icon="icon: question; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_questions') }}</span>
+    </a>
+  </li>
+  {% if role == 'admin' %}
+  <li class="{{ current starts with (basePath ~ '/admin/pages') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/pages">
+      <span uk-icon="icon: file-text; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_pages') }}</span>
+    </a>
+  </li>
+  {% endif %}
+  <li class="uk-nav-header">{{ t('menu_teams') }}</li>
+  <li class="{{ current starts with (basePath ~ '/admin/teams') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/teams">
+      <span uk-icon="icon: users; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_teams') }}</span>
+    </a>
+  </li>
+  <li class="uk-nav-header">{{ t('menu_evaluation') }}</li>
+  <li class="{{ current starts with (basePath ~ '/admin/summary') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/summary">
+      <span uk-icon="icon: thumbnails; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_summary') }}</span>
+    </a>
+  </li>
+  <li class="{{ current starts with (basePath ~ '/admin/results') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/results">
+      <span uk-icon="icon: list; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_results') }}</span>
+    </a>
+  </li>
+  <li class="{{ current starts with (basePath ~ '/admin/statistics') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/statistics">
+      <span uk-icon="icon: graph; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_statistics') }}</span>
+    </a>
+  </li>
+  {% if role == 'admin' %}
+  <li class="uk-nav-header">{{ t('menu_admin') }}</li>
+  <li class="{{ current starts with (basePath ~ '/admin/management') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/management">
+      <span uk-icon="icon: cog; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_management') }}</span>
+    </a>
+  </li>
+  {% if domainType == 'main' %}
+  <li class="{{ current starts with (basePath ~ '/admin/tenants') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/tenants">
+      <span uk-icon="icon: world; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_tenants') }}</span>
+    </a>
+  </li>
+  <li class="{{ current starts with (basePath ~ '/admin/profile') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/profile">
+      <span uk-icon="icon: user; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_profile') }}</span>
+    </a>
+  </li>
+  <li class="{{ current starts with (basePath ~ '/admin/subscription') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/subscription">
+      <span uk-icon="icon: credit-card; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_subscription') }}</span>
+    </a>
+  </li>
+  {% else %}
+  <li class="{{ current starts with (basePath ~ '/admin/profile') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/profile">
+      <span uk-icon="icon: user; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_profile') }}</span>
+    </a>
+  </li>
+  <li class="{{ current starts with (basePath ~ '/admin/subscription') ? 'uk-active' }}">
+    <a href="{{ basePath }}/admin/subscription">
+      <span uk-icon="icon: credit-card; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('tab_subscription') }}</span>
+    </a>
+  </li>
+  {% endif %}
+  {% endif %}
+  <li class="uk-nav-divider"></li>
+  <li>
+    <a href="{{ basePath }}/logout">
+      <span uk-icon="icon: sign-out; ratio: 0.95"></span>
+      <span class="qr-nav-text">{{ t('logout') }}</span>
+    </a>
+  </li>
+</ul>


### PR DESCRIPTION
## Summary
- replace tabbed admin menu with grid layout featuring a fixed sidebar and mobile off-canvas
- add reusable navigation partial with role-based items
- style sidebar navigation
- align sidebar entries with existing admin tabs and headings

## Testing
- `composer install`
- `composer test` *(fails: Slim Application Error and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689900a0e8b8832b83f49ffe5c0d5ea5