### PR TITLE
Forward QR options to catalog overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 - Fix style and security warnings
 - Reformat stripe tests for readability
 
+### Fix
+
+- Forward QR code query options on catalog overview
+
 ### Ci
 
 - Add workflow for automatic changelog

--- a/src/Controller/AdminCatalogController.php
+++ b/src/Controller/AdminCatalogController.php
@@ -43,6 +43,8 @@ class AdminCatalogController
 
         $params = $request->getQueryParams();
         $uid = (string)($params['event'] ?? '');
+        $qrOptions = $params;
+        unset($qrOptions['event']);
         if ($uid !== '') {
             $cfgSvc->getConfigForEvent($uid);
             $event = $eventSvc->getByUid($uid) ?? $eventSvc->getFirst();
@@ -82,6 +84,7 @@ class AdminCatalogController
             'kataloge' => $catalogs,
             'baseUrl' => $baseUrl,
             'event' => $event,
+            'qrOptions' => $qrOptions,
         ]);
     }
 }

--- a/tests/Controller/AdminCatalogControllerTest.php
+++ b/tests/Controller/AdminCatalogControllerTest.php
@@ -27,7 +27,10 @@ class AdminCatalogControllerTest extends TestCase
         $pdo->exec("INSERT INTO events(uid,name) VALUES('e1','Event')");
 
         $cfgSvc = new ConfigService($pdo);
-        $service = new CatalogService($pdo, $cfgSvc);
+        $service = $this->createMock(CatalogService::class);
+        $service->method('read')->willReturn(json_encode([
+            ['uid' => 'c1', 'sort_order' => 1, 'slug' => 'slug', 'file' => 'file', 'name' => 'Cat', 'beschreibung' => '']
+        ]));
         $controller = new AdminCatalogController($service);
         $twig = Twig::create(dirname(__DIR__, 2) . '/templates', ['cache' => false]);
 
@@ -38,6 +41,44 @@ class AdminCatalogControllerTest extends TestCase
             ->withAttribute('lang', 'de');
         $response = $controller($request, new Response());
         $this->assertEquals(200, $response->getStatusCode());
+        session_destroy();
+        unlink($db);
+    }
+
+    public function testQrOptionsForwarded(): void
+    {
+        $db = tempnam(sys_get_temp_dir(), 'db');
+        putenv('POSTGRES_DSN=sqlite:' . $db);
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        $pdo = new PDO('sqlite:' . $db);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        Migrator::migrate($pdo, dirname(__DIR__, 2) . '/migrations');
+        $pdo->exec("INSERT INTO events(uid,name) VALUES('e1','Event')");
+
+        $cfgSvc = new ConfigService($pdo);
+        $service = $this->createMock(CatalogService::class);
+        $service->method('read')->willReturn(json_encode([]));
+        $controller = new AdminCatalogController($service);
+
+        $captured = [];
+        $twig = $this->createMock(Twig::class);
+        $twig->method('render')->willReturnCallback(
+            function (Response $res, string $tpl, array $data) use (&$captured) {
+                $captured = $data;
+                return $res;
+            }
+        );
+
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
+        $request = $this->createRequest('GET', '/admin/kataloge?event=e1&size=123&round_mode=margin')
+            ->withAttribute('view', $twig)
+            ->withAttribute('lang', 'de');
+        $response = $controller($request, new Response());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('123', $captured['qrOptions']['size']);
+        $this->assertSame('margin', $captured['qrOptions']['round_mode']);
         session_destroy();
         unlink($db);
     }


### PR DESCRIPTION
## Summary
- forward request query parameters to catalog overview QR codes
- cover QR option forwarding with a controller test
- document QR option forwarding in changelog

## Testing
- `composer test` (fails: Missing STRIPE_SECRET_KEY...)
- `vendor/bin/phpunit tests/Controller/AdminCatalogControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689fa6149368832b8f16b0f7d672584a