### PR TITLE
Stream onboarding tenant output via chunked response

### DIFF
--- a/scripts/onboard_tenant.sh
+++ b/scripts/onboard_tenant.sh
@@ -2,6 +2,10 @@
 # Onboard a new tenant with dedicated subdomain and SSL
 set -e
 
+log() {
+  echo "$1"
+}
+
 error_exit() {
   echo "Fehler: $1" >&2
   exit 1
@@ -17,10 +21,14 @@ COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
 DOMAIN_SUFFIX="${MAIN_DOMAIN:-$DOMAIN}"
 EMAIL="${LETSENCRYPT_EMAIL:-admin@quizrace.app}"
 
+log "Starte Onboarding für Tenant '$SLUG'"
+
+log "Prüfe Domain-Konfiguration"
 if [ -z "$DOMAIN_SUFFIX" ]; then
   error_exit "MAIN_DOMAIN oder DOMAIN muss gesetzt sein"
 fi
 
+log "Prüfe APP_IMAGE"
 if [ -z "$APP_IMAGE" ]; then
   error_exit "APP_IMAGE ist nicht gesetzt"
 fi
@@ -32,6 +40,7 @@ NETWORK="${NETWORK:-webproxy}"
 # minimal free space in MB required to create a tenant
 MIN_DISK_MB=100
 
+log "Ermittle docker-compose Befehl"
 # detect docker compose command
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   DOCKER_COMPOSE="docker compose"
@@ -41,32 +50,38 @@ else
   error_exit "docker compose oder docker-compose ist nicht verfügbar"
 fi
 
+log "Validiere Domain ${SLUG}.${DOMAIN_SUFFIX}"
 # validate generated domain
 if ! echo "${SLUG}.${DOMAIN_SUFFIX}" | grep -Eq '^[a-z0-9-]+(\.[a-z0-9-]+)+$'; then
   error_exit "Generierte Domain '${SLUG}.${DOMAIN_SUFFIX}' ist ungültig."
 fi
 
+log "Prüfe Docker-Netzwerk ${NETWORK}"
 # ensure required docker network exists
 if ! docker network inspect ${NETWORK} >/dev/null 2>&1; then
   error_exit "Netzwerk '${NETWORK}' existiert nicht. Bitte zuerst mit 'docker network create --driver bridge ${NETWORK}' anlegen."
 fi
 
+log "Prüfe Containerkollisionen"
 # avoid container name collisions
 if docker ps -a --format '{{.Names}}' | grep -q "^${SLUG}_app$"; then
   error_exit "Ein Container mit dem Namen '${SLUG}_app' existiert bereits."
 fi
 
+log "Prüfe verfügbares Docker-Image ${IMAGE}"
 # optional image check
 if ! docker image inspect ${IMAGE} >/dev/null 2>&1; then
   echo "Warnung: Docker-Image '${IMAGE}' ist lokal nicht vorhanden. Der Container wird versuchen, es herunterzuladen."
 fi
 
+log "Prüfe freien Speicher"
 # check for sufficient disk space
 AVAILABLE_MB=$(df -Pm "$(dirname "$TENANT_DIR")" | awk 'NR==2{print $4}')
 if [ "$AVAILABLE_MB" -lt "$MIN_DISK_MB" ]; then
   error_exit "Zu wenig Speicherplatz (nur ${AVAILABLE_MB}MB verfügbar)."
 fi
 
+log "Erstelle Tenant-Verzeichnis"
 if [ -d "$TENANT_DIR" ]; then
   error_exit "Tenant directory '$TENANT_DIR' already exists"
 fi
@@ -75,6 +90,7 @@ if ! mkdir -p "$TENANT_DIR"; then
   error_exit "Konnte Verzeichnis '$TENANT_DIR' nicht anlegen"
 fi
 
+log "Erstelle docker-compose Datei"
 cat > "$COMPOSE_FILE" <<YAML
 version: '3.8'
 services:
@@ -99,17 +115,20 @@ networks:
     external: true
 YAML
 
+log "Validiere docker-compose Syntax"
 # validate compose file syntax
 if ! $DOCKER_COMPOSE -f "$COMPOSE_FILE" config >/dev/null 2>&1; then
   error_exit "docker compose config fehlgeschlagen (Syntaxfehler?)"
 fi
 
+log "Starte Tenant-Stack"
 # start the tenant stack
 if ! compose_out=$($DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" up -d 2>&1); then
   echo "$compose_out"
   error_exit "docker compose konnte den Tenant-Container nicht starten."
 fi
 
+log "Löse Nginx-Reload aus"
 # optional reload to speed up certificate issuance
 # Without a successful reload no certificate will be requested, so abort on failure
 RELOADER_URL="${NGINX_RELOADER_URL:-http://nginx-reloader:8080/reload}"
@@ -118,11 +137,13 @@ if ! curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null; th
   error_exit "Konnte Nginx-Reload nicht auslösen; kein Zertifikat beantragt"
 fi
 
+log "Starte Container neu"
 # restart the tenant container to pick up the certificate
 if ! $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" restart >/dev/null; then
   error_exit "Konnte Tenant-Container nicht neu starten"
 fi
 
+log "Löse zweiten Nginx-Reload aus"
 # trigger a second reload so nginx picks up the certificate
 if ! curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null; then
   echo "Warnung: Konnte zweiten Nginx-Reload nicht auslösen" >&2


### PR DESCRIPTION
## Summary
- stream onboarding script output line by line using `proc_open`
- add logging for each step in `onboard_tenant.sh`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689dfca94c04832bb803e866eeaea009