### PR TITLE
Fix catalog info display on start page

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -299,12 +299,20 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
         let qs = '?katalog=' + (cat.slug || cat.sort_order);
         if(eventUid) qs += '&event=' + encodeURIComponent(eventUid);
         history.replaceState(null, '', qs);
-        loadQuestions(cat.slug || cat.sort_order, cat.file, cat.raetsel_buchstabe, cat.uid, cat.name || cat.slug || cat.sort_order, cat.description || '', cat.comment || '');
+        loadQuestions(
+          cat.slug || cat.sort_order,
+          cat.file,
+          cat.raetsel_buchstabe,
+          cat.uid,
+          cat.name || cat.slug || cat.sort_order,
+          cat.description || cat.beschreibung || '',
+          cat.comment || cat.kommentar || ''
+        );
       });
       const title = document.createElement('h3');
       title.textContent = cat.name || cat.slug || cat.sort_order;
       const desc = document.createElement('p');
-      desc.textContent = cat.description || '';
+      desc.textContent = cat.description || cat.beschreibung || '';
       card.appendChild(title);
       card.appendChild(desc);
       cardWrap.appendChild(card);
@@ -605,7 +613,15 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
             showCatalogSolvedModal(selected.name || selected.slug || selected.id, remaining);
             return;
           }
-        loadQuestions(selected.slug || selected.id, selected.file, selected.raetsel_buchstabe, selected.uid, selected.name || selected.slug || selected.id, selected.description || '', selected.comment || '');
+        loadQuestions(
+          selected.slug || selected.id,
+          selected.file,
+          selected.raetsel_buchstabe,
+          selected.uid,
+          selected.name || selected.slug || selected.id,
+          selected.description || selected.beschreibung || '',
+          selected.comment || selected.kommentar || ''
+        );
       }else{
         showSelection(catalogs, solvedNow);
       }


### PR DESCRIPTION
## Summary
- Support alternate German field names for catalog description and comment
- Ensure catalog details show on catalog selection/start page

## Testing
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY)*
- `vendor/bin/phpstan analyse` *(fails: PHP memory limit 128M exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_689fb0b332c8832ba4ee2aac26e35e23