### PR TITLE
Make events.published migration idempotent

### DIFF
--- a/migrations/20241014_add_published_flag_to_events.sql
+++ b/migrations/20241014_add_published_flag_to_events.sql
@@ -1,3 +1,15 @@
-ALTER TABLE events ADD COLUMN IF NOT EXISTS published BOOLEAN;
-UPDATE events SET published = TRUE WHERE published IS NULL;
+DO $$
+BEGIN
+   IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_name='events'
+        AND column_name='published'
+   ) THEN
+      ALTER TABLE events ADD COLUMN published BOOLEAN DEFAULT FALSE;
+      UPDATE events SET published = TRUE;
+   END IF;
+END $$;
+
 ALTER TABLE events ALTER COLUMN published SET DEFAULT FALSE;
+UPDATE events SET published = TRUE WHERE published IS NULL;


### PR DESCRIPTION
## Summary
- Prevent duplicate `events.published` column errors by adding column only when missing and seeding existing rows

## Testing
- `composer test` *(fails: Missing STRIPE_* vars, nginx reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_689f94c6c2e0832bb8c1a4c66bfbdd11