### PR TITLE
Add randomNames column to config schema

### DIFF
--- a/data-default/config.json
+++ b/data-default/config.json
@@ -8,6 +8,7 @@
   "buttonColor": "#1e87f0",
   "CheckAnswerButton": "no",
   "QRRestrict": false,
+  "randomNames": true,
   "competitionMode": false,
   "teamResults": true,
   "photoUpload": true,

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS config (
     buttonColor TEXT,
     CheckAnswerButton TEXT,
     QRRestrict BOOLEAN,
+    randomNames BOOLEAN DEFAULT TRUE,
     competitionMode BOOLEAN,
     teamResults BOOLEAN,
     photoUpload BOOLEAN,

--- a/migrations/20241206_add_random_names_to_config.sql
+++ b/migrations/20241206_add_random_names_to_config.sql
@@ -1,0 +1,2 @@
+ALTER TABLE config ADD COLUMN IF NOT EXISTS randomNames BOOLEAN DEFAULT TRUE;
+UPDATE config SET randomNames = TRUE WHERE randomNames IS NULL;


### PR DESCRIPTION
## Summary
- ensure config table has `randomNames` column
- document `randomNames` in schema and default config

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689acc4a7d64832bab6cdb4caec023ec