### PR TITLE
Refine results step description on landing page

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -283,7 +283,7 @@ window.addEventListener('load', () => {
         <div class="uk-text-center">
           <div class="uk-step-circle">4</div>
           <p class="uk-text-uppercase uk-text-bold uk-margin-small-top" style="letter-spacing:2px;">Auswertung</p>
-          <p class="uk-text-small uk-text-muted">Live-Ranking &amp; Ergebnisse jederzeit im Blick – einfach auswerten und den Sieger küren.</p>
+          <p class="uk-text-small uk-text-muted">Live-Ranking, detaillierte Statistiken &amp; PDF-Export: Verfolge den Fortschritt in Echtzeit, werte die Ergebnisse komfortabel aus und küre am Ende das Siegerteam.</p>
         </div>
         </div>
   </div>


### PR DESCRIPTION
## Summary
- Expand "Auswertung" step on landing page with details like statistics and PDF export

## Testing
- `composer test -- --stop-on-failure` *(fails: AdminControllerTest::testPagesAndProfileDataLoadedOnEvents)*

------
https://chatgpt.com/codex/tasks/task_e_689974974b14832bbac23dbfad28e78f