### PR TITLE
ci: run deploy on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,12 +3,9 @@ name: Deploy
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [closed]
 
 jobs:
   deploy:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Execute remote deploy commands


### PR DESCRIPTION
## Summary
- run deploy workflow on push to main rather than waiting for a closed PR

## Testing
- `composer phpunit` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_689fb9dec3bc832ba78a0760c76c4921