### PR TITLE
Hide topbar title on mobile

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -189,6 +189,12 @@ body.uk-padding {
   justify-content: center;
 }
 
+@media (max-width: 639px) {
+  .topbar .uk-navbar-center {
+    display: none;
+  }
+}
+
 .nav-placeholder {
   height: 56px;
 }


### PR DESCRIPTION
## Summary
- hide topbar center area on small screens so dark mode, contrast, and help buttons align on the right

## Testing
- `composer test` *(fails: Slim Application Error, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_689a3898b868832b947225d8360d3f8e