### PR TITLE
Move landing page SEO into Pages tab

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/ui/trumbowyg.min.css">
   <script src="https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/trumbowyg.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/trumbowyg.min.js"></script>
   <script>
     window.profileVars = {
       NAME: '{{ tenant.imprint_name|default('')|e('js') }}',
@@ -18,8 +18,9 @@
       EMAIL: '{{ tenant.imprint_email|default('')|e('js') }}'
     };
   </script>
-  <script type="module" src="{{ basePath }}/js/trumbowyg-pages.js"></script>
-{% endblock %}
+    <script type="module" src="{{ basePath }}/js/trumbowyg-pages.js"></script>
+    <script type="module" src="{{ basePath }}/js/seo-form.js"></script>
+  {% endblock %}
 
 {% block body_class %}uk-background-muted uk-padding admin-page{% endblock %}
 
@@ -590,12 +591,71 @@
         <div class="uk-container uk-container-large">
           <h2 class="uk-heading-bullet">{{ t('heading_pages') }}</h2>
           <ul id="pageTabs" class="uk-tab" uk-tab="connect: #pageSwitcher">
-            <li class="uk-active" data-slug="landing"><a href="#">Landing</a></li>
+            <li class="uk-active"><a href="#">{{ t('tab_landingpage_seo') }}</a></li>
+            <li data-slug="landing"><a href="#">Landing</a></li>
             <li data-slug="impressum"><a href="#">Impressum</a></li>
             <li data-slug="datenschutz"><a href="#">Datenschutz</a></li>
             <li data-slug="faq"><a href="#">FAQ</a></li>
           </ul>
           <ul id="pageSwitcher" class="uk-switcher uk-margin">
+            <li>
+              <form class="uk-form-stacked seo-form" action="{{ basePath }}/admin/landingpage/seo" method="post">
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="metaTitle">Meta Title</label>
+                  <div class="uk-form-controls">
+                    <input class="uk-input" id="metaTitle" name="meta_title" type="text" required data-maxlength="60">
+                    <small class="uk-text-meta char-count" data-for="metaTitle">0/60</small>
+                  </div>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="metaDescription">Meta Description</label>
+                  <div class="uk-form-controls">
+                    <textarea class="uk-textarea" id="metaDescription" name="meta_description" required data-maxlength="160"></textarea>
+                    <small class="uk-text-meta char-count" data-for="metaDescription">0/160</small>
+                  </div>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="slug">Slug</label>
+                  <div class="uk-form-controls">
+                    <input class="uk-input" id="slug" name="slug" type="text" required data-maxlength="100">
+                  </div>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="canonical">Canonical</label>
+                  <div class="uk-form-controls">
+                    <input class="uk-input" id="canonical" name="canonical" type="url">
+                  </div>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="robots">Robots</label>
+                  <div class="uk-form-controls">
+                    <input class="uk-input" id="robots" name="robots" type="text" placeholder="index, follow">
+                  </div>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label">OG-Tags</label>
+                  <div class="uk-form-controls">
+                    <input class="uk-input uk-margin-small-bottom" id="ogTitle" name="og_title" type="text" placeholder="og:title" data-maxlength="60">
+                    <input class="uk-input" id="ogDescription" name="og_description" type="text" placeholder="og:description" data-maxlength="160">
+                  </div>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="schema">Schema.org</label>
+                  <div class="uk-form-controls">
+                    <textarea class="uk-textarea" id="schema" name="schema" rows="4" placeholder="{ }"></textarea>
+                  </div>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="hreflang">hreflang</label>
+                  <div class="uk-form-controls">
+                    <input class="uk-input" id="hreflang" name="hreflang" type="text" placeholder="de, en, ...">
+                  </div>
+                </div>
+                <div class="uk-margin">
+                  <button type="submit" class="uk-button uk-button-primary">Speichern</button>
+                </div>
+              </form>
+            </li>
             {% for slug, html in pages %}
             <li>
               <form class="page-form" data-slug="{{ slug }}">

--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -17,7 +17,6 @@
       { href: basePath ~ '/admin/catalogs', icon: 'file-text', text: t('tab_catalogs') },
       { href: basePath ~ '/admin/questions', icon: 'question', text: t('tab_questions') },
       { href: basePath ~ '/admin/pages', icon: 'file-text', text: t('tab_pages'), admin: true },
-      { href: basePath ~ '/admin/landingpage/seo', icon: 'link', text: t('tab_landingpage_seo'), admin: true },
     ]
   },
   {


### PR DESCRIPTION
## Summary
- Remove separate menu link for Landingpage SEO
- Add Landingpage SEO form as first tab within Admin Pages and load SEO form script

## Testing
- `composer test` *(fails: Failed asserting that two strings are identical)*

------
https://chatgpt.com/codex/tasks/task_e_689a7a1b62a8832bb575a2d27742f4bf