### PR TITLE
Consolidate landing page steps and add evaluation

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -267,25 +267,25 @@ window.addEventListener('load', () => {
         <div class="uk-grid uk-child-width-1-4@m uk-child-width-1-2@s uk-flex-center uk-margin-large-top uk-margin-large-bottom" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-left-small; delay: 150">
         <div class="uk-text-center">
           <div class="uk-step-circle">1</div>
-          <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">Event anlegen</p>
-          <p class="uk-text-small uk-text-muted">Erstelle in wenigen Minuten dein individuelles Quiz-Event im Online-Editor.</p>
+          <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">Event anlegen &amp; Fragen gestalten</p>
+          <p class="uk-text-small uk-text-muted">Erstelle in wenigen Minuten dein individuelles Quiz-Event im Online-Editor: Wähle Fragetypen und baue Quiz-Kataloge – jeder Katalog ist ein eigener Parcours-Stopp.</p>
         </div>
         <div class="uk-text-center">
           <div class="uk-step-circle">2</div>
-          <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">Fragen &amp; Kataloge gestalten</p>
-          <p class="uk-text-small uk-text-muted">Wähle Fragetypen, baue Quiz-Kataloge – jeder Katalog ist ein eigener Parcours-Stopp.</p>
-        </div>
-        <div class="uk-text-center">
-          <div class="uk-step-circle">3</div>
           <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">QR-Codes drucken &amp; Stationen gestalten</p>
           <p class="uk-text-small uk-text-muted">Drucke die automatisch generierten QR-Codes aus und platziere sie an beliebigen Stationen, Objekten oder Orten. Die Teilnehmenden scannen vor Ort mit ihrem Smartphone – und sind sofort im richtigen Quizbereich.</p>
         </div>
         <div class="uk-text-center">
-          <div class="uk-step-circle">4</div>
+          <div class="uk-step-circle">3</div>
           <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">Teams per QR-Code starten lassen</p>
           <p class="uk-text-small uk-text-muted">Die Teams melden sich eigenständig per Team-QR-Code an. Jeder Stationen-QR-Code führt direkt zu den passenden Aufgaben oder Info-Karten – kein Suchen, keine Verwirrung.</p>
         </div>
-      </div>
+        <div class="uk-text-center">
+          <div class="uk-step-circle">4</div>
+          <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">Auswertung</p>
+          <p class="uk-text-small uk-text-muted">Live-Ranking &amp; Ergebnisse jederzeit im Blick – einfach auswerten und den Sieger küren.</p>
+        </div>
+        </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Merge initial event creation and question catalog steps into a single first step
- Renumber subsequent steps and introduce evaluation as the new fourth step on the landing page

## Testing
- `composer test` *(fails: Failed asserting that 500 is identical to 204; Failed asserting that 500 is identical to 200; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689972973214832b9e13ec964e9113a3