### PR TITLE
Ensure Stripe checkout supports card payments

### DIFF
--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -13,8 +13,12 @@ class StripeService
 {
     private StripeClient $client;
 
-    public function __construct(?string $apiKey = null)
+    public function __construct(?string $apiKey = null, ?StripeClient $client = null)
     {
+        if ($client !== null) {
+            $this->client = $client;
+            return;
+        }
         $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
         $envKey = $useSandbox ? 'STRIPE_SANDBOX_SECRET_KEY' : 'STRIPE_SECRET_KEY';
         $apiKey = $apiKey ?? (getenv($envKey) ?: '');
@@ -35,6 +39,7 @@ class StripeService
             'line_items' => [
                 ['price' => $priceId, 'quantity' => 1],
             ],
+            'payment_method_types' => ['card'],
             'success_url' => $successUrl,
             'cancel_url' => $cancelUrl,
         ];

--- a/tests/Service/StripeServiceTest.php
+++ b/tests/Service/StripeServiceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\StripeService;
+use PHPUnit\Framework\TestCase;
+
+class FakeCheckoutSessions
+{
+    public array $lastParams = [];
+    public function create(array $params)
+    {
+        $this->lastParams = $params;
+        return (object) ['url' => 'https://example.com'];
+    }
+}
+
+class FakeCheckout
+{
+    public FakeCheckoutSessions $sessions;
+    public function __construct()
+    {
+        $this->sessions = new FakeCheckoutSessions();
+    }
+}
+
+class FakeStripeClient extends \Stripe\StripeClient
+{
+    public FakeCheckout $checkout;
+    public function __construct()
+    {
+        parent::__construct('sk_test_fake');
+        $this->checkout = new FakeCheckout();
+    }
+}
+
+final class StripeServiceTest extends TestCase
+{
+    public function testCreateCheckoutSessionAddsPaymentMethodTypes(): void
+    {
+        $client = new FakeStripeClient();
+        $service = new StripeService(client: $client);
+        $service->createCheckoutSession('price_123', 'https://success', 'https://cancel', 'user@example.com');
+        $this->assertSame(['card'], $client->checkout->sessions->lastParams['payment_method_types'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary
- explicitly request card payment method when creating Stripe checkout sessions
- allow injecting a StripeClient for easier testing
- add test verifying Stripe checkout sessions include card payment type

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689a9bc4e2dc832b9207e32918b07cef