### PR TITLE
Add onboarding step timeline with navigation

### DIFF
--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -19,6 +19,15 @@ body.high-contrast .onboarding-step {
   border-color: #000000;
   box-shadow: none;
 }
+body.high-contrast .onboarding-timeline .timeline-step {
+  border-color: #000000;
+  color: #000000;
+}
+body.high-contrast .onboarding-timeline .timeline-step.active,
+body.high-contrast .onboarding-timeline .timeline-step.completed {
+  border-color: #000000;
+  color: #000000;
+}
 body.high-contrast .uk-button-primary {
   background-color: #000000;
   border-color: #000000;
@@ -84,6 +93,15 @@ body.dark-mode.high-contrast .modern-info-card {
 body.dark-mode.high-contrast .onboarding-step {
   border-color: #ffffff;
   box-shadow: none;
+}
+body.dark-mode.high-contrast .onboarding-timeline .timeline-step {
+  border-color: #ffffff;
+  color: #ffffff;
+}
+body.dark-mode.high-contrast .onboarding-timeline .timeline-step.active,
+body.dark-mode.high-contrast .onboarding-timeline .timeline-step.completed {
+  border-color: #ffffff;
+  color: #ffffff;
 }
 
 body.dark-mode.high-contrast .uk-button-primary {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -454,6 +454,54 @@ body.dark-mode .onboarding-step {
   box-shadow: 0 6px 30px rgba(0,0,0,0.5);
 }
 
+/* Timeline for onboarding steps */
+.onboarding-timeline {
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+  padding: 0;
+}
+
+.onboarding-timeline .timeline-step {
+  padding: 0.5rem 1rem;
+  margin: 0 0.5rem;
+  border-bottom: 3px solid #e5e5e5;
+  cursor: pointer;
+  color: #666;
+}
+
+.onboarding-timeline .timeline-step.active {
+  border-color: #0c86d0;
+  color: #0c86d0;
+  font-weight: 600;
+}
+
+.onboarding-timeline .timeline-step.completed {
+  border-color: #0c86d0;
+  color: #0c86d0;
+}
+
+.onboarding-timeline .timeline-step.future {
+  cursor: default;
+  color: #999;
+}
+
+body.dark-mode .onboarding-timeline .timeline-step {
+  border-color: #555;
+  color: #aaa;
+}
+
+body.dark-mode .onboarding-timeline .timeline-step.future {
+  color: #555;
+}
+
+body.dark-mode .onboarding-timeline .timeline-step.active,
+body.dark-mode .onboarding-timeline .timeline-step.completed {
+  border-color: #1e87f0;
+  color: #1e87f0;
+}
+
 
 /* Wrapper for thumbnails with rotate button */
 .photo-wrapper {

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -12,13 +12,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const verifiedHint = document.getElementById('verifiedHint');
   const basePath = window.basePath || '';
   const withBase = p => basePath + p;
+  const timelineSteps = document.querySelectorAll('.timeline-step');
 
   const params = new URLSearchParams(window.location.search);
   const sessionId = params.get('session_id');
   const emailParam = params.get('email');
   const storedEmail = localStorage.getItem('onboard_email') || '';
-  const storedSubdomain = localStorage.getItem('onboard_subdomain');
-  const storedVerified = localStorage.getItem('onboard_verified') === '1';
+  let subdomainStored = localStorage.getItem('onboard_subdomain') || '';
+  let verified = params.get('verified') === '1' || localStorage.getItem('onboard_verified') === '1';
+  if (params.get('verified') === '1') {
+    localStorage.setItem('onboard_verified', '1');
+    verified = true;
+  }
 
   if (emailInput) {
     if (emailParam) {
@@ -28,21 +33,26 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  if (params.get('verified') === '1') {
-    localStorage.setItem('onboard_verified', '1');
-  }
-
-  if (params.get('verified') === '1' || storedVerified) {
-    step1.hidden = true;
-    if (storedSubdomain) {
-      step2.hidden = true;
-      if (step3) step3.hidden = false;
-      if (subdomainPreview) subdomainPreview.textContent = storedSubdomain;
-    } else {
-      step2.hidden = false;
+  let currentStep = 1;
+  function showStep(step) {
+    currentStep = step;
+    step1.hidden = step !== 1;
+    step2.hidden = step !== 2;
+    if (step3) step3.hidden = step !== 3;
+    if (verifiedHint) verifiedHint.hidden = !(step === 2 && verified);
+    if (subdomainPreview && subdomainStored) {
+      subdomainPreview.textContent = subdomainStored;
     }
-    if (verifiedHint && params.get('verified') === '1') verifiedHint.hidden = false;
+    timelineSteps.forEach(el => {
+      const s = parseInt(el.dataset.step, 10);
+      el.classList.toggle('active', s === step);
+      el.classList.toggle('completed', s < step);
+    });
   }
+  if (verified) {
+    currentStep = subdomainStored ? 3 : 2;
+  }
+  showStep(currentStep);
 
   if (sendEmailBtn) {
     sendEmailBtn.addEventListener('click', async () => {
@@ -84,8 +94,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       localStorage.setItem('onboard_subdomain', subdomain);
-      step2.hidden = true;
-      if (step3) step3.hidden = false;
+      subdomainStored = subdomain;
+      showStep(3);
     });
   }
   if (planButtons.length) {
@@ -146,6 +156,22 @@ document.addEventListener('DOMContentLoaded', () => {
           // ignore and show alert below
         }
         alert('Fehler beim Start der Zahlung.');
+      });
+    });
+  }
+
+  if (timelineSteps.length) {
+    timelineSteps.forEach(el => {
+      if (el.classList.contains('future')) return;
+      el.addEventListener('click', () => {
+        const target = parseInt(el.dataset.step, 10);
+        if (target === 1) {
+          showStep(1);
+        } else if (target === 2 && verified) {
+          showStep(2);
+        } else if (target === 3 && verified && subdomainStored) {
+          showStep(3);
+        }
       });
     });
   }

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -88,6 +88,13 @@
 {% block body %}
   {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-margin-large-top">
+    <ul class="onboarding-timeline uk-flex uk-flex-center uk-margin-bottom" id="stepTimeline">
+      <li class="timeline-step active" data-step="1">1. E-Mail</li>
+      <li class="timeline-step" data-step="2">2. Subdomain</li>
+      <li class="timeline-step" data-step="3">3. Tarif</li>
+      <li class="timeline-step future" data-step="4">4. Impressum</li>
+      <li class="timeline-step future" data-step="5">5. App erstellen</li>
+    </ul>
     <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1">
       <h3 class="uk-card-title">1. E-Mail eingeben und bestätigen</h3>
       <div class="uk-margin">


### PR DESCRIPTION
## Summary
- display onboarding steps in a clickable timeline
- allow users to navigate back and forth between steps
- style timeline with dark and high-contrast support
- show upcoming steps for Impressum and app creation

## Testing
- `composer test` *(fails: Tests: 205, Assertions: 440, Errors: 9, Failures: 16, Warnings: 9)*

------
https://chatgpt.com/codex/tasks/task_e_689ca387f97c832b84295d5f6dc9e304