### PR TITLE
refactor: redesign dashboard calendar

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -849,4 +849,36 @@ body.admin-page {
   border-radius: 8px;
 }
 
+/* Dashboard calendar */
+#calendar table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+#calendar td {
+  padding: 4px;
+  height: 80px;
+  vertical-align: top;
+  position: relative;
+}
+
+#calendar .cal-events {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 4px;
+}
+
+#calendar .cal-event {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #1e87f0;
+  display: block;
+}
+
 

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -37,7 +37,7 @@
     const h3 = cal.parentElement.querySelector('h3');
     h3.textContent = monthStart.toLocaleDateString('de-DE', { month: 'long', year: 'numeric' });
 
-    let html = '<table class="uk-table uk-table-divider uk-table-small uk-text-center">';
+    let html = '<table class="uk-table uk-table-small uk-text-center calendar-table">';
     html += '<thead><tr><th>Mo</th><th>Di</th><th>Mi</th><th>Do</th><th>Fr</th><th>Sa</th><th>So</th></tr></thead><tbody><tr>';
     for (let i = 0; i < startWeekday; i++) html += '<td></td>';
 
@@ -58,12 +58,12 @@
       const hasEvents = !!byDate[key];
       html += `<td class="${isToday ? 'uk-background-muted uk-text-bold' : ''}"><div>${day}</div>`;
       if (hasEvents) {
-        html += '<div class="uk-margin-small-top">' +
+        html += '<div class="cal-events">' +
           byDate[key].map(ev => {
             const s = new Date(ev.start).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
             const eTime = new Date(ev.end).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
             const label = `${s}–${eTime} ${short(ev.title)}`;
-            return `<a class="uk-badge uk-display-block uk-margin-xsmall-top" href="${withBase('/admin/events/' + ev.id)}" title="${ev.title}">${label}</a>`;
+            return `<a class="cal-event" href="${withBase('/admin/events/' + ev.id)}" title="${label}"></a>`;
           }).join('') +
           '</div>';
       }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -70,20 +70,6 @@
       <div class="uk-container uk-container-large">
         <div id="dashboard" class="uk-margin-large-top">
           <div class="uk-grid-large" uk-grid>
-            <!-- Spalte 1: Kalender -->
-            <div class="uk-width-1-1 uk-width-1-3@m">
-              <div class="uk-card uk-card-default uk-card-body">
-                <div class="uk-flex uk-flex-between uk-flex-middle uk-margin-small-bottom">
-                  <h3 class="uk-card-title uk-margin-remove">August 2025</h3>
-                  <div>
-                    <button class="uk-button uk-button-default uk-button-small" id="cal-prev" aria-label="Vorheriger Monat">‹</button>
-                    <button class="uk-button uk-button-default uk-button-small" id="cal-next" aria-label="Nächster Monat">›</button>
-                  </div>
-                </div>
-                <div id="calendar"></div>
-              </div>
-            </div>
-
             <!-- Spalte 2–3: Inhalt -->
             <div class="uk-width-1-1 uk-width-2-3@m">
               <div class="uk-card uk-card-default uk-card-body uk-margin-small">
@@ -129,8 +115,22 @@
               <div class="uk-margin-small">
                 <span class="uk-badge" id="badge-draft">0 Entwürfe</span>
                 <span class="uk-badge" id="badge-scheduled">0 geplant</span>
-                <span class="uk-badge" id="badge-running">0 live</span>
-                <span class="uk-badge" id="badge-finished">0 abgeschlossen</span>
+              <span class="uk-badge" id="badge-running">0 live</span>
+              <span class="uk-badge" id="badge-finished">0 abgeschlossen</span>
+              </div>
+            </div>
+
+            <!-- Spalte 1: Kalender -->
+            <div class="uk-width-1-1 uk-width-1-3@m">
+              <div class="uk-card uk-card-default uk-card-small uk-card-body uk-margin-small">
+                <div class="uk-flex uk-flex-between uk-flex-middle uk-margin-small-bottom">
+                  <h3 class="uk-card-title uk-margin-remove">August 2025</h3>
+                  <div>
+                    <button class="uk-button uk-button-default uk-button-small" id="cal-prev" aria-label="Vorheriger Monat">‹</button>
+                    <button class="uk-button uk-button-default uk-button-small" id="cal-next" aria-label="Nächster Monat">›</button>
+                  </div>
+                </div>
+                <div id="calendar"></div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- rearrange dashboard grid so main content precedes calendar and add spacing
- render calendar with compact event dots instead of badges
- style calendar table and markers for a lighter appearance

## Testing
- `composer test` *(fails: Slim Application Error; Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68996ee62188832b9ab82d68a0616bff