### PR TITLE
fix: add migration for password reset token hash

### DIFF
--- a/migrations/20241205_fix_password_resets_token_hash.sql
+++ b/migrations/20241205_fix_password_resets_token_hash.sql
@@ -1,0 +1,21 @@
+-- Ensure password_resets table has token_hash column and unique index
+ALTER TABLE IF EXISTS password_resets
+    ADD COLUMN IF NOT EXISTS token_hash TEXT;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'password_resets'
+          AND column_name = 'token'
+    ) THEN
+        UPDATE password_resets SET token_hash = token WHERE token_hash IS NULL;
+        ALTER TABLE password_resets DROP COLUMN token;
+    END IF;
+END $$;
+
+ALTER TABLE IF EXISTS password_resets
+    ALTER COLUMN token_hash SET NOT NULL;
+
+DROP INDEX IF EXISTS idx_password_resets_token;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_password_resets_token ON password_resets(token_hash);


### PR DESCRIPTION
## Summary
- ensure `password_resets` table has `token_hash` column and unique index

## Testing
- `composer test` *(fails: Tests: 188, Assertions: 378, Errors: 8, Failures: 15)*

------
https://chatgpt.com/codex/tasks/task_e_689a57ff3864832ba317b0a372cc5361