### PR TITLE
Show billing email in subscription tab

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -175,6 +175,7 @@ return [
       'billing_invoice' => 'Rechnung',
       'billing_credit' => 'Kreditkarte',
       'billing_paypal' => 'PayPal',
+      'subscription_email' => 'Rechnungs-E-Mail',
       'stripe_payment_terms' => 'Die Zahlung wird über Stripe abgewickelt. Es gelten die <a href="https://stripe.com/payment-terms/legal" target="_blank" rel="noopener">Stripe-Zahlungsbedingungen</a>.',
       'action_delete' => 'Löschen',
       'action_cancel' => 'Abbrechen',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -175,6 +175,7 @@ return [
       'billing_invoice' => 'Invoice',
       'billing_credit' => 'Credit card',
       'billing_paypal' => 'PayPal',
+      'subscription_email' => 'Billing email',
       'stripe_payment_terms' => 'Payment is processed via Stripe. The <a href="https://stripe.com/payment-terms/legal" target="_blank" rel="noopener">Stripe payment terms</a> apply.',
       'action_delete' => 'Delete',
       'action_cancel' => 'Cancel',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -830,6 +830,9 @@
             data-plan-starter="{{ t('plan_starter') }}"
             data-plan-standard="{{ t('plan_standard') }}"
             data-plan-professional="{{ t('plan_professional') }}"></div>
+          {% if tenant and tenant.imprint_email %}
+            <p>{{ t('subscription_email') }}: {{ tenant.imprint_email }}</p>
+          {% endif %}
         </div>
         <p><a class="uk-button uk-button-primary" href="{{ upgradeUrl }}">{{ hasCustomer ? t('action_open_subscription') : t('action_start_subscription') }}</a></p>
         <script>


### PR DESCRIPTION
## Summary
- Display tenant billing email on the admin subscription card
- Add `subscription_email` translation for English and German

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689aa3d565ec832ba45ce9997643b072