### PR TITLE
Allow all roles to access profile and subscription

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     'help' => 'Hilfe',
     'design_toggle' => 'Design wechseln',
@@ -50,6 +51,7 @@ return [
     'menu_content' => 'Inhalte',
     'menu_teams' => 'Teams',
     'menu_evaluation' => 'Auswertung',
+    'menu_account' => 'Konto',
     'menu_admin' => 'Administration',
     'logout' => 'Abmelden',
     'tip_logo_upload' => 'PNG-Datei als Logo für die Startseite hochladen.',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     'help' => 'Help',
     'design_toggle' => 'Toggle theme',
@@ -50,6 +51,7 @@ return [
     'menu_content' => 'Content',
     'menu_teams' => 'Teams',
     'menu_evaluation' => 'Evaluation',
+    'menu_account' => 'Account',
     'menu_admin' => 'Administration',
     'logout' => 'Logout',
     'tip_logo_upload' => 'Upload PNG logo for start page.',

--- a/src/routes.php
+++ b/src/routes.php
@@ -422,13 +422,13 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/pages', AdminController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
     $app->get('/admin/management', AdminController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
-    $app->get('/admin/profile', AdminController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
-    $app->get('/admin/subscription', AdminController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
-    $app->get('/admin/subscription/portal', SubscriptionController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
+    $app->get('/admin/profile', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
+    $app->get('/admin/subscription', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
+    $app->get('/admin/subscription/portal', SubscriptionController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->post('/admin/profile', function (Request $request, Response $response) {
         $controller = new ProfileController();
         return $controller->update($request, $response);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+    })->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/tenants', function (Request $request, Response $response) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(404);

--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -34,13 +34,18 @@
     ]
   },
   {
+    header: t('menu_account'),
+    items: [
+      { href: basePath ~ '/admin/profile', icon: 'user', text: t('tab_profile') },
+      { href: basePath ~ '/admin/subscription', icon: 'file-text', text: t('tab_subscription') },
+    ]
+  },
+  {
     header: t('menu_admin'),
     admin: true,
     items: [
       { href: basePath ~ '/admin/management', icon: 'cog', text: t('tab_management') },
       { href: basePath ~ '/admin/tenants', icon: 'users', text: t('tab_tenants'), domain: 'main' },
-      { href: basePath ~ '/admin/profile', icon: 'user', text: t('tab_profile') },
-      { href: basePath ~ '/admin/subscription', icon: 'file-text', text: t('tab_subscription') },
     ]
   },
 ] %}

--- a/tests/Controller/ProfileAccessTest.php
+++ b/tests/Controller/ProfileAccessTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class ProfileAccessTest extends TestCase
+{
+    private function setupDb(): string
+    {
+        $db = tempnam(sys_get_temp_dir(), 'db');
+        putenv('POSTGRES_DSN=sqlite:' . $db);
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        $_ENV['POSTGRES_DSN'] = 'sqlite:' . $db;
+        $_ENV['POSTGRES_USER'] = '';
+        $_ENV['POSTGRES_PASSWORD'] = '';
+        return $db;
+    }
+
+    public function testNonAdminCanAccessProfileAndSubscription(): void
+    {
+        $db = $this->setupDb();
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'team-manager'];
+
+        $profile = $app->handle($this->createRequest('GET', '/admin/profile'));
+        $this->assertEquals(200, $profile->getStatusCode());
+
+        $subscription = $app->handle($this->createRequest('GET', '/admin/subscription'));
+        $this->assertEquals(200, $subscription->getStatusCode());
+
+        session_destroy();
+        unlink($db);
+    }
+}


### PR DESCRIPTION
## Summary
- show profile and subscription menus to all roles
- permit every role to reach profile and subscription routes
- add regression test for non-admin access

## Testing
- `./vendor/bin/phpunit tests/Controller/ProfileAccessTest.php`
- `./vendor/bin/phpunit` *(fails: Tests: 179, Assertions: 371, Errors: 8, Failures: 7, Warnings: 2, PHPUnit Deprecations: 2, Notices: 11.)*
- `./vendor/bin/phpcs src/routes.php resources/lang/de.php resources/lang/en.php tests/Controller/ProfileAccessTest.php` *(warnings: line length)*

------
https://chatgpt.com/codex/tasks/task_e_689975d066e8832b818ead7fdb71c076