### PR TITLE
fix: remove fallback logo srcset

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -75,11 +75,13 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       if(img){
         if(cfg.logoPath){
           img.src = withBase(cfg.logoPath) + '?' + Date.now();
-          img.srcset = img.src;
+          img.removeAttribute('srcset');
+          img.removeAttribute('sizes');
           img.classList.remove('uk-hidden');
         }else{
           img.src = '';
-          img.srcset = '';
+          img.removeAttribute('srcset');
+          img.removeAttribute('sizes');
           img.classList.add('uk-hidden');
         }
       }


### PR DESCRIPTION
## Summary
- Ensure catalog logo uses uploaded image by removing leftover `srcset`/`sizes`

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars, Slim Application Error, database error)*

------
https://chatgpt.com/codex/tasks/task_e_689fa10c65bc832bac96c22ca1e94e45