### PR TITLE
Ensure CSRF token included in subscription checkout request

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const plan = btn.dataset.plan;
       if (!plan) return;
       try {
-        const res = await fetch(withBase('/admin/subscription/checkout'), {
+        const res = await apiFetch('/admin/subscription/checkout', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ plan, embedded: true })


### PR DESCRIPTION
## Summary
- use `apiFetch` for subscription checkout so CSRF token is sent

## Testing
- `vendor/bin/phpunit` *(fails: table tenants has no column named imprint_name and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689be330cca0832b9d1487b64e410891