### PR TITLE
Expose Stripe logs on checkout errors

### DIFF
--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -149,8 +149,13 @@ class AdminSubscriptionCheckoutController
 
     private function jsonError(Response $response, int $status, string $message): Response
     {
-        $payload = json_encode(['error' => $message]);
-        $response->getBody()->write($payload !== false ? $payload : '{}');
+        $payload = ['error' => $message];
+        $log = LogService::tail('stripe');
+        if ($log !== '') {
+            $payload['log'] = $log;
+        }
+        $json = json_encode($payload);
+        $response->getBody()->write($json !== false ? $json : '{}');
         return $response->withStatus($status)->withHeader('Content-Type', 'application/json');
     }
 }

--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -28,5 +28,22 @@ class LogService
         $logger->pushHandler(new StreamHandler($logDir . '/' . $channel . '.log', Level::Debug));
         return $logger;
     }
+
+    /**
+     * Fetch the most recent log lines for the given channel.
+     */
+    public static function tail(string $channel, int $lines = 20): string
+    {
+        $root = dirname(__DIR__, 2);
+        $file = $root . '/logs/' . $channel . '.log';
+        if (!is_file($file)) {
+            return '';
+        }
+        $content = file($file);
+        if ($content === false) {
+            return '';
+        }
+        return implode('', array_slice($content, -$lines));
+    }
 }
 


### PR DESCRIPTION
## Summary
- Add `LogService::tail` helper to retrieve recent log lines
- Return recent Stripe log output in admin checkout error responses
- Display Stripe error log content directly in admin UI notifications

## Testing
- `composer test` *(fails: unknown database information_schema, StripeWebhookControllerTest assertion)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb45a3f0832bb4259f2d8104cc0c