### PR TITLE
Fix non-null tenant service call

### DIFF
--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -41,7 +41,6 @@ class AdminSubscriptionCheckoutController
 
         $host = $request->getUri()->getHost();
         $sub = explode('.', $host)[0];
-        $tenantService = null;
         $domainType = (string) $request->getAttribute('domainType');
         $base = Database::connectFromEnv();
         $tenantService = new TenantService($base);
@@ -82,7 +81,10 @@ class AdminSubscriptionCheckoutController
                     $tenant['imprint_name'] ?? null
                 );
                 $tenant['stripe_customer_id'] = $customerId;
-                $tenantService?->updateProfile($domainType === 'main' ? 'main' : $sub, ['stripe_customer_id' => $customerId]);
+                $tenantService->updateProfile(
+                    $domainType === 'main' ? 'main' : $sub,
+                    ['stripe_customer_id' => $customerId]
+                );
             } catch (\Throwable $e) {
                 error_log($e->getMessage());
                 return $this->jsonError($response, 500, 'internal error');


### PR DESCRIPTION
## Summary
- avoid nullsafe call on TenantService during checkout profile update

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_689bc4e2775c832ba3561dd8774f5a10