### PR TITLE
Validate password confirmation and add mismatch check

### DIFF
--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -118,8 +118,14 @@ class PasswordResetController
 
         $token = (string) ($data['token'] ?? '');
         $pass = (string) ($data['password'] ?? '');
+        $repeat = (string) ($data['password_repeat'] ?? '');
         $next = (string) ($data['next'] ?? '');
-        if ($token === '' || $pass === '' || !$this->policy->validate($pass)) {
+        if (
+            $token === ''
+            || $pass === ''
+            || ($repeat !== '' && $repeat !== $pass)
+            || !$this->policy->validate($pass)
+        ) {
             return $response->withStatus(400);
         }
 

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -26,19 +26,22 @@
     <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
       <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
         <h3 class="uk-card-title uk-text-center">Neues Passwort</h3>
-        {% if success %}
-        <div class="uk-alert-success" uk-alert>
-          <p>Passwort erfolgreich geändert.</p>
-        </div>
-        {% elseif error %}
-        <div class="uk-alert-danger" uk-alert>
-          <p>Passwort konnte nicht geändert werden.</p>
-        </div>
-        {% endif %}
-        <form method="post" action="{{ action|default('/password/reset/confirm') }}">
-          <input type="hidden" name="token" value="{{ token }}">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-          {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
+          {% if success %}
+          <div class="uk-alert-success" uk-alert>
+            <p>Passwort erfolgreich geändert.</p>
+          </div>
+          {% elseif error %}
+          <div class="uk-alert-danger" uk-alert>
+            <p>Passwort konnte nicht geändert werden.</p>
+          </div>
+          {% endif %}
+          <div id="mismatch" class="uk-alert-danger" uk-alert hidden>
+            <p>Passwörter stimmen nicht überein.</p>
+          </div>
+          <form method="post" action="{{ action|default('/password/reset/confirm') }}">
+            <input type="hidden" name="token" value="{{ token }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
           <div class="uk-margin">
             <div class="uk-inline uk-width-1-1">
               <span class="uk-form-icon" uk-icon="icon: lock"></span>
@@ -60,7 +63,26 @@
   </div>
 {% endblock %}
 
-{% block scripts %}
-  <script src="{{ basePath }}/js/app.js"></script>
-  <script src="{{ basePath }}/js/custom-icons.js"></script>
-{% endblock %}
+  {% block scripts %}
+    <script src="{{ basePath }}/js/app.js"></script>
+    <script src="{{ basePath }}/js/custom-icons.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        const form = document.querySelector('form');
+        if (!form) {
+          return;
+        }
+        const pass = form.querySelector('input[name="password"]');
+        const repeat = form.querySelector('input[name="password_repeat"]');
+        const alert = document.getElementById('mismatch');
+        form.addEventListener('submit', function (e) {
+          if (pass.value !== repeat.value) {
+            e.preventDefault();
+            if (alert) {
+              alert.hidden = false;
+            }
+          }
+        });
+      });
+    </script>
+  {% endblock %}

--- a/tests/Controller/PasswordResetFlowTest.php
+++ b/tests/Controller/PasswordResetFlowTest.php
@@ -160,4 +160,76 @@ class PasswordResetFlowTest extends TestCase
         $this->assertIsArray($updated);
         $this->assertTrue(password_verify('oldpass', (string)$updated['password']));
     }
+
+    public function testRejectMismatchedPasswords(): void
+    {
+        putenv('PASSWORD_RESET_SECRET=secret');
+        $_ENV['PASSWORD_RESET_SECRET'] = 'secret';
+        putenv('POSTGRES_DSN=');
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        unset($_ENV['POSTGRES_DSN'], $_ENV['POSTGRES_USER'], $_ENV['POSTGRES_PASSWORD']);
+        $app = $this->getAppInstance();
+        $pdo = Database::connectFromEnv();
+        Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        try {
+            $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
+        } catch (\PDOException $e) {
+        }
+        try {
+            $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
+        } catch (\PDOException $e) {
+        }
+        try {
+            $pdo->exec(
+                'CREATE TABLE password_resets(' .
+                'user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)'
+            );
+        } catch (\PDOException $e) {
+        }
+        $userService = new UserService($pdo);
+        $userService->create('alice', 'oldpass', 'alice@example.com', Roles::ADMIN);
+
+        $mailer = new class extends MailService
+        {
+            public array $sent = [];
+
+            public function __construct()
+            {
+            }
+
+            public function sendPasswordReset(string $to, string $link): void
+            {
+                $this->sent[] = ['to' => $to, 'link' => $link];
+            }
+        };
+
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+        $request = $this->createRequest('POST', '/password/reset/request')
+            ->withAttribute('mailService', $mailer)
+            ->withParsedBody(['username' => 'alice', 'csrf_token' => 'tok']);
+        $response = $app->handle($request);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertCount(1, $mailer->sent);
+
+        $link = $mailer->sent[0]['link'];
+        $pos = strrpos($link, 'token=');
+        $token = $pos === false ? '' : substr($link, $pos + 6);
+        $this->assertNotSame('', $token, 'Token not found in link: ' . $link);
+
+        $confirm = $this->createRequest('POST', '/password/reset/confirm')
+            ->withParsedBody([
+                'token' => $token,
+                'password' => 'Str0ngPass1',
+                'password_repeat' => 'different',
+                'csrf_token' => 'tok',
+            ]);
+        $resp2 = $app->handle($confirm);
+        $this->assertSame(400, $resp2->getStatusCode());
+
+        $updated = $userService->getByUsername('alice');
+        $this->assertIsArray($updated);
+        $this->assertTrue(password_verify('oldpass', (string)$updated['password']));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure password reset checks repeated password before saving
- show a client-side warning when confirmation doesn't match
- add test covering mismatched password reset

## Testing
- `composer test` *(fails: Slim Application Error, Database error: fail, Error creating tenant: boom, Failed to reload nginx: reload failed)*
- `vendor/bin/phpcs src/Controller/PasswordResetController.php tests/Controller/PasswordResetFlowTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689a5ae8ef1c832ba8d554d2493a7d52