### PR TITLE
ci: use setup-php v2

### DIFF
--- a/.github/workflows/composer-install.yml
+++ b/.github/workflows/composer-install.yml
@@ -13,7 +13,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@355155f9fb51da580099149361dcbdad69cfab9c
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
 

--- a/.github/workflows/composer-require-phpcs.yml
+++ b/.github/workflows/composer-require-phpcs.yml
@@ -13,7 +13,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@355155f9fb51da580099149361dcbdad69cfab9c
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
                   curl -L -o resources/fonts/NotoSans-Bold.ttf https://github.com/googlefonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Bold.ttf
 
             - name: Set up PHP ${{ matrix.php }}
-              uses: shivammathur/setup-php@355155f9fb51da580099149361dcbdad69cfab9c
+              uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
                   coverage: xdebug


### PR DESCRIPTION
## Summary
- update setup-php action to v2 to support PHP 8.2

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b54c49368832b971b734708c757b5