### PR TITLE
fix: remove manual chunked encoding in tenant onboarding

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -929,8 +929,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         );
 
         $response = $response
-            ->withHeader('Content-Type', 'text/plain')
-            ->withHeader('Transfer-Encoding', 'chunked');
+            ->withHeader('Content-Type', 'text/plain');
 
         if (!is_resource($process)) {
             $response->getBody()->write("Failed to start process\n");
@@ -941,8 +940,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         fclose($pipes[0]);
 
         while (($line = fgets($pipes[1])) !== false) {
-            $chunk = dechex(strlen($line)) . "\r\n" . $line . "\r\n";
-            $response->getBody()->write($chunk);
+            $response->getBody()->write($line);
             if (function_exists('ob_flush') && ob_get_level() > 0) {
                 ob_flush();
             }
@@ -952,9 +950,6 @@ return function (\Slim\App $app, TranslationService $translator) {
         fclose($pipes[1]);
 
         $exitCode = proc_close($process);
-
-        // Terminate chunked transfer
-        $response->getBody()->write("0\r\n\r\n");
 
         if ($exitCode !== 0) {
             return $response->withStatus(500);


### PR DESCRIPTION
## Summary
- stream onboarding logs without manual HTTP chunk encoding

## Testing
- `composer test` *(fails: Tests\Controller\EventsRouteTest::testEventsListAccessibleForCatalogEditor, Tests\Controller\HomeControllerTest::testEventsAsHomePage, Tests\Controller\ProfileWelcomeControllerTest::testResendWelcomeMail)*
- `vendor/bin/phpcs src/routes.php`


------
https://chatgpt.com/codex/tasks/task_e_689fbcab9c00832bb3dd2c1c71c44648