### PR TITLE
Ensure Stripe customer IDs for subscriptions

### DIFF
--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -91,6 +91,19 @@ class StripeService
     }
 
     /**
+     * Create a new customer and return its id.
+     */
+    public function createCustomer(string $email, ?string $name = null): string
+    {
+        $params = ['email' => $email];
+        if ($name !== null) {
+            $params['name'] = $name;
+        }
+        $customer = $this->client->customers->create($params);
+        return (string) $customer->id;
+    }
+
+    /**
      * Create a billing portal session and return its URL.
      */
     public function createBillingPortal(string $customerId, string $returnUrl): string


### PR DESCRIPTION
## Summary
- add StripeService::createCustomer for creating customer records
- auto-generate missing stripe_customer_id in admin dashboard subscription section
- ensure checkout flow creates or finds Stripe customer and persists ID

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689b6cce1d58832b9c3de6ccb11f6c63