### PR TITLE
Fix QR login flag not respected in frontend

### DIFF
--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -15,6 +15,23 @@ class ConfigService
     private ?string $activeEvent = null;
 
     /**
+     * List of configuration keys that should be treated as booleans.
+     *
+     * @var array<int,string>
+     */
+    private const BOOL_KEYS = [
+        'displayErrorDetails',
+        'QRUser',
+        'QRRemember',
+        'QRRestrict',
+        'randomNames',
+        'competitionMode',
+        'teamResults',
+        'photoUpload',
+        'puzzleWordEnabled',
+    ];
+
+    /**
      * Inject PDO instance used for database operations.
      */
     public function __construct(PDO $pdo)
@@ -289,7 +306,16 @@ class ConfigService
         }
         $normalized = [];
         foreach ($row as $k => $v) {
-            $normalized[$map[strtolower($k)] ?? $k] = $v;
+            $key = $map[strtolower($k)] ?? $k;
+            if (in_array($key, self::BOOL_KEYS, true)) {
+                $normalized[$key] = $v === null ? null : filter_var(
+                    $v,
+                    FILTER_VALIDATE_BOOL,
+                    FILTER_NULL_ON_FAILURE
+                );
+            } else {
+                $normalized[$key] = $v;
+            }
         }
         return $normalized;
     }

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -39,13 +39,15 @@ class ConfigServiceTest extends TestCase
             SQL
         );
         $service = new ConfigService($pdo);
-        $data = ['pageTitle' => 'Demo'];
+        $data = ['pageTitle' => 'Demo', 'QRUser' => false, 'QRRemember' => true];
 
         $service->saveConfig($data);
         $json = $service->getJson();
         $this->assertNotNull($json);
         $cfg = $service->getConfig();
         $this->assertSame('Demo', $cfg['pageTitle']);
+        $this->assertFalse($cfg['QRUser']);
+        $this->assertTrue($cfg['QRRemember']);
     }
 
     public function testGetJsonReturnsNullIfFileMissing(): void


### PR DESCRIPTION
## Summary
- ensure boolean config flags are properly cast so `QRUser` affects frontend
- add regression test verifying boolean casting in ConfigService

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and related environment variables)*
- `vendor/bin/phpunit tests/Service/ConfigServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689fb1144e9c832bab305093f5bb1ec9