### PR TITLE
Price starter plan at €9

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -17,7 +17,7 @@
         </div>
         <div class="separator width-100 bottom-border border-2px border-color-gray-light margin-top-bottom-30px uk-width-1-2@s" uk-scrollspy="cls: uk-animation-fade; delay: 250"></div>
         <div class="hero-buttons uk-margin-top" uk-scrollspy="cls: uk-animation-scale-up; delay: 300">
-          <a class="cta-main" href="{{ basePath }}/onboarding">Event kostenlos starten</a>
+          <a class="cta-main" href="{{ basePath }}/onboarding">Event starten</a>
           <a class="btn btn-black" href="{{ basePath }}/kataloge">Demo anschauen</a>
         </div>
       </div>
@@ -121,7 +121,7 @@ window.addEventListener('load', () => {
         </ul>
       </div>
       <div class="uk-width-auto@m uk-text-center">
-        <a class="btn btn-black uk-button-large" href="{{ basePath }}/onboarding">Jetzt kostenlos ausprobieren</a>
+        <a class="btn btn-black uk-button-large" href="{{ basePath }}/onboarding">Jetzt ausprobieren</a>
       </div>
     </div>
   </div>
@@ -206,9 +206,10 @@ window.addEventListener('load', () => {
         <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
           <span class="uk-label uk-label-success uk-label-large">Kostenlos testen</span>
           <h3 class="uk-card-title uk-text-primary uk-margin-small-top">Starter</h3>
-          <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">0&nbsp;€</div>
+          <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">9&nbsp;€/Monat</div>
           <div class="uk-text-meta uk-margin-small-bottom">Für kleine Events & Einsteiger</div>
           <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom">
+            <li><b>7 Tage kostenlos testen</b></li>
             <li><b>1 Event gleichzeitig</b></li>
             <li>5 Teams &amp; 5 Kataloge à 5 Fragen</li>
             <li>Unbegrenzte Teilnehmende pro Team¹</li>
@@ -216,7 +217,7 @@ window.addEventListener('load', () => {
             <li>Alle Fragetypen &amp; QR-Codes</li>
             <li>Backup &amp; editierbare Texte³</li>
           </ul>
-          <a href="{{ basePath }}/login" class="btn btn-transparent uk-width-1-1 uk-button-large uk-margin-small-top">Jetzt kostenlos starten</a>
+          <a href="{{ basePath }}/login" class="btn btn-transparent uk-width-1-1 uk-button-large uk-margin-small-top">Jetzt starten</a>
         </div>
       </div>
       <!-- Standard -->

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -902,9 +902,10 @@
             <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
               <span class="uk-label uk-label-success uk-label-large">Kostenlos testen</span>
               <h3 class="uk-card-title uk-text-primary uk-margin-small-top">{{ t('plan_starter') }}</h3>
-              <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">0&nbsp;€</div>
+              <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">9&nbsp;€/Monat</div>
               <div class="uk-text-meta uk-margin-small-bottom">Für kleine Events &amp; Einsteiger</div>
               <ul class="uk-list uk-text-left uk-margin-small-bottom">
+                <li><b>7 Tage kostenlos testen</b></li>
                 <li><b>1 Event gleichzeitig</b></li>
                 <li>5 Teams &amp; 5 Kataloge à 5 Fragen</li>
                 <li>Unbegrenzte Teilnehmende pro Team¹</li>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -310,7 +310,7 @@
         </ul>
       {% endblock %}
       {% block right %}
-        <a class="top-cta" href="{{ basePath }}/onboarding">Kostenlos testen</a>
+        <a class="top-cta" href="{{ basePath }}/onboarding">Jetzt testen</a>
       {% endblock %}
       {% block offcanvas %}
       <div id="offcanvas-nav" uk-offcanvas="overlay: true">

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -151,7 +151,7 @@
       {% if stripe_configured %}
       <p>Wähle einen Tarif und schließe die Zahlung über Stripe ab. Du kannst jeden kostenpflichtigen Tarif 7 Tage lang kostenlos testen.</p>
       {% else %}
-      <p class="uk-text-danger">Zahlungsdienstleister nicht konfiguriert. Nur der kostenlose Starter-Tarif ist verfügbar.</p>
+      <p class="uk-text-danger">Zahlungsdienstleister nicht konfiguriert. Nur der Starter-Tarif ist verfügbar.</p>
       {% if stripe_missing %}
       <p class="uk-text-meta">Fehlende Variablen: {{ stripe_missing|join(', ') }}</p>
       {% endif %}
@@ -161,9 +161,10 @@
           <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
             <span class="uk-label uk-label-success uk-label-large">Kostenlos testen</span>
             <h3 class="uk-card-title uk-text-primary uk-margin-small-top">Starter</h3>
-            <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">0&nbsp;€</div>
+            <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">9&nbsp;€/Monat</div>
             <div class="uk-text-meta uk-margin-small-bottom">Für kleine Events &amp; Einsteiger</div>
             <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom">
+              <li><b>7 Tage kostenlos testen</b></li>
               <li><b>1 Event gleichzeitig</b></li>
               <li>5 Teams &amp; 5 Kataloge à 5 Fragen</li>
               <li>Unbegrenzte Teilnehmende pro Team¹</li>


### PR DESCRIPTION
## Summary
- Update Starter plan pricing to €9 per month and remove free wording
- Add 7-day trial note for Starter plan and adjust CTA text across pages

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689dea5f5904832b8d3e5f15aa10b64e