### PR TITLE
Add basic Page domain entity

### DIFF
--- a/src/Domain/Page.php
+++ b/src/Domain/Page.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain;
+
+use JsonSerializable;
+
+/**
+ * Represents a static page in the application.
+ */
+class Page implements JsonSerializable
+{
+    private int $id;
+
+    private string $slug;
+
+    private string $title;
+
+    private string $content;
+
+    public function __construct(int $id, string $slug, string $title, string $content)
+    {
+        $this->id = $id;
+        $this->slug = $slug;
+        $this->title = $title;
+        $this->content = $content;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'title' => $this->title,
+            'content' => $this->content,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add Page domain entity referenced by PageSeoConfig

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `vendor/bin/phpunit` *(fails: "Failed to reload nginx: reload failed" and multiple test errors)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_68998a70e580832b98731d96e73abee1