### PR TITLE
Add CSRF token to landing page SEO form

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -655,6 +655,7 @@
             <li>
               <form class="uk-form-stacked seo-form" action="{{ basePath }}/admin/landingpage/seo" method="post">
                 <input type="hidden" name="pageId" value="1">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <div class="uk-margin">
                   <label class="uk-form-label" for="metaTitle">Meta Title</label>
                   <div class="uk-form-controls">


### PR DESCRIPTION
## Summary
- ensure landing page SEO form submits CSRF token to avoid forbidden errors

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY... Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_689fa1b65bfc832bb559dfeff3ff1b8b