### PR TITLE
Fix phpstan strict comparison warnings

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -87,7 +87,7 @@ class MailService
             $port
         );
 
-        if ($encryption !== '' && strtolower($encryption) !== 'none') {
+        if (strtolower($encryption) !== 'none') {
             $dsn .= '?encryption=' . rawurlencode($encryption);
         }
 

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -55,11 +55,9 @@ class QrCodeService
         } else {
             $tmp = tempnam(sys_get_temp_dir(), 'qrlogo_fallback');
             if ($tmp !== false) {
-                $data = base64_decode(self::FALLBACK_LOGO_PNG_BASE64);
-                if ($data !== false) {
-                    file_put_contents($tmp, $data);
-                    $logoPath = $tmp;
-                }
+                $data = base64_decode(self::FALLBACK_LOGO_PNG_BASE64, true);
+                file_put_contents($tmp, $data);
+                $logoPath = $tmp;
             }
         }
 


### PR DESCRIPTION
## Summary
- remove redundant encryption blank check in MailService
- streamline QR code fallback logo decoding

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `vendor/bin/phpunit` *(fails: Tests: 178, Assertions: 369, Errors: 8, Failures: 7, Warnings: 2, PHPUnit Deprecations: 2, Notices: 11)*
- `vendor/bin/phpcs --standard=phpcs.xml` *(errors: see log)*

------
https://chatgpt.com/codex/tasks/task_e_68996682a990832b81f59ec68ddcc2de