### PR TITLE
Handle missing Stripe configuration in onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const step1 = document.getElementById('step1');
   const step2 = document.getElementById('step2');
   const step3 = document.getElementById('step3');
+  const step3Warning = document.getElementById('step3-warning');
   const emailInput = document.getElementById('email');
   const sendEmailBtn = document.getElementById('sendEmail');
   const emailStatus = document.getElementById('emailStatus');
@@ -12,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const verifiedHint = document.getElementById('verifiedHint');
   const basePath = window.basePath || '';
   const withBase = p => basePath + p;
+  const stripeConfigured = window.stripeConfigured !== false;
 
   const params = new URLSearchParams(window.location.search);
   const sessionId = params.get('session_id');
@@ -65,11 +67,19 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       localStorage.setItem('onboard_subdomain', subdomain);
       step2.hidden = true;
+      if (!stripeConfigured) {
+        if (step3Warning) {
+          step3Warning.hidden = false;
+        } else {
+          alert('Zahlungsdienstleister nicht konfiguriert. Bitte wende dich an den Support.');
+        }
+        return;
+      }
       if (step3) step3.hidden = false;
     });
   }
 
-  if (planButtons.length) {
+  if (stripeConfigured && planButtons.length) {
     planButtons.forEach(btn => {
       btn.addEventListener('click', async () => {
         const plan = btn.dataset.plan;

--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -8,6 +8,7 @@ use Slim\Views\Twig;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 use App\Service\UserService;
+use App\Service\StripeService;
 use App\Infrastructure\Database;
 use PDO;
 
@@ -57,6 +58,8 @@ class OnboardingController
         $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
         $_SESSION['csrf_token'] = $csrf;
 
+        $stripeConfigured = StripeService::isConfigured();
+
         return $view->render(
             $response,
             'onboarding.twig',
@@ -65,6 +68,7 @@ class OnboardingController
                 'logged_in' => $loggedIn,
                 'reload_token' => $reloadToken,
                 'csrf_token' => $csrf,
+                'stripe_configured' => $stripeConfigured,
             ]
         );
     }

--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -82,4 +82,26 @@ class StripeService
             return false;
         }
     }
+
+    /**
+     * Check whether Stripe is configured with a secret key and price IDs.
+     */
+    public static function isConfigured(): bool
+    {
+        $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
+        $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';
+        $required = [
+            'SECRET_KEY',
+            'PRICE_STARTER',
+            'PRICE_STANDARD',
+            'PRICE_PROFESSIONAL',
+        ];
+        foreach ($required as $suffix) {
+            $value = getenv($prefix . $suffix) ?: '';
+            if ($value === '') {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -111,6 +111,7 @@
       <button class="uk-button uk-button-primary" id="saveSubdomain">Subdomain speichern</button>
     </div>
 
+    {% if stripe_configured %}
     <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-margin-auto" id="step3" hidden>
       <h3 class="uk-card-title">3. Tarif wählen</h3>
       <p>Wähle einen Tarif und schließe die Zahlung über Stripe ab.</p>
@@ -169,6 +170,12 @@
       <p class="uk-text-meta uk-margin-top">2 (Im Starter-Paket mit Wasserzeichen oder ohne individuelles Layout/Logo)</p>
       <p class="uk-text-meta uk-margin-top">3 (z.&nbsp;B. Datenschutz, AGB, Einladung, FAQ, Spielanleitung – alles eigenständig editierbar)</p>
     </div>
+    {% else %}
+    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step3-warning" hidden>
+      <h3 class="uk-card-title">3. Tarif wählen</h3>
+      <p class="uk-text-danger">Zahlungsdienstleister nicht konfiguriert. Bitte wende dich an den Support.</p>
+    </div>
+    {% endif %}
   </div>
 {% endblock %}
 
@@ -176,6 +183,7 @@
   <script>
     window.mainDomain = '{{ main_domain }}';
     window.csrfToken = '{{ csrf_token|e('js') }}';
+    window.stripeConfigured = {{ stripe_configured ? 'true' : 'false' }};
   </script>
   <script src="{{ basePath }}/js/onboarding.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add centralized `StripeService::isConfigured` check
- Pass Stripe setup status to `OnboardingController` and template
- Warn or skip plan selection when Stripe is unavailable

## Testing
- `composer test` *(fails: Tests\Controller\QrControllerTest::testQrImageSvgFormat, Tests\Controller\QrControllerTest::testTeamQrSvgFormat, Tests\Service\SessionServiceTest::testInvalidateRemovesSessions)*

------
https://chatgpt.com/codex/tasks/task_e_689a13028b4c832b8dfd16e1bc48d6cf