### PR TITLE
style: improve event selector display

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -511,7 +511,7 @@ body.admin-page {
   transform: none;
 }
 
-.admin-page #eventSelect {
+.admin-page #eventSelectWrap {
   flex: 1;
 }
 
@@ -538,8 +538,9 @@ body.admin-page {
   .admin-page .topbar .uk-navbar-center {
     width: auto;
   }
-  .admin-page #eventSelect {
+  .admin-page #eventSelectWrap {
     flex: 0;
+    min-width: 220px;
   }
   .admin-page .nav-placeholder {
     height: 56px;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -34,7 +34,13 @@
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
-        <select id="eventSelect" class="uk-select"></select>
+        <div id="eventSelectWrap" class="uk-form-custom uk-flex-1" uk-form-custom="target: > * > span:first-child">
+          <select id="eventSelect" aria-label="{{ t('label_events') }}"></select>
+          <button class="uk-button uk-button-default" type="button" tabindex="-1">
+            <span></span>
+            <span uk-icon="icon: chevron-down"></span>
+          </button>
+        </div>
         <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
       </div>
     {% endblock %}

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -15,7 +15,13 @@
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
-        <select id="eventSelect" class="uk-select"></select>
+        <div id="eventSelectWrap" class="uk-form-custom uk-flex-1" uk-form-custom="target: > * > span:first-child">
+          <select id="eventSelect" aria-label="{{ t('label_events') }}"></select>
+          <button class="uk-button uk-button-default" type="button" tabindex="-1">
+            <span></span>
+            <span uk-icon="icon: chevron-down"></span>
+          </button>
+        </div>
         <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
       </div>
     {% endblock %}

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -15,7 +15,13 @@
     {% block center %}
       <div class="uk-flex uk-flex-middle">
         <div id="eventSelectWrap" class="uk-flex uk-flex-middle" hidden>
-          <select id="eventSelect" class="uk-select"></select>
+          <div class="uk-form-custom uk-flex-1" uk-form-custom="target: > * > span:first-child">
+            <select id="eventSelect" aria-label="{{ t('label_events') }}"></select>
+            <button class="uk-button uk-button-default" type="button" tabindex="-1">
+              <span></span>
+              <span uk-icon="icon: chevron-down"></span>
+            </button>
+          </div>
           <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
         </div>
         <span id="eventTitle" class="uk-navbar-title uk-text-center">{{ event.name|default('Sommerfest 2025') }}</span>


### PR DESCRIPTION
## Summary
- replace plain select with custom UIkit form for event switching
- size event selector wrapper so options stay visible on desktop

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689ac6d419bc832ba79d99fdefea1716