### PR TITLE
docs: note removal of unsupported automatic payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@
 
 ### Fix
 
+- Remove unsupported automatic payment methods from checkout
 - *(migrate)* Clear reference after uid update
 - *(qr)* Enable camera flip after scanner ready
 - *(qr)* Await scanner init


### PR DESCRIPTION
## Summary
- document removal of automatic_payment_methods from Stripe checkout to avoid 400 errors

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689cf853f420832b83aad1517d19f326