### PR TITLE
feat(admin): greet logged-in user on dashboard

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -204,6 +204,7 @@ class AdminController
               'tenant' => $tenant,
               'stripe_configured' => StripeService::isConfigured(),
               'currentPath' => $request->getUri()->getPath(),
+              'username' => $_SESSION['user']['username'] ?? '',
               'csrf_token' => $csrf,
           ]);
     }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -57,6 +57,21 @@
       </div>
       <button id="helpBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" aria-label="Hilfe"></button>
     {% endblock %}
+    {% block nav_placeholder %}
+      {% set activeRoute = currentPath|split('/admin/')|last %}
+      {% if activeRoute == '' %}
+        {% set activeRoute = 'dashboard' %}
+      {% endif %}
+      {% if activeRoute == 'dashboard' %}
+        <div class="nav-placeholder">
+          <div class="uk-container uk-container-large">
+            <h2 class="uk-heading-bullet">Willkommen {{ username }}</h2>
+          </div>
+        </div>
+      {% else %}
+        <div class="nav-placeholder"></div>
+      {% endif %}
+    {% endblock %}
   {% endembed %}
   {% if not stripe_configured %}
     <div class="uk-container uk-container-large">


### PR DESCRIPTION
## Summary
- show "Willkommen <username>" heading on admin dashboard
- expose username to admin template

## Testing
- `composer test` *(fails: Failed asserting that 500 matches expected 200; Errors: 8, Failures: 15)*

------
https://chatgpt.com/codex/tasks/task_e_689bf47fda2c832b9d6731a48e0e9420