### PR TITLE
Ensure event selector displays active event

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -53,6 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     if (selectWrap) selectWrap.hidden = false;
     if (eventTitle) eventTitle.hidden = true;
+    eventSelect.dispatchEvent(new Event('change'));
   }
 
   function setActive(uid) {


### PR DESCRIPTION
## Summary
- Trigger change event after populating event options so the current event name is shown

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689ac9d3c000832ba023c7c285f300a8