### PR TITLE
Add plan metadata to Stripe checkout session

### DIFF
--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -125,6 +125,7 @@ class AdminSubscriptionCheckoutController
                     $priceId,
                     $successUrl,
                     $cancelUrl,
+                    $plan->value,
                     $customerId === '' ? $email : null,
                     $customerId !== '' ? $customerId : null,
                     $tenant['subdomain'] ?? $sub,

--- a/src/Controller/StripeCheckoutController.php
+++ b/src/Controller/StripeCheckoutController.php
@@ -72,6 +72,7 @@ class StripeCheckoutController
                 $priceId,
                 $successUrl,
                 $cancelUrl,
+                $plan->value,
                 $email,
                 $customerId,
                 $subdomain

--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -35,6 +35,7 @@ class StripeService
         string $priceId,
         string $successUrl,
         string $cancelUrl,
+        string $plan,
         ?string $customerEmail = null,
         ?string $customerId = null,
         ?string $clientReferenceId = null,
@@ -47,6 +48,7 @@ class StripeService
             ],
             'payment_method_types' => ['card'],
             'subscription_data' => ['trial_period_days' => 7],
+            'metadata' => ['plan' => $plan],
         ];
         if ($embedded) {
             $params['ui_mode'] = 'embedded';

--- a/tests/Controller/StripeCheckoutControllerTest.php
+++ b/tests/Controller/StripeCheckoutControllerTest.php
@@ -43,7 +43,9 @@ class StripeCheckoutControllerTest extends TestCase
         $_SESSION['csrf_token'] = 'tok';
         $service = new class extends StripeService {
             public array $args = [];
-            public function __construct() {}
+            public function __construct()
+            {
+            }
             public function findCustomerIdByEmail(string $email): ?string
             {
                 $this->args['email'] = $email;
@@ -53,6 +55,7 @@ class StripeCheckoutControllerTest extends TestCase
                 string $priceId,
                 string $successUrl,
                 string $cancelUrl,
+                string $plan,
                 ?string $customerEmail = null,
                 ?string $customerId = null,
                 ?string $clientReferenceId = null,
@@ -77,6 +80,7 @@ class StripeCheckoutControllerTest extends TestCase
         $request = $request->withAttribute('stripeService', $service);
         $response = $app->handle($request);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('tenant1', $service->args['create'][5] ?? null);
+        $this->assertSame('standard', $service->args['create'][3] ?? null);
+        $this->assertSame('tenant1', $service->args['create'][6] ?? null);
     }
 }

--- a/tests/Service/StripeServiceTest.php
+++ b/tests/Service/StripeServiceTest.php
@@ -93,16 +93,31 @@ final class StripeServiceTest extends TestCase
     {
         $client = $this->createFakeStripeClient();
         $service = new StripeService(client: $client);
-        $service->createCheckoutSession('price_123', 'https://success', 'https://cancel', 'user@example.com');
+        $service->createCheckoutSession(
+            'price_123',
+            'https://success',
+            'https://cancel',
+            'starter',
+            'user@example.com'
+        );
         $this->assertSame(['card'], $client->checkout->sessions->lastParams['payment_method_types'] ?? null);
         $this->assertSame(7, $client->checkout->sessions->lastParams['subscription_data']['trial_period_days'] ?? null);
+        $this->assertSame('starter', $client->checkout->sessions->lastParams['metadata']['plan'] ?? null);
     }
 
     public function testCreateCheckoutSessionWithCustomerIdAndReference(): void
     {
         $client = $this->createFakeStripeClient();
         $service = new StripeService(client: $client);
-        $service->createCheckoutSession('price_123', 'https://success', 'https://cancel', null, 'cus_123', 'tenant1');
+        $service->createCheckoutSession(
+            'price_123',
+            'https://success',
+            'https://cancel',
+            'standard',
+            null,
+            'cus_123',
+            'tenant1'
+        );
         $this->assertSame('cus_123', $client->checkout->sessions->lastParams['customer'] ?? null);
         $this->assertSame('tenant1', $client->checkout->sessions->lastParams['client_reference_id'] ?? null);
     }
@@ -111,7 +126,13 @@ final class StripeServiceTest extends TestCase
     {
         $client = $this->createFakeStripeClient();
         $service = new StripeService(client: $client);
-        $secret = $service->createCheckoutSession('price_123', 'https://success', 'https://cancel', embedded: true);
+        $secret = $service->createCheckoutSession(
+            'price_123',
+            'https://success',
+            'https://cancel',
+            'starter',
+            embedded: true
+        );
         $this->assertSame('embedded', $client->checkout->sessions->lastParams['ui_mode'] ?? null);
         $this->assertSame('https://success', $client->checkout->sessions->lastParams['return_url'] ?? null);
         $this->assertSame('sec_123', $secret);


### PR DESCRIPTION
## Summary
- Include plan metadata when creating Stripe checkout sessions
- Pass plan value from controllers and adjust related tests

## Testing
- `composer test` *(fails: Tests: 210, Assertions: 459, Errors: 8, Failures: 3)*


------
https://chatgpt.com/codex/tasks/task_e_689ce7c4f6a8832bbe004f5e057f4b2c