### PR TITLE
Remove 'eingeben' from feedback text button

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', function () {
       puzzleLabel.textContent = 'Feedbacktext bearbeiten';
     } else {
       puzzleIcon.setAttribute('uk-icon', 'icon: pencil');
-      puzzleLabel.textContent = 'Feedbacktext eingeben';
+      puzzleLabel.textContent = 'Feedbacktext';
     }
     UIkit.icon(puzzleIcon, { icon: puzzleIcon.getAttribute('uk-icon').split(': ')[1] });
   }

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -146,7 +146,7 @@ return [
     'label_puzzle_word' => 'Rätselwort',
     'placeholder_puzzle_word' => 'Rätselwort',
     'action_edit_feedback' => 'Feedbacktext bearbeiten',
-    'placeholder_feedback' => 'Feedbacktext eingeben...',
+    'placeholder_feedback' => 'Feedbacktext...',
     'heading_feedback' => 'Feedbacktext für das Rätselwort',
     'heading_catalog_comment' => 'Kommentar zum Katalog',
     'placeholder_catalog_comment' => 'Kommentar eingeben...',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -146,7 +146,7 @@ return [
     'label_puzzle_word' => 'Puzzle word',
     'placeholder_puzzle_word' => 'Puzzle word',
     'action_edit_feedback' => 'Edit feedback text',
-    'placeholder_feedback' => 'Enter feedback text...',
+    'placeholder_feedback' => 'Feedback text...',
     'heading_feedback' => 'Feedback text for the puzzle word',
     'heading_catalog_comment' => 'Catalog comment',
     'placeholder_catalog_comment' => 'Enter comment...',


### PR DESCRIPTION
## Summary
- Trim feedback text button label
- Drop 'eingeben' from feedback placeholder in translations

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689acb9977e4832b800968fe49390937