### PR TITLE
Fix mobile layout for today widget

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -76,7 +76,14 @@
                 <div class="uk-flex uk-flex-between uk-flex-middle">
                   <h3 class="uk-card-title uk-margin-remove">Für heute geplant</h3>
                   <div>
-                    <a href="{{ basePath }}/admin/events" class="uk-button uk-button-primary">+ Erstellen</a>
+                    <a
+                      href="{{ basePath }}/admin/events"
+                      class="uk-button uk-button-primary uk-button-small"
+                      aria-label="{{ t('tip_event_add') }}"
+                    >
+                      <span uk-icon="plus"></span>
+                      <span class="button-text">{{ t('tip_event_add') }}</span>
+                    </a>
                   </div>
                 </div>
                 <div id="today-empty" class="uk-text-meta uk-margin-small">Für heute nichts geplant</div>


### PR DESCRIPTION
## Summary
- Make 'Für heute geplant' new event button responsive and icon-based on small screens

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_689a1b72d134832b8f5c1d1e2e4c346c