### PR TITLE
Add 7-day trial information to subscription descriptions

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -199,7 +199,7 @@ window.addEventListener('load', () => {
 <section id="pricing" class="uk-section" style="background:#f9f9f9">
     <div class="uk-container">
       <h2 class="uk-heading-medium uk-text-center text-black" uk-scrollspy="cls: uk-animation-slide-top-small">Abomodelle für jedes Event</h2>
-      <p class="uk-text-center uk-text-lead uk-margin-large-bottom" uk-scrollspy="cls: uk-animation-fade; delay: 150">Einfacher Start – faire Preise – alle Funktionen jederzeit testen!</p>
+      <p class="uk-text-center uk-text-lead uk-margin-large-bottom" uk-scrollspy="cls: uk-animation-fade; delay: 150">Einfacher Start – faire Preise – alle Abos 7 Tage kostenlos testen!</p>
       <div class="uk-grid-large uk-child-width-1-3@m uk-flex-center uk-grid-match pricing-grid" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
       <!-- Starter -->
       <div>
@@ -227,6 +227,7 @@ window.addEventListener('load', () => {
           <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700; color:#fff;">39&nbsp;€/Monat</div>
           <div class="uk-text-meta uk-margin-small-bottom" style="color:#fff;">Beliebt bei Schulen & Teams</div>
           <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom" style="color:#fff;">
+            <li><b>7 Tage kostenlos testen</b></li>
             <li><b>Alle Starter-Funktionen</b></li>
             <li>Bis zu 3 Events gleichzeitig</li>
             <li>10 Teams &amp; 10 Kataloge à 10 Fragen</li>
@@ -244,6 +245,7 @@ window.addEventListener('load', () => {
           <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">79&nbsp;€/Monat</div>
           <div class="uk-text-meta uk-margin-small-bottom">Für Agenturen & Unternehmen</div>
           <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom">
+            <li><b>7 Tage kostenlos testen</b></li>
             <li><b>Alle Standard-Funktionen</b></li>
             <li>20 Events gleichzeitig (mehr auf Anfrage)</li>
             <li>100 Teams &amp; 50 Kataloge à 50 Fragen</li>

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -114,7 +114,7 @@
     <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-margin-auto" id="step3" hidden>
       <h3 class="uk-card-title">3. Tarif wählen</h3>
       {% if stripe_configured %}
-      <p>Wähle einen Tarif und schließe die Zahlung über Stripe ab.</p>
+      <p>Wähle einen Tarif und schließe die Zahlung über Stripe ab. Du kannst jeden kostenpflichtigen Tarif 7 Tage lang kostenlos testen.</p>
       {% else %}
       <p class="uk-text-danger">Zahlungsdienstleister nicht konfiguriert. Nur der kostenlose Starter-Tarif ist verfügbar.</p>
       {% endif %}
@@ -144,6 +144,7 @@
             <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700; color:#fff;">39&nbsp;€/Monat</div>
             <div class="uk-text-meta uk-margin-small-bottom" style="color:#fff;">Beliebt bei Schulen &amp; Teams</div>
             <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom" style="color:#fff;">
+              <li><b>7 Tage kostenlos testen</b></li>
               <li><b>Alle Starter-Funktionen</b></li>
               <li>Bis zu 3 Events gleichzeitig</li>
               <li>10 Teams &amp; 10 Kataloge à 10 Fragen</li>
@@ -160,6 +161,7 @@
             <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">79&nbsp;€/Monat</div>
             <div class="uk-text-meta uk-margin-small-bottom">Für Agenturen &amp; Unternehmen</div>
             <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom">
+              <li><b>7 Tage kostenlos testen</b></li>
               <li><b>Alle Standard-Funktionen</b></li>
               <li>20 Events gleichzeitig (mehr auf Anfrage)</li>
               <li>100 Teams &amp; 50 Kataloge à 50 Fragen</li>


### PR DESCRIPTION
## Summary
- Highlight 7-day free trial availability on the landing page pricing section
- Emphasize 7-day trial during onboarding and in paid plan feature lists

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689aca4ee1a0832b9197eb095f39abdb