### PR TITLE
Add tenant sync for missing subdomains

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1890,6 +1890,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const exportJsonBtn = document.getElementById('exportJsonBtn');
   const backupTableBody = document.getElementById('backupTableBody');
   const tenantTableBody = document.getElementById('tenantTableBody');
+  const tenantSyncBtn = document.getElementById('tenantSyncBtn');
 
   function loadBackups() {
     if (!backupTableBody) return;
@@ -1989,6 +1990,24 @@ document.addEventListener('DOMContentLoaded', function () {
       .catch(err => {
         console.error(err);
         notify('Fehler beim Export', 'danger');
+      });
+  });
+
+  tenantSyncBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    const original = tenantSyncBtn.innerHTML;
+    tenantSyncBtn.disabled = true;
+    tenantSyncBtn.innerHTML = '<div uk-spinner></div>';
+    apiFetch('/tenants/sync', { method: 'POST' })
+      .then(r => r.json())
+      .then(() => {
+        notify('Mandanten eingelesen', 'success');
+        loadTenants();
+      })
+      .catch(() => notify('Fehler beim Synchronisieren', 'danger'))
+      .finally(() => {
+        tenantSyncBtn.disabled = false;
+        tenantSyncBtn.innerHTML = original;
       });
   });
 

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -202,6 +202,7 @@ return [
     'action_open_evaluation' => 'Auswertung öffnen',
     'action_download' => 'Herunterladen',
     'action_delete_tenant' => 'Mandant löschen',
+    'action_sync_tenants' => 'Fehlende Mandanten suchen',
     'action_renew_ssl' => 'SSL erneuern',
     'help_admin_pass' => 'Definiert das Admin-Passwort des neuen Mandanten. Bleibt das Feld leer, ' .
         'wird ein zufälliges Passwort erzeugt',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -201,6 +201,7 @@ return [
     'action_open_evaluation' => 'Open evaluation',
     'action_download' => 'Download',
     'action_delete_tenant' => 'Delete tenant',
+    'action_sync_tenants' => 'Import missing subdomains',
     'action_renew_ssl' => 'Renew SSL',
     'help_admin_pass' => 'Defines the admin password for the new tenant. Leave empty to generate a random one',
     'info_admin_email' => 'The link to set the admin password will be sent by email.',

--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -94,6 +94,16 @@ class TenantController
     }
 
     /**
+     * Import missing tenants by scanning available schemas.
+     */
+    public function sync(Request $request, Response $response): Response
+    {
+        $count = $this->service->importMissing();
+        $response->getBody()->write(json_encode(['imported' => $count]));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    /**
      * List all tenants as JSON.
      */
     public function list(Request $request, Response $response): Response

--- a/src/routes.php
+++ b/src/routes.php
@@ -630,6 +630,13 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('tenantController')->delete($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT));
 
+    $app->post('/tenants/sync', function (Request $request, Response $response) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(403);
+        }
+        return $request->getAttribute('tenantController')->sync($request, $response);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+
     $app->get('/tenants.json', function (Request $request, Response $response) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(403);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -789,6 +789,9 @@
     <li class="{{ activeRoute == 'tenants' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_tenants') }}</h2>
+        <p>
+          <button id="tenantSyncBtn" class="uk-button uk-button-default uk-margin-small-bottom">{{ t('action_sync_tenants') }}</button>
+        </p>
         <div class="uk-overflow-auto">
           <table id="tenantTable" class="uk-table uk-table-divider uk-table-small">
             <thead>

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -254,4 +254,34 @@ SQL;
         $this->assertSame('2000-01-01 00:00:00+00:00', $row['plan_started_at']);
         $this->assertSame('2000-01-31 00:00:00+00:00', $row['plan_expires_at']);
     }
+
+    public function testImportMissingCreatesTenants(): void
+    {
+        $pdo = new class extends PDO {
+            public function __construct()
+            {
+                parent::__construct('sqlite::memory:');
+            }
+
+            public function getAttribute($attr): mixed
+            {
+                if ($attr === PDO::ATTR_DRIVER_NAME) {
+                    return 'pgsql';
+                }
+                return parent::getAttribute($attr);
+            }
+        };
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE tenants(' .
+            'uid TEXT PRIMARY KEY, subdomain TEXT, plan TEXT, billing_info TEXT, stripe_customer_id TEXT, ' .
+            'imprint_name TEXT, imprint_street TEXT, imprint_zip TEXT, imprint_city TEXT, ' .
+            'imprint_email TEXT, custom_limits TEXT, plan_started_at TEXT, plan_expires_at TEXT, created_at TEXT)');
+        $pdo->exec('CREATE TABLE information_schema.schemata(schema_name TEXT)');
+        $pdo->exec("INSERT INTO information_schema.schemata(schema_name) VALUES('s1'),('public'),('s2')");
+        $service = new TenantService($pdo);
+        $count = $service->importMissing();
+        $this->assertSame(2, $count);
+        $subs = $pdo->query('SELECT subdomain FROM tenants ORDER BY subdomain')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['s1', 's2'], $subs);
+    }
 }


### PR DESCRIPTION
## Summary
- add TenantService::importMissing to register DB schemas without entries
- expose /tenants/sync route and admin button to trigger scan
- translate and test tenant sync

## Testing
- `vendor/bin/phpcs src/Service/TenantService.php src/Controller/TenantController.php src/routes.php tests/Service/TenantServiceTest.php`
- `composer test` *(fails: Database error and controller tests failures)*

------
https://chatgpt.com/codex/tasks/task_e_689c2681f778832bbdcbd5375652fcb9