### PR TITLE
Add manual workflow to rebuild image and update tenants

### DIFF
--- a/.github/workflows/update-tenants.yml
+++ b/.github/workflows/update-tenants.yml
@@ -1,0 +1,25 @@
+name: Update tenants
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build image and update tenants
+        uses: appleboy/ssh-action@d91a1af6f57cd4478ceee14d7705601dafabaa19
+        with:
+          host: ${{ secrets.DOMAIN }}
+          username: ${{ secrets.USER }}
+          password: ${{ secrets.PASSWORD }}
+          script: |
+            cd /var/sommerfest-quiz
+            git pull
+            docker build -t Sommerfest-Quiz:latest .
+            for compose in tenants/*/docker-compose.yml; do
+              slug=$(basename "$(dirname "$compose")")
+              docker compose -f "$compose" -p "$slug" pull
+              docker compose -f "$compose" -p "$slug" up -d
+            done
+


### PR DESCRIPTION
## Summary
- add manually triggered workflow to build `Sommerfest-Quiz:latest` on server and redeploy tenant stacks

## Testing
- `composer test` *(fails: Slim Application Error, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_689c25eef6f0832b8512aa35d3894c00