### PR TITLE
Include onboarding email in tenant creation

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify({ email })
       });
       if (res.ok) {
+        localStorage.setItem('onboard_email', email);
         emailStatus.textContent = 'E-Mail versendet. Bitte prüfe dein Postfach.';
         emailStatus.hidden = false;
       }
@@ -72,7 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
     planButtons.forEach(btn => {
       btn.addEventListener('click', async () => {
         const plan = btn.dataset.plan;
-        const email = emailInput.value.trim();
+        const email = localStorage.getItem('onboard_email') || emailInput.value.trim();
         if (!plan) return;
         localStorage.setItem('onboard_plan', plan);
         if (plan === 'starter') {
@@ -87,12 +88,14 @@ document.addEventListener('DOMContentLoaded', () => {
               body: JSON.stringify({
                 uid: subdomain,
                 schema: subdomain,
-                plan
+                plan,
+                email
               })
             });
             if (tRes.ok) {
               localStorage.removeItem('onboard_subdomain');
               localStorage.removeItem('onboard_plan');
+              localStorage.removeItem('onboard_email');
               window.location.href = `https://${subdomain}.${window.mainDomain}/`;
               return;
             }
@@ -135,6 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
           if (data.paid) {
             const subdomain = localStorage.getItem('onboard_subdomain') || '';
             const plan = localStorage.getItem('onboard_plan') || '';
+            const email = localStorage.getItem('onboard_email') || '';
             if (subdomain && plan) {
               const tRes = await fetch('/tenants', {
                 method: 'POST',
@@ -146,12 +150,14 @@ document.addEventListener('DOMContentLoaded', () => {
                   uid: subdomain,
                   schema: subdomain,
                   plan,
-                  billing: sessionId
+                  billing: sessionId,
+                  email
                 })
               });
               if (tRes.ok) {
                 localStorage.removeItem('onboard_subdomain');
                 localStorage.removeItem('onboard_plan');
+                localStorage.removeItem('onboard_email');
                 window.location.href = `https://${subdomain}.${window.mainDomain}/`;
                 return;
               }

--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -32,7 +32,8 @@ class TenantController
         try {
             $plan = isset($data['plan']) ? (string) $data['plan'] : null;
             $billing = isset($data['billing']) ? (string) $data['billing'] : null;
-            $this->service->createTenant((string) $data['uid'], (string) $data['schema'], $plan, $billing);
+            $email = isset($data['email']) ? (string) $data['email'] : null;
+            $this->service->createTenant((string) $data['uid'], (string) $data['schema'], $plan, $billing, $email);
         } catch (PDOException $e) {
             $msg = 'Database error: ' . $e->getMessage();
             error_log($msg);

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -49,6 +49,7 @@ class TenantService
         string $schema,
         ?string $plan = null,
         ?string $billing = null,
+        ?string $email = null,
         ?array $customLimits = null
     ): void {
         if ($this->exists($schema)) {
@@ -85,7 +86,7 @@ class TenantService
             null,
             null,
             null,
-            null,
+            $email,
             $customLimits !== null ? json_encode($customLimits) : null,
             $start?->format('Y-m-d H:i:sP'),
             $end?->format('Y-m-d H:i:sP'),

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -67,9 +67,11 @@ SQL;
         $dir = sys_get_temp_dir() . '/mig' . uniqid();
         $pdo = new PDO('sqlite::memory:');
         $service = $this->createService($dir, $pdo);
-        $service->createTenant('u1', 's1');
+        $service->createTenant('u1', 's1', null, null, 'u1@example.com');
         $count = (int) $pdo->query('SELECT COUNT(*) FROM tenants')->fetchColumn();
         $this->assertSame(1, $count);
+        $email = $pdo->query("SELECT imprint_email FROM tenants WHERE uid='u1'")->fetchColumn();
+        $this->assertSame('u1@example.com', $email);
     }
 
     public function testDeleteTenantRemovesRow(): void
@@ -206,7 +208,7 @@ SQL;
         $dir = sys_get_temp_dir() . '/mig' . uniqid();
         $pdo = new PDO('sqlite::memory:');
         $service = $this->createService($dir, $pdo);
-        $service->createTenant('u10', 'sub10', 'starter', null, ['maxEvents' => 2]);
+        $service->createTenant('u10', 'sub10', 'starter', null, null, ['maxEvents' => 2]);
         $limits = $service->getCustomLimitsBySubdomain('sub10');
         $this->assertSame(['maxEvents' => 2], $limits);
         $service->setCustomLimits('sub10', ['maxEvents' => 5]);


### PR DESCRIPTION
## Summary
- Store and reuse onboarding email during tenant setup
- Support optional email in tenant creation API and persistence
- Test tenant creation with imprint email

## Testing
- `vendor/bin/phpunit tests/Controller/TenantControllerTest.php tests/Service/TenantServiceTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689aa262cf20832b9275384c3db5c361