### PR TITLE
Fix SQLite test schema and mailer deprecation

### DIFF
--- a/migrations/20240910_base_schema.sql
+++ b/migrations/20240910_base_schema.sql
@@ -16,7 +16,8 @@ CREATE TABLE IF NOT EXISTS events (
     name TEXT NOT NULL,
     start_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     end_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    description TEXT
+    description TEXT,
+    published BOOLEAN DEFAULT FALSE
 );
 
 -- Config
@@ -171,6 +172,13 @@ CREATE TABLE IF NOT EXISTS users (
     username TEXT UNIQUE NOT NULL,
     password TEXT NOT NULL,
     role user_role NOT NULL DEFAULT 'catalog-editor'
+);
+
+-- Sessions for logged-in users
+CREATE TABLE IF NOT EXISTS user_sessions (
+    user_id INTEGER NOT NULL,
+    session_id TEXT PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Tenant definitions

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -204,7 +204,7 @@ class MailServiceTest extends TestCase
 
                     public function send(
                         \Symfony\Component\Mime\RawMessage $message,
-                        \Symfony\Component\Mailer\Envelope $envelope = null
+                        ?\Symfony\Component\Mailer\Envelope $envelope = null
                     ): void {
                         $this->outer->messages[] = $message;
                     }


### PR DESCRIPTION
## Summary
- Add `published` and `user_sessions` tables to SQLite base schema used in tests
- Update test mailer stub to use explicit nullable envelope parameter

## Testing
- `vendor/bin/phpcs tests/Service/MailServiceTest.php`
- `composer test` *(fails: HomeControllerTest::testLandingAsHomePage, QrControllerTest::testQrImageSvgFormat, QrControllerTest::testTeamQrSvgFormat, QrControllerTest::testPdfUsesUploadedLogo and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a7571b270832bae8507cd19f88d41