### PR TITLE
Remove unnecessary menu label beside admin hamburger icon

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -28,7 +28,6 @@
     {% block left %}
       <a class="uk-navbar-toggle uk-hidden@m" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
         <span uk-navbar-toggle-icon></span>
-        <span class="uk-margin-small-left">{{ t('menu') }}</span>
       </a>
       <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left">QuizRace Admin</a>
     {% endblock %}


### PR DESCRIPTION
## Summary
- remove textual menu label next to admin hamburger toggle

## Testing
- `composer test` *(fails: "Tests: 187, Assertions: 357, Errors: 17, Failures: 15, Warnings: 96, PHPUnit Deprecations: 2.")*


------
https://chatgpt.com/codex/tasks/task_e_689a1b0ef9ac832b874376a57aa5d8f1