### PR TITLE
feat: fallback logo path when event id missing

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -424,7 +424,9 @@ document.addEventListener('DOMContentLoaded', function () {
         }, 1000);
         const file = cfgFields.logoFile.files && cfgFields.logoFile.files[0];
         const ext = file && file.name.toLowerCase().endsWith('.webp') ? 'webp' : 'png';
-        cfgInitial.logoPath = '/logo-' + activeEventUid + '.' + ext;
+        cfgInitial.logoPath = activeEventUid
+          ? `/logo-${activeEventUid}.${ext}`
+          : `/logo.${ext}`;
         cfgFields.logoPreview.src = withBase(cfgInitial.logoPath) + '?' + Date.now();
         notify('Logo hochgeladen', 'success');
       }


### PR DESCRIPTION
## Summary
- handle admin logo upload when no event id is set by falling back to a default logo path

## Testing
- `STRIPE_SECRET_KEY=1 STRIPE_PUBLISHABLE_KEY=1 STRIPE_PRICE_STARTER=1 STRIPE_PRICE_STANDARD=1 STRIPE_PRICE_PROFESSIONAL=1 STRIPE_WEBHOOK_SECRET=1 composer test` *(fails: SQLSTATE[HY000]: General error: 1 no such column: published)*

------
https://chatgpt.com/codex/tasks/task_e_689f8de4b994832ba2145dee276621e9