### PR TITLE
Handle missing tenant context gracefully

### DIFF
--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -21,8 +21,12 @@ class SubscriptionController
         $parts = explode('.', $host);
         $mainDomain = getenv('MAIN_DOMAIN') ?: $host;
         if ($host === $mainDomain || count($parts) < 2) {
+            if ($host === $mainDomain) {
+                $selectUrl = $request->getUri()->getScheme() . '://' . $host . '/admin/tenants';
+                return $response->withHeader('Location', $selectUrl)->withStatus(302);
+            }
             $response->getBody()->write('Missing tenant context');
-            return $response->withStatus(500);
+            return $response->withStatus(400);
         }
         $sub = $parts[0];
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -905,7 +905,9 @@
           </div>
         </div>
         {% endif %}
+        {% if domainType == 'tenant' and hasCustomer %}
         <p class="uk-margin-top"><a class="uk-button uk-button-text" href="{{ basePath }}/admin/subscription/portal">{{ t('action_open_subscription') }}</a></p>
+        {% endif %}
         <script>
           window.upgradeUrl = '{{ basePath }}/admin/subscription';
         </script>


### PR DESCRIPTION
## Summary
- Redirect to tenant selection or return 400 when subscription portal is accessed without a subdomain
- Show subscription portal link only when a tenant and Stripe customer ID are present

## Testing
- `composer test`
- `vendor/bin/phpcs src/Controller/SubscriptionController.php templates/admin.twig`

------
https://chatgpt.com/codex/tasks/task_e_689b6cf00f2c832b9351c88abc564d45