### PR TITLE
fix: address code style issues

### DIFF
--- a/src/Controller/StripeSessionController.php
+++ b/src/Controller/StripeSessionController.php
@@ -24,4 +24,3 @@ class StripeSessionController
         return $response->withHeader('Content-Type', 'application/json');
     }
 }
-

--- a/src/Service/PasswordResetService.php
+++ b/src/Service/PasswordResetService.php
@@ -116,4 +116,3 @@ class PasswordResetService
         $stmt->execute([(new DateTimeImmutable())->format('Y-m-d H:i:s')]);
     }
 }
-

--- a/tests/Controller/LandingControllerTest.php
+++ b/tests/Controller/LandingControllerTest.php
@@ -95,6 +95,5 @@ class LandingControllerTest extends TestCase
         $response = $app->handle($request);
         $body = (string) $response->getBody();
         $this->assertStringContainsString('href="/faq"', $body);
-
     }
 }

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -51,5 +51,4 @@ class ProfileControllerTest extends TestCase
         putenv('MAIN_DOMAIN');
         unset($_ENV['MAIN_DOMAIN']);
     }
-
 }

--- a/tests/Service/ArrayLogger.php
+++ b/tests/Service/ArrayLogger.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * Simple in-memory logger for tests.
+ */
+class ArrayLogger extends AbstractLogger
+{
+    /** @var list<array{level:string,message:string}> */
+    public array $records = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->records[] = ['level' => (string) $level, 'message' => (string) $message];
+    }
+
+    public function has(string $level, string $fragment): bool
+    {
+        foreach ($this->records as $r) {
+            if ($r['level'] === $level && str_contains($r['message'], $fragment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -194,7 +194,7 @@ class MailServiceTest extends TestCase
 
             protected function createTransport(string $dsn): MailerInterface
             {
-                return new class($this) implements MailerInterface {
+                return new class ($this) implements MailerInterface {
                     private $outer;
 
                     public function __construct($outer)

--- a/tests/Service/PasswordResetServiceTest.php
+++ b/tests/Service/PasswordResetServiceTest.php
@@ -6,29 +6,7 @@ namespace Tests\Service;
 
 use App\Service\PasswordResetService;
 use App\Service\UserService;
-use Psr\Log\AbstractLogger;
 use Tests\TestCase;
-
-class ArrayLogger extends AbstractLogger
-{
-    /** @var list<array{level:string,message:string}> */
-    public array $records = [];
-
-    public function log($level, $message, array $context = []): void
-    {
-        $this->records[] = ['level' => (string)$level, 'message' => (string)$message];
-    }
-
-    public function has(string $level, string $fragment): bool
-    {
-        foreach ($this->records as $r) {
-            if ($r['level'] === $level && str_contains($r['message'], $fragment)) {
-                return true;
-            }
-        }
-        return false;
-    }
-}
 
 class PasswordResetServiceTest extends TestCase
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,3 +2,4 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/TestCase.php';
+require __DIR__ . '/Service/ArrayLogger.php';


### PR DESCRIPTION
## Summary
- trim trailing blank lines in PasswordResetService and StripeSessionController
- split ArrayLogger helper into its own test file and require it
- tidy up test code formatting

## Testing
- `vendor/bin/phpcs src/Service/PasswordResetService.php src/Controller/StripeSessionController.php tests/Service/PasswordResetServiceTest.php tests/Service/MailServiceTest.php tests/Controller/ProfileControllerTest.php tests/Controller/LandingControllerTest.php tests/bootstrap.php tests/Service/ArrayLogger.php`
- `composer test` *(failed: Tests: 186, Assertions: 370, Errors: 8, Failures: 14, Warnings: 96, PHPUnit Deprecations: 2.)*

------
https://chatgpt.com/codex/tasks/task_e_689a12f1f1b4832b8e1a1be41408cbc5