### PR TITLE
Fix phpstan complaints

### DIFF
--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -75,7 +75,7 @@ class AdminSubscriptionCheckoutController
         }
 
         $service = new StripeService();
-        if ($customerId === '' && $email !== '') {
+        if ($customerId === '') {
             try {
                 $customerId = $service->findCustomerIdByEmail($email) ?? $service->createCustomer(
                     $email,

--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -160,7 +160,7 @@ class StripeService
         }
         $item = $sub->items->data[0] ?? null;
         $price = $item?->price;
-        $priceId = $price?->id ?? '';
+        $priceId = $price->id ?? '';
 
         $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
         $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';


### PR DESCRIPTION
## Summary
- remove redundant `$email !== ''` check in AdminSubscriptionCheckoutController
- simplify price ID lookup in StripeService

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689b767afb40832b9e8961e410a2bba4