### PR TITLE
refactor: fix PHPCS issues in Stripe tests

### DIFF
--- a/tests/Controller/StripeCheckoutControllerTest.php
+++ b/tests/Controller/StripeCheckoutControllerTest.php
@@ -43,12 +43,17 @@ class StripeCheckoutControllerTest extends TestCase
         $_SESSION['csrf_token'] = 'tok';
         $service = new class extends StripeService {
             public array $args = [];
-            public function __construct() {}
+
+            public function __construct()
+            {
+            }
+
             public function findCustomerIdByEmail(string $email): ?string
             {
                 $this->args['email'] = $email;
                 return 'cus_123';
             }
+
             public function createCheckoutSession(
                 string $priceId,
                 string $successUrl,

--- a/tests/Service/StripeServiceTest.php
+++ b/tests/Service/StripeServiceTest.php
@@ -93,17 +93,38 @@ final class StripeServiceTest extends TestCase
     {
         $client = $this->createFakeStripeClient();
         $service = new StripeService(client: $client);
-        $service->createCheckoutSession('price_123', 'https://success', 'https://cancel', 'user@example.com');
-        $this->assertSame(['card'], $client->checkout->sessions->lastParams['payment_method_types'] ?? null);
-        $this->assertSame(7, $client->checkout->sessions->lastParams['subscription_data']['trial_period_days'] ?? null);
+        $service->createCheckoutSession(
+            'price_123',
+            'https://success',
+            'https://cancel',
+            'user@example.com'
+        );
+        $this->assertSame(
+            ['card'],
+            $client->checkout->sessions->lastParams['payment_method_types'] ?? null
+        );
+        $this->assertSame(
+            7,
+            $client->checkout->sessions->lastParams['subscription_data']['trial_period_days'] ?? null
+        );
     }
 
     public function testCreateCheckoutSessionWithCustomerIdAndReference(): void
     {
         $client = $this->createFakeStripeClient();
         $service = new StripeService(client: $client);
-        $service->createCheckoutSession('price_123', 'https://success', 'https://cancel', null, 'cus_123', 'tenant1');
-        $this->assertSame('cus_123', $client->checkout->sessions->lastParams['customer'] ?? null);
+        $service->createCheckoutSession(
+            'price_123',
+            'https://success',
+            'https://cancel',
+            null,
+            'cus_123',
+            'tenant1'
+        );
+        $this->assertSame(
+            'cus_123',
+            $client->checkout->sessions->lastParams['customer'] ?? null
+        );
         $this->assertSame('tenant1', $client->checkout->sessions->lastParams['client_reference_id'] ?? null);
     }
 
@@ -111,8 +132,16 @@ final class StripeServiceTest extends TestCase
     {
         $client = $this->createFakeStripeClient();
         $service = new StripeService(client: $client);
-        $secret = $service->createCheckoutSession('price_123', 'https://success', 'https://cancel', embedded: true);
-        $this->assertSame('embedded', $client->checkout->sessions->lastParams['ui_mode'] ?? null);
+        $secret = $service->createCheckoutSession(
+            'price_123',
+            'https://success',
+            'https://cancel',
+            embedded: true
+        );
+        $this->assertSame(
+            'embedded',
+            $client->checkout->sessions->lastParams['ui_mode'] ?? null
+        );
         $this->assertSame('https://success', $client->checkout->sessions->lastParams['return_url'] ?? null);
         $this->assertSame('sec_123', $secret);
     }


### PR DESCRIPTION
## Summary
- reformat Stripe service test for PSR-12 line length compliance
- ensure controller test anonymous class uses proper brace style

## Testing
- `./vendor/bin/phpcs tests/Service/StripeServiceTest.php tests/Controller/StripeCheckoutControllerTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_689ce8f96240832bb75cc42974b4d39d