### PR TITLE
Add disabled placeholders for upcoming onboarding steps

### DIFF
--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -28,6 +28,11 @@ body.high-contrast .onboarding-timeline .timeline-step.completed {
   border-color: #000000;
   color: #000000;
 }
+body.high-contrast .onboarding-timeline .timeline-step.inactive {
+  border-color: #666666;
+  color: #666666;
+  cursor: not-allowed;
+}
 body.high-contrast .uk-button-primary {
   background-color: #000000;
   border-color: #000000;
@@ -102,6 +107,11 @@ body.dark-mode.high-contrast .onboarding-timeline .timeline-step.active,
 body.dark-mode.high-contrast .onboarding-timeline .timeline-step.completed {
   border-color: #ffffff;
   color: #ffffff;
+}
+body.dark-mode.high-contrast .onboarding-timeline .timeline-step.inactive {
+  border-color: #999999;
+  color: #999999;
+  cursor: not-allowed;
 }
 
 body.dark-mode.high-contrast .uk-button-primary {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -471,6 +471,11 @@ body.dark-mode .onboarding-step {
   color: #666;
 }
 
+.onboarding-timeline .timeline-step.inactive {
+  cursor: not-allowed;
+  color: #bbb;
+}
+
 .onboarding-timeline .timeline-step.active {
   border-color: #0c86d0;
   color: #0c86d0;
@@ -485,6 +490,12 @@ body.dark-mode .onboarding-step {
 body.dark-mode .onboarding-timeline .timeline-step {
   border-color: #555;
   color: #aaa;
+}
+
+body.dark-mode .onboarding-timeline .timeline-step.inactive {
+  color: #444;
+  border-color: #555;
+  cursor: not-allowed;
 }
 
 body.dark-mode .onboarding-timeline .timeline-step.active,

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -162,6 +162,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (timelineSteps.length) {
     timelineSteps.forEach(el => {
+      if (el.classList.contains('inactive')) {
+        return;
+      }
       el.addEventListener('click', () => {
         const target = parseInt(el.dataset.step, 10);
         if (target === 1) {

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -92,6 +92,8 @@
       <li class="timeline-step active" data-step="1">1. E-Mail</li>
       <li class="timeline-step" data-step="2">2. Subdomain</li>
       <li class="timeline-step" data-step="3">3. Tarif</li>
+      <li class="timeline-step inactive" data-step="4">4. Impressum</li>
+      <li class="timeline-step inactive" data-step="5">5. App erstellen</li>
     </ul>
     <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1">
       <h3 class="uk-card-title">1. E-Mail eingeben und bestätigen</h3>


### PR DESCRIPTION
## Summary
- Show upcoming “Impressum” and “App erstellen” steps in onboarding timeline
- Style future steps as inactive across light, dark, and high-contrast modes
- Skip click handling for inactive steps so they appear disabled

## Testing
- `composer test` *(fails: Slim Application Error, Database error)*

------
https://chatgpt.com/codex/tasks/task_e_689ca9dec98c832bb8e5ecf274a1e6e9