### PR TITLE
Add CSRF protection for admin endpoints

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2,6 +2,9 @@
 
 const basePath = window.basePath || '';
 const withBase = path => basePath + path;
+const getCsrfToken = () =>
+  document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ||
+  window.csrfToken || '';
 function showUpgradeModal() {
   if (document.getElementById('upgrade-modal')) return;
   const modal = document.createElement('div');
@@ -21,9 +24,15 @@ function showUpgradeModal() {
 }
 
 window.apiFetch = (path, options = {}) => {
+  const token = getCsrfToken();
+  const headers = {
+    'X-CSRF-Token': token,
+    ...(options.headers || {})
+  };
   return fetch(withBase(path), {
     credentials: 'same-origin',
-    ...options
+    ...options,
+    headers
   }).then(res => {
     if (res.status === 402) {
       showUpgradeModal();

--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -18,6 +18,15 @@ class AdminSubscriptionCheckoutController
 {
     public function __invoke(Request $request, Response $response): Response
     {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $sessionToken = $_SESSION['csrf_token'] ?? '';
+        $headerToken = $request->getHeaderLine('X-CSRF-Token');
+        if ($sessionToken === '' || $headerToken !== $sessionToken) {
+            return $response->withStatus(403);
+        }
+
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data)) {
             return $response->withStatus(400);

--- a/src/routes.php
+++ b/src/routes.php
@@ -470,7 +470,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post(
         '/admin/subscription/checkout',
         AdminSubscriptionCheckoutController::class
-    )->add(new RoleAuthMiddleware(...Roles::ALL));
+    )->add(new RoleAuthMiddleware(...Roles::ALL))->add(new CsrfMiddleware());
     $app->get(
         '/admin/subscription/checkout/{id}',
         StripeSessionController::class
@@ -478,7 +478,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/admin/profile', function (Request $request, Response $response) {
         $controller = new ProfileController();
         return $controller->update($request, $response);
-    })->add(new RoleAuthMiddleware(...Roles::ALL));
+    })->add(new RoleAuthMiddleware(...Roles::ALL))->add(new CsrfMiddleware());
     $app->get('/admin/tenants', function (Request $request, Response $response) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(404);
@@ -497,7 +497,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/admin/pages/{slug}', function (Request $request, Response $response, array $args) {
         $controller = new PageController();
         return $controller->update($request, $response, $args);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+    })->add(new RoleAuthMiddleware(Roles::ADMIN))->add(new CsrfMiddleware());
 
     $app->get('/admin/landingpage/seo', function (Request $request, Response $response) {
         if ($request->getAttribute('domainType') !== 'main') {
@@ -510,7 +510,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/admin/landingpage/seo', function (Request $request, Response $response) {
         $controller = new LandingpageController();
         return $controller->save($request, $response);
-    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+    })->add(new RoleAuthMiddleware(Roles::ADMIN))->add(new CsrfMiddleware());
 
     $app->get('/admin/{path:.*}', function (Request $request, Response $response) {
         $base = \Slim\Routing\RouteContext::fromRequest($request)->getBasePath();

--- a/tests/Controller/AdminSubscriptionCheckoutControllerTest.php
+++ b/tests/Controller/AdminSubscriptionCheckoutControllerTest.php
@@ -14,9 +14,11 @@ final class AdminSubscriptionCheckoutControllerTest extends TestCase
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $_SESSION['csrf_token'] = 'token';
 
         $request = $this->createRequest('POST', '/admin/subscription/checkout', [
             'HTTP_CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => 'token',
         ]);
         $stream = (new StreamFactory())->createStream(json_encode(['plan' => 'starter']));
         $request = $request->withBody($stream);

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -21,11 +21,14 @@ class PageControllerTest extends TestCase
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $_SESSION['csrf_token'] = 'token';
 
         $response = $app->handle($this->createRequest('GET', '/admin/pages/landing'));
         $this->assertEquals(200, $response->getStatusCode());
 
-        $req = $this->createRequest('POST', '/admin/pages/landing');
+        $req = $this->createRequest('POST', '/admin/pages/landing', [
+            'HTTP_X_CSRF_TOKEN' => 'token',
+        ]);
         $req = $req->withParsedBody(['content' => '<p>new</p>']);
         $res = $app->handle($req);
         $this->assertEquals(204, $res->getStatusCode());

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -31,7 +31,11 @@ class ProfileControllerTest extends TestCase
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
-        $request = $this->createRequest('POST', '/admin/profile', ['HTTP_CONTENT_TYPE' => 'application/json']);
+        $_SESSION['csrf_token'] = 'token';
+        $request = $this->createRequest('POST', '/admin/profile', [
+            'HTTP_CONTENT_TYPE' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => 'token',
+        ]);
         $stream = (new StreamFactory())->createStream(json_encode(['plan' => 'Pro']));
         $request = $request->withBody($stream)
             ->withUri(new Uri('http', 'example.com', 80, '/admin/profile'));

--- a/tests/RoleAccessTest.php
+++ b/tests/RoleAccessTest.php
@@ -99,7 +99,10 @@ class RoleAccessTest extends TestCase
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
-        $req = $this->createRequest('POST', '/admin/landingpage/seo');
+        $_SESSION['csrf_token'] = 'token';
+        $req = $this->createRequest('POST', '/admin/landingpage/seo', [
+            'HTTP_X_CSRF_TOKEN' => 'token',
+        ]);
         $req = $req->withParsedBody(['pageId' => 1, 'slug' => 'test']);
         $res = $app->handle($req);
         $this->assertEquals(204, $res->getStatusCode());
@@ -113,7 +116,10 @@ class RoleAccessTest extends TestCase
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
-        $req = $this->createRequest('POST', '/admin/landingpage/seo');
+        $_SESSION['csrf_token'] = 'token';
+        $req = $this->createRequest('POST', '/admin/landingpage/seo', [
+            'HTTP_X_CSRF_TOKEN' => 'token',
+        ]);
         $req = $req->withParsedBody(['pageId' => 1, 'slug' => 'test']);
         $res = $app->handle($req);
         $this->assertEquals(302, $res->getStatusCode());


### PR DESCRIPTION
## Summary
- include CSRF token header on admin API requests
- validate CSRF tokens for subscription checkout
- protect admin POST routes with CSRF middleware and update tests

## Testing
- `composer test` *(fails: Slim Application Error, database errors)*

------
https://chatgpt.com/codex/tasks/task_e_689bb166f440832ba86ae4e379b7a5b5