### PR TITLE
feat: resend welcome mail

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -66,6 +66,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const pagesInitial = window.pagesContent || {};
   const profileForm = document.getElementById('profileForm');
   const profileSaveBtn = document.getElementById('profileSaveBtn');
+  const welcomeMailBtn = document.getElementById('welcomeMailBtn');
   const checkoutContainer = document.getElementById('stripe-checkout');
   const planButtons = document.querySelectorAll('.plan-select');
   const emailInput = document.getElementById('subscription-email');
@@ -2452,6 +2453,16 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!r.ok) throw new Error(r.statusText);
         notify('Profil gespeichert', 'success');
       }).catch(() => notify('Fehler beim Speichern', 'danger'));
+    });
+
+    welcomeMailBtn?.addEventListener('click', e => {
+      e.preventDefault();
+      apiFetch('/admin/profile/welcome', { method: 'POST' })
+        .then(r => {
+          if (!r.ok) throw new Error('failed');
+          notify('Willkommensmail gesendet', 'success');
+        })
+        .catch(() => notify('Fehler beim Senden', 'danger'));
     });
 
   // Page editors are handled in trumbowyg-pages.js

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -204,6 +204,7 @@ return [
     'action_delete_tenant' => 'Mandant löschen',
     'action_sync_tenants' => 'Fehlende Mandanten suchen',
     'action_renew_ssl' => 'SSL erneuern',
+    'action_send_welcome_mail' => 'Willkommensmail senden',
     'help_admin_pass' => 'Definiert das Admin-Passwort des neuen Mandanten. Bleibt das Feld leer, ' .
         'wird ein zufälliges Passwort erzeugt',
     'info_admin_email' => 'Der Link zum Setzen des Admin-Passworts wird per E-Mail verschickt.',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -203,6 +203,7 @@ return [
     'action_delete_tenant' => 'Delete tenant',
     'action_sync_tenants' => 'Import missing subdomains',
     'action_renew_ssl' => 'Renew SSL',
+    'action_send_welcome_mail' => 'Send welcome email',
     'help_admin_pass' => 'Defines the admin password for the new tenant. Leave empty to generate a random one',
     'info_admin_email' => 'The link to set the admin password will be sent by email.',
     'text_admin_email_sent' => 'A link to set the admin password has been sent to %s.',

--- a/src/routes.php
+++ b/src/routes.php
@@ -481,6 +481,57 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = new ProfileController();
         return $controller->update($request, $response);
     })->add(new RoleAuthMiddleware(...Roles::ALL))->add(new CsrfMiddleware());
+    $app->post('/admin/profile/welcome', function (Request $request, Response $response) {
+        if ($request->getAttribute('domainType') !== 'tenant') {
+            return $response->withStatus(403);
+        }
+        $uri = $request->getUri();
+        $sub = explode('.', $uri->getHost())[0];
+        $base = Database::connectFromEnv();
+        $tenantSvc = new TenantService($base);
+        $tenant = $tenantSvc->getBySubdomain($sub);
+        if ($tenant === null || ($tenant['imprint_email'] ?? '') === '') {
+            return $response->withStatus(404);
+        }
+        $email = (string) $tenant['imprint_email'];
+        $pdo = Database::connectWithSchema($sub);
+        Migrator::migrate($pdo, __DIR__ . '/../migrations');
+        $userService = new UserService($pdo);
+        $auditLogger = new AuditLogger($pdo);
+        $admin = $userService->getByUsername('admin');
+        $randomPass = bin2hex(random_bytes(16));
+        if ($admin === null) {
+            $userService->create('admin', $randomPass, $email, Roles::ADMIN);
+            $admin = $userService->getByUsername('admin');
+        } else {
+            $userService->updatePassword((int) $admin['id'], $randomPass);
+            $userService->setEmail((int) $admin['id'], $email);
+        }
+        if ($admin === null) {
+            return $response->withStatus(500);
+        }
+        $resetService = new PasswordResetService($pdo);
+        $token = $resetService->createToken((int) $admin['id']);
+        $mailer = $request->getAttribute('mailService');
+        if (!$mailer instanceof MailService) {
+            if (!MailService::isConfigured()) {
+                return $response->withStatus(503);
+            }
+            $twig = Twig::fromRequest($request)->getEnvironment();
+            $mailer = new MailService($twig, $auditLogger);
+        }
+        $mainDomain = getenv('MAIN_DOMAIN') ?: getenv('DOMAIN') ?: $uri->getHost();
+        $domain = sprintf('%s.%s', $sub, $mainDomain);
+        $link = sprintf('https://%s/password/set?token=%s&next=%%2Fadmin', $domain, urlencode($token));
+        $html = $mailer->sendWelcome($email, $domain, $link);
+        $baseDir = dirname(__DIR__, 1);
+        $dir = $baseDir . '/data/' . $sub;
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        file_put_contents($dir . '/welcome_email.html', $html);
+        return $response->withStatus(204);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN))->add(new CsrfMiddleware());
     $app->get('/admin/tenants', function (Request $request, Response $response) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(404);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -894,6 +894,11 @@
               <input class="uk-input" type="text" value="{{ tenant.created_at }}" readonly>
             </div>
           </div>
+          {% if domainType == 'tenant' %}
+          <div class="uk-margin">
+            <button id="welcomeMailBtn" type="button" class="uk-button uk-button-default">{{ t('action_send_welcome_mail') }}</button>
+          </div>
+          {% endif %}
           <button id="profileSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: {{ t('tip_save_changes') }}; pos: left"></button>
         </form>
         {% else %}

--- a/tests/Controller/ProfileWelcomeControllerTest.php
+++ b/tests/Controller/ProfileWelcomeControllerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+use Slim\Psr7\Uri;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use App\Service\MailService;
+use PDO;
+
+class ProfileWelcomeControllerTest extends TestCase
+{
+    public function testResendWelcomeMail(): void
+    {
+        putenv('MAIN_DOMAIN=example.com');
+        $_ENV['MAIN_DOMAIN'] = 'example.com';
+        putenv('SMTP_HOST=localhost');
+        putenv('SMTP_USER=user');
+        putenv('SMTP_PASS=pass');
+        $_ENV['SMTP_HOST'] = 'localhost';
+        $_ENV['SMTP_USER'] = 'user';
+        $_ENV['SMTP_PASS'] = 'pass';
+
+        $app = $this->getAppInstance();
+        $pdo = new PDO(getenv('POSTGRES_DSN'));
+        $pdo->exec("INSERT INTO tenants(uid, subdomain, imprint_email) VALUES('t1','foo','admin@example.com')");
+
+        $twig = new Environment(new FilesystemLoader(__DIR__ . '/../../templates'));
+        $mailer = new class($twig) extends MailService {
+            public array $messages = [];
+            protected function createTransport(string $dsn): \Symfony\Component\Mailer\MailerInterface
+            {
+                return new class($this) implements \Symfony\Component\Mailer\MailerInterface {
+                    private $outer;
+                    public function __construct($outer) { $this->outer = $outer; }
+                    public function send(\Symfony\Component\Mime\RawMessage $message, ?\Symfony\Component\Mailer\Envelope $envelope = null): void
+                    {
+                        $this->outer->messages[] = $message;
+                    }
+                };
+            }
+        };
+
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $_SESSION['csrf_token'] = 'token';
+
+        $request = $this->createRequest('POST', '/admin/profile/welcome', [
+            'HTTP_X_CSRF_TOKEN' => 'token',
+        ])->withUri(new Uri('http', 'foo.example.com', 80, '/admin/profile/welcome'))
+          ->withAttribute('mailService', $mailer);
+        $response = $app->handle($request);
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertNotEmpty($mailer->messages);
+
+        session_destroy();
+        putenv('MAIN_DOMAIN');
+        putenv('SMTP_HOST');
+        putenv('SMTP_USER');
+        putenv('SMTP_PASS');
+        unset($_ENV['MAIN_DOMAIN'], $_ENV['SMTP_HOST'], $_ENV['SMTP_USER'], $_ENV['SMTP_PASS']);
+    }
+}


### PR DESCRIPTION
## Summary
- allow tenant admins to resend onboarding email from profile
- provide i18n strings and JS handler
- add route and tests for welcome mail resend

## Testing
- `composer test` *(fails: Tests\Controller\EventsRouteTest::testEventsListAccessibleForCatalogEditor; Tests\Controller\HomeControllerTest::testEventsAsHomePage; Tests\Controller\ProfileWelcomeControllerTest::testResendWelcomeMail)*

------
https://chatgpt.com/codex/tasks/task_e_689fb163cf9c832ba7d8f0573b45b5bc