### PR TITLE
fix: avoid published column migration error

### DIFF
--- a/migrations/20241014_add_published_flag_to_events.sql
+++ b/migrations/20241014_add_published_flag_to_events.sql
@@ -1,15 +1,6 @@
-DO $$
-BEGIN
-   IF NOT EXISTS (
-      SELECT 1
-      FROM information_schema.columns
-      WHERE table_name='events'
-        AND column_name='published'
-   ) THEN
-      ALTER TABLE events ADD COLUMN published BOOLEAN DEFAULT FALSE;
-      UPDATE events SET published = TRUE;
-   END IF;
-END $$;
+ALTER TABLE events
+  ADD COLUMN IF NOT EXISTS published BOOLEAN DEFAULT FALSE;
+
+UPDATE events SET published = TRUE WHERE published IS NULL;
 
 ALTER TABLE events ALTER COLUMN published SET DEFAULT FALSE;
-UPDATE events SET published = TRUE WHERE published IS NULL;


### PR DESCRIPTION
## Summary
- simplify events "published" migration to avoid parse-time errors

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_689f9914e514832b9a980ae83d3b2a5b