### PR TITLE
fix: remove redundant null coalesce

### DIFF
--- a/src/Controller/StripeCheckoutController.php
+++ b/src/Controller/StripeCheckoutController.php
@@ -42,7 +42,7 @@ class StripeCheckoutController
             'standard' => getenv($prefix . 'PRICE_STANDARD') ?: '',
             'professional' => getenv($prefix . 'PRICE_PROFESSIONAL') ?: '',
         ];
-        $priceId = $priceMap[$plan] ?? '';
+        $priceId = $priceMap[$plan];
         if ($priceId === '') {
             return $this->jsonError($response, 422, 'invalid plan');
         }


### PR DESCRIPTION
## Summary
- fix: remove redundant null coalesce in StripeCheckoutController

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `vendor/bin/phpunit`
- `vendor/bin/phpcs src/Controller/StripeCheckoutController.php`


------
https://chatgpt.com/codex/tasks/task_e_689abdfd30bc832b93a3628590a14484