### PR TITLE
Fix saving of landing page SEO settings

### DIFF
--- a/src/Controller/Admin/LandingpageController.php
+++ b/src/Controller/Admin/LandingpageController.php
@@ -40,29 +40,47 @@ class LandingpageController
         if (!is_array($data)) {
             return $response->withStatus(400);
         }
-        $errors = $this->seoService->validate($data);
+
+        $payload = [
+            'pageId' => (int) ($data['pageId'] ?? 0),
+            'slug' => (string) ($data['slug'] ?? ''),
+            'metaTitle' => $data['metaTitle'] ?? $data['meta_title'] ?? null,
+            'metaDescription' => $data['metaDescription'] ?? $data['meta_description'] ?? null,
+            'canonicalUrl' => $data['canonicalUrl'] ?? $data['canonical'] ?? null,
+            'robotsMeta' => $data['robotsMeta'] ?? $data['robots'] ?? null,
+            'ogTitle' => $data['ogTitle'] ?? $data['og_title'] ?? null,
+            'ogDescription' => $data['ogDescription'] ?? $data['og_description'] ?? null,
+            'ogImage' => $data['ogImage'] ?? $data['og_image'] ?? null,
+            'schemaJson' => $data['schemaJson'] ?? $data['schema'] ?? null,
+            'hreflang' => $data['hreflang'] ?? null,
+        ];
+
+        $errors = $this->seoService->validate($payload);
         if ($errors !== []) {
             $response->getBody()->write(json_encode(['errors' => $errors]));
             return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
         }
-        $pageId = (int) ($data['pageId'] ?? 0);
-        if ($pageId <= 0) {
+
+        if ($payload['pageId'] <= 0) {
             return $response->withStatus(400);
         }
+
         $config = new PageSeoConfig(
-            $pageId,
-            (string) $data['slug'],
-            $data['metaTitle'] ?? null,
-            $data['metaDescription'] ?? null,
-            $data['canonicalUrl'] ?? null,
-            $data['robotsMeta'] ?? null,
-            $data['ogTitle'] ?? null,
-            $data['ogDescription'] ?? null,
-            $data['ogImage'] ?? null,
-            $data['schemaJson'] ?? null,
-            $data['hreflang'] ?? null
+            $payload['pageId'],
+            $payload['slug'],
+            $payload['metaTitle'],
+            $payload['metaDescription'],
+            $payload['canonicalUrl'],
+            $payload['robotsMeta'],
+            $payload['ogTitle'],
+            $payload['ogDescription'],
+            $payload['ogImage'],
+            $payload['schemaJson'],
+            $payload['hreflang']
         );
+
         $this->seoService->save($config);
+
         return $response->withStatus(204);
     }
 }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -643,6 +643,7 @@
           <ul id="pageSwitcher" class="uk-switcher uk-margin">
             <li>
               <form class="uk-form-stacked seo-form" action="{{ basePath }}/admin/landingpage/seo" method="post">
+                <input type="hidden" name="pageId" value="1">
                 <div class="uk-margin">
                   <label class="uk-form-label" for="metaTitle">Meta Title</label>
                   <div class="uk-form-controls">

--- a/templates/admin/landingpage/edit.html.twig
+++ b/templates/admin/landingpage/edit.html.twig
@@ -14,6 +14,7 @@
   <div class="uk-container uk-container-small">
     <h1 class="uk-heading-bullet">Landingpage bearbeiten</h1>
     <form class="uk-form-stacked seo-form">
+      <input type="hidden" name="pageId" value="1">
       <h2>SEO</h2>
       <div class="uk-margin">
         <label class="uk-form-label" for="metaTitle">Meta Title</label>


### PR DESCRIPTION
## Summary
- accept snake_case form fields in landing page SEO controller
- include pageId hidden field in landing page SEO forms

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*
- `php -l src/Controller/Admin/LandingpageController.php`


------
https://chatgpt.com/codex/tasks/task_e_689f8dd51a64832b814cfceb36015504