### PR TITLE
Verify Stripe client reference before saving customer id

### DIFF
--- a/src/Controller/StripeSessionController.php
+++ b/src/Controller/StripeSessionController.php
@@ -21,12 +21,16 @@ class StripeSessionController
         $service = new StripeService();
         $info = $sessionId !== ''
             ? $service->getCheckoutSessionInfo($sessionId)
-            : ['paid' => false, 'customer_id' => null];
+            : ['paid' => false, 'customer_id' => null, 'client_reference_id' => null];
 
-        if ($info['paid'] && $info['customer_id'] !== null) {
+        $host = $request->getUri()->getHost();
+        $sub = explode('.', $host)[0];
+        if (
+            $info['paid']
+            && $info['customer_id'] !== null
+            && $info['client_reference_id'] === $sub
+        ) {
             $base = Database::connectFromEnv();
-            $host = $request->getUri()->getHost();
-            $sub = explode('.', $host)[0];
             $tenantService = new TenantService($base);
             $tenantService->updateProfile($sub, ['stripe_customer_id' => $info['customer_id']]);
         }

--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -124,20 +124,24 @@ class StripeService
     }
 
     /**
-     * Retrieve checkout session payment status and customer id.
+     * Retrieve checkout session payment status, customer id and client reference.
      *
-     * @return array{paid:bool, customer_id:?string}
+     * @return array{paid:bool, customer_id:?string, client_reference_id:?string}
      */
     public function getCheckoutSessionInfo(string $sessionId): array
     {
         try {
             $session = $this->client->checkout->sessions->retrieve($sessionId, []);
+
             return [
                 'paid' => ($session->payment_status ?? '') === 'paid',
                 'customer_id' => isset($session->customer) ? (string) $session->customer : null,
+                'client_reference_id' => isset($session->client_reference_id)
+                    ? (string) $session->client_reference_id
+                    : null,
             ];
         } catch (\Throwable $e) {
-            return ['paid' => false, 'customer_id' => null];
+            return ['paid' => false, 'customer_id' => null, 'client_reference_id' => null];
         }
     }
 


### PR DESCRIPTION
## Summary
- expose `client_reference_id` from Stripe checkout session info
- only accept Stripe customer id when session reference matches subdomain
- cover new Stripe session info in unit tests

## Testing
- `composer test` *(fails: Failed to reload nginx: reload failed)*
- `vendor/bin/phpunit tests/Service/StripeServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689ba337262c832ba5b26c0e6b52f159