### PR TITLE
fix: ensure mobile nav active items remain readable

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -204,7 +204,7 @@ body.uk-padding {
 .qr-sidebar { min-height: calc(100vh - 56px); }
 .qr-sidebar-card { height: 100%; overflow-y: auto; }
 .qr-nav-text { margin-left: 8px; }
-.uk-nav > li.uk-active > a {
+.uk-nav-default > li.uk-active > a {
   background: var(--uk-background-muted, #f8f8f8);
   border-radius: 6px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- narrow active nav styling to default navs so mobile menu keeps readable colors

## Testing
- `composer install`
- `composer test` *(fails: Failed asserting that 500 is identical to 200; 17 errors, 15 failures)*

------
https://chatgpt.com/codex/tasks/task_e_689a1a7d5534832baa4be744674e43de