### PR TITLE
Show version number in admin header

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -18,6 +18,7 @@ use App\Service\TenantService;
 use App\Domain\Roles;
 use App\Infrastructure\Database;
 use App\Service\StripeService;
+use App\Service\VersionService;
 use PDO;
 
 /**
@@ -45,6 +46,8 @@ class AdminController
         $eventSvc = new EventService($pdo);
         $settingsSvc = new SettingsService($pdo);
         $settings = $settingsSvc->getAll();
+        $versionSvc = new VersionService();
+        $version = $versionSvc->getCurrentVersion();
 
         $params = $request->getQueryParams();
         $uid = (string)($params['event'] ?? '');
@@ -208,6 +211,7 @@ class AdminController
               'currentPath' => $request->getUri()->getPath(),
               'username' => $_SESSION['user']['username'] ?? '',
               'csrf_token' => $csrf,
+              'version' => $version,
           ]);
     }
 }

--- a/src/Service/VersionService.php
+++ b/src/Service/VersionService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Provides the current application version.
+ */
+class VersionService
+{
+    /**
+     * Return the latest version string from the changelog.
+     */
+    public function getCurrentVersion(): string
+    {
+        $path = dirname(__DIR__, 2) . '/CHANGELOG.md';
+        if (is_readable($path)) {
+            $content = file_get_contents($path);
+            if ($content !== false && preg_match('/^## \[(\d+\.\d+\.\d+)\]/m', $content, $m)) {
+                return $m[1];
+            }
+        }
+        return 'dev';
+    }
+}

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -34,7 +34,10 @@
       <a class="uk-navbar-toggle uk-hidden@m" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
         <span uk-navbar-toggle-icon></span>
       </a>
-      <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">QuizRace Admin</a>
+      <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">
+        QuizRace Admin
+        <div class="uk-text-meta uk-text-small">v{{ version }}</div>
+      </a>
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">


### PR DESCRIPTION
## Summary
- add VersionService to read latest version from changelog
- display current version under admin logo

## Testing
- `composer test --no-interaction` *(fails: SQLSTATE[HY000]: General error: 1 no such column: published)*


------
https://chatgpt.com/codex/tasks/task_e_68a2067ab00c832b9e96d60c6260f72f