### PR TITLE
Handle mail errors in contact form

### DIFF
--- a/src/Controller/Marketing/ContactController.php
+++ b/src/Controller/Marketing/ContactController.php
@@ -8,6 +8,7 @@ use App\Service\MailService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use RuntimeException;
 
 /**
  * Handles contact form submissions from the landing page.
@@ -46,7 +47,13 @@ class ContactController
             $twig = Twig::fromRequest($request)->getEnvironment();
             $mailer = new MailService($twig);
         }
-        $mailer->sendContact($to, $name, $email, $message);
+        try {
+            $mailer->sendContact($to, $name, $email, $message);
+        } catch (RuntimeException $e) {
+            error_log('Contact mail failed: ' . $e->getMessage());
+            $response->getBody()->write('Mailversand fehlgeschlagen');
+            return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
+        }
 
         return $response->withStatus(204);
     }

--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Service\MailService;
+use RuntimeException;
+use Tests\TestCase;
+
+class ContactControllerTest extends TestCase
+{
+    public function testContactFailsWithoutMailConfiguration(): void
+    {
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+        $request = $this->createRequest('POST', '/landing/contact', [
+            'Content-Type' => 'application/json',
+            'X-CSRF-Token' => 'tok',
+        ]);
+        $request->getBody()->write(json_encode([
+            'name' => 'Jane',
+            'email' => 'jane@example.com',
+            'message' => 'Hi',
+        ]));
+        $request->getBody()->rewind();
+
+        $mailer = new class extends MailService {
+            public function __construct()
+            {
+            }
+
+            public function sendContact(string $to, string $name, string $email, string $message): void
+            {
+                throw new RuntimeException('no smtp');
+            }
+        };
+        $request = $request->withAttribute('mailService', $mailer);
+
+        $response = $app->handle($request);
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame('Mailversand fehlgeschlagen', (string) $response->getBody());
+        session_destroy();
+    }
+}


### PR DESCRIPTION
## Summary
- catch mailer failures in ContactController and return 500 with error message
- add integration test covering missing SMTP configuration

## Testing
- `vendor/bin/phpunit tests/Controller/ContactControllerTest.php`
- `vendor/bin/phpcs src/Controller/Marketing/ContactController.php tests/Controller/ContactControllerTest.php`
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 no such column: published)*

------
https://chatgpt.com/codex/tasks/task_e_68990bb3cb78832b9d28f88e62343fdf