### PR TITLE
Avoid ob_flush notices when no buffer

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -892,7 +892,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         while (($line = fgets($pipes[1])) !== false) {
             $chunk = dechex(strlen($line)) . "\r\n" . $line . "\r\n";
             $response->getBody()->write($chunk);
-            if (function_exists('ob_flush')) {
+            if (function_exists('ob_flush') && ob_get_level() > 0) {
                 ob_flush();
             }
             flush();


### PR DESCRIPTION
## Summary
- guard `ob_flush()` call with output-buffer check to prevent notices during tenant onboarding

## Testing
- `composer test` *(fails: Missing STRIPE_* variables, nginx reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_689fa6f8a964832ba6c09b460c4e02da