### PR TITLE
Fix team restriction validation

### DIFF
--- a/tests/test_team_restrict.js
+++ b/tests/test_team_restrict.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const code = fs.readFileSync('public/js/catalog.js', 'utf8');
+
+if (!/allowed = allowed\.map\(t => String\(t\)\.toLowerCase\(\)\);/.test(code)) {
+  throw new Error('allowed normalization missing');
+}
+if (!/allowed.indexOf\(name.toLowerCase\(\)\) === -1/.test(code)) {
+  throw new Error('case-insensitive check missing');
+}
+if (!/cfg.QRRestrict && allowed.indexOf\(name.toLowerCase\(\)\) === -1\)\{\n\s*alert\('Unbekanntes oder nicht berechtigtes Team\/Person'\)/.test(code)) {
+  throw new Error('manual entry validation missing');
+}
+console.log('ok');


### PR DESCRIPTION
## Summary
- normalize allowed team names and compare case-insensitively for QR and manual entry
- add test verifying team restriction enforcement

## Testing
- `./vendor/bin/phpcs src/`
- `php -d memory_limit=1G ./vendor/bin/phpstan analyse src/ --no-progress`
- `./vendor/bin/phpunit` *(fails: no such column: published)*
- `node tests/test_random_name_prompt.js`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_team_restrict.js`


------
https://chatgpt.com/codex/tasks/task_e_689fa5c977b0832bafabef554a48de92