### PR TITLE
Validate Stripe webhook signatures

### DIFF
--- a/tests/Controller/StripeWebhookControllerTest.php
+++ b/tests/Controller/StripeWebhookControllerTest.php
@@ -20,6 +20,7 @@ class StripeWebhookControllerTest extends TestCase
             . "VALUES('u1', 'foo', NULL, NULL, NULL, '')"
         );
 
+        putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
         $payload = json_encode([
             'type' => 'checkout.session.completed',
             'data' => ['object' => [
@@ -27,7 +28,15 @@ class StripeWebhookControllerTest extends TestCase
                 'customer' => 'cus_123',
             ]],
         ]);
-        $request = $this->createRequest('POST', '/stripe/webhook', ['Content-Type' => 'application/json']);
+
+        $timestamp = (string) time();
+        $signature = hash_hmac('sha256', $timestamp . '.' . ($payload !== false ? $payload : ''), 'whsec_test');
+        $sigHeader = 't=' . $timestamp . ',v1=' . $signature;
+
+        $request = $this->createRequest('POST', '/stripe/webhook', [
+            'Content-Type' => 'application/json',
+            'Stripe-Signature' => $sigHeader,
+        ]);
         $request->getBody()->write($payload !== false ? $payload : '');
         $request->getBody()->rewind();
         $response = $app->handle($request);


### PR DESCRIPTION
## Summary
- Secure Stripe webhook handling by verifying `Stripe-Signature` with environment-provided secret
- Add test utility to sign webhook payloads for verification

## Testing
- `vendor/bin/phpunit tests/Controller/StripeWebhookControllerTest.php`
- `composer test` *(fails: Tests: 198, Assertions: 427, Errors: 8, Failures: 15)*

------
https://chatgpt.com/codex/tasks/task_e_689b8845ab28832bacbed9795d4ddbe7