### PR TITLE
Use dynamic logo path in quiz

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -75,9 +75,11 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       if(img){
         if(cfg.logoPath){
           img.src = withBase(cfg.logoPath) + '?' + Date.now();
+          img.srcset = img.src;
           img.classList.remove('uk-hidden');
         }else{
           img.src = '';
+          img.srcset = '';
           img.classList.add('uk-hidden');
         }
       }

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -35,9 +35,11 @@
     <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin" uk-scrollspy="cls: uk-animation-fade">
       <div id="quiz-header" class="uk-text-center uk-margin" uk-scrollspy="cls: uk-animation-scale-up; delay: 100">
         <img id="quiz-logo" class="logo-placeholder"
-             src="{{ basePath }}/logo-160.svg"
+             src="{% if config.logoPath %}{{ basePath ~ config.logoPath }}{% else %}{{ basePath }}/logo-160.svg{% endif %}"
+             {% if not config.logoPath %}
              srcset="{{ basePath }}/logo-160.svg 160w, {{ basePath }}/logo-320.svg 320w"
              sizes="(max-width: 600px) 160px, 320px"
+             {% endif %}
              alt="Logo" width="160" height="240" loading="lazy">
       </div>
       <progress id="progress" class="uk-progress" value="0" max="1" aria-label="{{ t('quiz_progress') }}" aria-valuenow="0" uk-scrollspy="cls: uk-animation-fade; delay: 200"></progress>


### PR DESCRIPTION
## Summary
- Load logo from configured `logoPath` in quiz template and ignore static `srcset`
- Keep client logo updates in sync by updating `srcset` alongside `src`

## Testing
- `composer test` *(fails: Missing STRIPE_* keys and 2 test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689f993b18c8832b97c68f788a632ee1