### PR TITLE
Use base path when applying catalog logos

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -1,4 +1,5 @@
-/* global UIkit, Html5Qrcode, generateUserName */
+/* global UIkit, Html5Qrcode, generateUserName, basePath */
+const withBase = p => basePath + p;
 // Hilfsfunktion, um nur eine Front- und eine Rückkamera zu behalten
 window.filterCameraOrientations = window.filterCameraOrientations || function(cams){
   if(!Array.isArray(cams)) return [];
@@ -73,7 +74,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       let title = headerEl.querySelector('h1');
       if(img){
         if(cfg.logoPath){
-          img.src = cfg.logoPath;
+          img.src = withBase(cfg.logoPath) + '?' + Date.now();
           img.classList.remove('uk-hidden');
         }else{
           img.src = '';


### PR DESCRIPTION
## Summary
- add a `withBase` helper for catalog paths
- load catalog logos through `withBase` and cache-bust with a timestamp

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET, Slim Application Error)*
- `node -e "const basePath='/base';const withBase=p=>basePath+p;const cfg={logoPath:'/img/logo.png'};const img={src:'',classList:{remove(c){this.hidden=false;},add(c){this.hidden=true;},hidden:true}};if(cfg.logoPath){img.src=withBase(cfg.logoPath)+'?'+Date.now();img.classList.remove('uk-hidden');}else{img.src='';img.classList.add('uk-hidden');}console.log(img);"`

------
https://chatgpt.com/codex/tasks/task_e_689f8f0e8c9c832bb011c93e8a5161fe