### PR TITLE
Add catalog link to tenant welcome email

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -165,9 +165,12 @@ class MailService
      */
     public function sendWelcome(string $to, string $domain, string $link): string
     {
+        $catalogLink = sprintf('https://%s/admin/catalogs', $domain);
+
         $html = $this->twig->render('emails/welcome.twig', [
-            'domain' => $domain,
-            'link'   => $link,
+            'domain'       => $domain,
+            'link'         => $link,
+            'catalog_link' => $catalogLink,
         ]);
 
         $email = (new Email())

--- a/templates/emails/welcome.twig
+++ b/templates/emails/welcome.twig
@@ -1,5 +1,7 @@
 <p>Hallo,</p>
 <p>Ihr QuizRace wurde unter <a href="https://{{ domain }}">{{ domain }}</a> eingerichtet.</p>
-<p>Setzen Sie Ihr Admin-Passwort über folgenden Link und greifen Sie anschließend direkt auf den Administrationsbereich zu:</p>
+<p>Verwalten Sie Ihre Fragenkataloge hier:</p>
+<p><a href="{{ catalog_link }}">{{ catalog_link }}</a></p>
+<p>Um das Admin-Passwort Ihrer Domain zu setzen oder zurückzusetzen, verwenden Sie folgenden Link:</p>
 <p><a href="{{ link }}">{{ link }}</a></p>
 <p>Viel Erfolg!</p>

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -8,6 +8,7 @@ use App\Service\MailService;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use Twig\Loader\FilesystemLoader;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use App\Infrastructure\Migrations\Migrator;
@@ -230,5 +231,56 @@ class MailServiceTest extends TestCase
         $this->assertSame('to@example.org', $svc->messages[0]->getTo()[0]->getAddress());
         $this->assertSame('Ihre Kontaktanfrage', $svc->messages[1]->getSubject());
         $this->assertSame('john@example.org', $svc->messages[1]->getTo()[0]->getAddress());
+    }
+
+    public function testSendWelcomeContainsCatalogAndPasswordLinks(): void
+    {
+        putenv('SMTP_HOST=localhost');
+        putenv('SMTP_USER=user@example.org');
+        putenv('SMTP_PASS=secret');
+        putenv('SMTP_PORT=587');
+        putenv('SMTP_FROM');
+        putenv('SMTP_FROM_NAME');
+        $_ENV['SMTP_HOST'] = 'localhost';
+        $_ENV['SMTP_USER'] = 'user@example.org';
+        $_ENV['SMTP_PASS'] = 'secret';
+        $_ENV['SMTP_PORT'] = '587';
+        unset($_ENV['SMTP_FROM'], $_ENV['SMTP_FROM_NAME']);
+
+        $twig = new Environment(new FilesystemLoader(dirname(__DIR__, 2) . '/templates'));
+
+        $svc = new class ($twig) extends MailService {
+            /** @var Email[] */
+            public array $messages = [];
+
+            protected function createTransport(string $dsn): MailerInterface
+            {
+                return new class ($this) implements MailerInterface {
+                    private $outer;
+
+                    public function __construct($outer)
+                    {
+                        $this->outer = $outer;
+                    }
+
+                    public function send(
+                        \Symfony\Component\Mime\RawMessage $message,
+                        ?\Symfony\Component\Mailer\Envelope $envelope = null
+                    ): void {
+                        $this->outer->messages[] = $message;
+                    }
+                };
+            }
+        };
+
+        $html = $svc->sendWelcome(
+            'user@example.org',
+            'foo.example.com',
+            'https://foo.example.com/password/set?token=abc'
+        );
+
+        $this->assertStringContainsString('https://foo.example.com/admin/catalogs', $html);
+        $this->assertStringContainsString('https://foo.example.com/password/set?token=abc', $html);
+        $this->assertCount(1, $svc->messages);
     }
 }


### PR DESCRIPTION
## Summary
- include catalog management link in tenant welcome emails
- clarify admin password reset link for new domain
- cover welcome mail in tests

## Testing
- `composer test` *(fails: Tests: 219, Assertions: 499, Errors: 3, Failures: 2)*

------
https://chatgpt.com/codex/tasks/task_e_689faf3896e4832bbdc6c76074287cd7