### PR TITLE
Make events published flag migration idempotent

### DIFF
--- a/migrations/20241014_add_published_flag_to_events.sql
+++ b/migrations/20241014_add_published_flag_to_events.sql
@@ -1,2 +1,3 @@
-ALTER TABLE events ADD COLUMN published BOOLEAN DEFAULT FALSE;
-UPDATE events SET published = TRUE;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS published BOOLEAN;
+UPDATE events SET published = TRUE WHERE published IS NULL;
+ALTER TABLE events ALTER COLUMN published SET DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- guard `events.published` migration against re-running by using `ADD COLUMN IF NOT EXISTS`
- update only unset rows and reapply default to keep published flag stable

## Testing
- `composer test` *(fails: Tests\Controller\EventsRouteTest::testEventsListAccessibleForCatalogEditor failed with status 500)*

------
https://chatgpt.com/codex/tasks/task_e_689f86748548832b8851184a9a1fa88a