### PR TITLE
Remove SSL data when deleting tenant

### DIFF
--- a/scripts/delete_tenant.sh
+++ b/scripts/delete_tenant.sh
@@ -65,6 +65,8 @@ curl -s -X DELETE \
   "http://$DOMAIN/tenants"
 
 rm -f "$BASE_DIR/vhost.d/${SUBDOMAIN}.$DOMAIN"
+rm -f "$BASE_DIR"/certs/"${SUBDOMAIN}.${DOMAIN}"*
+rm -rf "$BASE_DIR/acme/${SUBDOMAIN}.${DOMAIN}" "$BASE_DIR/acme/${SUBDOMAIN}.${DOMAIN}_ecc"
 
 if [ -n "$RELOADER_URL" ]; then
   curl -s -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL"

--- a/tests/DeleteTenantScriptTest.php
+++ b/tests/DeleteTenantScriptTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class DeleteTenantScriptTest extends TestCase
+{
+    public function testDeleteTenantRemovesSslArtifacts(): void
+    {
+        $slug = 't' . bin2hex(random_bytes(3));
+        $root = dirname(__DIR__);
+        $domain = 'example.test';
+
+        $envFile = $root . '/.env';
+        file_put_contents($envFile, "DOMAIN=$domain\nNGINX_RELOAD=0\n");
+
+        $vhost = "$root/vhost.d/$slug.$domain";
+        file_put_contents($vhost, 'dummy');
+
+        $certCrt = "$root/certs/$slug.$domain.crt";
+        $certKey = "$root/certs/$slug.$domain.key";
+        touch($certCrt);
+        touch($certKey);
+
+        $acmeDir = "$root/acme/$slug.$domain";
+        $acmeDirEcc = $acmeDir . '_ecc';
+        mkdir($acmeDir);
+        mkdir($acmeDirEcc);
+
+        $stubDir = sys_get_temp_dir() . '/curl_stub_' . uniqid();
+        mkdir($stubDir);
+        file_put_contents($stubDir . '/curl', "#!/bin/sh\nexit 0\n");
+        chmod($stubDir . '/curl', 0755);
+        $envPath = $stubDir . ':' . getenv('PATH');
+
+        $cmd = sprintf(
+            'PATH=%s %s/scripts/delete_tenant.sh %s --subdomain 2>&1',
+            escapeshellarg($envPath),
+            escapeshellarg($root),
+            escapeshellarg($slug)
+        );
+        exec($cmd, $output, $ret);
+
+        $this->assertSame(0, $ret, implode("\n", $output));
+        $this->assertFileDoesNotExist($vhost);
+        $this->assertFileDoesNotExist($certCrt);
+        $this->assertFileDoesNotExist($certKey);
+        $this->assertDirectoryDoesNotExist($acmeDir);
+        $this->assertDirectoryDoesNotExist($acmeDirEcc);
+
+        unlink($envFile);
+        @rmdir($stubDir);
+    }
+}


### PR DESCRIPTION
## Summary
- Clean up certificates and ACME data when removing a tenant
- Add regression test ensuring tenant deletion removes SSL artifacts

## Testing
- `composer test` *(fails: 3 errors, 2 failures)*
- `vendor/bin/phpunit tests/DeleteTenantScriptTest.php`

------
https://chatgpt.com/codex/tasks/task_e_689f96373064832ba482d2a6913e74ac