### PR TITLE
Fix failing tests and optional Stripe webhook secret

### DIFF
--- a/migrations/20240910_base_schema.sql
+++ b/migrations/20240910_base_schema.sql
@@ -190,6 +190,19 @@ CREATE TABLE IF NOT EXISTS tenants (
     plan TEXT,
     billing_info TEXT,
     stripe_customer_id TEXT,
+    stripe_subscription_id TEXT,
+    stripe_price_id TEXT,
+    stripe_status TEXT,
+    stripe_current_period_end TIMESTAMP WITH TIME ZONE,
+    stripe_cancel_at_period_end BOOLEAN,
+    imprint_name TEXT,
+    imprint_street TEXT,
+    imprint_zip TEXT,
+    imprint_city TEXT,
+    imprint_email TEXT,
+    custom_limits TEXT,
+    plan_started_at TIMESTAMP WITH TIME ZONE,
+    plan_expires_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -87,9 +87,9 @@ class OnboardingController
                 'logged_in' => $loggedIn,
                 'reload_token' => $reloadToken,
                 'csrf_token' => $csrf,
-                'stripe_configured' => (bool) ($stripeConfig['ok'] ?? false),
-                'stripe_missing' => $stripeConfig['missing'] ?? [],
-                'stripe_warnings' => $stripeConfig['warnings'] ?? [],
+                'stripe_configured' => (bool) $stripeConfig['ok'],
+                'stripe_missing' => $stripeConfig['missing'],
+                'stripe_warnings' => $stripeConfig['warnings'],
                 'stripe_error' => $stripeConfig['error'] ?? null,
             ]
         );

--- a/src/Service/PageVariableService.php
+++ b/src/Service/PageVariableService.php
@@ -17,8 +17,15 @@ class PageVariableService
      */
     public static function apply(string $html): string
     {
-        $pdo = Database::connectFromEnv();
-        $profile = (new TenantService($pdo))->getMainTenant();
+        try {
+            $pdo = Database::connectFromEnv();
+            $profile = (new TenantService($pdo))->getMainTenant();
+        } catch (\Throwable $e) {
+            $file = dirname(__DIR__, 2) . '/data/profile.json';
+            $profile = is_readable($file)
+                ? json_decode((string) file_get_contents($file), true) ?: []
+                : [];
+        }
 
         $replacements = [
             '[NAME]' => $profile['imprint_name'] ?? '',

--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -217,13 +217,13 @@ class StripeService
         $mapRequired = [
             $prefix . 'SECRET_KEY' => $sk,
             $prefix . 'PUBLISHABLE_KEY' => $pk,
-            $prefix . 'WEBHOOK_SECRET' => $wh,
             $prefix . 'PRICE_STARTER' => $priceStarter,
             $prefix . 'PRICE_STANDARD' => $priceStandard,
             $prefix . 'PRICE_PROFESSIONAL' => $pricePro,
         ];
 
         $missing = [];
+        $warnings = [];
         foreach ($mapRequired as $name => $val) {
             if ($val === '') {
                 $missing[] = $name;
@@ -231,7 +231,10 @@ class StripeService
             }
         }
 
-        $warnings = [];
+        if ($wh === '') {
+            $warnings[] = $prefix . 'WEBHOOK_SECRET missing';
+            error_log('Missing ' . $prefix . 'WEBHOOK_SECRET');
+        }
         $skLive = str_starts_with($sk, 'sk_live_');
         $pkLive = str_starts_with($pk, 'pk_live_');
         if (($skLive && !$pkLive) || (!$skLive && $pkLive)) {

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -457,6 +457,9 @@ class TenantService
                 if ($f === 'plan' && $value !== null && Plan::tryFrom((string) $value) === null) {
                     throw new \RuntimeException('invalid-plan');
                 }
+                if (is_bool($value)) {
+                    $value = $value ? 1 : 0;
+                }
                 $set[] = $f . ' = ?';
                 $params[] = $f === 'custom_limits'
                     ? ($value !== null ? json_encode($value) : null)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -162,7 +162,11 @@ class TestCase extends PHPUnit_TestCase
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         \App\Infrastructure\Migrations\Migrator::migrate($pdo, __DIR__ . '/../migrations');
-        $pdo->exec('ALTER TABLE tenants ADD COLUMN custom_limits TEXT');
+        try {
+            $pdo->exec('ALTER TABLE tenants ADD COLUMN custom_limits TEXT');
+        } catch (\Throwable $e) {
+            // ignore
+        }
         return $pdo;
     }
 


### PR DESCRIPTION
## Summary
- include all tenant columns in base schema to support tests
- fall back to default profile when database unavailable
- loosen Stripe configuration check and handle booleans in tenant updates
- fix test harness and array access to satisfy static analysis

## Testing
- `composer test`
- `vendor/bin/phpstan analyse --memory-limit=512M`
- `vendor/bin/phpcs migrations/20240910_base_schema.sql src/Controller/OnboardingController.php src/Service/PageVariableService.php src/Service/StripeService.php src/Service/TenantService.php tests/TestCase.php`

------
https://chatgpt.com/codex/tasks/task_e_689cd62bc9dc832bba598c6c3e0255f7