### PR TITLE
Handle demo subscriptions without Stripe customer

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -187,6 +187,7 @@ return [
     'action_restore_demo' => 'Demodaten wiederherstellen',
     'action_refresh' => 'Aktualisieren',
     'action_open_subscription' => 'Kundenportal öffnen',
+    'action_start_subscription' => 'Abo buchen',
     'action_open_evaluation' => 'Auswertung öffnen',
     'action_download' => 'Herunterladen',
     'action_delete_tenant' => 'Mandant löschen',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -187,6 +187,7 @@ return [
     'action_restore_demo' => 'Restore demo data',
     'action_refresh' => 'Refresh',
     'action_open_subscription' => 'Open customer portal',
+    'action_start_subscription' => 'Start subscription',
     'action_open_evaluation' => 'Open evaluation',
     'action_download' => 'Download',
     'action_delete_tenant' => 'Delete tenant',

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -30,12 +30,12 @@ class SubscriptionController
         $tenantService = new TenantService($base);
         $tenant = $tenantService->getBySubdomain($sub);
         $customerId = (string) ($tenant['stripe_customer_id'] ?? '');
+        $uri = $request->getUri();
         if ($customerId === '') {
-            $response->getBody()->write('Missing Stripe customer id');
-            return $response->withStatus(500);
+            $upgradeUrl = $uri->getScheme() . '://' . $uri->getHost() . '/onboarding';
+            return $response->withHeader('Location', $upgradeUrl)->withStatus(302);
         }
 
-        $uri = $request->getUri();
         $returnUrl = $uri->getScheme() . '://' . $uri->getHost() . '/admin';
         $service = new StripeService();
         $url = $service->createBillingPortal($customerId, $returnUrl);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -750,6 +750,8 @@
     <li class="{{ activeRoute == 'subscription' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_subscription') }}</h2>
+        {% set hasCustomer = tenant and tenant.stripe_customer_id %}
+        {% set upgradeUrl = hasCustomer ? basePath ~ '/admin/subscription/portal' : basePath ~ '/onboarding' %}
         <div class="uk-card uk-card-default uk-card-body uk-margin-small" id="subscription-card">
           <div id="subscription"
             data-label-plan="{{ t('label_plan') }}"
@@ -760,7 +762,10 @@
             data-plan-standard="{{ t('plan_standard') }}"
             data-plan-professional="{{ t('plan_professional') }}"></div>
         </div>
-        <p><a class="uk-button uk-button-primary" href="{{ basePath }}/admin/subscription/portal">{{ t('action_open_subscription') }}</a></p>
+        <p><a class="uk-button uk-button-primary" href="{{ upgradeUrl }}">{{ hasCustomer ? t('action_open_subscription') : t('action_start_subscription') }}</a></p>
+        <script>
+          window.upgradeUrl = '{{ upgradeUrl }}';
+        </script>
       </div>
     </li>
       </ul>
@@ -794,7 +799,6 @@
     window.transUpgradeTitle = '{{ t('heading_limit_reached') }}';
     window.transUpgradeText = '{{ t('text_upgrade_required') }}';
     window.transUpgradeAction = '{{ t('action_upgrade') }}';
-    window.upgradeUrl = '{{ basePath }}/admin/subscription';
   </script>
   <script src="{{ basePath }}/js/dashboard.js"></script>
   <script src="{{ basePath }}/js/admin.js"></script>


### PR DESCRIPTION
## Summary
- Redirect to onboarding when opening subscription portal without a Stripe customer
- Show "Abo buchen"/"Start subscription" button on subscription page for demo tenants and expose upgrade URL accordingly
- Add translation strings for starting a subscription

## Testing
- `composer test` *(fails: Tests: 189, Assertions: 384, Errors: 8, Failures: 15)*

------
https://chatgpt.com/codex/tasks/task_e_689a609d0df4832b8ccef482010580ba