### PR TITLE
Ensure lead text remains white on dark sections

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -13,6 +13,11 @@ body {
   color: #fff;
 }
 
+.about-section .uk-text-lead,
+.uk-light .uk-text-lead {
+  color: #fff;
+}
+
 
 body.uk-padding {
   padding-top: 56px;


### PR DESCRIPTION
## Summary
- Override UIkit's `uk-text-lead` colour so lead text in dark sections (e.g. about and contact) displays white

## Testing
- `composer test` *(fails: Tests: 173, Assertions: 358, Errors: 8, Failures: 7)*

------
https://chatgpt.com/codex/tasks/task_e_68990413da64832b863033b26b6f30ae