### PR TITLE
Handle additional Stripe webhook events

### DIFF
--- a/src/Controller/StripeWebhookController.php
+++ b/src/Controller/StripeWebhookController.php
@@ -66,6 +66,18 @@ class StripeWebhookController
                     $tenantService->updateByStripeCustomerId($customerId, ['plan' => null]);
                 }
                 break;
+            case 'customer.deleted':
+                $customerId = (string) ($object['id'] ?? '');
+                if ($customerId !== '') {
+                    $tenantService->removeStripeCustomer($customerId);
+                }
+                break;
+            case 'invoice.payment_failed':
+                $customerId = (string) ($object['customer'] ?? '');
+                if ($customerId !== '') {
+                    $tenantService->cancelPlanForCustomer($customerId);
+                }
+                break;
         }
 
         return $response->withStatus(200);

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -506,6 +506,28 @@ class TenantService
     }
 
     /**
+     * Remove Stripe association and plan for a given customer.
+     */
+    public function removeStripeCustomer(string $customerId): void
+    {
+        $stmt = $this->pdo->prepare(
+            'UPDATE tenants SET stripe_customer_id = NULL, plan = NULL WHERE stripe_customer_id = ?'
+        );
+        $stmt->execute([$customerId]);
+    }
+
+    /**
+     * Cancel the plan for a given customer.
+     */
+    public function cancelPlanForCustomer(string $customerId): void
+    {
+        $stmt = $this->pdo->prepare(
+            'UPDATE tenants SET plan = NULL WHERE stripe_customer_id = ?'
+        );
+        $stmt->execute([$customerId]);
+    }
+
+    /**
      * Retrieve all tenants ordered by creation date.
      *
      * @return list<array{

--- a/tests/Controller/StripeWebhookControllerTest.php
+++ b/tests/Controller/StripeWebhookControllerTest.php
@@ -15,6 +15,7 @@ class StripeWebhookControllerTest extends TestCase
         $app = $this->getAppInstance();
         $pdo = Database::connectFromEnv();
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        $pdo->exec('DELETE FROM tenants');
         $pdo->exec(
             "INSERT INTO tenants(uid, subdomain, plan, billing_info, stripe_customer_id, created_at) "
             . "VALUES('u1', 'foo', NULL, NULL, NULL, '')"
@@ -44,5 +45,81 @@ class StripeWebhookControllerTest extends TestCase
 
         $stmt = $pdo->query("SELECT stripe_customer_id FROM tenants WHERE subdomain = 'foo'");
         $this->assertEquals('cus_123', $stmt->fetchColumn());
+    }
+
+    public function testCustomerDeletedRemovesCustomerAndPlan(): void
+    {
+        $app = $this->getAppInstance();
+        $pdo = Database::connectFromEnv();
+        Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        $pdo->exec('DELETE FROM tenants');
+        $pdo->exec(
+            "INSERT INTO tenants(uid, subdomain, plan, billing_info, stripe_customer_id, created_at) "
+            . "VALUES('u1', 'foo', 'starter', NULL, 'cus_123', '')"
+        );
+
+        putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
+        $payload = json_encode([
+            'type' => 'customer.deleted',
+            'data' => ['object' => [
+                'id' => 'cus_123',
+            ]],
+        ]);
+
+        $timestamp = (string) time();
+        $signature = hash_hmac('sha256', $timestamp . '.' . ($payload !== false ? $payload : ''), 'whsec_test');
+        $sigHeader = 't=' . $timestamp . ',v1=' . $signature;
+
+        $request = $this->createRequest('POST', '/stripe/webhook', [
+            'Content-Type' => 'application/json',
+            'Stripe-Signature' => $sigHeader,
+        ]);
+        $request->getBody()->write($payload !== false ? $payload : '');
+        $request->getBody()->rewind();
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $stmt = $pdo->query("SELECT plan, stripe_customer_id FROM tenants WHERE subdomain = 'foo'");
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertNull($row['plan']);
+        $this->assertNull($row['stripe_customer_id']);
+    }
+
+    public function testInvoicePaymentFailedCancelsPlan(): void
+    {
+        $app = $this->getAppInstance();
+        $pdo = Database::connectFromEnv();
+        Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        $pdo->exec('DELETE FROM tenants');
+        $pdo->exec(
+            "INSERT INTO tenants(uid, subdomain, plan, billing_info, stripe_customer_id, created_at) "
+            . "VALUES('u1', 'foo', 'starter', NULL, 'cus_123', '')"
+        );
+
+        putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
+        $payload = json_encode([
+            'type' => 'invoice.payment_failed',
+            'data' => ['object' => [
+                'customer' => 'cus_123',
+            ]],
+        ]);
+
+        $timestamp = (string) time();
+        $signature = hash_hmac('sha256', $timestamp . '.' . ($payload !== false ? $payload : ''), 'whsec_test');
+        $sigHeader = 't=' . $timestamp . ',v1=' . $signature;
+
+        $request = $this->createRequest('POST', '/stripe/webhook', [
+            'Content-Type' => 'application/json',
+            'Stripe-Signature' => $sigHeader,
+        ]);
+        $request->getBody()->write($payload !== false ? $payload : '');
+        $request->getBody()->rewind();
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $stmt = $pdo->query("SELECT plan, stripe_customer_id FROM tenants WHERE subdomain = 'foo'");
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertNull($row['plan']);
+        $this->assertEquals('cus_123', $row['stripe_customer_id']);
     }
 }


### PR DESCRIPTION
## Summary
- handle `customer.deleted` and `invoice.payment_failed` webhook events
- add TenantService helpers to remove Stripe data or cancel plans
- test new webhook flows for plan and customer updates

## Testing
- `vendor/bin/phpunit tests/Controller/StripeWebhookControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689bb4c321d8832ba17d8d91d64f1bc8