### PR TITLE
Improve subscription selection and upgrade options

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -69,6 +69,23 @@ document.addEventListener('DOMContentLoaded', function () {
   const checkoutContainer = document.getElementById('stripe-checkout');
   const planButtons = document.querySelectorAll('.plan-select');
   const emailInput = document.getElementById('subscription-email');
+  if (planButtons.length) {
+    fetch(withBase('/admin/subscription/status'))
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        const currentPlan = data?.plan || '';
+        planButtons.forEach(btn => {
+          const btnPlan = btn.dataset.plan;
+          if (!btnPlan) return;
+          if (btnPlan === currentPlan) {
+            btn.disabled = true;
+          } else if (currentPlan) {
+            btn.textContent = window.transUpgradeAction || 'Upgrade';
+          }
+        });
+      })
+      .catch(() => {});
+  }
   planButtons.forEach(btn => {
     btn.addEventListener('click', async () => {
       const plan = btn.dataset.plan;

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -198,7 +198,7 @@ return [
     'action_restore_demo' => 'Demodaten wiederherstellen',
     'action_refresh' => 'Aktualisieren',
     'action_open_subscription' => 'Kundenportal öffnen',
-    'action_start_subscription' => 'Abo buchen',
+    'action_start_subscription' => 'Buchen',
     'action_open_evaluation' => 'Auswertung öffnen',
     'action_download' => 'Herunterladen',
     'action_delete_tenant' => 'Mandant löschen',
@@ -219,6 +219,6 @@ return [
     'action_set_password' => 'Passwort setzen',
     'heading_limit_reached' => 'Limit erreicht',
     'text_upgrade_required' => 'Abo-Limit erreicht. Bitte upgraden, um mehr Ressourcen anzulegen.',
-    'action_upgrade' => 'Jetzt upgraden',
+    'action_upgrade' => 'Upgrade',
     'text_stripe_config_missing' => 'Stripe-Konfiguration fehlt. Bitte erforderliche Umgebungsvariablen setzen.',
 ];

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -197,7 +197,7 @@ return [
     'action_restore_demo' => 'Restore demo data',
     'action_refresh' => 'Refresh',
     'action_open_subscription' => 'Open customer portal',
-    'action_start_subscription' => 'Start subscription',
+    'action_start_subscription' => 'Subscribe',
     'action_open_evaluation' => 'Open evaluation',
     'action_download' => 'Download',
     'action_delete_tenant' => 'Delete tenant',
@@ -217,6 +217,6 @@ return [
     'action_set_password' => 'Set password',
     'heading_limit_reached' => 'Limit reached',
     'text_upgrade_required' => 'Subscription limit reached. Please upgrade to add more resources.',
-    'action_upgrade' => 'Upgrade now',
+    'action_upgrade' => 'Upgrade',
     'text_stripe_config_missing' => 'Stripe configuration missing. Please set required environment variables.',
 ];


### PR DESCRIPTION
## Summary
- shorten subscription and upgrade labels in German and English translations
- disable the current plan and label remaining subscription options as upgrades

## Testing
- `composer test` *(fails: Slim Application Error; Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_689cb5703cc0832ba6ec8d8a2f8ba264