### PR TITLE
Display subscription plan details and improve checkout errors

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -69,7 +69,10 @@ document.addEventListener('DOMContentLoaded', function () {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ plan, embedded: true })
         });
-        if (!res.ok) return;
+        if (!res.ok) {
+          notify('Fehler beim Starten der Zahlung', 'danger');
+          return;
+        }
         const data = await res.json();
         if ([data.client_secret, data.publishable_key, window.Stripe, checkoutContainer].every(Boolean)) {
           const stripe = Stripe(data.publishable_key);
@@ -82,6 +85,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
       } catch (e) {
         console.error(e);
+        notify('Fehler beim Starten der Zahlung', 'danger');
       }
     });
   });

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -853,9 +853,56 @@
         <script src="https://js.stripe.com/v3/"></script>
         <div id="stripe-checkout"></div>
         <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-small uk-margin-top" uk-grid>
-          <div><button class="uk-button uk-button-default plan-select" data-plan="starter">{{ t('plan_starter') }}</button></div>
-          <div><button class="uk-button uk-button-default plan-select" data-plan="standard">{{ t('plan_standard') }}</button></div>
-          <div><button class="uk-button uk-button-default plan-select" data-plan="professional">{{ t('plan_professional') }}</button></div>
+          <div>
+            <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
+              <span class="uk-label uk-label-success uk-label-large">Kostenlos testen</span>
+              <h3 class="uk-card-title uk-text-primary uk-margin-small-top">{{ t('plan_starter') }}</h3>
+              <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">0&nbsp;€</div>
+              <div class="uk-text-meta uk-margin-small-bottom">Für kleine Events &amp; Einsteiger</div>
+              <ul class="uk-list uk-text-left uk-margin-small-bottom">
+                <li><b>1 Event gleichzeitig</b></li>
+                <li>5 Teams &amp; 5 Kataloge à 5 Fragen</li>
+                <li>Unbegrenzte Teilnehmende pro Team¹</li>
+                <li>Live-Ranking &amp; Basis-PDF-Export²</li>
+                <li>Alle Fragetypen &amp; QR-Codes</li>
+                <li>Backup &amp; editierbare Texte³</li>
+              </ul>
+              <button class="uk-button uk-button-default uk-width-1-1 plan-select" data-plan="starter">{{ t('action_start_subscription') }}</button>
+            </div>
+          </div>
+          <div>
+            <div class="uk-card uk-card-popular uk-card-quizrace uk-text-center">
+              <span class="uk-label uk-label-large">Meist gewählt</span>
+              <h3 class="uk-card-title uk-margin-small-top" style="color:#fff;">{{ t('plan_standard') }}</h3>
+              <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700; color:#fff;">39&nbsp;€/Monat</div>
+              <div class="uk-text-meta uk-margin-small-bottom" style="color:#fff;">Beliebt bei Schulen &amp; Teams</div>
+              <ul class="uk-list uk-text-left uk-margin-small-bottom" style="color:#fff;">
+                <li><b>7 Tage kostenlos testen</b></li>
+                <li><b>Alle Starter-Funktionen</b></li>
+                <li>Bis zu 3 Events gleichzeitig</li>
+                <li>10 Teams &amp; 10 Kataloge à 10 Fragen</li>
+                <li>Eigene Subdomain</li>
+                <li>Vollständiger PDF-Export</li>
+              </ul>
+              <button class="uk-button uk-button-primary uk-width-1-1 plan-select" data-plan="standard">{{ t('action_start_subscription') }}</button>
+            </div>
+          </div>
+          <div>
+            <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
+              <span class="uk-label uk-label-primary uk-label-large">Professional</span>
+              <h3 class="uk-card-title uk-text-primary uk-margin-small-top">{{ t('plan_professional') }}</h3>
+              <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">79&nbsp;€/Monat</div>
+              <div class="uk-text-meta uk-margin-small-bottom">Für Agenturen &amp; Unternehmen</div>
+              <ul class="uk-list uk-text-left uk-margin-small-bottom">
+                <li><b>7 Tage kostenlos testen</b></li>
+                <li><b>Alle Standard-Funktionen</b></li>
+                <li>20 Events gleichzeitig (mehr auf Anfrage)</li>
+                <li>100 Teams &amp; 50 Kataloge à 50 Fragen</li>
+                <li>White-Label &amp; Rollenverwaltung</li>
+              </ul>
+              <button class="uk-button uk-button-default uk-width-1-1 plan-select" data-plan="professional">{{ t('action_start_subscription') }}</button>
+            </div>
+          </div>
         </div>
         {% endif %}
         <p class="uk-margin-top"><a class="uk-button uk-button-text" href="{{ basePath }}/admin/subscription/portal">{{ t('action_open_subscription') }}</a></p>


### PR DESCRIPTION
## Summary
- Display detailed pricing cards for Starter, Standard, and Professional plans on the admin subscription page
- Notify admins when subscription checkout fails via `window.notify`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689b6b185f9c832bb1890f9cfb90974c