### PR TITLE
Fix lines exceeding 120 characters

### DIFF
--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -81,8 +81,8 @@ class EventService
         $this->pdo->beginTransaction();
 
         $updateStmt = $this->pdo->prepare(
-            'UPDATE events SET name = ?, start_date = ?, end_date = ?, description = ?, published = ?, sort_order = ? ' .
-            'WHERE uid = ?'
+            'UPDATE events SET name = ?, start_date = ?, end_date = ?, ' .
+            'description = ?, published = ?, sort_order = ? WHERE uid = ?'
         );
         $insertStmt = $this->pdo->prepare(
             'INSERT INTO events(uid,name,start_date,end_date,description,published,sort_order) VALUES(?,?,?,?,?,?,?)'

--- a/src/routes.php
+++ b/src/routes.php
@@ -443,8 +443,14 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/admin/profile', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/subscription', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/subscription/portal', SubscriptionController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
-    $app->post('/admin/subscription/checkout', AdminSubscriptionCheckoutController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
-    $app->get('/admin/subscription/checkout/{id}', StripeSessionController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
+    $app->post(
+        '/admin/subscription/checkout',
+        AdminSubscriptionCheckoutController::class
+    )->add(new RoleAuthMiddleware(...Roles::ALL));
+    $app->get(
+        '/admin/subscription/checkout/{id}',
+        StripeSessionController::class
+    )->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->post('/admin/profile', function (Request $request, Response $response) {
         $controller = new ProfileController();
         return $controller->update($request, $response);

--- a/tests/Controller/HelpControllerTest.php
+++ b/tests/Controller/HelpControllerTest.php
@@ -96,7 +96,8 @@ class HelpControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT, sort_order INTEGER DEFAULT 0' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
             ');'
         );
         $pdo->exec("INSERT INTO events(uid,name) VALUES('1','Event')");

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -216,7 +216,8 @@ class QrControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT, sort_order INTEGER DEFAULT 0' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
             ');'
         );
         $pdo->exec(
@@ -259,7 +260,8 @@ class QrControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT, sort_order INTEGER DEFAULT 0' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
             ');'
         );
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','Event','Desc')");
@@ -311,7 +313,8 @@ class QrControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT, sort_order INTEGER DEFAULT 0' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
             ');'
         );
         $pdo->exec("INSERT INTO events(uid,name) VALUES('1','Event')");
@@ -371,7 +374,8 @@ class QrControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT, sort_order INTEGER DEFAULT 0' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
             ');'
         );
         $pdo->exec("INSERT INTO events(uid,name,description) VALUES('1','First','A'),('2','Second','B')");

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -157,7 +157,8 @@ class ResultControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, description TEXT, sort_order INTEGER DEFAULT 0' .
+            'uid TEXT PRIMARY KEY, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
             ');'
         );
         $pdo->exec(


### PR DESCRIPTION
## Summary
- wrap admin subscription routes onto multiple lines
- split long SQL update statement in EventService
- break long test SQL strings to meet PSR-12 line-length rule

## Testing
- `vendor/bin/phpcs`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689b5836b044832b92a1875619ccda2d