### PR TITLE
Add Stripe webhook endpoint

### DIFF
--- a/src/Controller/StripeWebhookController.php
+++ b/src/Controller/StripeWebhookController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use App\Service\TenantService;
+use App\Infrastructure\Database;
+
+/**
+ * Handle Stripe webhook events.
+ */
+class StripeWebhookController
+{
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $payload = json_decode((string) $request->getBody(), true);
+        if (!is_array($payload) || !isset($payload['type'])) {
+            return $response->withStatus(400);
+        }
+        $type = (string) $payload['type'];
+        $object = $payload['data']['object'] ?? [];
+
+        $base = Database::connectFromEnv();
+        $tenantService = new TenantService($base);
+
+        switch ($type) {
+            case 'checkout.session.completed':
+                $sub = (string) ($object['client_reference_id'] ?? '');
+                $customerId = (string) ($object['customer'] ?? '');
+                if ($sub !== '' && $customerId !== '') {
+                    $tenantService->updateProfile($sub, ['stripe_customer_id' => $customerId]);
+                }
+                break;
+            case 'customer.subscription.updated':
+                $customerId = (string) ($object['customer'] ?? '');
+                if ($customerId !== '') {
+                    $plan = $this->mapPriceToPlan((string) ($object['items']['data'][0]['price']['id'] ?? ''));
+                    $billing = ((string) ($object['collection_method'] ?? '') === 'charge_automatically') ? 'credit' : null;
+                    $tenantService->updateByStripeCustomerId($customerId, [
+                        'plan' => $plan,
+                        'billing_info' => $billing,
+                    ]);
+                }
+                break;
+            case 'customer.subscription.deleted':
+                $customerId = (string) ($object['customer'] ?? '');
+                if ($customerId !== '') {
+                    $tenantService->updateByStripeCustomerId($customerId, ['plan' => null]);
+                }
+                break;
+        }
+
+        return $response->withStatus(200);
+    }
+
+    private function mapPriceToPlan(string $priceId): ?string
+    {
+        $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
+        $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';
+        $map = [
+            getenv($prefix . 'PRICE_STARTER') ?: '' => 'starter',
+            getenv($prefix . 'PRICE_STANDARD') ?: '' => 'standard',
+            getenv($prefix . 'PRICE_PROFESSIONAL') ?: '' => 'professional',
+        ];
+        return $map[$priceId] ?? null;
+    }
+}

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -469,6 +469,22 @@ class TenantService
     }
 
     /**
+     * Update a tenant identified by its Stripe customer id.
+     *
+     * @param array<string,mixed> $data
+     */
+    public function updateByStripeCustomerId(string $customerId, array $data): void
+    {
+        $stmt = $this->pdo->prepare('SELECT subdomain FROM tenants WHERE stripe_customer_id = ?');
+        $stmt->execute([$customerId]);
+        $sub = $stmt->fetchColumn();
+        if ($sub === false) {
+            return;
+        }
+        $this->updateProfile((string) $sub, $data);
+    }
+
+    /**
      * Retrieve all tenants ordered by creation date.
      *
      * @return list<array{

--- a/src/routes.php
+++ b/src/routes.php
@@ -66,6 +66,7 @@ use App\Controller\OnboardingController;
 use App\Controller\OnboardingEmailController;
 use App\Controller\StripeCheckoutController;
 use App\Controller\StripeSessionController;
+use App\Controller\StripeWebhookController;
 use App\Controller\SubscriptionController;
 use App\Controller\InvitationController;
 use Slim\Views\Twig;
@@ -111,6 +112,7 @@ require_once __DIR__ . '/Controller/OnboardingController.php';
 require_once __DIR__ . '/Controller/OnboardingEmailController.php';
 require_once __DIR__ . '/Controller/StripeCheckoutController.php';
 require_once __DIR__ . '/Controller/StripeSessionController.php';
+require_once __DIR__ . '/Controller/StripeWebhookController.php';
 require_once __DIR__ . '/Controller/SubscriptionController.php';
 require_once __DIR__ . '/Controller/InvitationController.php';
 
@@ -276,6 +278,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     });
     $app->post('/onboarding/checkout', StripeCheckoutController::class);
     $app->get('/onboarding/checkout/{id}', StripeSessionController::class);
+    $app->post('/stripe/webhook', StripeWebhookController::class);
     $app->get('/login', [LoginController::class, 'show']);
     $app->post('/login', [LoginController::class, 'login']);
     $app->get('/register', [RegisterController::class, 'show']);

--- a/tests/Controller/StripeWebhookControllerTest.php
+++ b/tests/Controller/StripeWebhookControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+use App\Infrastructure\Database;
+use App\Infrastructure\Migrations\Migrator;
+
+class StripeWebhookControllerTest extends TestCase
+{
+    public function testCheckoutSessionCompletedUpdatesCustomerId(): void
+    {
+        $app = $this->getAppInstance();
+        $pdo = Database::connectFromEnv();
+        Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        $pdo->exec("INSERT INTO tenants(uid, subdomain, plan, billing_info, stripe_customer_id, created_at) VALUES('u1', 'foo', NULL, NULL, NULL, '')");
+
+        $payload = json_encode([
+            'type' => 'checkout.session.completed',
+            'data' => ['object' => [
+                'client_reference_id' => 'foo',
+                'customer' => 'cus_123',
+            ]],
+        ]);
+        $request = $this->createRequest('POST', '/stripe/webhook', ['Content-Type' => 'application/json']);
+        $request->getBody()->write($payload !== false ? $payload : '');
+        $request->getBody()->rewind();
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $stmt = $pdo->query("SELECT stripe_customer_id FROM tenants WHERE subdomain = 'foo'");
+        $this->assertEquals('cus_123', $stmt->fetchColumn());
+    }
+
+}


### PR DESCRIPTION
## Summary
- handle Stripe checkout and subscription events via new `/stripe/webhook` endpoint
- update tenant records by Stripe customer ID
- cover webhook logic with test

## Testing
- `vendor/bin/phpunit tests/Controller/StripeWebhookControllerTest.php`
- `composer test` *(fails: Database error: fail; Error creating tenant: boom)*

------
https://chatgpt.com/codex/tasks/task_e_689a1522d6f0832ba82e6202a1bc8ea1