### PR TITLE
Remove unsupported automatic payment methods from checkout

### DIFF
--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -54,7 +54,6 @@ class StripeService
             'line_items' => [
                 ['price' => $priceId, 'quantity' => 1],
             ],
-            'automatic_payment_methods' => ['enabled' => true],
             'metadata' => ['plan' => $plan],
         ];
         if ($trialPeriodDays !== null) {

--- a/tests/Service/StripeServiceTest.php
+++ b/tests/Service/StripeServiceTest.php
@@ -89,7 +89,7 @@ final class StripeServiceTest extends TestCase
         };
     }
 
-    public function testCreateCheckoutSessionAddsAutomaticPaymentMethodsAndTrialPeriod(): void
+    public function testCreateCheckoutSessionAddsTrialPeriod(): void
     {
         $client = $this->createFakeStripeClient();
         $service = new StripeService(client: $client);
@@ -104,16 +104,16 @@ final class StripeServiceTest extends TestCase
             7
         );
         $this->assertSame(
-            ['enabled' => true],
-            $client->checkout->sessions->lastParams['automatic_payment_methods'] ?? null
-        );
-        $this->assertSame(
             7,
             $client->checkout->sessions->lastParams['subscription_data']['trial_period_days'] ?? null
         );
         $this->assertSame(
             'starter',
             $client->checkout->sessions->lastParams['metadata']['plan'] ?? null
+        );
+        $this->assertArrayNotHasKey(
+            'automatic_payment_methods',
+            $client->checkout->sessions->lastParams
         );
     }
 


### PR DESCRIPTION
## Summary
- avoid Stripe API error by no longer sending `automatic_payment_methods` for checkout sessions
- adjust checkout session test for trial period and ensure parameter omission

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET, Database error: fail, Error creating tenant: boom)*
- `vendor/bin/phpunit tests/Service/StripeServiceTest.php`
- `vendor/bin/phpcs src/Service/StripeService.php tests/Service/StripeServiceTest.php`

------
https://chatgpt.com/codex/tasks/task_e_689cf21d04f0832b9e85d4e310bba54d