### PR TITLE
Prefill email after verification during onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -12,6 +12,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const verifiedHint = document.getElementById('verifiedHint');
 
   const params = new URLSearchParams(window.location.search);
+  const emailParam = params.get('email');
+  if (emailParam && emailInput) {
+    emailInput.value = emailParam;
+  }
   if (params.get('verified') === '1') {
     step1.hidden = true;
     step2.hidden = false;


### PR DESCRIPTION
## Summary
- Prefill email field from query params after verification so plan selection works in onboarding

## Testing
- `composer test` *(fails: Database error: fail, Error creating tenant: boom, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689991d3bd6c832b898ce51e788f3a45