### PR TITLE
Remove redundant top padding below navbar

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -20,13 +20,13 @@ body {
 
 
 body.uk-padding {
-  padding-top: 56px;
+  padding-top: 0;
   padding-left: 8px;
   padding-right: 8px;
 }
 
 .index-page {
-  padding-top: 56px;
+  padding-top: 0;
 }
 
 .wrapper {
@@ -487,7 +487,7 @@ body.dark-mode .onboarding-step {
 }
 
 body.admin-page {
-  padding-top: 112px;
+  padding-top: 0;
 }
 
 .admin-page .topbar {
@@ -523,7 +523,7 @@ body.admin-page {
     display: flex;
   }
   body.admin-page {
-    padding-top: 56px;
+    padding-top: 0;
   }
   .admin-page .topbar {
     height: 56px;


### PR DESCRIPTION
## Summary
- eliminate unnecessary top padding on regular and admin pages
- rely on nav placeholder for spacing below fixed topbar

## Testing
- `composer test` *(fails: Tests\Controller\PasswordResetFlowTest::testFullResetFlow, QrController tests, 177 tests, 8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689920119c18832b827b5f93e71bb39a