### PR TITLE
feat: add page SEO config

### DIFF
--- a/migrations/20241203_create_page_seo_config.php
+++ b/migrations/20241203_create_page_seo_config.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use PDO;
+
+return static function (PDO $pdo): void {
+    $pdo->exec(<<<'SQL'
+        CREATE TABLE IF NOT EXISTS page_seo_config (
+            page_id INTEGER PRIMARY KEY REFERENCES pages(id) ON DELETE CASCADE,
+            meta_title TEXT,
+            meta_description TEXT,
+            slug TEXT UNIQUE NOT NULL,
+            canonical_url TEXT,
+            robots_meta TEXT,
+            og_title TEXT,
+            og_description TEXT,
+            og_image TEXT,
+            schema_json JSONB,
+            hreflang TEXT,
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS page_seo_config_history (
+            id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+            meta_title TEXT,
+            meta_description TEXT,
+            slug TEXT,
+            canonical_url TEXT,
+            robots_meta TEXT,
+            og_title TEXT,
+            og_description TEXT,
+            og_image TEXT,
+            schema_json JSONB,
+            hreflang TEXT,
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_page_seo_config_slug ON page_seo_config(slug);
+    SQL);
+};

--- a/src/Domain/PageSeoConfig.php
+++ b/src/Domain/PageSeoConfig.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain;
+
+use JsonSerializable;
+
+/**
+ * SEO configuration associated with a Page.
+ */
+class PageSeoConfig implements JsonSerializable
+{
+    private int $pageId;
+
+    private ?string $metaTitle;
+
+    private ?string $metaDescription;
+
+    private string $slug;
+
+    private ?string $canonicalUrl;
+
+    private ?string $robotsMeta;
+
+    private ?string $ogTitle;
+
+    private ?string $ogDescription;
+
+    private ?string $ogImage;
+
+    private ?string $schemaJson;
+
+    private ?string $hreflang;
+
+    /** @var Page|null */
+    private $page;
+
+    public function __construct(
+        int $pageId,
+        string $slug,
+        ?string $metaTitle = null,
+        ?string $metaDescription = null,
+        ?string $canonicalUrl = null,
+        ?string $robotsMeta = null,
+        ?string $ogTitle = null,
+        ?string $ogDescription = null,
+        ?string $ogImage = null,
+        ?string $schemaJson = null,
+        ?string $hreflang = null
+    ) {
+        $this->pageId = $pageId;
+        $this->slug = $slug;
+        $this->metaTitle = $metaTitle;
+        $this->metaDescription = $metaDescription;
+        $this->canonicalUrl = $canonicalUrl;
+        $this->robotsMeta = $robotsMeta;
+        $this->ogTitle = $ogTitle;
+        $this->ogDescription = $ogDescription;
+        $this->ogImage = $ogImage;
+        $this->schemaJson = $schemaJson;
+        $this->hreflang = $hreflang;
+    }
+
+    public function getPageId(): int
+    {
+        return $this->pageId;
+    }
+
+    public function getMetaTitle(): ?string
+    {
+        return $this->metaTitle;
+    }
+
+    public function getMetaDescription(): ?string
+    {
+        return $this->metaDescription;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getCanonicalUrl(): ?string
+    {
+        return $this->canonicalUrl;
+    }
+
+    public function getRobotsMeta(): ?string
+    {
+        return $this->robotsMeta;
+    }
+
+    public function getOgTitle(): ?string
+    {
+        return $this->ogTitle;
+    }
+
+    public function getOgDescription(): ?string
+    {
+        return $this->ogDescription;
+    }
+
+    public function getOgImage(): ?string
+    {
+        return $this->ogImage;
+    }
+
+    public function getSchemaJson(): ?string
+    {
+        return $this->schemaJson;
+    }
+
+    public function getHreflang(): ?string
+    {
+        return $this->hreflang;
+    }
+
+    /**
+     * @return Page|null
+     */
+    public function getPage()
+    {
+        return $this->page;
+    }
+
+    /**
+     * @param Page $page
+     */
+    public function setPage($page): void
+    {
+        $this->page = $page;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize(): array
+    {
+        return [
+            'pageId' => $this->pageId,
+            'metaTitle' => $this->metaTitle,
+            'metaDescription' => $this->metaDescription,
+            'slug' => $this->slug,
+            'canonicalUrl' => $this->canonicalUrl,
+            'robotsMeta' => $this->robotsMeta,
+            'ogTitle' => $this->ogTitle,
+            'ogDescription' => $this->ogDescription,
+            'ogImage' => $this->ogImage,
+            'schemaJson' => $this->schemaJson,
+            'hreflang' => $this->hreflang,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add migration and history for page SEO configuration
- introduce domain model for page SEO data

## Testing
- `composer test` *(fails: Slim Application Error / database error)*

------
https://chatgpt.com/codex/tasks/task_e_689971793c5c832ba179ebdf446c17b6