### PR TITLE
feat(admin): move stats filter below header on mobile

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -566,9 +566,9 @@
     </li>
     <li class="{{ activeRoute == 'statistics' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
-        <div class="uk-flex uk-flex-between uk-flex-middle">
+        <div class="uk-flex uk-flex-middle uk-flex-column uk-flex-row@s uk-flex-between@s">
           <h2 class="uk-heading-bullet">{{ t('heading_statistics') }}</h2>
-          <div class="uk-flex uk-flex-middle">
+          <div class="uk-flex uk-flex-middle uk-margin-small-top uk-margin-remove-top@s">
             <select id="statsFilter" class="uk-select uk-width-small uk-margin-right">
               <option value="">Alle</option>
             </select>


### PR DESCRIPTION
## Summary
- ensure admin statistics filter stack under heading on small screens

## Testing
- `composer test` (fails: Failed asserting that 500 is identical to 200)

------
https://chatgpt.com/codex/tasks/task_e_689a7398aae8832b914fe4f79a59e54a