### PR TITLE
Remove reset button from admin configuration

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -452,11 +452,6 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     }).catch(() => notify('Fehler beim Speichern', 'danger'));
   });
-  document.getElementById('cfgResetBtn').addEventListener('click', function (e) {
-    e.preventDefault();
-    renderCfg(cfgInitial);
-  });
-
   [
     cfgFields.pageTitle,
     cfgFields.backgroundColor,

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -66,7 +66,6 @@ return [
     'tip_team_results' => 'Zeigt Teams nach Abschluss aller Kataloge eine Übersicht ihrer Ergebnisse.',
     'tip_photo_upload' => 'Blendet die Buttons zum Hochladen von Fotos ein oder aus.',
     'tip_puzzle_word' => 'Blendet Buchstaben für das Rätselwort ein und speichert den vollständigen Begriff.',
-    'tip_form_reset' => 'Setzt alle Felder auf gespeicherte Werte zurück',
     'tip_save_settings' => 'Einstellungen speichern',
     'tip_sort_rows' => 'Zum Sortieren Zeile ziehen',
     'tip_event_remove' => 'Veranstaltung entfernen',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -66,7 +66,6 @@ return [
     'tip_team_results' => 'Shows teams a summary of their results after all catalogs are completed.',
     'tip_photo_upload' => 'Shows or hides buttons for uploading photos.',
     'tip_puzzle_word' => 'Displays letters for the puzzle word and saves the full term.',
-    'tip_form_reset' => 'Resets all fields to saved values',
     'tip_save_settings' => 'Save settings',
     'tip_sort_rows' => 'Drag row to sort',
     'tip_event_remove' => 'Remove event',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -279,13 +279,6 @@
             </div>
           </div>
         </form>
-        <div class="uk-margin uk-flex uk-flex-right">
-          <button id="cfgResetBtn"
-            class="uk-button uk-button-default"
-            uk-tooltip="title: {{ t('tip_form_reset') }}; pos: right">
-            {{ t('action_reset') }}
-          </button>
-        </div>
 
         <div id="puzzleFeedbackModal" uk-modal>
           <div class="uk-modal-dialog uk-modal-body">


### PR DESCRIPTION
## Summary
- remove obsolete reset button and tooltip from admin settings form
- drop unused reset handler in admin JS
- clean up unused translation strings

## Testing
- `composer test` *(fails: Database error: fail; ERRORs and Failures)*

------
https://chatgpt.com/codex/tasks/task_e_689a72be4994832b94f6c6a878cd9617