### PR TITLE
Add SEO metadata for landing page

### DIFF
--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -3,12 +3,39 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-  <meta name="description" content="Interaktives QuizRace für Teams und Freunde">
-  <meta property="og:title" content="QuizRace">
-  <meta property="og:description" content="Spielen Sie ein spannendes Quiz bei Ihrem Event">
-  <meta property="og:image" content="{{ basePath }}/favicon.svg">
+  <title>{% block title %}QuizRace – Das interaktive Team-Quiz für Events{% endblock %}</title>
+  <meta name="description" content="QuizRace macht Ihr Event einzigartig: QR-Code-Stationen, Live-Ranking & Rätselspaß – datensicher, flexibel, ohne App-Download.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://quizrace.app/">
+  <meta property="og:title" content="QuizRace – Das interaktive Team-Quiz für Events">
+  <meta property="og:description" content="Gestalten Sie in Minuten ein Event-Quiz mit QR-Code-Stationen, Live-Ranking & Rätselwort. DSGVO-konform, ohne App-Download.">
+  <meta property="og:image" content="https://quizrace.app/img/social-preview.jpg">
+  <meta property="og:url" content="https://quizrace.app/">
+  <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
-  <title>{% block title %}Quiz{% endblock %}</title>
+  <link rel="alternate" href="https://quizrace.app/" hreflang="de">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "QuizRace",
+    "url": "https://quizrace.app/",
+    "description": "QuizRace ist das interaktive Event-Quiz mit QR-Code-Stationen, Live-Ranking & Rätselspaß – datensicher, flexibel, ohne App-Download.",
+    "publisher": {
+      "@type": "Organization",
+      "name": "QuizRace",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://quizrace.app/img/logo.png"
+      }
+    },
+    "sameAs": [
+      "https://www.facebook.com/quizrace",
+      "https://www.instagram.com/quizrace",
+      "https://www.linkedin.com/company/quizrace"
+    ]
+  }
+  </script>
   <link rel="icon" href="{{ basePath }}/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="{{ basePath }}/css/uikit.min.css">
   {% block head %}{% endblock %}

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -1,6 +1,6 @@
 {% extends 'layout.twig' %}
 
-{% block title %}QuizRace – Professionelle Quiz-Events für Unternehmen, Teams & Schulen{% endblock %}
+{% block title %}QuizRace – Das interaktive Team-Quiz für Events{% endblock %}
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">


### PR DESCRIPTION
## Summary
- Define default SEO title and social preview metadata
- Add canonical, robots, hreflang and JSON-LD schema
- Align marketing landing title with new branding

## Testing
- `composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_689a78023958832b9d3c05c1b2d17c18