### PR TITLE
Handle missing Monolog dependency with NullLogger fallback

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -34,10 +34,13 @@ use App\Service\TranslationService;
 use App\Service\StripeService;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
+use Psr\Log\NullLogger;
 
-// set up logger
-$logger = new Logger('app');
-$logger->pushHandler(new StreamHandler(__DIR__ . '/../logs/app.log'));
+// set up logger and fall back to NullLogger if Monolog is unavailable
+$logger = class_exists(Logger::class) ? new Logger('app') : new NullLogger();
+if ($logger instanceof Logger) {
+    $logger->pushHandler(new StreamHandler(__DIR__ . '/../logs/app.log'));
+}
 
 // verify Stripe configuration before starting the app
 if (!StripeService::isConfigured()) {


### PR DESCRIPTION
## Summary
- Gracefully handle missing Monolog by falling back to Psr\Log\NullLogger

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689ac2051aec832bb51fc63db51acd99