### PR TITLE
Fix landing page contact form email handling

### DIFF
--- a/src/Controller/Marketing/ContactController.php
+++ b/src/Controller/Marketing/ContactController.php
@@ -17,9 +17,13 @@ class ContactController
 {
     public function __invoke(Request $request, Response $response): Response
     {
-        $data = json_decode((string) $request->getBody(), true);
+        $data = $request->getParsedBody();
         if (!is_array($data)) {
-            $data = $request->getParsedBody();
+            $body = $request->getBody();
+            if ($body->isSeekable()) {
+                $body->rewind();
+            }
+            $data = json_decode((string) $body, true);
         }
         if (!is_array($data)) {
             return $response->withStatus(400);
@@ -28,7 +32,12 @@ class ContactController
         $name = trim((string) ($data['name'] ?? ''));
         $email = trim((string) ($data['email'] ?? ''));
         $message = trim((string) ($data['message'] ?? ''));
-        if ($name === '' || $email === '' || $message === '') {
+        if (
+            $name === '' ||
+            $message === '' ||
+            $email === '' ||
+            !filter_var($email, FILTER_VALIDATE_EMAIL)
+        ) {
             return $response->withStatus(400);
         }
 


### PR DESCRIPTION
## Summary
- handle URL-encoded and JSON bodies in landing contact controller
- validate email addresses in contact form submissions
- test that contact form triggers mail sending

## Testing
- `composer test` *(fails: Slim Application Error; Database error: fail; Error creating tenant: boom; Failed to reload nginx: reload failed)*
- `./vendor/bin/phpunit tests/Controller/ContactControllerTest.php`
- `./vendor/bin/phpcs src/Controller/Marketing/ContactController.php tests/Controller/ContactControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6899446af790832b9cb49f05645fcae1