### PR TITLE
Handle Stripe service failures with 503

### DIFF
--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -110,7 +110,7 @@ class AdminSubscriptionCheckoutController
                 );
             } catch (\Throwable $e) {
                 $logger->error('Failed to create/find customer', ['error' => $e->getMessage()]);
-                return $this->jsonError($response, 500, 'internal error');
+                return $this->jsonError($response, 503, 'service unavailable');
             }
         }
 
@@ -131,7 +131,7 @@ class AdminSubscriptionCheckoutController
             );
         } catch (\Throwable $e) {
             $logger->error('Checkout session creation failed', ['error' => $e->getMessage()]);
-            return $this->jsonError($response, 500, 'internal error');
+            return $this->jsonError($response, 503, 'service unavailable');
         }
 
         if ($embedded) {


### PR DESCRIPTION
## Summary
- return 503 service unavailable when Stripe customer lookup or checkout session creation fails in admin subscription checkout

## Testing
- `composer test` *(fails: missing STRIPE_WEBHOOK_SECRET, database errors, failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc16ec28832bb2b75e876829aa90