### PR TITLE
Add SEO example import button

### DIFF
--- a/public/js/seo-form.js
+++ b/public/js/seo-form.js
@@ -17,6 +17,50 @@ export function initSeoForm() {
     }
   });
 
+  const importBtn = form.querySelector('.import-seo-example');
+  if (importBtn) {
+    importBtn.addEventListener('click', () => {
+      const example = {
+        metaTitle: 'QuizRace – Gestalten Sie Ihr interaktives Team-Quiz für Events',
+        metaDescription: 'QuizRace macht Ihr Event einzigartig: QR-Code-Stationen, Live-Ranking & Rätselspaß – datensicher, flexibel, ohne App. Jetzt kostenlos testen!',
+        slug: '/',
+        canonical: 'https://quizrace.app/',
+        robots: 'index, follow',
+        ogTitle: 'QuizRace – Gestalten Sie Ihr interaktives Team-Quiz für Events',
+        ogDescription: 'Erstellen Sie Ihr eigenes Event-Quiz mit QR-Code-Stationen, Live-Ranking & Rätselspaß. DSGVO-konform, flexibel, ohne App. Jetzt kostenlos testen!',
+        ogImage: 'https://quizrace.app/img/social-preview.jpg',
+        schema: `{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "QuizRace",
+  "url": "https://quizrace.app/",
+  "description": "QuizRace ist das interaktive Event-Quiz mit QR-Code-Stationen, Live-Ranking & Rätselspaß – datensicher, flexibel, ohne App. Jetzt kostenlos testen!",
+  "publisher": {
+    "@type": "Organization",
+    "name": "QuizRace",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://quizrace.app/img/logo.png"
+    }
+  },
+  "sameAs": [
+    "https://www.facebook.com/quizrace",
+    "https://www.instagram.com/quizrace",
+    "https://www.linkedin.com/company/quizrace"
+  ]
+}`,
+        hreflang: '<link rel="alternate" href="https://quizrace.app/" hreflang="de" />'
+      };
+      Object.entries(example).forEach(([id, value]) => {
+        const field = form.querySelector(`#${id}`);
+        if (field) {
+          field.value = value;
+          field.dispatchEvent(new Event('input'));
+        }
+      });
+    });
+  }
+
   form.addEventListener('submit', e => {
     let valid = true;
     inputs.forEach(input => {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -637,7 +637,8 @@
                   <label class="uk-form-label">OG-Tags</label>
                   <div class="uk-form-controls">
                     <input class="uk-input uk-margin-small-bottom" id="ogTitle" name="og_title" type="text" placeholder="og:title" data-maxlength="60">
-                    <input class="uk-input" id="ogDescription" name="og_description" type="text" placeholder="og:description" data-maxlength="160">
+                    <input class="uk-input uk-margin-small-bottom" id="ogDescription" name="og_description" type="text" placeholder="og:description" data-maxlength="160">
+                    <input class="uk-input" id="ogImage" name="og_image" type="url" placeholder="og:image">
                   </div>
                 </div>
                 <div class="uk-margin">
@@ -653,7 +654,8 @@
                   </div>
                 </div>
                 <div class="uk-margin">
-                  <button type="submit" class="uk-button uk-button-primary">Speichern</button>
+                  <button type="button" class="uk-button uk-button-default import-seo-example">Beispiel importieren</button>
+                  <button type="submit" class="uk-button uk-button-primary uk-margin-left">Speichern</button>
                 </div>
               </form>
             </li>

--- a/templates/admin/landingpage/edit.html.twig
+++ b/templates/admin/landingpage/edit.html.twig
@@ -51,7 +51,8 @@
         <label class="uk-form-label">OG-Tags</label>
         <div class="uk-form-controls">
           <input class="uk-input uk-margin-small-bottom" id="ogTitle" name="og_title" type="text" placeholder="og:title" data-maxlength="60">
-          <input class="uk-input" id="ogDescription" name="og_description" type="text" placeholder="og:description" data-maxlength="160">
+          <input class="uk-input uk-margin-small-bottom" id="ogDescription" name="og_description" type="text" placeholder="og:description" data-maxlength="160">
+          <input class="uk-input" id="ogImage" name="og_image" type="url" placeholder="og:image">
         </div>
       </div>
       <div class="uk-margin">
@@ -67,7 +68,8 @@
         </div>
       </div>
       <div class="uk-margin">
-        <button type="submit" class="uk-button uk-button-primary">Speichern</button>
+        <button type="button" class="uk-button uk-button-default import-seo-example">Beispiel importieren</button>
+        <button type="submit" class="uk-button uk-button-primary uk-margin-left">Speichern</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- allow importing a predefined SEO example for landing pages
- preload fields like meta tags, schema and hreflang
- add optional OG image field

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689a9df86da0832b9e0c5a21bf62d96d