### PR TITLE
Use automatic payment methods for Stripe checkout

### DIFF
--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -54,7 +54,7 @@ class StripeService
             'line_items' => [
                 ['price' => $priceId, 'quantity' => 1],
             ],
-            'payment_method_types' => ['card'],
+            'automatic_payment_methods' => ['enabled' => true],
             'metadata' => ['plan' => $plan],
         ];
         if ($trialPeriodDays !== null) {

--- a/tests/Service/StripeServiceTest.php
+++ b/tests/Service/StripeServiceTest.php
@@ -89,7 +89,7 @@ final class StripeServiceTest extends TestCase
         };
     }
 
-    public function testCreateCheckoutSessionAddsPaymentMethodTypesAndTrialPeriod(): void
+    public function testCreateCheckoutSessionAddsAutomaticPaymentMethodsAndTrialPeriod(): void
     {
         $client = $this->createFakeStripeClient();
         $service = new StripeService(client: $client);
@@ -104,8 +104,8 @@ final class StripeServiceTest extends TestCase
             7
         );
         $this->assertSame(
-            ['card'],
-            $client->checkout->sessions->lastParams['payment_method_types'] ?? null
+            ['enabled' => true],
+            $client->checkout->sessions->lastParams['automatic_payment_methods'] ?? null
         );
         $this->assertSame(
             7,


### PR DESCRIPTION
## Summary
- use Stripe automatic payment methods in checkout session creation
- update tests for automatic payment methods

## Testing
- `composer phpunit`
- `vendor/bin/phpcs src/Service/StripeService.php tests/Service/StripeServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689ced52fd58832ba602641fff3744df