### PR TITLE
Use Plan enum for Stripe checkout

### DIFF
--- a/src/Domain/Plan.php
+++ b/src/Domain/Plan.php
@@ -4,57 +4,36 @@ declare(strict_types=1);
 
 namespace App\Domain;
 
-final class Plan
+enum Plan: string
 {
-    public const STARTER = 'starter';
-    public const STANDARD = 'standard';
-    public const PROFESSIONAL = 'professional';
-
-    public const ALL = [
-        self::STARTER,
-        self::STANDARD,
-        self::PROFESSIONAL,
-    ];
+    case STARTER = 'starter';
+    case STANDARD = 'standard';
+    case PROFESSIONAL = 'professional';
 
     /**
-     * @var array<
-     *     string,
-     *     array{
-     *         maxEvents: int|null,
-     *         maxTeamsPerEvent: int|null,
-     *         maxCatalogsPerEvent: int|null,
-     *         maxQuestionsPerCatalog: int|null
-     *     }
-     * >
+     * @return array<string,int|null>
      */
-    public const LIMITS = [
-        self::STARTER => [
-            'maxEvents' => 1,
-            'maxTeamsPerEvent' => 5,
-            'maxCatalogsPerEvent' => 5,
-            'maxQuestionsPerCatalog' => 5,
-        ],
-        self::STANDARD => [
-            'maxEvents' => 3,
-            'maxTeamsPerEvent' => 10,
-            'maxCatalogsPerEvent' => 10,
-            'maxQuestionsPerCatalog' => 10,
-        ],
-        self::PROFESSIONAL => [
-            'maxEvents' => 20,
-            'maxTeamsPerEvent' => 100,
-            'maxCatalogsPerEvent' => 50,
-            'maxQuestionsPerCatalog' => 50,
-        ],
-    ];
-
-    public static function limits(string $plan): array
+    public function limits(): array
     {
-        return self::LIMITS[$plan] ?? [];
-    }
-
-    public static function isValid(string $plan): bool
-    {
-        return in_array($plan, self::ALL, true);
+        return match ($this) {
+            self::STARTER => [
+                'maxEvents' => 1,
+                'maxTeamsPerEvent' => 5,
+                'maxCatalogsPerEvent' => 5,
+                'maxQuestionsPerCatalog' => 5,
+            ],
+            self::STANDARD => [
+                'maxEvents' => 3,
+                'maxTeamsPerEvent' => 10,
+                'maxCatalogsPerEvent' => 10,
+                'maxQuestionsPerCatalog' => 10,
+            ],
+            self::PROFESSIONAL => [
+                'maxEvents' => 20,
+                'maxTeamsPerEvent' => 100,
+                'maxCatalogsPerEvent' => 50,
+                'maxQuestionsPerCatalog' => 50,
+            ],
+        };
     }
 }

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -55,7 +55,7 @@ class TenantService
         if ($this->exists($schema)) {
             throw new \RuntimeException('tenant-exists');
         }
-        if ($plan !== null && !Plan::isValid($plan)) {
+        if ($plan !== null && Plan::tryFrom($plan) === null) {
             throw new \RuntimeException('invalid-plan');
         }
         if ($this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
@@ -345,7 +345,7 @@ class TenantService
             return $custom;
         }
         $plan = $this->getPlanBySubdomain($subdomain);
-        return $plan !== null ? Plan::limits($plan) : [];
+        return $plan !== null ? (Plan::tryFrom($plan)?->limits() ?? []) : [];
     }
 
     /**
@@ -408,7 +408,7 @@ class TenantService
         $params = [];
         foreach ($fields as $f) {
             if (array_key_exists($f, $data)) {
-                if ($f === 'plan' && $data[$f] !== null && !Plan::isValid((string) $data[$f])) {
+                if ($f === 'plan' && $data[$f] !== null && Plan::tryFrom((string) $data[$f]) === null) {
                     throw new \RuntimeException('invalid-plan');
                 }
                 $set[] = $f . ' = ?';

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -221,8 +221,8 @@ SQL;
         $dir = sys_get_temp_dir() . '/mig' . uniqid();
         $pdo = new PDO('sqlite::memory:');
         $service = $this->createService($dir, $pdo);
-        $service->createTenant('u12', 'sub12', Plan::STARTER);
-        $this->assertSame(Plan::STARTER, $service->getPlanBySubdomain('sub12'));
+        $service->createTenant('u12', 'sub12', Plan::STARTER->value);
+        $this->assertSame(Plan::STARTER->value, $service->getPlanBySubdomain('sub12'));
 
         $webhook = new TenantService($pdo, $dir, new class extends \App\Service\NginxService {
             public function __construct()
@@ -233,9 +233,9 @@ SQL;
             {
             }
         });
-        $webhook->updateProfile('sub12', ['plan' => Plan::STANDARD]);
-        $this->assertSame(Plan::STANDARD, $service->getPlanBySubdomain('sub12'));
-        $this->assertSame(Plan::limits(Plan::STANDARD), $service->getLimitsBySubdomain('sub12'));
+        $webhook->updateProfile('sub12', ['plan' => Plan::STANDARD->value]);
+        $this->assertSame(Plan::STANDARD->value, $service->getPlanBySubdomain('sub12'));
+        $this->assertSame(Plan::STANDARD->limits(), $service->getLimitsBySubdomain('sub12'));
 
         $webhook->setCustomLimits('sub12', ['maxEvents' => 4]);
         $this->assertSame(['maxEvents' => 4], $service->getLimitsBySubdomain('sub12'));


### PR DESCRIPTION
## Summary
- replace string plan handling with `Plan` enum
- look up Stripe prices and tenant limits via enum cases

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689abfd1b8f0832b9fb7d45fafd66b58