### PR TITLE
test: update profile plan enum

### DIFF
--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -36,14 +36,14 @@ class ProfileControllerTest extends TestCase
             'HTTP_CONTENT_TYPE' => 'application/json',
             'HTTP_X_CSRF_TOKEN' => 'token',
         ]);
-        $stream = (new StreamFactory())->createStream(json_encode(['plan' => 'Pro']));
+        $stream = (new StreamFactory())->createStream(json_encode(['plan' => 'standard']));
         $request = $request->withBody($stream)
             ->withUri(new Uri('http', 'example.com', 80, '/admin/profile'));
         $response = $app->handle($request);
         $this->assertEquals(204, $response->getStatusCode());
         $pdo = new PDO('sqlite:' . $db);
         $plan = $pdo->query("SELECT plan FROM tenants WHERE subdomain = 'main'")?->fetchColumn();
-        $this->assertSame('Pro', $plan);
+        $this->assertSame('standard', $plan);
         session_destroy();
         unlink($db);
         putenv('POSTGRES_DSN');


### PR DESCRIPTION
## Summary
- replace legacy plan value `Pro` with enum `standard` in profile update test
- confirm no remaining tests reference deprecated plan names

## Testing
- `vendor/bin/phpcs tests/Controller/ProfileControllerTest.php`
- `vendor/bin/phpstan analyse -c phpstan.neon.dist` *(fails: Allowed memory size exhausted)*
- `composer test` *(fails: Slim Application Error, failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_689c1f2054c0832b96f818f3935415dd