### PR TITLE
Handle missing Stripe config gracefully

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -45,10 +45,6 @@ if ($logger instanceof Logger) {
 // verify Stripe configuration before starting the app
 if (!StripeService::isConfigured()) {
     $logger->error('Stripe configuration missing');
-    http_response_code(500);
-    header('Content-Type: text/plain; charset=utf-8');
-    echo "Stripe configuration missing. Please set required environment variables.\n";
-    exit(1);
 }
 
 $settings = require __DIR__ . '/../config/settings.php';

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -219,4 +219,5 @@ return [
     'heading_limit_reached' => 'Limit erreicht',
     'text_upgrade_required' => 'Abo-Limit erreicht. Bitte upgraden, um mehr Ressourcen anzulegen.',
     'action_upgrade' => 'Jetzt upgraden',
+    'text_stripe_config_missing' => 'Stripe-Konfiguration fehlt. Bitte erforderliche Umgebungsvariablen setzen.',
 ];

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -217,4 +217,5 @@ return [
     'heading_limit_reached' => 'Limit reached',
     'text_upgrade_required' => 'Subscription limit reached. Please upgrade to add more resources.',
     'action_upgrade' => 'Upgrade now',
+    'text_stripe_config_missing' => 'Stripe configuration missing. Please set required environment variables.',
 ];

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -54,6 +54,13 @@
       <button id="helpBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" aria-label="Hilfe"></button>
     {% endblock %}
   {% endembed %}
+  {% if not stripe_configured %}
+    <div class="uk-container uk-container-large">
+      <div class="uk-alert-danger uk-margin" uk-alert>
+        {{ t('text_stripe_config_missing') }}
+      </div>
+    </div>
+  {% endif %}
   <div class="uk-grid-collapse" uk-grid>
     <aside class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
       <div class="uk-card uk-card-default uk-card-body qr-sidebar-card">


### PR DESCRIPTION
## Summary
- Log missing Stripe configuration without halting startup
- Show dashboard alert when Stripe variables are missing
- Add translations for Stripe configuration warning

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689b7dba961c832bbcf304629e4d485b