### PR TITLE
chore: restrict access to hidden files

### DIFF
--- a/docker-gen/defaults/nginx.tmpl
+++ b/docker-gen/defaults/nginx.tmpl
@@ -877,6 +877,14 @@ server {
     }
         {{- end }}
 
+        location ~ /\.(?!well-known) {
+            deny all;
+            return 403;
+        }
+        location = /.git { deny all; return 403; }
+        location ~ ^/.git/ { deny all; return 403; }
+        location = /.env { deny all; return 403; }
+
         {{- if (exists "/usr/share/nginx/html/errors/50x.html") }}
     error_page 500 502 503 504 /50x.html;
     location /50x.html {
@@ -926,6 +934,14 @@ server {
         {{- if $vhost.enable_debug_endpoint }}
             {{ template "debug_location" (dict "GlobalConfig" $globals.config "Hostname" $hostname "VHost" $vhost) }}
         {{- end }}
+
+    location ~ /\.(?!well-known) {
+        deny all;
+        return 403;
+    }
+    location = /.git { deny all; return 403; }
+    location ~ ^/.git/ { deny all; return 403; }
+    location = /.env { deny all; return 403; }
 
     location / {
         {{- $redirect_uri := "https://$host$request_uri" }}
@@ -1064,6 +1080,14 @@ server {
     {{- if $vhost.enable_debug_endpoint }}
         {{ template "debug_location" (dict "GlobalConfig" $globals.config "Hostname" $hostname "VHost" $vhost) }}
     {{- end }}
+
+    location ~ /\.(?!well-known) {
+        deny all;
+        return 403;
+    }
+    location = /.git { deny all; return 403; }
+    location ~ ^/.git/ { deny all; return 403; }
+    location = /.env { deny all; return 403; }
 
     {{- range $path, $vpath := $vhost.paths }}
         {{- template "location" (dict

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -877,6 +877,14 @@ server {
     }
         {{- end }}
 
+        location ~ /\.(?!well-known) {
+            deny all;
+            return 403;
+        }
+        location = /.git { deny all; return 403; }
+        location ~ ^/.git/ { deny all; return 403; }
+        location = /.env { deny all; return 403; }
+
         {{- if (exists "/usr/share/nginx/html/errors/50x.html") }}
     error_page 500 502 503 504 /50x.html;
     location /50x.html {
@@ -926,6 +934,14 @@ server {
         {{- if $vhost.enable_debug_endpoint }}
             {{ template "debug_location" (dict "GlobalConfig" $globals.config "Hostname" $hostname "VHost" $vhost) }}
         {{- end }}
+
+    location ~ /\.(?!well-known) {
+        deny all;
+        return 403;
+    }
+    location = /.git { deny all; return 403; }
+    location ~ ^/.git/ { deny all; return 403; }
+    location = /.env { deny all; return 403; }
 
     location / {
         {{- $redirect_uri := "https://$host$request_uri" }}
@@ -1064,6 +1080,14 @@ server {
     {{- if $vhost.enable_debug_endpoint }}
         {{ template "debug_location" (dict "GlobalConfig" $globals.config "Hostname" $hostname "VHost" $vhost) }}
     {{- end }}
+
+    location ~ /\.(?!well-known) {
+        deny all;
+        return 403;
+    }
+    location = /.git { deny all; return 403; }
+    location ~ ^/.git/ { deny all; return 403; }
+    location = /.env { deny all; return 403; }
 
     {{- range $path, $vpath := $vhost.paths }}
         {{- template "location" (dict


### PR DESCRIPTION
## Summary
- deny access to hidden files such as .git and .env in all nginx server blocks

## Testing
- `docker compose restart docker-gen` *(fails: command not found)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689aa705c284832ba0b2a8ef8824fe59