### PR TITLE
Allow onboarding without Stripe for free plan

### DIFF
--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -111,10 +111,13 @@
       <button class="uk-button uk-button-primary" id="saveSubdomain">Subdomain speichern</button>
     </div>
 
-    {% if stripe_configured %}
     <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-margin-auto" id="step3" hidden>
       <h3 class="uk-card-title">3. Tarif wählen</h3>
+      {% if stripe_configured %}
       <p>Wähle einen Tarif und schließe die Zahlung über Stripe ab.</p>
+      {% else %}
+      <p class="uk-text-danger">Zahlungsdienstleister nicht konfiguriert. Nur der kostenlose Starter-Tarif ist verfügbar.</p>
+      {% endif %}
       <div class="pricing-grid uk-child-width-1-1 uk-child-width-1-3@m" uk-grid>
         <div>
           <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
@@ -133,6 +136,7 @@
             <button class="btn btn-transparent uk-width-1-1 uk-button-large uk-margin-small-top plan-select" data-plan="starter">Tarif wählen</button>
           </div>
         </div>
+        {% if stripe_configured %}
         <div>
           <div class="uk-card uk-card-popular uk-card-quizrace uk-text-center">
             <span class="uk-label uk-label-large">Meist gewählt</span>
@@ -164,18 +168,13 @@
             <button class="btn btn-transparent uk-width-1-1 uk-button-large plan-select" data-plan="professional">Tarif wählen</button>
           </div>
         </div>
+        {% endif %}
       </div>
       <p class="uk-text-meta uk-text-center uk-margin-large-top">Alle Preise zzgl. MwSt. – individuelle Lösungen auf Anfrage.</p>
       <p class="uk-text-meta uk-margin-top">1 (Die Teamgröße ist nicht technisch limitiert und kann bedarfsgerecht festgelegt werden.)</p>
       <p class="uk-text-meta uk-margin-top">2 (Im Starter-Paket mit Wasserzeichen oder ohne individuelles Layout/Logo)</p>
       <p class="uk-text-meta uk-margin-top">3 (z.&nbsp;B. Datenschutz, AGB, Einladung, FAQ, Spielanleitung – alles eigenständig editierbar)</p>
     </div>
-    {% else %}
-    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step3-warning" hidden>
-      <h3 class="uk-card-title">3. Tarif wählen</h3>
-      <p class="uk-text-danger">Zahlungsdienstleister nicht konfiguriert. Bitte wende dich an den Support.</p>
-    </div>
-    {% endif %}
   </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- allow selecting the free Starter plan even when Stripe isn't configured
- create tenants directly when Starter plan is chosen, bypassing Stripe checkout

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689a9c244cdc832b9996ce6aa7ca3f63