### PR TITLE
Fix profile and subscription visibility for non-admin users

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -708,6 +708,7 @@
       </div>
     </li>
     {% endif %}
+    {% endif %}
     <li class="{{ activeRoute == 'profile' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_profile') }}</h2>
@@ -770,7 +771,6 @@
         <p><a class="uk-button uk-button-primary" href="{{ basePath }}/admin/subscription/portal">{{ t('action_open_subscription') }}</a></p>
       </div>
     </li>
-    {% endif %}
       </ul>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- Render tenant profile and subscription sections for all roles instead of restricting them to admin-only

## Testing
- `composer test` (fails: Script vendor/bin/phpunit handling the phpunit event returned with error code 2)


------
https://chatgpt.com/codex/tasks/task_e_6899782a08ec832b9c2a725143b79fcc