### PR TITLE
Fix team scanner path for allowed team names

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -330,7 +330,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       try{
         allowed = JSON.parse(sessionStorage.getItem('allowedTeams') || 'null');
         if(!Array.isArray(allowed) || !allowed.length){
-          const r = await fetch('/teams.json', {headers:{'Accept':'application/json'}});
+          const r = await fetch(withBase('/teams.json'), {headers:{'Accept':'application/json'}});
           if(r.ok){
             allowed = await r.json();
           } else {


### PR DESCRIPTION
## Summary
- ensure QR login fetches allowed teams via base path
- revert accidental config changes

## Testing
- `composer test` *(fails: Tests: 220, Assertions: 502, Errors: 3, Failures: 3)*

------
https://chatgpt.com/codex/tasks/task_e_689fb8116e78832b858c59e9a3ab82a9