### PR TITLE
Fix QR SVG generation and add session tracking table

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -9,6 +9,7 @@
             Das Team-Quiz, das Ihr Event <span id="rotating-word" class="marker-text">unvergesslich</span> macht.
           </h2>
           <p class="hero-subtext" uk-scrollspy="cls: uk-animation-fade; delay: 150">
+            Trete gegen Freunde und Kollegen an.<br>
             Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams.<br>
             In Minuten startklar – live, vor Ort oder hybrid!<br>
             Ohne App-Download, 100% datensicher, individuell anpassbar.

--- a/migrations/20240910_base_schema.sql
+++ b/migrations/20240910_base_schema.sql
@@ -16,7 +16,8 @@ CREATE TABLE IF NOT EXISTS events (
     name TEXT NOT NULL,
     start_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     end_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    description TEXT
+    description TEXT,
+    published BOOLEAN DEFAULT FALSE
 );
 
 -- Config
@@ -197,3 +198,10 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs(action);
+
+-- Persisted user sessions
+CREATE TABLE IF NOT EXISTS user_sessions (
+    user_id INTEGER NOT NULL,
+    session_id TEXT PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -86,7 +86,8 @@ class LogoController
         }
 
         $manager = ImageManager::gd();
-        $img = $manager->read($file->getStream());
+        $stream = $file->getStream();
+        $img = $manager->read($stream->detach());
         $img->scaleDown(512, 512);
         $img->save($target, 80);
 

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -60,6 +60,7 @@ class QrCodeService
         }
 
         $writer = strtolower($format) === 'svg' ? new SvgWriter() : new PngWriter();
+        $punchout = $logoPath !== null && !($writer instanceof SvgWriter);
 
         try {
             $result = (new Builder(
@@ -74,7 +75,7 @@ class QrCodeService
                 backgroundColor: $bg,
                 logoPath: $logoPath ?? '',
                 logoResizeToWidth: $logoPath !== null ? self::LOGO_WIDTH_DEF : null,
-                logoPunchoutBackground: $logoPath !== null,
+                logoPunchoutBackground: $punchout,
             ))->build();
         } finally {
             if ($logoPath !== null && file_exists($logoPath)) {
@@ -230,6 +231,7 @@ class QrCodeService
         }
 
         $writer = $format === 'svg' ? new SvgWriter() : new PngWriter();
+        $punchout = $logoPath !== null && !($writer instanceof SvgWriter) ? $logoPunchout : false;
 
         try {
             $result = (new Builder(
@@ -244,7 +246,7 @@ class QrCodeService
                 backgroundColor: new Color($bgRgb[0], $bgRgb[1], $bgRgb[2]),
                 logoPath: $logoPath ?? '',
                 logoResizeToWidth: $logoPath !== null ? $logoW : null,
-                logoPunchoutBackground: $logoPath !== null ? $logoPunchout : false,
+                logoPunchoutBackground: $punchout,
             ))->build();
         } finally {
             if ($logoPath !== null) {

--- a/tests/Controller/LogoControllerTest.php
+++ b/tests/Controller/LogoControllerTest.php
@@ -17,6 +17,7 @@ class LogoControllerTest extends TestCase
     {
         $pdo = $this->createDatabase();
         $cfg = new ConfigService($pdo);
+        $cfg->saveConfig([]);
         $controller = new LogoController($cfg);
         @rename(dirname(__DIR__, 2) . '/data/logo.png', dirname(__DIR__, 2) . '/data/logo.png.bak');
         @rename(dirname(__DIR__, 2) . '/data/logo.webp', dirname(__DIR__, 2) . '/data/logo.webp.bak');

--- a/tests/Service/SessionServiceTest.php
+++ b/tests/Service/SessionServiceTest.php
@@ -12,7 +12,7 @@ class SessionServiceTest extends TestCase
     public function testInvalidateRemovesSessions(): void
     {
         $pdo = $this->createDatabase();
-        $pdo->exec('CREATE TABLE user_sessions(user_id INTEGER NOT NULL, session_id TEXT PRIMARY KEY)');
+        $pdo->exec('CREATE TABLE IF NOT EXISTS user_sessions(user_id INTEGER NOT NULL, session_id TEXT PRIMARY KEY)');
 
         $pdo->exec("INSERT INTO user_sessions(user_id, session_id) VALUES (1,'abc'),(1,'def'),(2,'zzz')");
 


### PR DESCRIPTION
## Summary
- add `published` column and `user_sessions` table to base schema
- handle SVG QR codes without logo punchout and fix logo upload stream handling
- document landing page tagline
- adjust tests for logo fallback and session service

## Testing
- `vendor/bin/phpunit tests/Controller/PasswordControllerTest.php`
- `vendor/bin/phpunit tests/Controller/QrControllerTest.php`
- `vendor/bin/phpunit tests/Controller/HomeControllerTest.php`
- `vendor/bin/phpunit tests/Controller/LogoControllerTest.php`
- `vendor/bin/phpunit tests/Service/SessionServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689a70a672e4832ba4139fe0d8a63063