### PR TITLE
Add 7-day trial to Stripe checkout sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Mit dieser App zeigen wir, was heute schon möglich ist, wenn Menschen und versc
 - **Backup per JSON**: Alle Daten lassen sich exportieren und wieder importieren.
 - **Automatische Bildkompression**: Hochgeladene Fotos werden nun standardmäßig verkleinert und komprimiert.
 - **Rätselwort und Foto-Einwilligung**: Optionales Puzzlewort-Spiel mit DSGVO-konformen Foto-Uploads.
+- **Kostenloser Testzeitraum**: Neue Stripe-Abonnements starten mit einer 7-tägigen Testphase.
 
 ## Fokus der Entwicklung
 

--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -40,6 +40,7 @@ class StripeService
                 ['price' => $priceId, 'quantity' => 1],
             ],
             'payment_method_types' => ['card'],
+            'subscription_data' => ['trial_period_days' => 7],
             'success_url' => $successUrl,
             'cancel_url' => $cancelUrl,
         ];

--- a/tests/Service/StripeServiceTest.php
+++ b/tests/Service/StripeServiceTest.php
@@ -38,11 +38,12 @@ class FakeStripeClient extends \Stripe\StripeClient
 
 final class StripeServiceTest extends TestCase
 {
-    public function testCreateCheckoutSessionAddsPaymentMethodTypes(): void
+    public function testCreateCheckoutSessionAddsPaymentMethodTypesAndTrialPeriod(): void
     {
         $client = new FakeStripeClient();
         $service = new StripeService(client: $client);
         $service->createCheckoutSession('price_123', 'https://success', 'https://cancel', 'user@example.com');
         $this->assertSame(['card'], $client->checkout->sessions->lastParams['payment_method_types'] ?? null);
+        $this->assertSame(7, $client->checkout->sessions->lastParams['subscription_data']['trial_period_days'] ?? null);
     }
 }


### PR DESCRIPTION
## Summary
- start new Stripe checkout sessions with a 7-day trial period
- verify trial period and payment method in StripeService test
- document new trial period in README

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689ac9eb777c832b8cc65e3329e26abe