### PR TITLE
Handle tenant creation conflicts

### DIFF
--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -34,6 +34,13 @@ class TenantController
             $billing = isset($data['billing']) ? (string) $data['billing'] : null;
             $this->service->createTenant((string) $data['uid'], (string) $data['schema'], $plan, $billing);
         } catch (PDOException $e) {
+            $code = (string) $e->getCode();
+            if (in_array($code, ['23505', '23000'], true)) {
+                $response->getBody()->write(json_encode(['error' => 'tenant-exists']));
+                return $response
+                    ->withStatus(409)
+                    ->withHeader('Content-Type', 'application/json');
+            }
             $msg = 'Database error: ' . $e->getMessage();
             error_log($msg);
             if ($this->displayErrors) {


### PR DESCRIPTION
## Summary
- Return HTTP 409 with JSON `{"error":"tenant-exists"}` when tenant creation hits a unique constraint.
- Keep existing logging for other PDO errors.

## Testing
- `composer test`
- `vendor/bin/phpcs src/Controller/TenantController.php`


------
https://chatgpt.com/codex/tasks/task_e_689aa3894ef0832ba2178b964adca34a