### PR TITLE
Add landing page SEO tab to admin navigation

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -25,6 +25,7 @@ return [
     'tab_results' => 'Ergebnisse',
     'tab_statistics' => 'Statistik',
     'tab_pages' => 'Seiten',
+    'tab_landingpage_seo' => 'Landingpage SEO',
     'tab_management' => 'Administration',
     'tab_tenants' => 'Subdomains',
     'tab_profile' => 'Profil',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -25,6 +25,7 @@ return [
     'tab_results' => 'Results',
     'tab_statistics' => 'Statistics',
     'tab_pages' => 'Pages',
+    'tab_landingpage_seo' => 'Landing Page SEO',
     'tab_management' => 'Management',
     'tab_tenants' => 'Subdomains',
     'tab_profile' => 'Profile',

--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -17,6 +17,7 @@
       { href: basePath ~ '/admin/catalogs', icon: 'file-text', text: t('tab_catalogs') },
       { href: basePath ~ '/admin/questions', icon: 'question', text: t('tab_questions') },
       { href: basePath ~ '/admin/pages', icon: 'file-text', text: t('tab_pages'), admin: true },
+      { href: basePath ~ '/admin/landingpage/seo', icon: 'link', text: t('tab_landingpage_seo'), admin: true },
     ]
   },
   {


### PR DESCRIPTION
## Summary
- add landing page SEO link to admin navigation
- localize new navigation item in English and German

## Testing
- `composer test` *(fails: Tests: 191, Assertions: 392, Errors: 8, Failures: 14, Warnings: 100, PHPUnit Deprecations: 2.)*

------
https://chatgpt.com/codex/tasks/task_e_689a73ee4cb8832bbb9a46fbf7a56947