### PR TITLE
Fix coding standard issues

### DIFF
--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -46,4 +46,3 @@ class LogService
         return implode('', array_slice($content, -$lines));
     }
 }
-

--- a/tests/Controller/StripeWebhookControllerTest.php
+++ b/tests/Controller/StripeWebhookControllerTest.php
@@ -39,7 +39,9 @@ class StripeWebhookControllerTest extends TestCase
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
 
-        $stmt = $pdo->query("SELECT stripe_customer_id, stripe_subscription_id, plan FROM tenants WHERE subdomain = 'foo'");
+        $stmt = $pdo->query(
+            "SELECT stripe_customer_id, stripe_subscription_id, plan FROM tenants WHERE subdomain = 'foo'"
+        );
         $row = $stmt->fetch(\PDO::FETCH_ASSOC);
         $this->assertEquals('cus_123', $row['stripe_customer_id']);
         $this->assertEquals('sub_123', $row['stripe_subscription_id']);
@@ -78,7 +80,10 @@ class StripeWebhookControllerTest extends TestCase
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
 
-        $stmt = $pdo->query("SELECT stripe_subscription_id, plan, stripe_price_id, stripe_status, stripe_current_period_end, stripe_cancel_at_period_end FROM tenants WHERE subdomain = 'foo'");
+        $stmt = $pdo->query(
+            "SELECT stripe_subscription_id, plan, stripe_price_id, stripe_status, "
+            . "stripe_current_period_end, stripe_cancel_at_period_end FROM tenants WHERE subdomain = 'foo'"
+        );
         $row = $stmt->fetch(\PDO::FETCH_ASSOC);
         $this->assertEquals('sub_123', $row['stripe_subscription_id']);
         $this->assertEquals('standard', $row['plan']);

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -28,7 +28,10 @@ class MailServiceTest extends TestCase
         $_ENV['POSTGRES_PASSWORD'] = '';
         $pdo = new PDO('sqlite:' . $this->db);
         Migrator::migrate($pdo, dirname(__DIR__, 2) . '/migrations');
-        $pdo->exec("INSERT INTO tenants(uid, subdomain, imprint_name, imprint_email) VALUES('main','main','Example Org','admin@example.org')");
+        $pdo->exec(
+            "INSERT INTO tenants(uid, subdomain, imprint_name, imprint_email) "
+            . "VALUES('main','main','Example Org','admin@example.org')"
+        );
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Summary
- remove redundant newline from log service
- wrap long SQL strings in tests to respect line length limits

## Testing
- `vendor/bin/phpcs src/Service/LogService.php tests/Service/MailServiceTest.php tests/Controller/StripeWebhookControllerTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689d346ce5d8832bbf0dd9b1e946395a