### PR TITLE
fix: improve active nav contrast in dark menu

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -116,6 +116,12 @@ body.dark-mode .uk-icon-button {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
+/* Active state for navigation items in dark off-canvas menus */
+.uk-offcanvas-bar .uk-nav-default > li.uk-active > a {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
 /* Styles for Trumbowyg editor in Dark Mode */
 body.dark-mode .trumbowyg-box,
 body.dark-mode .trumbowyg-editor {


### PR DESCRIPTION
## Summary
- ensure active hamburger menu items remain visible on dark backgrounds

## Testing
- `composer test` (fails: PHPUnit errors and other failures)

------
https://chatgpt.com/codex/tasks/task_e_689a38300a08832b9b141e3cd22d3fd4