### PR TITLE
Use customer email only for Stripe checkout

### DIFF
--- a/src/Controller/StripeCheckoutController.php
+++ b/src/Controller/StripeCheckoutController.php
@@ -61,12 +61,6 @@ class StripeCheckoutController
         if (!$service instanceof StripeService) {
             $service = new StripeService();
         }
-        $customerId = null;
-        try {
-            $customerId = $service->findCustomerIdByEmail($email);
-        } catch (Throwable $e) {
-            $customerId = null;
-        }
         try {
             $url = $service->createCheckoutSession(
                 $priceId,
@@ -74,7 +68,7 @@ class StripeCheckoutController
                 $cancelUrl,
                 $plan->value,
                 $email,
-                $customerId,
+                null,
                 $subdomain,
                 7
             );

--- a/tests/Controller/StripeCheckoutControllerTest.php
+++ b/tests/Controller/StripeCheckoutControllerTest.php
@@ -49,11 +49,6 @@ class StripeCheckoutControllerTest extends TestCase
             public function __construct()
             {
             }
-            public function findCustomerIdByEmail(string $email): ?string
-            {
-                $this->args['email'] = $email;
-                return 'cus_123';
-            }
             public function createCheckoutSession(
                 string $priceId,
                 string $successUrl,
@@ -85,6 +80,8 @@ class StripeCheckoutControllerTest extends TestCase
         $response = $app->handle($request);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('standard', $service->args['create'][3] ?? null);
+        $this->assertSame('u@example.com', $service->args['create'][4] ?? null);
+        $this->assertNull($service->args['create'][5] ?? null);
         $this->assertSame('tenant1', $service->args['create'][6] ?? null);
         $this->assertSame(7, $service->args['create'][7] ?? null);
     }


### PR DESCRIPTION
## Summary
- ensure Stripe checkout session only uses customer_email
- update onboarding test to expect null customer ID

## Testing
- `composer test`
- `vendor/bin/phpcs src/Controller/StripeCheckoutController.php tests/Controller/StripeCheckoutControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689cee776244832b9afa8be8728de059