### PR TITLE
Integrate Stripe checkout on admin subscription page

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -57,6 +57,38 @@ document.addEventListener('DOMContentLoaded', function () {
   const pagesInitial = window.pagesContent || {};
   const profileForm = document.getElementById('profileForm');
   const profileSaveBtn = document.getElementById('profileSaveBtn');
+  const planButtons = document.querySelectorAll('.plan-select');
+  planButtons.forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const plan = btn.dataset.plan;
+      if (!plan) return;
+      try {
+        const res = await fetch(withBase('/admin/subscription/checkout'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ plan })
+        });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.url) {
+            window.location.href = data.url;
+          }
+        }
+      } catch (e) {
+        // ignore
+      }
+    });
+  });
+
+  const params = new URLSearchParams(window.location.search);
+  const sessionId = params.get('session_id');
+  if (sessionId) {
+    fetch(withBase('/admin/subscription/checkout/' + encodeURIComponent(sessionId)))
+      .then(() => {
+        window.history.replaceState({}, document.title, window.location.pathname);
+        window.location.reload();
+      });
+  }
 
   function slugify(text) {
     return text

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -17,6 +17,7 @@ use App\Service\UserService;
 use App\Service\TenantService;
 use App\Domain\Roles;
 use App\Infrastructure\Database;
+use App\Service\StripeService;
 use PDO;
 
 /**
@@ -176,6 +177,7 @@ class AdminController
               'pages' => $pages,
               'domainType' => $request->getAttribute('domainType'),
               'tenant' => $tenant,
+              'stripe_configured' => StripeService::isConfigured(),
               'currentPath' => $request->getUri()->getPath(),
           ]);
     }

--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Domain\Plan;
+use App\Infrastructure\Database;
+use App\Service\StripeService;
+use App\Service\TenantService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Start a Stripe Checkout session from the admin subscription page.
+ */
+class AdminSubscriptionCheckoutController
+{
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+
+        $plan = Plan::tryFrom((string) ($data['plan'] ?? ''));
+        if ($plan === null) {
+            return $this->jsonError($response, 422, 'invalid plan');
+        }
+
+        $host = $request->getUri()->getHost();
+        $sub = explode('.', $host)[0];
+
+        $base = Database::connectFromEnv();
+        $tenantService = new TenantService($base);
+        $tenant = $tenantService->getBySubdomain($sub);
+        if ($tenant === null) {
+            return $this->jsonError($response, 404, 'tenant not found');
+        }
+
+        $email = (string) ($tenant['imprint_email'] ?? '');
+        $customerId = (string) ($tenant['stripe_customer_id'] ?? '');
+        if ($email === '' && $customerId === '') {
+            return $this->jsonError($response, 422, 'missing email');
+        }
+
+        if (!StripeService::isConfigured()) {
+            return $this->jsonError($response, 503, 'service unavailable');
+        }
+
+        $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
+        $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';
+        $priceMap = [
+            Plan::STARTER->value => getenv($prefix . 'PRICE_STARTER') ?: '',
+            Plan::STANDARD->value => getenv($prefix . 'PRICE_STANDARD') ?: '',
+            Plan::PROFESSIONAL->value => getenv($prefix . 'PRICE_PROFESSIONAL') ?: '',
+        ];
+        $priceId = $priceMap[$plan->value];
+        if ($priceId === '') {
+            return $this->jsonError($response, 422, 'invalid plan');
+        }
+
+        $uri = $request->getUri();
+        $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
+        $successUrl = $baseUrl . '/admin/subscription?session_id={CHECKOUT_SESSION_ID}';
+        $cancelUrl = $baseUrl . '/admin/subscription';
+
+        $service = new StripeService();
+        try {
+            $url = $service->createCheckoutSession(
+                $priceId,
+                $successUrl,
+                $cancelUrl,
+                $customerId === '' ? $email : null,
+                $customerId !== '' ? $customerId : null,
+                $sub
+            );
+        } catch (\Throwable $e) {
+            error_log($e->getMessage());
+            return $this->jsonError($response, 500, 'internal error');
+        }
+
+        $payload = json_encode(['url' => $url]);
+        $response->getBody()->write($payload !== false ? $payload : '{}');
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    private function jsonError(Response $response, int $status, string $message): Response
+    {
+        $payload = json_encode(['error' => $message]);
+        $response->getBody()->write($payload !== false ? $payload : '{}');
+        return $response->withStatus($status)->withHeader('Content-Type', 'application/json');
+    }
+}

--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -32,7 +32,9 @@ class StripeService
         string $priceId,
         string $successUrl,
         string $cancelUrl,
-        ?string $customerEmail = null
+        ?string $customerEmail = null,
+        ?string $customerId = null,
+        ?string $clientReferenceId = null
     ): string {
         $params = [
             'mode' => 'subscription',
@@ -46,6 +48,12 @@ class StripeService
         ];
         if ($customerEmail !== null) {
             $params['customer_email'] = $customerEmail;
+        }
+        if ($customerId !== null) {
+            $params['customer'] = $customerId;
+        }
+        if ($clientReferenceId !== null) {
+            $params['client_reference_id'] = $clientReferenceId;
         }
         $session = $this->client->checkout->sessions->create($params);
         return (string) $session->url;

--- a/src/routes.php
+++ b/src/routes.php
@@ -67,6 +67,7 @@ use App\Controller\StripeCheckoutController;
 use App\Controller\StripeSessionController;
 use App\Controller\StripeWebhookController;
 use App\Controller\SubscriptionController;
+use App\Controller\AdminSubscriptionCheckoutController;
 use App\Controller\InvitationController;
 use Slim\Views\Twig;
 use GuzzleHttp\Client;
@@ -113,6 +114,7 @@ require_once __DIR__ . '/Controller/StripeCheckoutController.php';
 require_once __DIR__ . '/Controller/StripeSessionController.php';
 require_once __DIR__ . '/Controller/StripeWebhookController.php';
 require_once __DIR__ . '/Controller/SubscriptionController.php';
+require_once __DIR__ . '/Controller/AdminSubscriptionCheckoutController.php';
 require_once __DIR__ . '/Controller/InvitationController.php';
 
 use App\Infrastructure\Migrations\Migrator;
@@ -441,6 +443,8 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/admin/profile', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/subscription', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/subscription/portal', SubscriptionController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
+    $app->post('/admin/subscription/checkout', AdminSubscriptionCheckoutController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
+    $app->get('/admin/subscription/checkout/{id}', StripeSessionController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->post('/admin/profile', function (Request $request, Response $response) {
         $controller = new ProfileController();
         return $controller->update($request, $response);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -838,7 +838,6 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_subscription') }}</h2>
         {% set hasCustomer = tenant and tenant.stripe_customer_id %}
-        {% set upgradeUrl = hasCustomer ? basePath ~ '/admin/subscription/portal' : basePath ~ '/onboarding' %}
         <div class="uk-card uk-card-default uk-card-body uk-margin-small" id="subscription-card">
           <div data-subscription
             data-label-plan="{{ t('label_plan') }}"
@@ -852,9 +851,16 @@
             <p>{{ t('subscription_email') }}: {{ tenant.imprint_email }}</p>
           {% endif %}
         </div>
-        <p><a class="uk-button uk-button-primary" href="{{ upgradeUrl }}">{{ hasCustomer ? t('action_open_subscription') : t('action_start_subscription') }}</a></p>
+        {% if stripe_configured %}
+        <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-small uk-margin-top" uk-grid>
+          <div><button class="uk-button uk-button-default plan-select" data-plan="starter">{{ t('plan_starter') }}</button></div>
+          <div><button class="uk-button uk-button-default plan-select" data-plan="standard">{{ t('plan_standard') }}</button></div>
+          <div><button class="uk-button uk-button-default plan-select" data-plan="professional">{{ t('plan_professional') }}</button></div>
+        </div>
+        {% endif %}
+        <p class="uk-margin-top"><a class="uk-button uk-button-text" href="{{ basePath }}/admin/subscription/portal">{{ t('action_open_subscription') }}</a></p>
         <script>
-          window.upgradeUrl = '{{ upgradeUrl }}';
+          window.upgradeUrl = '{{ basePath }}/admin/subscription';
         </script>
       </div>
     </li>

--- a/tests/Service/StripeServiceTest.php
+++ b/tests/Service/StripeServiceTest.php
@@ -46,4 +46,13 @@ final class StripeServiceTest extends TestCase
         $this->assertSame(['card'], $client->checkout->sessions->lastParams['payment_method_types'] ?? null);
         $this->assertSame(7, $client->checkout->sessions->lastParams['subscription_data']['trial_period_days'] ?? null);
     }
+
+    public function testCreateCheckoutSessionWithCustomerIdAndReference(): void
+    {
+        $client = new FakeStripeClient();
+        $service = new StripeService(client: $client);
+        $service->createCheckoutSession('price_123', 'https://success', 'https://cancel', null, 'cus_123', 'tenant1');
+        $this->assertSame('cus_123', $client->checkout->sessions->lastParams['customer'] ?? null);
+        $this->assertSame('tenant1', $client->checkout->sessions->lastParams['client_reference_id'] ?? null);
+    }
 }


### PR DESCRIPTION
## Summary
- add admin-side Stripe checkout controller and routes
- expose Stripe configuration to admin view and show plan selection
- expand Stripe service for customer and reference IDs with tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689b5209f990832b80648480899db20a