### PR TITLE
Ensure admin subscription email field appears without tenant

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -69,6 +69,11 @@ document.addEventListener('DOMContentLoaded', function () {
   const checkoutContainer = document.getElementById('stripe-checkout');
   const planButtons = document.querySelectorAll('.plan-select');
   const emailInput = document.getElementById('subscription-email');
+  if (emailInput) {
+    emailInput.addEventListener('input', () => {
+      emailInput.classList.remove('uk-form-danger');
+    });
+  }
   if (planButtons.length) {
     fetch(withBase('/admin/subscription/status'))
       .then(r => (r.ok ? r.json() : null))
@@ -92,7 +97,14 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!plan) return;
       const payload = { plan, embedded: true };
       if (emailInput) {
-        payload.email = emailInput.value;
+        const email = emailInput.value.trim();
+        if (email === '') {
+          emailInput.classList.add('uk-form-danger');
+          emailInput.focus();
+          notify('Bitte E-Mail-Adresse eingeben', 'warning');
+          return;
+        }
+        payload.email = email;
       }
       try {
         const res = await apiFetch('/admin/subscription/checkout', {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -890,13 +890,13 @@
         {% if stripe_configured %}
         <script src="https://js.stripe.com/v3/"></script>
         <div id="stripe-checkout"></div>
-        {% if tenant and not tenant.imprint_email %}
-        <div class="uk-margin-top uk-width-1-2@s">
-          <label class="uk-form-label">E-Mail für Abrechnung</label>
-          <input class="uk-input" type="email" id="subscription-email" placeholder="name@firma.de" required>
-          <div class="uk-text-meta">Wird für Stripe-Kund*in verwendet.</div>
-        </div>
-        {% endif %}
+          {% if not tenant or not tenant.imprint_email %}
+          <div class="uk-margin-top uk-width-1-2@s">
+            <label class="uk-form-label">E-Mail für Abrechnung</label>
+            <input class="uk-input" type="email" id="subscription-email" placeholder="name@firma.de" required>
+            <div class="uk-text-meta">Wird für Stripe-Kund*in verwendet.</div>
+          </div>
+          {% endif %}
         <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-small uk-margin-top" uk-grid>
           <div>
             <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -147,4 +147,30 @@ class AdminControllerTest extends TestCase
         putenv('MAIN_DOMAIN');
         unset($_ENV['MAIN_DOMAIN']);
     }
+
+    /**
+     * Render subscription page without existing tenant to ensure email input is shown.
+     *
+     * @runInSeparateProcess
+     */
+    public function testSubscriptionPageShowsEmailInputWhenTenantMissing(): void
+    {
+        require __DIR__ . '/../Service/StripeServiceStub.php';
+        $db = $this->setupDb();
+        putenv('MAIN_DOMAIN=example.com');
+        $_ENV['MAIN_DOMAIN'] = 'example.com';
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $request = $this->createRequest('GET', '/admin/subscription')
+            ->withUri(new Uri('http', 'foo.example.com', 80, '/admin/subscription'));
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('id="subscription-email"', $body);
+        session_destroy();
+        unlink($db);
+        putenv('MAIN_DOMAIN');
+        unset($_ENV['MAIN_DOMAIN']);
+    }
 }


### PR DESCRIPTION
## Summary
- Always render subscription email input when tenant data is missing
- Guard subscription checkout with client-side email validation
- Test subscription page renders email input without existing tenant

## Testing
- `vendor/bin/phpunit tests/Controller/AdminControllerTest.php --filter SubscriptionPageShowsEmailInputWhenTenantMissing`
- `vendor/bin/phpcs tests/Controller/AdminControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689cb8db0018832b995e632a2b12a471