### PR TITLE
Add SEO form page for admins

### DIFF
--- a/src/Controller/Admin/LandingpageController.php
+++ b/src/Controller/Admin/LandingpageController.php
@@ -8,6 +8,7 @@ use App\Application\Seo\PageSeoConfigService;
 use App\Domain\PageSeoConfig;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
 
 /**
  * Handles admin actions for the marketing landing page.
@@ -19,6 +20,15 @@ class LandingpageController
     public function __construct(?PageSeoConfigService $seoService = null)
     {
         $this->seoService = $seoService ?? new PageSeoConfigService();
+    }
+
+    /**
+     * Display the SEO edit form.
+     */
+    public function page(Request $request, Response $response): Response
+    {
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'admin/landingpage/edit.html.twig');
     }
 
     /**

--- a/src/routes.php
+++ b/src/routes.php
@@ -454,6 +454,14 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $controller->update($request, $response, $args);
     })->add(new RoleAuthMiddleware(Roles::ADMIN));
 
+    $app->get('/admin/landingpage/seo', function (Request $request, Response $response) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(404);
+        }
+        $controller = new LandingpageController();
+        return $controller->page($request, $response);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+
     $app->post('/admin/landingpage/seo', function (Request $request, Response $response) {
         $controller = new LandingpageController();
         return $controller->save($request, $response);

--- a/tests/RoleAccessTest.php
+++ b/tests/RoleAccessTest.php
@@ -121,4 +121,31 @@ class RoleAccessTest extends TestCase
         session_destroy();
         unlink($db);
     }
+
+    public function testAdminCanViewSeoForm(): void
+    {
+        $db = $this->setupDb();
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $req = $this->createRequest('GET', '/admin/landingpage/seo');
+        $res = $app->handle($req);
+        $this->assertEquals(200, $res->getStatusCode());
+        session_destroy();
+        unlink($db);
+    }
+
+    public function testCatalogEditorCannotViewSeoForm(): void
+    {
+        $db = $this->setupDb();
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
+        $req = $this->createRequest('GET', '/admin/landingpage/seo');
+        $res = $app->handle($req);
+        $this->assertEquals(302, $res->getStatusCode());
+        $this->assertEquals('/login', $res->getHeaderLine('Location'));
+        session_destroy();
+        unlink($db);
+    }
 }


### PR DESCRIPTION
## Summary
- allow admins to access landing page SEO form
- restrict SEO form to main domain only
- test admin vs non-admin access for SEO form

## Testing
- `composer test` (fails: Failed to reload nginx: reload failed)
- `vendor/bin/phpunit tests/RoleAccessTest.php`

------
https://chatgpt.com/codex/tasks/task_e_689a69a18750832b96dc679f61f94e24