### PR TITLE
feat: show event summary on dashboard

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -101,14 +101,15 @@
 
   function renderBadges() {
     const s = state.stats || {};
-    const d = document.getElementById('badge-draft');
-    const sch = document.getElementById('badge-scheduled');
-    const r = document.getElementById('badge-running');
-    const f = document.getElementById('badge-finished');
-    if (d) d.textContent = `${s.draftCount || 0} Entwürfe`;
-    if (sch) sch.textContent = `${s.scheduledCount || 0} geplant`;
-    if (r) r.textContent = `${s.runningCount || 0} live`;
-    if (f) f.textContent = `${s.finishedCount || 0} abgeschlossen`;
+    const total = (s.draftCount || 0) + (s.scheduledCount || 0) + (s.runningCount || 0) + (s.finishedCount || 0);
+    const upcoming = (s.scheduledCount || 0) + (s.runningCount || 0);
+    const past = s.finishedCount || 0;
+    const e = document.getElementById('badge-events');
+    const u = document.getElementById('badge-upcoming');
+    const p = document.getElementById('badge-past');
+    if (e) e.textContent = `${total} Veranstaltungen`;
+    if (u) u.textContent = `${upcoming} kommende`;
+    if (p) p.textContent = `${past} vergangene`;
   }
 
   function renderSubscription() {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -89,6 +89,11 @@
                 <div id="today-empty" class="uk-text-meta uk-margin-small">Für heute nichts geplant</div>
                 <ul id="upcoming-list" class="uk-list uk-list-divider uk-margin-small-top"></ul>
               </div>
+              <div class="uk-margin-small">
+                <span class="uk-badge" id="badge-events">0 Veranstaltungen</span>
+                <span class="uk-badge" id="badge-upcoming">0 kommende</span>
+                <span class="uk-badge" id="badge-past">0 vergangene</span>
+              </div>
 
               <div class="uk-child-width-1-2@m uk-grid-small uk-margin-small" uk-grid>
                 <div>
@@ -105,13 +110,6 @@
                     <a href="{{ basePath }}/admin/results" class="uk-link-reset uk-text-bold">Zur Auswertung →</a>
                   </div>
                 </div>
-              </div>
-
-              <div class="uk-margin-small">
-                <span class="uk-badge" id="badge-draft">0 Entwürfe</span>
-                <span class="uk-badge" id="badge-scheduled">0 geplant</span>
-                <span class="uk-badge" id="badge-running">0 live</span>
-                <span class="uk-badge" id="badge-finished">0 abgeschlossen</span>
               </div>
 
               <div class="uk-card uk-card-default uk-card-body uk-margin-small">


### PR DESCRIPTION
## Summary
- replace event status badges with summary of total, upcoming, and past events
- reposition summary badges directly beneath the first dashboard widget

## Testing
- `composer test`
- `vendor/bin/phpcs`


------
https://chatgpt.com/codex/tasks/task_e_689b680f111c832bb34462b3dc11da2d