### PR TITLE
Add logging for Stripe subscription checkout

### DIFF
--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Factory for Monolog loggers that write to the application's log directory.
+ */
+class LogService
+{
+    /**
+     * Create a logger instance for the given channel.
+     */
+    public static function create(string $channel = 'app'): LoggerInterface
+    {
+        $root = dirname(__DIR__, 2);
+        $logDir = $root . '/logs';
+        if (!is_dir($logDir)) {
+            mkdir($logDir, 0777, true);
+        }
+        $logger = new Logger($channel);
+        $logger->pushHandler(new StreamHandler($logDir . '/' . $channel . '.log', Level::Debug));
+        return $logger;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Monolog-based `LogService` for file logging
- log validation steps and Stripe session creation in `AdminSubscriptionCheckoutController`

## Testing
- `composer test` *(fails: multiple PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_689bc64ee68c832bb705325573098c53