### PR TITLE
Automatisches Speichern der Veranstaltungseinstellungen

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -215,7 +215,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function scheduleConfigSave() {
     clearTimeout(cfgSaveTimer);
-    cfgSaveTimer = setTimeout(() => saveConfig(false), 1000);
+    cfgSaveTimer = setTimeout(saveConfig, 1000);
   }
 
   function wrapSelection(textarea, before, after) {
@@ -455,10 +455,6 @@ document.addEventListener('DOMContentLoaded', function () {
   document.getElementById('cfgResetBtn').addEventListener('click', function (e) {
     e.preventDefault();
     renderCfg(cfgInitial);
-  });
-  document.getElementById('cfgSaveBtn').addEventListener('click', function (e) {
-    e.preventDefault();
-    saveConfig();
   });
 
   [

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -291,11 +291,12 @@
             </div>
           </div>
         </form>
-        <div class="uk-margin uk-flex uk-flex-between">
-          <button id="cfgResetBtn" class="uk-button uk-button-default" uk-tooltip="title: {{ t('tip_form_reset') }}; pos: right">{{ t('action_reset') }}</button>
-          <div>
-            <button id="cfgSaveBtn" class="uk-button uk-button-primary" uk-tooltip="title: {{ t('tip_save_settings') }}; pos: right"><span uk-icon="check"></span> {{ t('action_save') }}</button>
-          </div>
+        <div class="uk-margin uk-flex uk-flex-right">
+          <button id="cfgResetBtn"
+            class="uk-button uk-button-default"
+            uk-tooltip="title: {{ t('tip_form_reset') }}; pos: right">
+            {{ t('action_reset') }}
+          </button>
         </div>
 
         <div id="puzzleFeedbackModal" uk-modal>


### PR DESCRIPTION
## Summary
- Speichern-Button auf der Konfigurationsseite entfernt
- Einstellungsspeicherung erfolgt nun automatisch nach Änderungen

## Testing
- `./vendor/bin/phpcs src/` (errors and warnings)
- `./vendor/bin/phpstan analyse src/ --memory-limit=1G` (3 errors)
- `./vendor/bin/phpunit` (8 errors, 14 failures)


------
https://chatgpt.com/codex/tasks/task_e_68998698eb70832b88e0e091b0b09365