### PR TITLE
Fix admin event switch population for all roles

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -532,7 +532,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
     $app->get('/events.json', function (Request $request, Response $response) {
         return $request->getAttribute('eventController')->get($request, $response);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
+    })->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->post('/events.json', function (Request $request, Response $response) {
         return $request->getAttribute('eventController')->post($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));

--- a/tests/Controller/EventsRouteTest.php
+++ b/tests/Controller/EventsRouteTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Domain\Roles;
+use Tests\TestCase;
+
+class EventsRouteTest extends TestCase
+{
+    public function testEventsListAccessibleForCatalogEditor(): void
+    {
+        $app = $this->getAppInstance();
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        $_SESSION['user'] = ['role' => Roles::CATALOG_EDITOR];
+
+        $request = $this->createRequest('GET', '/events.json', ['HTTP_ACCEPT' => 'application/json']);
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        @session_destroy();
+    }
+}


### PR DESCRIPTION
## Summary
- allow any admin role to fetch `/events.json` so the event switch dropdown fills correctly
- cover access with PHPUnit test ensuring catalog editors can read events list

## Testing
- `composer test` *(fails: Tests: 184, Assertions: 381, Errors: 8, Failures: 8)*
- `vendor/bin/phpstan analyse --no-progress` *(fails: Allowed memory size exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68997cd620c4832bb1e9ff042d9c8325