### PR TITLE
feat: add csrf protection to profile page

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -441,7 +441,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/pages', AdminController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
     $app->get('/admin/management', AdminController::class)->add(new RoleAuthMiddleware(Roles::ADMIN));
-    $app->get('/admin/profile', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
+    $app->get('/admin/profile', AdminController::class)
+        ->add(new RoleAuthMiddleware(...Roles::ALL))
+        ->add(new CsrfMiddleware());
     $app->get('/admin/subscription', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/subscription/portal', SubscriptionController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/subscription/status', function (Request $request, Response $response) {


### PR DESCRIPTION
## Summary
- ensure the admin profile view initializes a CSRF token for subsequent updates

## Testing
- `vendor/bin/phpcs src/routes.php`
- `composer test` *(fails: Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_689be3f12658832b9f20256ad8363f52