### PR TITLE
Ensure 'Wer steckt hinter QuizRace?' heading uses white text

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -292,7 +292,7 @@ window.addEventListener('load', () => {
 <!-- Über uns / Founder -->
 <section class="uk-section about-section" style="color:#fff;">
   <div class="uk-container">
-    <h2 class="uk-text-center uk-heading-medium" uk-scrollspy="cls: uk-animation-slide-top-small">Wer steckt hinter QuizRace?</h2>
+    <h2 class="uk-text-center uk-heading-medium" uk-scrollspy="cls: uk-animation-slide-top-small" style="color:#fff;">Wer steckt hinter QuizRace?</h2>
     <div class="uk-width-2xlarge uk-margin-auto uk-text-center uk-text-lead" uk-scrollspy="cls: uk-animation-fade; delay: 150">
       <b>QuizRace wurde von René Buske entwickelt – einem erfahrenen Softwarearchitekten und Digital-Event-Profi mit über 20 Jahren Erfahrung.</b>
       <br>


### PR DESCRIPTION
## Summary
- Make the "Wer steckt hinter QuizRace?" heading explicitly use white text for consistency with landing page design

## Testing
- `composer test` *(fails: Tests: 177, Assertions: 366, Errors: 8, Failures: 7, Warnings: 2, PHPUnit Deprecations: 2, Notices: 11)*

------
https://chatgpt.com/codex/tasks/task_e_689921ab8ce0832b8ef81a32b6636789