### PR TITLE
feat: add subscription usage widget

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -108,30 +108,32 @@
   }
 
   function renderSubscription() {
-    const el = document.getElementById('subscription');
-    if (!el || !state.subscription) return;
+    const els = document.querySelectorAll('[data-subscription]');
+    if (!els.length || !state.subscription) return;
     const sub = state.subscription;
-    const labels = {
-      plan: el.dataset.labelPlan || 'Plan',
-      events: el.dataset.labelEvents || 'Events',
-      catalogs: el.dataset.labelCatalogs || 'Catalogs',
-      questions: el.dataset.labelQuestions || 'Questions'
-    };
-    const planKey = sub.plan || '';
-    const planName = el.dataset['plan' + capitalize(planKey)] || planKey || '-';
-    const limits = sub.limits || {};
-    const usage = sub.usage || {};
-    const items = [
-      { label: labels.events, used: usage.events, max: limits.maxEvents },
-      { label: labels.catalogs, used: usage.catalogs, max: limits.maxCatalogsPerEvent },
-      { label: labels.questions, used: usage.questions, max: limits.maxQuestionsPerCatalog }
-    ];
-    el.innerHTML = `<div><strong>${labels.plan}: ${planName}</strong></div>` +
-      items.map(it => {
-        const maxText = it.max === null || it.max === undefined ? '∞' : it.max;
-        const pct = typeof it.max === 'number' ? Math.min(100, Math.round((it.used / it.max) * 100)) : 0;
-        return `<div class="uk-margin-small-top"><div class="uk-flex uk-flex-between"><span>${it.label}</span><span>${it.used}${it.max !== null && it.max !== undefined ? ' / ' + maxText : ''}</span></div>${it.max !== null && it.max !== undefined ? `<progress class="uk-progress" value="${pct}" max="100"></progress>` : ''}</div>`;
-      }).join('');
+    els.forEach(el => {
+      const labels = {
+        plan: el.dataset.labelPlan || 'Plan',
+        events: el.dataset.labelEvents || 'Events',
+        catalogs: el.dataset.labelCatalogs || 'Catalogs',
+        questions: el.dataset.labelQuestions || 'Questions'
+      };
+      const planKey = sub.plan || '';
+      const planName = el.dataset['plan' + capitalize(planKey)] || planKey || '-';
+      const limits = sub.limits || {};
+      const usage = sub.usage || {};
+      const items = [
+        { label: labels.events, used: usage.events, max: limits.maxEvents },
+        { label: labels.catalogs, used: usage.catalogs, max: limits.maxCatalogsPerEvent },
+        { label: labels.questions, used: usage.questions, max: limits.maxQuestionsPerCatalog }
+      ];
+      el.innerHTML = `<div><strong>${labels.plan}: ${planName}</strong></div>` +
+        items.map(it => {
+          const maxText = it.max === null || it.max === undefined ? '∞' : it.max;
+          const pct = typeof it.max === 'number' ? Math.min(100, Math.round((it.used / it.max) * 100)) : 0;
+          return `<div class="uk-margin-small-top"><div class="uk-flex uk-flex-between"><span>${it.label}</span><span>${it.used}${it.max !== null && it.max !== undefined ? ' / ' + maxText : ''}</span></div>${it.max !== null && it.max !== undefined ? `<progress class="uk-progress" value="${pct}" max="100"></progress>` : ''}</div>`;
+        }).join('');
+    });
   }
 
   function capitalize(s){ return s ? s.charAt(0).toUpperCase() + s.slice(1) : s; }

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -43,6 +43,7 @@ return [
     'heading_tenants' => 'Subdomains',
     'heading_profile' => 'Profil',
     'heading_subscription' => 'Abo',
+    'heading_subscription_usage' => 'Abo-Auslastung',
     'heading_homepage' => 'Startseite',
     'heading_registration' => 'Registrierung',
     'heading_users' => 'Benutzer',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -43,6 +43,7 @@ return [
     'heading_tenants' => 'Subdomains',
     'heading_profile' => 'Profile',
     'heading_subscription' => 'Subscription',
+    'heading_subscription_usage' => 'Subscription usage',
     'heading_homepage' => 'Homepage',
     'heading_registration' => 'Registration',
     'heading_users' => 'Users',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -104,8 +104,20 @@
               <div class="uk-margin-small">
                 <span class="uk-badge" id="badge-draft">0 Entwürfe</span>
                 <span class="uk-badge" id="badge-scheduled">0 geplant</span>
-              <span class="uk-badge" id="badge-running">0 live</span>
-              <span class="uk-badge" id="badge-finished">0 abgeschlossen</span>
+                <span class="uk-badge" id="badge-running">0 live</span>
+                <span class="uk-badge" id="badge-finished">0 abgeschlossen</span>
+              </div>
+
+              <div class="uk-card uk-card-default uk-card-body uk-margin-small">
+                <h3 class="uk-card-title uk-margin-remove">{{ t('heading_subscription_usage') }}</h3>
+                <div data-subscription
+                     data-label-plan="{{ t('label_plan') }}"
+                     data-label-events="{{ t('label_events') }}"
+                     data-label-catalogs="{{ t('label_catalogs') }}"
+                     data-label-questions="{{ t('label_questions') }}"
+                     data-plan-starter="{{ t('plan_starter') }}"
+                     data-plan-standard="{{ t('plan_standard') }}"
+                     data-plan-professional="{{ t('plan_professional') }}"></div>
               </div>
             </div>
 
@@ -822,7 +834,7 @@
         {% set hasCustomer = tenant and tenant.stripe_customer_id %}
         {% set upgradeUrl = hasCustomer ? basePath ~ '/admin/subscription/portal' : basePath ~ '/onboarding' %}
         <div class="uk-card uk-card-default uk-card-body uk-margin-small" id="subscription-card">
-          <div id="subscription"
+          <div data-subscription
             data-label-plan="{{ t('label_plan') }}"
             data-label-events="{{ t('label_events') }}"
             data-label-catalogs="{{ t('label_catalogs') }}"


### PR DESCRIPTION
## Summary
- show plan usage on dashboard with progress bars
- render subscription info for both dashboard and subscription page
- translate subscription usage heading

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689ac356b24c832bbe143f9b8fef5f69