### PR TITLE
Allow admins to manage SEO settings

### DIFF
--- a/src/Domain/Roles.php
+++ b/src/Domain/Roles.php
@@ -12,7 +12,6 @@ final class Roles
     public const ANALYST = 'analyst';
     public const TEAM_MANAGER = 'team-manager';
     public const SERVICE_ACCOUNT = 'service-account';
-    public const SEO_EDITOR = 'seo-editor';
 
     public const ALL = [
         self::ADMIN,
@@ -21,6 +20,5 @@ final class Roles
         self::ANALYST,
         self::TEAM_MANAGER,
         self::SERVICE_ACCOUNT,
-        self::SEO_EDITOR,
     ];
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -15,7 +15,6 @@ use App\Controller\LogoutController;
 use App\Controller\ConfigController;
 use App\Controller\CatalogController;
 use App\Application\Middleware\RoleAuthMiddleware;
-use App\Application\Security\AuthorizationMiddleware;
 use App\Service\ConfigService;
 use App\Service\CatalogService;
 use App\Service\ResultService;
@@ -458,7 +457,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/admin/landingpage/seo', function (Request $request, Response $response) {
         $controller = new LandingpageController();
         return $controller->save($request, $response);
-    })->add(new AuthorizationMiddleware(Roles::SEO_EDITOR));
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
 
     $app->get('/admin/{path:.*}', function (Request $request, Response $response) {
         $base = \Slim\Routing\RouteContext::fromRequest($request)->getBasePath();

--- a/tests/RoleAccessTest.php
+++ b/tests/RoleAccessTest.php
@@ -93,12 +93,12 @@ class RoleAccessTest extends TestCase
         unlink($db);
     }
 
-    public function testSeoEditorCanAccessSeoForm(): void
+    public function testAdminCanAccessSeoForm(): void
     {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
-        $_SESSION['user'] = ['id' => 1, 'role' => 'seo-editor'];
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
         $req = $this->createRequest('POST', '/admin/landingpage/seo');
         $req = $req->withParsedBody(['pageId' => 1, 'slug' => 'test']);
         $res = $app->handle($req);
@@ -107,12 +107,12 @@ class RoleAccessTest extends TestCase
         unlink($db);
     }
 
-    public function testAdminCannotAccessSeoForm(): void
+    public function testCatalogEditorCannotAccessSeoForm(): void
     {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
-        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
         $req = $this->createRequest('POST', '/admin/landingpage/seo');
         $req = $req->withParsedBody(['pageId' => 1, 'slug' => 'test']);
         $res = $app->handle($req);


### PR DESCRIPTION
## Summary
- Remove standalone `seo-editor` role
- Gate landingpage SEO route behind admin role
- Update access tests for SEO form

## Testing
- `vendor/bin/phpunit tests/RoleAccessTest.php`
- `composer test` *(fails: Database error: fail; Errors: 8, Failures: 14)*

------
https://chatgpt.com/codex/tasks/task_e_689a60e8022c832bb8fcff3e0c8880db