### PR TITLE
Add SEO config events and listener

### DIFF
--- a/docs/seo-hooks.md
+++ b/docs/seo-hooks.md
@@ -1,0 +1,27 @@
+# SEO Hooks
+
+Neue SEO-Features können über Events eingebunden werden. Bei Änderungen der Seiteneinstellungen
+werden Events aus dem Domain-Layer ausgelöst, die Listener im Application-Layer verarbeiten.
+
+## Verfügbare Events
+
+- `SeoConfigSaved` – Wird ausgelöst, wenn eine SEO-Konfiguration erstmals gespeichert wird.
+- `SeoConfigUpdated` – Wird ausgelöst, wenn eine bestehende Konfiguration aktualisiert wird.
+
+## Listener registrieren
+
+Listener befinden sich im Verzeichnis `src/Application/EventListener/`. Ein Listener registriert sich
+am `EventDispatcher` und reagiert auf die oben genannten Events. Beispiel:
+
+```php
+use App\Application\EventListener\SeoConfigListener;
+use App\Infrastructure\Event\EventDispatcher;
+use App\Infrastructure\Cache\PageSeoCache;
+
+$dispatcher = new EventDispatcher();
+SeoConfigListener::register($dispatcher, new PageSeoCache());
+```
+
+Im Listener können Aktionen wie Cache-Invalidierung oder Pings an externe Dienste implementiert
+werden. Eigene Listener können analog aufgebaut und über `addListener` am Dispatcher registriert
+werden.

--- a/src/Application/EventListener/SeoConfigListener.php
+++ b/src/Application/EventListener/SeoConfigListener.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\EventListener;
+
+use App\Domain\Event\SeoConfigSaved;
+use App\Domain\Event\SeoConfigUpdated;
+use App\Infrastructure\Cache\PageSeoCache;
+use App\Infrastructure\Event\EventDispatcher;
+
+/**
+ * Handles actions that should occur after SEO configuration changes.
+ */
+class SeoConfigListener
+{
+    private PageSeoCache $cache;
+
+    public function __construct(PageSeoCache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public static function register(EventDispatcher $dispatcher, PageSeoCache $cache): void
+    {
+        $listener = new self($cache);
+        $dispatcher->addListener(SeoConfigSaved::class, [$listener, 'onSaved']);
+        $dispatcher->addListener(SeoConfigUpdated::class, [$listener, 'onUpdated']);
+    }
+
+    public function onSaved(SeoConfigSaved $event): void
+    {
+        // Invalidate cache and trigger any additional hooks such as search-console pings.
+        $this->cache->invalidate($event->getConfig()->getPageId());
+    }
+
+    public function onUpdated(SeoConfigUpdated $event): void
+    {
+        // Invalidate cache and trigger any additional hooks such as search-console pings.
+        $this->cache->invalidate($event->getConfig()->getPageId());
+    }
+}

--- a/src/Domain/Event/SeoConfigSaved.php
+++ b/src/Domain/Event/SeoConfigSaved.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Event;
+
+use App\Domain\PageSeoConfig;
+
+/**
+ * Event triggered when a SEO configuration is initially saved.
+ */
+class SeoConfigSaved
+{
+    private PageSeoConfig $config;
+
+    public function __construct(PageSeoConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    public function getConfig(): PageSeoConfig
+    {
+        return $this->config;
+    }
+}

--- a/src/Domain/Event/SeoConfigUpdated.php
+++ b/src/Domain/Event/SeoConfigUpdated.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Event;
+
+use App\Domain\PageSeoConfig;
+
+/**
+ * Event triggered when an existing SEO configuration is updated.
+ */
+class SeoConfigUpdated
+{
+    private PageSeoConfig $config;
+
+    public function __construct(PageSeoConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    public function getConfig(): PageSeoConfig
+    {
+        return $this->config;
+    }
+}

--- a/src/Infrastructure/Event/EventDispatcher.php
+++ b/src/Infrastructure/Event/EventDispatcher.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Event;
+
+/**
+ * Minimal event dispatcher to register and dispatch events.
+ */
+class EventDispatcher
+{
+    /** @var array<string, callable[]> */
+    private array $listeners = [];
+
+    public function addListener(string $eventClass, callable $listener): void
+    {
+        $this->listeners[$eventClass][] = $listener;
+    }
+
+    public function dispatch(object $event): void
+    {
+        $class = $event::class;
+        foreach ($this->listeners[$class] ?? [] as $listener) {
+            $listener($event);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SeoConfigSaved` and `SeoConfigUpdated` domain events
- wire `SeoConfigListener` to handle events via minimal dispatcher
- document SEO hooks and event-based extensions

## Testing
- `composer test` *(fails: Failed asserting that 500 is identical to 200; Tests: 185, Assertions: 369, Errors: 8, Failures: 14, Warnings: 96, PHPUnit Deprecations: 2.)*

------
https://chatgpt.com/codex/tasks/task_e_689985d14fac832b90b5ec1bc308e413