### PR TITLE
Normalize host detection

### DIFF
--- a/src/Application/Middleware/DomainMiddleware.php
+++ b/src/Application/Middleware/DomainMiddleware.php
@@ -19,9 +19,21 @@ class DomainMiddleware implements MiddlewareInterface
      */
     public function process(Request $request, RequestHandler $handler): Response
     {
-        $host = $request->getUri()->getHost();
-        $mainDomain = getenv('MAIN_DOMAIN') ?: '';
-        $domainType = $host === $mainDomain ? 'main' : 'tenant';
+        $host = strtolower($request->getUri()->getHost());
+        $host = (string) preg_replace('/^www\./', '', $host);
+
+        $mainDomain = strtolower((string) getenv('MAIN_DOMAIN'));
+        $mainDomain = (string) preg_replace('/^www\./', '', $mainDomain);
+
+        $domainType = 'main';
+        if (
+            $mainDomain !== ''
+            && $host !== $mainDomain
+            && str_ends_with($host, '.' . $mainDomain)
+        ) {
+            $domainType = 'tenant';
+        }
+
         $request = $request->withAttribute('domainType', $domainType);
 
         return $handler->handle($request);

--- a/tests/Controller/DomainAccessTest.php
+++ b/tests/Controller/DomainAccessTest.php
@@ -34,7 +34,7 @@ class DomainAccessTest extends TestCase
         }
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
         $request = $this->createRequest('POST', '/tenants');
-        $request = $request->withUri($request->getUri()->withHost('tenant.test'));
+        $request = $request->withUri($request->getUri()->withHost('tenant.main.test'));
         $response = $app->handle($request);
         $this->assertEquals(403, $response->getStatusCode());
         if (session_status() === PHP_SESSION_ACTIVE) {
@@ -57,7 +57,7 @@ class DomainAccessTest extends TestCase
         }
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
         $req = $this->createRequest('GET', '/tenants/foo');
-        $req = $req->withUri($req->getUri()->withHost('tenant.test'));
+        $req = $req->withUri($req->getUri()->withHost('tenant.main.test'));
         $res = $app->handle($req);
         $this->assertEquals(403, $res->getStatusCode());
         if (session_status() === PHP_SESSION_ACTIVE) {

--- a/tests/Controller/LandingControllerTest.php
+++ b/tests/Controller/LandingControllerTest.php
@@ -22,7 +22,7 @@ class LandingControllerTest extends TestCase
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/landing');
-        $request = $request->withUri($request->getUri()->withHost('tenant.test'));
+        $request = $request->withUri($request->getUri()->withHost('tenant.main.test'));
         $response = $app->handle($request);
         $this->assertEquals(404, $response->getStatusCode());
         if ($old === false) {

--- a/tests/Controller/TenantControllerTest.php
+++ b/tests/Controller/TenantControllerTest.php
@@ -164,7 +164,7 @@ class TenantControllerTest extends TestCase
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
         $req = $this->createRequest('POST', '/tenants');
-        $req = $req->withUri($req->getUri()->withHost('tenant.test'));
+        $req = $req->withUri($req->getUri()->withHost('tenant.main.test'));
         $res = $app->handle($req);
         $this->assertEquals(403, $res->getStatusCode());
         session_destroy();
@@ -183,7 +183,7 @@ class TenantControllerTest extends TestCase
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
         $req = $this->createRequest('DELETE', '/tenants');
-        $req = $req->withUri($req->getUri()->withHost('tenant.test'));
+        $req = $req->withUri($req->getUri()->withHost('tenant.main.test'));
         $res = $app->handle($req);
         $this->assertEquals(403, $res->getStatusCode());
         session_destroy();

--- a/tests/DomainMiddlewareTest.php
+++ b/tests/DomainMiddlewareTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Application\Middleware\DomainMiddleware;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response;
+
+class DomainMiddlewareTest extends TestCase
+{
+    public function testWwwHostTreatedAsMain(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main-domain.tld');
+
+        $middleware = new DomainMiddleware();
+        $factory = new ServerRequestFactory();
+        $request = $factory->createServerRequest('GET', 'https://www.main-domain.tld/');
+
+        $handler = new class implements RequestHandlerInterface {
+            public ?Request $request = null;
+
+            public function handle(Request $request): ResponseInterface
+            {
+                $this->request = $request;
+                return new Response();
+            }
+        };
+
+        $middleware->process($request, $handler);
+        $this->assertSame('main', $handler->request->getAttribute('domainType'));
+
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+
+    public function testMissingMainDomainDefaultsToMain(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN');
+
+        $middleware = new DomainMiddleware();
+        $factory = new ServerRequestFactory();
+        $request = $factory->createServerRequest('GET', 'https://foo.test/');
+
+        $handler = new class implements RequestHandlerInterface {
+            public ?Request $request = null;
+
+            public function handle(Request $request): ResponseInterface
+            {
+                $this->request = $request;
+                return new Response();
+            }
+        };
+
+        $middleware->process($request, $handler);
+        $this->assertSame('main', $handler->request->getAttribute('domainType'));
+
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize main-domain comparison by lowercasing, trimming leading `www.` and using suffix checks
- Default to main domain when host lacks subdomain and add coverage for absent `MAIN_DOMAIN`
- Adjust tests and test harness for new domain rules

## Testing
- `vendor/bin/phpcs src/Application/Middleware/DomainMiddleware.php tests/DomainMiddlewareTest.php tests/Controller/DomainAccessTest.php tests/Controller/LandingControllerTest.php tests/Controller/TenantControllerTest.php tests/TestCase.php`
- `vendor/bin/phpunit` *(fails: unknown database information_schema, StripeWebhookControllerTest assertion)*

------
https://chatgpt.com/codex/tasks/task_e_689cb3a43ee4832bad2cf875c6920b0a