### PR TITLE
Handle optional plan and billing fields

### DIFF
--- a/src/Controller/Admin/ProfileController.php
+++ b/src/Controller/Admin/ProfileController.php
@@ -19,14 +19,20 @@ class ProfileController
             return $response->withStatus(400);
         }
         $fields = [
-            'plan' => (string) ($data['plan'] ?? ''),
-            'billing_info' => (string) ($data['billing_info'] ?? ''),
             'imprint_name' => (string) ($data['imprint_name'] ?? ''),
             'imprint_street' => (string) ($data['imprint_street'] ?? ''),
             'imprint_zip' => (string) ($data['imprint_zip'] ?? ''),
             'imprint_city' => (string) ($data['imprint_city'] ?? ''),
             'imprint_email' => (string) ($data['imprint_email'] ?? ''),
         ];
+
+        if (isset($data['plan']) && $data['plan'] !== '') {
+            $fields['plan'] = (string) $data['plan'];
+        }
+
+        if (isset($data['billing_info']) && $data['billing_info'] !== '') {
+            $fields['billing_info'] = (string) $data['billing_info'];
+        }
 
         $domainType = $request->getAttribute('domainType');
         $pdo = $request->getAttribute('pdo');

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -437,6 +437,13 @@ class TenantService
      */
     public function updateProfile(string $subdomain, array $data): void
     {
+        foreach ($data as &$value) {
+            if ($value === '') {
+                $value = null;
+            }
+        }
+        unset($value);
+
         $fields = [
             'plan',
             'billing_info',
@@ -452,13 +459,14 @@ class TenantService
         $params = [];
         foreach ($fields as $f) {
             if (array_key_exists($f, $data)) {
-                if ($f === 'plan' && $data[$f] !== null && Plan::tryFrom((string) $data[$f]) === null) {
+                $value = $data[$f];
+                if ($f === 'plan' && $value !== null && Plan::tryFrom((string) $value) === null) {
                     throw new \RuntimeException('invalid-plan');
                 }
                 $set[] = $f . ' = ?';
                 $params[] = $f === 'custom_limits'
-                    ? ($data[$f] !== null ? json_encode($data[$f]) : null)
-                    : $data[$f];
+                    ? ($value !== null ? json_encode($value) : null)
+                    : $value;
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid storing empty plan or billing info in profile updates
- treat empty strings as null in tenant profile updates

## Testing
- `vendor/bin/phpunit` *(fails: Slim Application Error / Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_689c1ef20744832b81b04e1aa8c16c93