### PR TITLE
Place help, dark, and contrast buttons on top right

### DIFF
--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -14,9 +14,6 @@
   {% embed 'topbar.twig' %}
     {% block mobile_menu_toggle %}{% endblock %}
     {% block offcanvas %}{% endblock %}
-    {% block left %}
-      <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
-    {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">Veranstaltungen</span>
     {% endblock %}
@@ -27,6 +24,7 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
+      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-large">

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -12,9 +12,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block left %}
-      <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
-    {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">{{ t('game_flow') }} <br>{{ event.name|default('Sommerfest 2025') }}</span>
     {% endblock %}
@@ -25,6 +22,7 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="{{ t('contrast_toggle') }}"></button>
       </div>
+      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small">

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -13,9 +13,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block left %}
-      <a href="faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
-    {% endblock %}
     {% block center %}
       <span id="topbar-title" class="uk-navbar-title uk-text-center" data-default-title="{{ event.name|default('Sommerfest 2025') }}">{{ event.name|default('Sommerfest 2025') }}</span>
     {% endblock %}
@@ -26,6 +23,7 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="{{ t('contrast_toggle') }}"></button>
       </div>
+      <a href="faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
     {% endblock %}
     {% block headerbar %}
       {% if event.description %}

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -12,9 +12,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block left %}
-      <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
-    {% endblock %}
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
@@ -22,6 +19,7 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
+      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
   {% endembed %}
 <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -12,9 +12,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block left %}
-      <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
-    {% endblock %}
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
@@ -22,6 +19,7 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
+      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -12,9 +12,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block left %}
-      <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
-    {% endblock %}
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
@@ -22,6 +19,7 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
+      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">

--- a/templates/register.twig
+++ b/templates/register.twig
@@ -12,9 +12,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block left %}
-      <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
-    {% endblock %}
     {% block right %}
       <div class="theme-switch">
         <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
@@ -22,6 +19,7 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
+      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -12,9 +12,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block left %}
-      <a href="{{ basePath }}/faq" class="uk-icon-button" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
-    {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
         <div id="eventSelectWrap" class="uk-flex uk-flex-middle" hidden>
@@ -31,6 +28,7 @@
       <div class="contrast-switch uk-margin-small-left">
         <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
       </div>
+      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small uk-text-center">


### PR DESCRIPTION
## Summary
- Group dark mode, contrast, and help buttons on the top-right of the navigation bar
- Update templates to keep utility controls consistently aligned

## Testing
- `composer test` *(fails: Slim Application Error / Failed to reload nginx: reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a479032ec832bbcf068692da8b19b