### PR TITLE
Send welcome mail after subdomain activation

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -543,28 +543,6 @@
         setTaskStatus('ssl', 'done');
         logMessage(boardJson.status || 'Container gestartet');
 
-        try {
-          logMessage('Sende Willkommensmail...');
-          const welcomeRes = await fetch(withBase('/tenant-welcome'), {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify({
-              schema: data.subdomain,
-              email: data.imprintEmail,
-              password: data.adminPass
-            })
-          });
-          if (!welcomeRes.ok) {
-            const text = await welcomeRes.text();
-            logMessage('Fehler Willkommensmail: ' + text);
-          } else {
-            logMessage('Willkommensmail gesendet');
-          }
-        } catch (e) {
-          logMessage('Fehler Willkommensmail');
-        }
-
         if (successDomain) {
           successDomain.textContent = data.subdomain + '.' + mainDomain;
           successDomain.hidden = false;
@@ -632,6 +610,26 @@
           setTaskStatus('wait', 'done');
           if (typeof UIkit !== 'undefined') {
             UIkit.notification({ message: 'Instanz ist bereit', status: 'success' });
+          }
+          try {
+            logMessage('Sende Willkommensmail...');
+            const welcomeRes = await fetch(withBase('/tenant-welcome'), {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
+              body: JSON.stringify({
+                schema: data.subdomain,
+                email: data.imprintEmail
+              })
+            });
+            if (!welcomeRes.ok) {
+              const text = await welcomeRes.text();
+              logMessage('Fehler Willkommensmail: ' + text);
+            } else {
+              logMessage('Willkommensmail gesendet');
+            }
+          } catch (e) {
+            logMessage('Fehler Willkommensmail');
           }
         } else {
           logMessage('Subdomain nach Wartezeit nicht erreichbar');

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -158,7 +158,7 @@ class MailService
     }
 
     /**
-     * Send initial welcome mail with set-password link.
+     * Send initial welcome mail with admin link.
      *
      * Returns the rendered HTML (useful for logging/preview).
      *

--- a/src/routes.php
+++ b/src/routes.php
@@ -656,16 +656,14 @@ return function (\Slim\App $app, TranslationService $translator) {
         if ($admin === null) {
             return $response->withStatus(500);
         }
-        $resetService = new PasswordResetService($pdo);
-        $token = $resetService->createToken((int) $admin['id']);
         $mainDomain = getenv('MAIN_DOMAIN') ?: getenv('DOMAIN') ?: $request->getUri()->getHost();
-        $twig = Twig::fromRequest($request);
+        $twig = Twig::fromRequest($request)->getEnvironment();
         if (!MailService::isConfigured()) {
             return $response->withStatus(503);
         }
         $mailer = new MailService($twig, $auditLogger);
         $domain = sprintf('%s.%s', $schema, $mainDomain);
-        $link = sprintf('https://%s/password/set?token=%s', $domain, urlencode($token));
+        $link = sprintf('https://%s/admin', $domain);
         $html = $mailer->sendWelcome($email, $domain, $link);
         $base = dirname(__DIR__, 1);
         $dir = $base . '/data/' . $schema;

--- a/templates/emails/welcome.twig
+++ b/templates/emails/welcome.twig
@@ -1,5 +1,5 @@
 <p>Hallo,</p>
 <p>Ihr QuizRace wurde unter <a href="https://{{ domain }}">{{ domain }}</a> eingerichtet.</p>
-<p>Zum Setzen des Admin-Passworts klicken Sie bitte auf folgenden Link:</p>
+<p>Zum Administrationsbereich gelangen Sie über folgenden Link:</p>
 <p><a href="{{ link }}">{{ link }}</a></p>
 <p>Viel Erfolg!</p>


### PR DESCRIPTION
## Summary
- Send welcome email only after the tenant subdomain is reachable
- Link welcome email directly to the admin interface
- Fix MailService instantiation by passing Twig Environment

## Testing
- `composer test` *(fails: Tests: 178, Assertions: 369, Errors: 8, Failures: 7, Warnings: 2, PHPUnit Deprecations: 2, Notices: 11.)*

------
https://chatgpt.com/codex/tasks/task_e_68996d37f87c832bb486e0133f07ce7d