### PR TITLE
Replace puzzle feedback save icon with text button

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -312,7 +312,7 @@
             <h2 class="uk-modal-title">{{ t('heading_feedback') }}</h2>
             <textarea id="puzzleFeedbackTextarea" class="uk-textarea" rows="5" placeholder="{{ t('placeholder_feedback') }}"></textarea>
             <div class="uk-flex uk-flex-right uk-margin-top">
-              <button id="puzzleFeedbackSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="button"></button>
+              <button id="puzzleFeedbackSave" class="uk-button uk-button-primary" type="button">{{ t('action_save') }}</button>
               <button class="uk-button uk-button-default uk-modal-close" type="button">{{ t('action_cancel') }}</button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- replace save icon in puzzle feedback modal with primary save button using translation

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689b5099878c832bbe3056524c6837b6