### PR TITLE
Harden Stripe onboarding checks

### DIFF
--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -88,6 +88,31 @@
 {% block body %}
   {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-margin-large-top">
+    {% if stripe_error %}
+      <div class="uk-alert-danger" uk-alert>
+        <p>{{ stripe_error }}</p>
+      </div>
+    {% endif %}
+
+    {% if not stripe_configured %}
+      <div class="uk-alert-danger" uk-alert>
+        <p>Stripe ist unvollständig konfiguriert.</p>
+        <ul>
+          {% for key in stripe_missing %}
+            <li>{{ key }} fehlt</li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% elseif stripe_warnings|length %}
+      <div class="uk-alert-warning" uk-alert>
+        <p>Stripe-Warnungen:</p>
+        <ul>
+          {% for w in stripe_warnings %}
+            <li>{{ w }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
     <ul class="onboarding-timeline uk-flex uk-flex-center uk-margin-bottom" id="stepTimeline">
       <li class="timeline-step active" data-step="1">1. E-Mail</li>
       <li class="timeline-step" data-step="2">2. Subdomain</li>

--- a/tests/Service/StripeServiceStub.php
+++ b/tests/Service/StripeServiceStub.php
@@ -20,6 +20,6 @@ class StripeService
 
     public static function isConfigured(): array
     {
-        return ['ok' => true];
+        return ['ok' => true, 'missing' => [], 'warnings' => []];
     }
 }


### PR DESCRIPTION
## Summary
- Harden service auto-login by env checks and add Stripe config error handling in onboarding
- Enrich `StripeService::isConfigured` with warnings & webhook/price checks plus preflight helper
- Display Stripe config errors and warnings in onboarding UI

## Testing
- `composer test` *(fails: Tests: 210, Assertions: 467, Errors: 8, Failures: 2)*

------
https://chatgpt.com/codex/tasks/task_e_689cd49fa028832bae60ca4db5e3b2f9