### PR TITLE
Log missing Stripe configuration

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -43,7 +43,7 @@ if ($logger instanceof Logger) {
 }
 
 // verify Stripe configuration before starting the app
-if (!StripeService::isConfigured()) {
+if (!StripeService::isConfigured()['ok']) {
     $logger->error('Stripe configuration missing');
 }
 

--- a/scripts/check_stripe_config.php
+++ b/scripts/check_stripe_config.php
@@ -20,10 +20,12 @@ if (is_readable($envFile)) {
     }
 }
 
-if (StripeService::isConfigured()) {
+$config = StripeService::isConfigured();
+if ($config['ok']) {
     echo "Stripe configuration OK\n";
     exit(0);
 }
 
-fwrite(STDERR, "Stripe configuration missing\n");
+$missing = implode(', ', $config['missing'] ?? []);
+fwrite(STDERR, "Stripe configuration missing: $missing\n");
 exit(1);

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -147,7 +147,7 @@ class AdminController
             && $tenant !== null
             && ($tenant['stripe_customer_id'] ?? '') === ''
             && ($tenant['imprint_email'] ?? '') !== ''
-            && StripeService::isConfigured()
+            && StripeService::isConfigured()['ok']
         ) {
             $service = new StripeService();
             try {
@@ -204,7 +204,7 @@ class AdminController
               'pages' => $pages,
               'domainType' => $request->getAttribute('domainType'),
               'tenant' => $tenant,
-              'stripe_configured' => StripeService::isConfigured(),
+              'stripe_configured' => StripeService::isConfigured()['ok'],
               'currentPath' => $request->getUri()->getPath(),
               'username' => $_SESSION['user']['username'] ?? '',
               'csrf_token' => $csrf,

--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -78,7 +78,7 @@ class AdminSubscriptionCheckoutController
             return $this->jsonError($response, 422, 'missing email');
         }
 
-        if (!StripeService::isConfigured()) {
+        if (!StripeService::isConfigured()['ok']) {
             $logger->error('Stripe configuration incomplete');
             return $this->jsonError($response, 503, 'service unavailable');
         }

--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -58,7 +58,7 @@ class OnboardingController
         $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
         $_SESSION['csrf_token'] = $csrf;
 
-        $stripeConfigured = StripeService::isConfigured();
+        $stripeConfig = StripeService::isConfigured();
 
         return $view->render(
             $response,
@@ -68,7 +68,8 @@ class OnboardingController
                 'logged_in' => $loggedIn,
                 'reload_token' => $reloadToken,
                 'csrf_token' => $csrf,
-                'stripe_configured' => $stripeConfigured,
+                'stripe_configured' => $stripeConfig['ok'],
+                'stripe_missing' => $stripeConfig['missing'] ?? [],
             ]
         );
     }

--- a/src/Controller/StripeCheckoutController.php
+++ b/src/Controller/StripeCheckoutController.php
@@ -36,7 +36,7 @@ class StripeCheckoutController
             return $this->jsonError($response, 422, 'invalid subdomain');
         }
 
-        if (!StripeService::isConfigured()) {
+        if (!StripeService::isConfigured()['ok']) {
             return $this->jsonError($response, 503, 'service unavailable');
         }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -455,7 +455,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             : $tenantSvc->getBySubdomain(explode('.', $request->getUri()->getHost())[0]);
         $customerId = (string) ($tenant['stripe_customer_id'] ?? '');
         $payload = [];
-        if ($customerId !== '' && StripeService::isConfigured()) {
+        if ($customerId !== '' && StripeService::isConfigured()['ok']) {
             $service = new StripeService();
             try {
                 $info = $service->getActiveSubscription($customerId);

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -127,6 +127,9 @@
       <p>Wähle einen Tarif und schließe die Zahlung über Stripe ab. Du kannst jeden kostenpflichtigen Tarif 7 Tage lang kostenlos testen.</p>
       {% else %}
       <p class="uk-text-danger">Zahlungsdienstleister nicht konfiguriert. Nur der kostenlose Starter-Tarif ist verfügbar.</p>
+      {% if stripe_missing %}
+      <p class="uk-text-meta">Fehlende Variablen: {{ stripe_missing|join(', ') }}</p>
+      {% endif %}
       {% endif %}
       <div class="pricing-grid uk-child-width-1-1 uk-child-width-1-3@m" uk-grid>
         <div>

--- a/tests/Service/StripeServiceStub.php
+++ b/tests/Service/StripeServiceStub.php
@@ -18,8 +18,8 @@ class StripeService
         return 'cus_test';
     }
 
-    public static function isConfigured(): bool
+    public static function isConfigured(): array
     {
-        return true;
+        return ['ok' => true];
     }
 }


### PR DESCRIPTION
## Summary
- log missing Stripe environment variables
- surface missing Stripe config in onboarding wizard

## Testing
- `vendor/bin/phpcs public/index.php scripts/check_stripe_config.php src/Controller/AdminController.php src/Controller/AdminSubscriptionCheckoutController.php src/Controller/OnboardingController.php src/Controller/StripeCheckoutController.php src/Service/StripeService.php src/routes.php tests/Service/StripeServiceStub.php`
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 unknown database information_schema)*

------
https://chatgpt.com/codex/tasks/task_e_689ccd5a135c832bb6a458ff06611f60