### PR TITLE
Move admin language selector to profile

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -44,12 +44,6 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
-      <div class="lang-switch uk-margin-small-left">
-        <select id="langSelect" class="uk-select uk-form-width-small">
-          <option value="de" {{ locale() == 'de' ? 'selected' }}>{{ t('german') }}</option>
-          <option value="en" {{ locale() == 'en' ? 'selected' }}>{{ t('english') }}</option>
-        </select>
-      </div>
       <button id="helpBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" aria-label="Hilfe"></button>
     {% endblock %}
   {% endembed %}
@@ -738,6 +732,13 @@
               <label class="uk-form-label">{{ t('column_billing') }}</label>
               <select class="uk-select" name="billing_info">
                 <option value="credit" {% if tenant.billing_info == 'credit' %}selected{% endif %}>{{ t('billing_credit') }}</option>
+              </select>
+            </div>
+            <div class="uk-width-1-1">
+              <label class="uk-form-label">{{ t('language') }}</label>
+              <select id="langSelect" class="uk-select uk-form-width-small">
+                <option value="de" {{ locale() == 'de' ? 'selected' }}>{{ t('german') }}</option>
+                <option value="en" {{ locale() == 'en' ? 'selected' }}>{{ t('english') }}</option>
               </select>
             </div>
             <div class="uk-width-1-1">

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -43,6 +43,7 @@ class AdminControllerTest extends TestCase
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringContainsString('export-card', (string) $response->getBody());
+        $this->assertStringNotContainsString('id="langSelect"', (string) $response->getBody());
         session_destroy();
         unlink($db);
     }
@@ -73,7 +74,9 @@ class AdminControllerTest extends TestCase
             ->withUri(new Uri('http', 'example.com', 80, '/admin/profile'));
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertStringContainsString('Example Org', (string) $response->getBody());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('Example Org', $body);
+        $this->assertStringContainsString('id="langSelect"', $body);
         session_destroy();
         unlink($db);
         putenv('MAIN_DOMAIN');


### PR DESCRIPTION
## Summary
- remove language dropdown from admin topbar
- add language selection to profile form
- update admin tests to expect language selector only on profile page

## Testing
- `composer test` *(fails: Tests: 188, Assertions: 378, Errors: 8, Failures: 15, Warnings: 95)*

------
https://chatgpt.com/codex/tasks/task_e_689a1de82520832bb2818c74301214ba