### PR TITLE
Fix mobile admin topbar layout

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -189,6 +189,7 @@ body.uk-padding {
   justify-content: center;
 }
 
+
 .nav-placeholder {
   height: 56px;
 }
@@ -516,6 +517,12 @@ body.admin-page {
 
 .admin-page .nav-placeholder {
   height: 112px;
+}
+
+@media (max-width: 639px) {
+  .admin-page .topbar .uk-navbar-left .uk-logo {
+    display: none;
+  }
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
- keep topbar center visible on small screens so the event switch remains
- hide QuizRace Admin logo on mobile so theme, contrast, and help icons stay on the top row

## Testing
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3898b868832b947225d8360d3f8e