### PR TITLE
Ensure admin tools and event switch remain visible on mobile

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -184,15 +184,10 @@ body.uk-padding {
   display: flex;
   justify-content: center;
 }
+
 .topbar .uk-navbar-center .uk-navbar-item {
   width: 100%;
   justify-content: center;
-}
-
-@media (max-width: 639px) {
-  .topbar .uk-navbar-center {
-    display: none;
-  }
 }
 
 .nav-placeholder {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -29,7 +29,7 @@
       <a class="uk-navbar-toggle uk-hidden@m" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
         <span uk-navbar-toggle-icon></span>
       </a>
-      <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left">QuizRace Admin</a>
+      <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">QuizRace Admin</a>
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">


### PR DESCRIPTION
## Summary
- Remove mobile rule that hid the topbar center so the event switch stays visible on small screens
- Hide the "QuizRace Admin" logo on narrow screens to keep dark mode, contrast and help buttons on the top row

## Testing
- `composer test` *(fails: Tests: 188, Assertions: 378, Errors: 8, Failures: 15, Warnings: 95)*

------
https://chatgpt.com/codex/tasks/task_e_689a3d5c6734832bb328bb3e73899bdd