### PR TITLE
Handle missing SMTP config for contact

### DIFF
--- a/src/Controller/Marketing/ContactController.php
+++ b/src/Controller/Marketing/ContactController.php
@@ -44,6 +44,10 @@ class ContactController
 
         $mailer = $request->getAttribute('mailService');
         if (!$mailer instanceof MailService) {
+            if (!MailService::isConfigured()) {
+                $response->getBody()->write('Mailservice nicht konfiguriert');
+                return $response->withStatus(503)->withHeader('Content-Type', 'text/plain');
+            }
             $twig = Twig::fromRequest($request)->getEnvironment();
             $mailer = new MailService($twig);
         }

--- a/src/Controller/Marketing/LandingController.php
+++ b/src/Controller/Marketing/LandingController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Marketing;
 
+use App\Service\MailService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteContext;
@@ -30,6 +31,14 @@ class LandingController
         $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
         $_SESSION['csrf_token'] = $csrf;
         $html = str_replace('{{ csrf_token }}', $csrf, $html);
+
+        if (!MailService::isConfigured()) {
+            $html = preg_replace(
+                '/<form id="contact-form"[\s\S]*?<\/form>/',
+                '<p class="uk-text-center">Kontaktformular derzeit nicht verfügbar.</p>',
+                $html
+            );
+        }
 
         $view = Twig::fromRequest($request);
         return $view->render($response, 'marketing/landing.twig', [

--- a/src/Controller/OnboardingEmailController.php
+++ b/src/Controller/OnboardingEmailController.php
@@ -43,6 +43,9 @@ class OnboardingEmailController
 
         $mailer = $request->getAttribute('mailService');
         if (!$mailer instanceof MailService) {
+            if (!MailService::isConfigured()) {
+                return $response->withStatus(503);
+            }
             $twig = Twig::fromRequest($request)->getEnvironment();
             $mailer = new MailService($twig);
         }

--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -84,6 +84,9 @@ class PasswordResetController
 
         $mailer = $request->getAttribute('mailService');
         if (!$mailer instanceof MailService) {
+            if (!MailService::isConfigured()) {
+                return $response->withStatus(503);
+            }
             $twig = Twig::fromRequest($request)->getEnvironment();
             $audit = $request->getAttribute('auditLogger');
             $logger = $audit instanceof AuditLogger ? $audit : null;

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -21,6 +21,23 @@ class MailService
     private string $from;
     private ?AuditLogger $audit;
 
+    public static function isConfigured(): bool
+    {
+        $root = dirname(__DIR__, 2);
+        $envFile = $root . '/.env';
+        $env = [];
+
+        if (is_readable($envFile)) {
+            $env = parse_ini_file($envFile, false, INI_SCANNER_RAW) ?: [];
+        }
+
+        $host = (string) ($env['SMTP_HOST'] ?? getenv('SMTP_HOST') ?: '');
+        $user = (string) ($env['SMTP_USER'] ?? getenv('SMTP_USER') ?: '');
+        $pass = (string) ($env['SMTP_PASS'] ?? getenv('SMTP_PASS') ?: '');
+
+        return $host !== '' && $user !== '' && $pass !== '';
+    }
+
     public function __construct(Environment $twig, ?AuditLogger $audit = null)
     {
         $root = dirname(__DIR__, 2);

--- a/src/routes.php
+++ b/src/routes.php
@@ -514,6 +514,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/invite', function (Request $request, Response $response) {
         $pdo = $request->getAttribute('pdo');
         $twig = Twig::fromRequest($request)->getEnvironment();
+        if (!MailService::isConfigured()) {
+            return $response->withStatus(503);
+        }
         $mailer = new MailService($twig);
         $service = new InvitationService($pdo);
         $controller = new InvitationController($service, $mailer);
@@ -638,6 +641,9 @@ return function (\Slim\App $app, TranslationService $translator) {
         $token = $resetService->createToken((int) $admin['id']);
         $mainDomain = getenv('MAIN_DOMAIN') ?: getenv('DOMAIN') ?: $request->getUri()->getHost();
         $twig = Twig::fromRequest($request);
+        if (!MailService::isConfigured()) {
+            return $response->withStatus(503);
+        }
         $mailer = new MailService($twig, $auditLogger);
         $domain = sprintf('%s.%s', $schema, $mainDomain);
         $link = sprintf('https://%s/password/set?token=%s', $domain, urlencode($token));

--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -43,4 +43,30 @@ class ContactControllerTest extends TestCase
         $this->assertSame('Mailversand fehlgeschlagen', (string) $response->getBody());
         session_destroy();
     }
+
+    public function testContactUnavailableWhenMailConfigMissing(): void
+    {
+        putenv('SMTP_HOST');
+        putenv('SMTP_USER');
+        putenv('SMTP_PASS');
+        unset($_ENV['SMTP_HOST'], $_ENV['SMTP_USER'], $_ENV['SMTP_PASS']);
+
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+        $request = $this->createRequest('POST', '/landing/contact', [
+            'Content-Type' => 'application/json',
+            'X-CSRF-Token' => 'tok',
+        ]);
+        $request->getBody()->write(json_encode([
+            'name' => 'Jane',
+            'email' => 'jane@example.com',
+            'message' => 'Hi',
+        ]));
+        $request->getBody()->rewind();
+
+        $response = $app->handle($request);
+        $this->assertEquals(503, $response->getStatusCode());
+        session_destroy();
+    }
 }

--- a/tests/Controller/LandingControllerTest.php
+++ b/tests/Controller/LandingControllerTest.php
@@ -31,4 +31,60 @@ class LandingControllerTest extends TestCase
             putenv('MAIN_DOMAIN=' . $old);
         }
     }
+
+    public function testContactFormHiddenWhenMailConfigMissing(): void
+    {
+        $host = getenv('SMTP_HOST');
+        $user = getenv('SMTP_USER');
+        $pass = getenv('SMTP_PASS');
+        putenv('SMTP_HOST');
+        putenv('SMTP_USER');
+        putenv('SMTP_PASS');
+        unset($_ENV['SMTP_HOST'], $_ENV['SMTP_USER'], $_ENV['SMTP_PASS']);
+
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/landing');
+        $response = $app->handle($request);
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('id="contact-form"', $body);
+        $this->assertStringContainsString('Kontaktformular derzeit nicht verfügbar', $body);
+
+        if ($host !== false) {
+            putenv('SMTP_HOST=' . $host);
+            $_ENV['SMTP_HOST'] = $host;
+        }
+        if ($user !== false) {
+            putenv('SMTP_USER=' . $user);
+            $_ENV['SMTP_USER'] = $user;
+        }
+        if ($pass !== false) {
+            putenv('SMTP_PASS=' . $pass);
+            $_ENV['SMTP_PASS'] = $pass;
+        }
+    }
+
+    public function testContactFormVisibleWhenMailConfigured(): void
+    {
+        putenv('SMTP_HOST=localhost');
+        putenv('SMTP_USER=user@example.org');
+        putenv('SMTP_PASS=secret');
+        $_ENV['SMTP_HOST'] = 'localhost';
+        $_ENV['SMTP_USER'] = 'user@example.org';
+        $_ENV['SMTP_PASS'] = 'secret';
+
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/landing');
+        $response = $app->handle($request);
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('id="contact-form"', $body);
+
+        putenv('SMTP_HOST');
+        putenv('SMTP_USER');
+        putenv('SMTP_PASS');
+        unset($_ENV['SMTP_HOST'], $_ENV['SMTP_USER'], $_ENV['SMTP_PASS']);
+    }
 }


### PR DESCRIPTION
## Summary
- add MailService::isConfigured to detect missing SMTP settings
- hide landing contact form and avoid MailService use when SMTP is absent
- guard controllers and routes so MailService is only created with full config
- add tests for contact form visibility and contact endpoint availability

## Testing
- `vendor/bin/phpunit tests/Controller/LandingControllerTest.php tests/Controller/ContactControllerTest.php`
- `vendor/bin/phpcs src/Controller/Marketing/LandingController.php src/Controller/Marketing/ContactController.php src/Controller/OnboardingEmailController.php src/Controller/PasswordResetController.php src/Service/MailService.php src/routes.php tests/Controller/LandingControllerTest.php tests/Controller/ContactControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68990db3684c832b9bf9169aac27ba2c