### PR TITLE
fix: improve dark mode menu active state

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -122,6 +122,13 @@ body.dark-mode .uk-icon-button {
   color: #fff;
 }
 
+/* Active state for navigation items in dark mode */
+body.dark-mode .uk-navbar-nav > li.uk-active > a,
+body.dark-mode .uk-nav-default > li.uk-active > a {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
 /* Styles for Trumbowyg editor in Dark Mode */
 body.dark-mode .trumbowyg-box,
 body.dark-mode .trumbowyg-editor {


### PR DESCRIPTION
## Summary
- ensure dark theme navigation links use contrasting background color

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689ace79b404832b8402231d39480e08