### PR TITLE
Use explicit conditional for admin logo placeholder

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -222,7 +222,18 @@
                 <label class="uk-form-label" for="cfgLogoPreview">{{ t('label_logo_preview') }}</label>
                 <div class="uk-form-controls">
                   <div class="logo-frame uk-margin-small-top">
-                    <img id="cfgLogoPreview" src="{{ basePath ~ config.logoPath|default('https://via.placeholder.com/160x240?text=Logo') }}" alt="{{ t('label_logo_preview') }}" class="logo-placeholder" width="160" height="240" loading="lazy">
+                    <img
+                      id="cfgLogoPreview"
+                      src="{% if config.logoPath %}
+                            {{ basePath ~ config.logoPath }}
+                          {% else %}
+                            https://via.placeholder.com/160x240?text=Logo
+                          {% endif %}"
+                      alt="{{ t('label_logo_preview') }}"
+                      class="logo-placeholder"
+                      width="160"
+                      height="240"
+                      loading="lazy">
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- handle missing logoPath with Twig conditional when rendering the admin logo preview

## Testing
- `php <<'PHP' ... ?>`
- `composer test` *(fails: 2 failures, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f95d04ca4832b80f921665b898d9b