### PR TITLE
Add FAQ link to landing page menu

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -305,6 +305,7 @@
           <li><a href="#features">Features</a></li>
           <li><a href="#pricing">Preise</a></li>
           <li><a href="#contact-us">Kontakt</a></li>
+          <li><a href="{{ basePath }}/faq">FAQ</a></li>
           <li><a href="{{ basePath }}/login">Login</a></li>
         </ul>
       {% endblock %}
@@ -318,6 +319,7 @@
             <li><a href="#features">Features</a></li>
             <li><a href="#pricing">Preise</a></li>
             <li><a href="#contact-us">Kontakt</a></li>
+            <li><a href="{{ basePath }}/faq">FAQ</a></li>
             <li><a href="{{ basePath }}/login">Login</a></li>
           </ul>
         </div>

--- a/tests/Controller/LandingControllerTest.php
+++ b/tests/Controller/LandingControllerTest.php
@@ -87,4 +87,14 @@ class LandingControllerTest extends TestCase
         putenv('SMTP_PASS');
         unset($_ENV['SMTP_HOST'], $_ENV['SMTP_USER'], $_ENV['SMTP_PASS']);
     }
+
+    public function testLandingPageContainsFaqLink(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/landing');
+        $response = $app->handle($request);
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('href="/faq"', $body);
+
+    }
 }


### PR DESCRIPTION
## Summary
- add FAQ link to the landing page navigation and offcanvas menu
- test that landing page renders FAQ link

## Testing
- `composer test` *(fails: Slim Application Error; Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b03453c832baf0165cbad397ea0