### PR TITLE
Remove redundant null coalescing from onboarding controller

### DIFF
--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -87,9 +87,9 @@ class OnboardingController
                 'logged_in' => $loggedIn,
                 'reload_token' => $reloadToken,
                 'csrf_token' => $csrf,
-                'stripe_configured' => (bool) ($stripeConfig['ok'] ?? false),
-                'stripe_missing' => $stripeConfig['missing'] ?? [],
-                'stripe_warnings' => $stripeConfig['warnings'] ?? [],
+                'stripe_configured' => (bool) $stripeConfig['ok'],
+                'stripe_missing' => $stripeConfig['missing'],
+                'stripe_warnings' => $stripeConfig['warnings'],
                 'stripe_error' => $stripeConfig['error'] ?? null,
             ]
         );


### PR DESCRIPTION
## Summary
- eliminate unnecessary null coalescing on Stripe config keys

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `composer test` *(fails: Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_689cd6f9278c832bb1ff8d85dfb71bff