### PR TITLE
feat: enforce stripe-only payments

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2202,7 +2202,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const data = {};
       formData.forEach((value, key) => { data[key] = value; });
       const allowedPlans = ['starter', 'standard', 'professional'];
-      const allowedBilling = ['invoice', 'credit', 'paypal'];
+      const allowedBilling = ['credit'];
       if (!allowedPlans.includes(data.plan)) delete data.plan;
       if (!allowedBilling.includes(data.billing_info)) delete data.billing_info;
       apiFetch('/admin/profile', {

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -319,12 +319,11 @@
     });
 
       const allowedPlans = ['starter', 'standard', 'professional'];
-      const allowedPayments = ['invoice', 'credit', 'paypal'];
+      const allowedPayments = ['credit'];
 
       paymentSelect?.addEventListener('change', () => {
-        const credit = paymentSelect.value === 'credit';
-        if (payBtn) payBtn.hidden = !credit;
-        if (paymentInfo) paymentInfo.hidden = !credit;
+        if (payBtn) payBtn.hidden = false;
+        if (paymentInfo) paymentInfo.hidden = false;
       });
       paymentSelect?.dispatchEvent(new Event('change'));
 
@@ -335,8 +334,7 @@
       });
 
       next3.addEventListener('click', () => {
-        const paymentValue = paymentSelect?.value || '';
-        data.payment = allowedPayments.includes(paymentValue) ? paymentValue : '';
+        data.payment = 'credit';
         document.getElementById('summary-name').textContent = data.name;
         document.getElementById('summary-subdomain').textContent = data.subdomain;
         document.getElementById('summary-plan').textContent = data.plan;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -729,9 +729,7 @@
             <div class="uk-width-1-1">
               <label class="uk-form-label">{{ t('column_billing') }}</label>
               <select class="uk-select" name="billing_info">
-                <option value="invoice" {% if tenant.billing_info == 'invoice' %}selected{% endif %}>{{ t('billing_invoice') }}</option>
                 <option value="credit" {% if tenant.billing_info == 'credit' %}selected{% endif %}>{{ t('billing_credit') }}</option>
-                <option value="paypal" {% if tenant.billing_info == 'paypal' %}selected{% endif %}>{{ t('billing_paypal') }}</option>
               </select>
             </div>
             <div class="uk-width-1-1">

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -68,9 +68,7 @@
       <h3 class="uk-card-title">3. Zahlungsart</h3>
       <div class="uk-margin">
         <select id="payment" class="uk-select">
-          <option value="invoice">{{ t('billing_invoice') }}</option>
           <option value="credit">{{ t('billing_credit') }}</option>
-          <option value="paypal">{{ t('billing_paypal') }}</option>
         </select>
       </div>
       <p id="payment-info" class="uk-text-meta" hidden>{{ t('stripe_payment_terms')|raw }}</p>


### PR DESCRIPTION
## Summary
- show only Stripe credit card option during onboarding payments
- restrict tenant billing settings to Stripe in admin panel

## Testing
- `composer test` *(fails: Slim Application Error ... ERROR: Tests: 178, Assertions: 369, Errors: 8, Failures: 7)*

------
https://chatgpt.com/codex/tasks/task_e_68996db450bc832bb4c37ce606ca43aa