### PR TITLE
Add service and route for page SEO configuration

### DIFF
--- a/src/Application/Routing/RedirectManager.php
+++ b/src/Application/Routing/RedirectManager.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Routing;
+
+/**
+ * Stores and registers HTTP redirects.
+ */
+class RedirectManager
+{
+    private string $file;
+
+    public function __construct(?string $file = null)
+    {
+        $this->file = $file ?? dirname(__DIR__, 3) . '/data/redirects.json';
+    }
+
+    /**
+     * Register a redirect from one path or URL to another.
+     */
+    public function register(string $from, string $to, int $status = 301): void
+    {
+        $redirects = [];
+        if (is_file($this->file)) {
+            $data = json_decode((string) file_get_contents($this->file), true);
+            if (is_array($data)) {
+                $redirects = $data;
+            }
+        }
+        $redirects[] = [
+            'from' => $from,
+            'to' => $to,
+            'status' => $status,
+        ];
+        file_put_contents($this->file, json_encode($redirects, JSON_PRETTY_PRINT) . "\n");
+    }
+}

--- a/src/Application/Seo/PageSeoConfigService.php
+++ b/src/Application/Seo/PageSeoConfigService.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Seo;
+
+use App\Application\Routing\RedirectManager;
+use App\Domain\PageSeoConfig;
+
+/**
+ * Handles loading, saving and validating SEO configuration for pages.
+ */
+class PageSeoConfigService
+{
+    private string $file;
+    private RedirectManager $redirects;
+
+    public function __construct(?string $file = null, ?RedirectManager $redirects = null)
+    {
+        $this->file = $file ?? dirname(__DIR__, 3) . '/data/page-seo.json';
+        $this->redirects = $redirects ?? new RedirectManager();
+    }
+
+    public function load(int $pageId): ?PageSeoConfig
+    {
+        if (!is_file($this->file)) {
+            return null;
+        }
+        $data = json_decode((string) file_get_contents($this->file), true);
+        if (!is_array($data) || !isset($data[$pageId]) || !is_array($data[$pageId])) {
+            return null;
+        }
+        $cfg = $data[$pageId];
+        return new PageSeoConfig(
+            $pageId,
+            (string) ($cfg['slug'] ?? ''),
+            $cfg['metaTitle'] ?? null,
+            $cfg['metaDescription'] ?? null,
+            $cfg['canonicalUrl'] ?? null,
+            $cfg['robotsMeta'] ?? null,
+            $cfg['ogTitle'] ?? null,
+            $cfg['ogDescription'] ?? null,
+            $cfg['ogImage'] ?? null,
+            $cfg['schemaJson'] ?? null,
+            $cfg['hreflang'] ?? null
+        );
+    }
+
+    public function save(PageSeoConfig $config): void
+    {
+        $data = [];
+        if (is_file($this->file)) {
+            $json = json_decode((string) file_get_contents($this->file), true);
+            if (is_array($json)) {
+                $data = $json;
+            }
+        }
+        $existing = $data[$config->getPageId()] ?? null;
+        if (is_array($existing)) {
+            $oldSlug = $existing['slug'] ?? null;
+            $oldCanonical = $existing['canonicalUrl'] ?? null;
+            if ($oldSlug && $oldSlug !== $config->getSlug()) {
+                $this->redirects->register('/' . ltrim((string) $oldSlug, '/'), '/' . ltrim($config->getSlug(), '/'));
+            }
+            if ($oldCanonical && $config->getCanonicalUrl() && $oldCanonical !== $config->getCanonicalUrl()) {
+                $this->redirects->register($oldCanonical, (string) $config->getCanonicalUrl());
+            }
+        }
+        $data[$config->getPageId()] = $config->jsonSerialize();
+        file_put_contents($this->file, json_encode($data, JSON_PRETTY_PRINT) . "\n");
+    }
+
+    /**
+     * Validate input data and return array of errors keyed by field.
+     *
+     * @param array<string,mixed> $data
+     * @return array<string,string>
+     */
+    public function validate(array $data): array
+    {
+        $errors = [];
+        $slug = (string) ($data['slug'] ?? '');
+        if ($slug === '') {
+            $errors['slug'] = 'Slug is required';
+        } elseif (!preg_match('/^[a-z0-9\-]+$/', $slug)) {
+            $errors['slug'] = 'Slug must contain lowercase letters, numbers and dashes only';
+        }
+        $canonical = $data['canonicalUrl'] ?? null;
+        if ($canonical !== null && $canonical !== '' && filter_var($canonical, FILTER_VALIDATE_URL) === false) {
+            $errors['canonicalUrl'] = 'Invalid URL';
+        }
+        return $errors;
+    }
+}

--- a/src/Controller/Admin/LandingpageController.php
+++ b/src/Controller/Admin/LandingpageController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Application\Seo\PageSeoConfigService;
+use App\Domain\PageSeoConfig;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Handles admin actions for the marketing landing page.
+ */
+class LandingpageController
+{
+    private PageSeoConfigService $seoService;
+
+    public function __construct(?PageSeoConfigService $seoService = null)
+    {
+        $this->seoService = $seoService ?? new PageSeoConfigService();
+    }
+
+    /**
+     * Persist SEO settings submitted via POST.
+     */
+    public function save(Request $request, Response $response): Response
+    {
+        $data = $request->getParsedBody();
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $errors = $this->seoService->validate($data);
+        if ($errors !== []) {
+            $response->getBody()->write(json_encode(['errors' => $errors]));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+        $pageId = (int) ($data['pageId'] ?? 0);
+        if ($pageId <= 0) {
+            return $response->withStatus(400);
+        }
+        $config = new PageSeoConfig(
+            $pageId,
+            (string) $data['slug'],
+            $data['metaTitle'] ?? null,
+            $data['metaDescription'] ?? null,
+            $data['canonicalUrl'] ?? null,
+            $data['robotsMeta'] ?? null,
+            $data['ogTitle'] ?? null,
+            $data['ogDescription'] ?? null,
+            $data['ogImage'] ?? null,
+            $data['schemaJson'] ?? null,
+            $data['hreflang'] ?? null
+        );
+        $this->seoService->save($config);
+        return $response->withStatus(204);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -56,6 +56,7 @@ use App\Controller\EventController;
 use App\Controller\EventListController;
 use App\Controller\SettingsController;
 use App\Controller\Admin\PageController;
+use App\Controller\Admin\LandingpageController;
 use App\Controller\TenantController;
 use App\Controller\Marketing\LandingController;
 use App\Controller\Marketing\ContactController;
@@ -89,6 +90,7 @@ require_once __DIR__ . '/Controller/PasswordController.php';
 require_once __DIR__ . '/Controller/PasswordResetController.php';
 require_once __DIR__ . '/Controller/AdminCatalogController.php';
 require_once __DIR__ . '/Controller/Admin/PageController.php';
+require_once __DIR__ . '/Controller/Admin/LandingpageController.php';
 require_once __DIR__ . '/Controller/QrController.php';
 require_once __DIR__ . '/Controller/LogoController.php';
 require_once __DIR__ . '/Controller/CatalogDesignController.php';
@@ -447,6 +449,11 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/admin/pages/{slug}', function (Request $request, Response $response, array $args) {
         $controller = new PageController();
         return $controller->update($request, $response, $args);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+
+    $app->post('/admin/landingpage/seo', function (Request $request, Response $response) {
+        $controller = new LandingpageController();
+        return $controller->save($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN));
 
     $app->get('/admin/{path:.*}', function (Request $request, Response $response) {


### PR DESCRIPTION
## Summary
- Implement RedirectManager to persist 301 redirects
- Provide PageSeoConfigService for loading, saving and validating page SEO config
- Add LandingpageController endpoint to persist SEO settings and register redirects
- Wire up new admin route

## Testing
- `composer test` *(fails: Slim Application Error; Database error: fail; Error creating tenant: boom; Failed to reload nginx: reload failed; 178 tests, 8 errors, 7 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6899741a0470832b82ebad3a5daed511