### PR TITLE
Handle unexpected errors during Stripe checkout

### DIFF
--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -20,131 +20,136 @@ class AdminSubscriptionCheckoutController
     public function __invoke(Request $request, Response $response): Response
     {
         $logger = LogService::create('stripe');
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
-        $sessionToken = $_SESSION['csrf_token'] ?? '';
-        $headerToken = $request->getHeaderLine('X-CSRF-Token');
-        if ($sessionToken === '' || $headerToken !== $sessionToken) {
-            $logger->warning('CSRF token mismatch', [
-                'session' => $sessionToken,
-                'header' => $headerToken,
-            ]);
-            return $response->withStatus(403);
-        }
-
-        $data = json_decode((string) $request->getBody(), true);
-        if (!is_array($data)) {
-            $logger->warning('Invalid JSON payload');
-            return $response->withStatus(400);
-        }
-
-        $plan = Plan::tryFrom((string) ($data['plan'] ?? ''));
-        if ($plan === null) {
-            $logger->warning('Invalid plan', ['plan' => $data['plan'] ?? null]);
-            return $this->jsonError($response, 422, 'invalid plan');
-        }
-
-        $embedded = filter_var($data['embedded'] ?? false, FILTER_VALIDATE_BOOLEAN);
-
-        $host = $request->getUri()->getHost();
-        $sub = explode('.', $host)[0];
-        $domainType = (string) $request->getAttribute('domainType');
-        $base = Database::connectFromEnv();
-        $tenantService = new TenantService($base);
-        $tenant = $domainType === 'main'
-            ? $tenantService->getMainTenant()
-            : $tenantService->getBySubdomain($sub);
-        if ($tenant === null) {
-            $logger->warning('Tenant not found', ['subdomain' => $sub, 'domainType' => $domainType]);
-            return $this->jsonError($response, 404, 'tenant not found');
-        }
-
-        $email = (string) ($tenant['imprint_email'] ?? '');
-        $customerId = (string) ($tenant['stripe_customer_id'] ?? '');
-        if ($email === '') {
-            $payloadEmail = (string) ($data['email'] ?? '');
-            if ($payloadEmail !== '' && filter_var($payloadEmail, FILTER_VALIDATE_EMAIL)) {
-                $email = $payloadEmail;
-                $tenant['imprint_email'] = $email;
-                $tenantService->updateProfile(
-                    $domainType === 'main' ? 'main' : $sub,
-                    ['imprint_email' => $email]
-                );
+        try {
+            if (session_status() === PHP_SESSION_NONE) {
+                session_start();
             }
-        }
-        if ($email === '' && $customerId === '') {
-            $logger->warning('Missing tenant email', ['tenant' => $tenant['subdomain'] ?? $sub]);
-            return $this->jsonError($response, 422, 'missing email');
-        }
+            $sessionToken = $_SESSION['csrf_token'] ?? '';
+            $headerToken = $request->getHeaderLine('X-CSRF-Token');
+            if ($sessionToken === '' || $headerToken !== $sessionToken) {
+                $logger->warning('CSRF token mismatch', [
+                    'session' => $sessionToken,
+                    'header' => $headerToken,
+                ]);
+                return $response->withStatus(403);
+            }
 
-        if (!StripeService::isConfigured()['ok']) {
-            $logger->error('Stripe configuration incomplete');
-            return $this->jsonError($response, 503, 'service unavailable');
-        }
+            $data = json_decode((string) $request->getBody(), true);
+            if (!is_array($data)) {
+                $logger->warning('Invalid JSON payload');
+                return $response->withStatus(400);
+            }
 
-        $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
-        $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';
-        $priceMap = [
-            Plan::STARTER->value => getenv($prefix . 'PRICE_STARTER') ?: '',
-            Plan::STANDARD->value => getenv($prefix . 'PRICE_STANDARD') ?: '',
-            Plan::PROFESSIONAL->value => getenv($prefix . 'PRICE_PROFESSIONAL') ?: '',
-        ];
-        $priceId = $priceMap[$plan->value];
-        if ($priceId === '') {
-            $logger->error('Price ID missing', ['plan' => $plan->value]);
-            return $this->jsonError($response, 422, 'invalid plan');
-        }
+            $plan = Plan::tryFrom((string) ($data['plan'] ?? ''));
+            if ($plan === null) {
+                $logger->warning('Invalid plan', ['plan' => $data['plan'] ?? null]);
+                return $this->jsonError($response, 422, 'invalid plan');
+            }
 
-        $service = new StripeService();
-        if ($customerId === '') {
-            try {
-                $customerId = $service->findCustomerIdByEmail($email) ?? $service->createCustomer(
-                    $email,
-                    $tenant['imprint_name'] ?? null
-                );
-                $tenant['stripe_customer_id'] = $customerId;
-                $tenantService->updateProfile(
-                    $domainType === 'main' ? 'main' : $sub,
-                    ['stripe_customer_id' => $customerId]
-                );
-            } catch (\Throwable $e) {
-                $logger->error('Failed to create/find customer', ['error' => $e->getMessage()]);
+            $embedded = filter_var($data['embedded'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+            $host = $request->getUri()->getHost();
+            $sub = explode('.', $host)[0];
+            $domainType = (string) $request->getAttribute('domainType');
+            $base = Database::connectFromEnv();
+            $tenantService = new TenantService($base);
+            $tenant = $domainType === 'main'
+                ? $tenantService->getMainTenant()
+                : $tenantService->getBySubdomain($sub);
+            if ($tenant === null) {
+                $logger->warning('Tenant not found', ['subdomain' => $sub, 'domainType' => $domainType]);
+                return $this->jsonError($response, 404, 'tenant not found');
+            }
+
+            $email = (string) ($tenant['imprint_email'] ?? '');
+            $customerId = (string) ($tenant['stripe_customer_id'] ?? '');
+            if ($email === '') {
+                $payloadEmail = (string) ($data['email'] ?? '');
+                if ($payloadEmail !== '' && filter_var($payloadEmail, FILTER_VALIDATE_EMAIL)) {
+                    $email = $payloadEmail;
+                    $tenant['imprint_email'] = $email;
+                    $tenantService->updateProfile(
+                        $domainType === 'main' ? 'main' : $sub,
+                        ['imprint_email' => $email]
+                    );
+                }
+            }
+            if ($email === '' && $customerId === '') {
+                $logger->warning('Missing tenant email', ['tenant' => $tenant['subdomain'] ?? $sub]);
+                return $this->jsonError($response, 422, 'missing email');
+            }
+
+            if (!StripeService::isConfigured()['ok']) {
+                $logger->error('Stripe configuration incomplete');
                 return $this->jsonError($response, 503, 'service unavailable');
             }
-        }
 
-        $uri = $request->getUri();
-        $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
-        $successUrl = $baseUrl . '/admin/subscription?session_id={CHECKOUT_SESSION_ID}';
-        $cancelUrl = $baseUrl . '/admin/subscription';
+            $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
+            $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';
+            $priceMap = [
+                Plan::STARTER->value => getenv($prefix . 'PRICE_STARTER') ?: '',
+                Plan::STANDARD->value => getenv($prefix . 'PRICE_STANDARD') ?: '',
+                Plan::PROFESSIONAL->value => getenv($prefix . 'PRICE_PROFESSIONAL') ?: '',
+            ];
+            $priceId = $priceMap[$plan->value];
+            if ($priceId === '') {
+                $logger->error('Price ID missing', ['plan' => $plan->value]);
+                return $this->jsonError($response, 422, 'invalid plan');
+            }
 
-        try {
-            $result = $service->createCheckoutSession(
-                $priceId,
-                $successUrl,
-                $cancelUrl,
-                $customerId === '' ? $email : null,
-                $customerId !== '' ? $customerId : null,
-                $tenant['subdomain'] ?? $sub,
-                $embedded
-            );
+            $service = new StripeService();
+            if ($customerId === '') {
+                try {
+                    $customerId = $service->findCustomerIdByEmail($email) ?? $service->createCustomer(
+                        $email,
+                        $tenant['imprint_name'] ?? null
+                    );
+                    $tenant['stripe_customer_id'] = $customerId;
+                    $tenantService->updateProfile(
+                        $domainType === 'main' ? 'main' : $sub,
+                        ['stripe_customer_id' => $customerId]
+                    );
+                } catch (\Throwable $e) {
+                    $logger->error('Failed to create/find customer', ['error' => $e->getMessage()]);
+                    return $this->jsonError($response, 503, 'service unavailable');
+                }
+            }
+
+            $uri = $request->getUri();
+            $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
+            $successUrl = $baseUrl . '/admin/subscription?session_id={CHECKOUT_SESSION_ID}';
+            $cancelUrl = $baseUrl . '/admin/subscription';
+
+            try {
+                $result = $service->createCheckoutSession(
+                    $priceId,
+                    $successUrl,
+                    $cancelUrl,
+                    $customerId === '' ? $email : null,
+                    $customerId !== '' ? $customerId : null,
+                    $tenant['subdomain'] ?? $sub,
+                    $embedded
+                );
+            } catch (\Throwable $e) {
+                $logger->error('Checkout session creation failed', ['error' => $e->getMessage()]);
+                return $this->jsonError($response, 503, 'service unavailable');
+            }
+
+            if ($embedded) {
+                $payload = json_encode([
+                    'client_secret' => $result,
+                    'publishable_key' => $service->getPublishableKey(),
+                ]);
+            } else {
+                $payload = json_encode(['url' => $result]);
+            }
+            $logger->info('Checkout session created', ['embedded' => $embedded]);
+            $response->getBody()->write($payload !== false ? $payload : '{}');
+            return $response->withHeader('Content-Type', 'application/json');
         } catch (\Throwable $e) {
-            $logger->error('Checkout session creation failed', ['error' => $e->getMessage()]);
-            return $this->jsonError($response, 503, 'service unavailable');
+            $logger->error('Unexpected checkout failure', ['error' => $e->getMessage()]);
+            return $this->jsonError($response, 500, 'internal error');
         }
-
-        if ($embedded) {
-            $payload = json_encode([
-                'client_secret' => $result,
-                'publishable_key' => $service->getPublishableKey(),
-            ]);
-        } else {
-            $payload = json_encode(['url' => $result]);
-        }
-        $logger->info('Checkout session created', ['embedded' => $embedded]);
-        $response->getBody()->write($payload !== false ? $payload : '{}');
-        return $response->withHeader('Content-Type', 'application/json');
     }
 
     private function jsonError(Response $response, int $status, string $message): Response


### PR DESCRIPTION
## Summary
- avoid raw 500 errors when initializing Stripe checkout by wrapping logic in try/catch
- surface internal failures as JSON and log details for debugging

## Testing
- `composer test` *(fails: Tests\Controller\StripeCheckoutControllerTest::testPostStartsCheckoutWithReference; Tests\Controller\StripeWebhookControllerTest::testCustomerSubscriptionUpdatedUpdatesDetails)*
- `vendor/bin/phpcs src/Controller/AdminSubscriptionCheckoutController.php`


------
https://chatgpt.com/codex/tasks/task_e_689cdf3162f4832b820b3b1294f9c7a3