### PR TITLE
Remove qrcode_url field from catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Optimize landing page images
 - Add ghostscript to Docker image
 - Require PHP 8.2
+- Remove `qrcode_url` field from catalogs
 - Test against php 8.2
 - Update dependencies
 - Pin php base images to patch release

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Bleibt das Feld leer, erzeugt die Anwendung automatisch ein sicheres Passwort un
 
 Alle wichtigen Einstellungen finden Sie in `data/config.json`. Ändern Sie hier Logo, Farben oder die Verwendung des QR-Code-Logins. Die Fragen selbst liegen in `data/kataloge/*.json` und können mit jedem Texteditor angepasst werden. Jede Katalogdefinition besitzt weiterhin ein `slug` für die URL. Fragen verknüpfen den Katalog nun über `catalog_uid`. Das bisherige `id` dient ausschließlich der Sortierung und wird automatisch vergeben.
 
-QR-Codes können pro Eintrag über `qr_image` oder `qrcode_url` hinterlegt werden. Neben Data-URIs und lokalen Pfaden werden dabei nun auch HTTP- oder HTTPS-URLs unterstützt.
+QR-Codes können pro Eintrag über `qr_image` hinterlegt werden, etwa als Data-URI oder lokaler Pfad.
 
 Die Übersichtsseiten erzeugen ihre QR-Codes jetzt lokal mit der Bibliothek *Endroid\\QrCode*. Katalog-Links erscheinen rot, Team-Links blau.
 

--- a/data-default/kataloge/catalogs.json
+++ b/data-default/kataloge/catalogs.json
@@ -6,7 +6,6 @@
     "file": "station_1.json",
     "name": "Station-1",
     "description": "Speicher und Geraete",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_1",
     "raetsel_buchstabe": "A",
     "comment": ""
   },
@@ -17,7 +16,6 @@
     "file": "station_2.json",
     "name": "Station-2",
     "description": "Bedienung und Symbole",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_2",
     "raetsel_buchstabe": "B",
     "comment": ""
   },
@@ -28,7 +26,6 @@
     "file": "station_3.json",
     "name": "Station-3",
     "description": "WWW und Speicherarten",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_3",
     "raetsel_buchstabe": "C",
     "comment": ""
   },
@@ -39,7 +36,6 @@
     "file": "station_4.json",
     "name": "Station-4",
     "description": "Begriffe und Geraetegroessen",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_4",
     "raetsel_buchstabe": "D",
     "comment": ""
   },
@@ -50,7 +46,6 @@
     "file": "station_5.json",
     "name": "Station-5",
     "description": "Programme und Binaersystem",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_5",
     "raetsel_buchstabe": "E",
     "comment": ""
   },
@@ -61,7 +56,6 @@
     "file": "station_6.json",
     "name": "Station-6",
     "description": "Dateien und URLs",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_6",
     "raetsel_buchstabe": "F",
     "comment": ""
   },
@@ -72,7 +66,6 @@
     "file": "station_7.json",
     "name": "Station-7",
     "description": "Netzwerke und Kuerzel",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_7",
     "raetsel_buchstabe": "G",
     "comment": ""
   },
@@ -83,7 +76,6 @@
     "file": "station_8.json",
     "name": "Station-8",
     "description": "Cloud und Steuerung",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_8",
     "raetsel_buchstabe": "H",
     "comment": ""
   }

--- a/data/kataloge/catalogs.json
+++ b/data/kataloge/catalogs.json
@@ -6,7 +6,6 @@
     "file": "station_1.json",
     "name": "Station-1",
     "description": "Speicher und Geraete",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_1",
     "raetsel_buchstabe": "A",
     "comment": ""
   },
@@ -17,7 +16,6 @@
     "file": "station_2.json",
     "name": "Station-2",
     "description": "Bedienung und Symbole",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_2",
     "raetsel_buchstabe": "B",
     "comment": ""
   },
@@ -28,7 +26,6 @@
     "file": "station_3.json",
     "name": "Station-3",
     "description": "WWW und Speicherarten",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_3",
     "raetsel_buchstabe": "C",
     "comment": ""
   },
@@ -39,7 +36,6 @@
     "file": "station_4.json",
     "name": "Station-4",
     "description": "Begriffe und Geraetegroessen",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_4",
     "raetsel_buchstabe": "D",
     "comment": ""
   },
@@ -50,7 +46,6 @@
     "file": "station_5.json",
     "name": "Station-5",
     "description": "Programme und Binaersystem",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_5",
     "raetsel_buchstabe": "E",
     "comment": ""
   },
@@ -61,7 +56,6 @@
     "file": "station_6.json",
     "name": "Station-6",
     "description": "Dateien und URLs",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_6",
     "raetsel_buchstabe": "F",
     "comment": ""
   },
@@ -72,7 +66,6 @@
     "file": "station_7.json",
     "name": "Station-7",
     "description": "Netzwerke und Kuerzel",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_7",
     "raetsel_buchstabe": "G",
     "comment": ""
   },
@@ -83,7 +76,6 @@
     "file": "station_8.json",
     "name": "Station-8",
     "description": "Cloud und Steuerung",
-    "qrcode_url": "https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=station_8",
     "raetsel_buchstabe": "H",
     "comment": ""
   }

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -99,7 +99,6 @@ CREATE TABLE IF NOT EXISTS catalogs (
     file TEXT NOT NULL,
     name TEXT NOT NULL,
     description TEXT,
-    qrcode_url TEXT,
     raetsel_buchstabe TEXT,
     comment TEXT,
     design_path TEXT,

--- a/migrations/20240910_base_schema.sql
+++ b/migrations/20240910_base_schema.sql
@@ -109,7 +109,6 @@ CREATE TABLE IF NOT EXISTS catalogs (
     file TEXT NOT NULL,
     name TEXT NOT NULL,
     description TEXT,
-    qrcode_url TEXT,
     raetsel_buchstabe TEXT,
     comment TEXT,
     design_path TEXT,

--- a/scripts/import_to_pgsql.php
+++ b/scripts/import_to_pgsql.php
@@ -171,7 +171,7 @@ if (is_readable($catalogsFile)) {
     $catalogs = json_decode(file_get_contents($catalogsFile), true) ?? [];
     $catStmt = $pdo->prepare(
         'INSERT INTO catalogs(uid,sort_order,slug,file,name,description,' .
-        'qrcode_url,raetsel_buchstabe,comment,event_uid) VALUES(?,?,?,?,?,?,?,?,?,?)'
+        'raetsel_buchstabe,comment,event_uid) VALUES(?,?,?,?,?,?,?,?,?)'
     );
     $qStmt = $pdo->prepare(
         'INSERT INTO questions(catalog_uid,type,prompt,options,answers,terms,items,sort_order)' .
@@ -185,7 +185,6 @@ if (is_readable($catalogsFile)) {
             $cat['file'] ?? '',
             $cat['name'] ?? '',
             $cat['description'] ?? null,
-            $cat['qrcode_url'] ?? null,
             $cat['raetsel_buchstabe'] ?? null,
             $cat['comment'] ?? null,
             $activeUid

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -189,7 +189,7 @@ class CatalogService
     public function read(string $file): ?string
     {
         if ($file === 'catalogs.json') {
-            $fields = 'uid,sort_order,slug,file,name,description,qrcode_url,raetsel_buchstabe';
+            $fields = 'uid,sort_order,slug,file,name,description,raetsel_buchstabe';
             if ($this->hasCommentColumn()) {
                 $fields .= ',comment';
             }
@@ -296,8 +296,8 @@ class CatalogService
             } else {
                 $this->pdo->exec('DELETE FROM catalogs');
             }
-            $fields = 'uid,sort_order,slug,file,name,description,qrcode_url,raetsel_buchstabe,event_uid';
-            $placeholders = '?,?,?,?,?,?,?,?,?';
+            $fields = 'uid,sort_order,slug,file,name,description,raetsel_buchstabe,event_uid';
+            $placeholders = '?,?,?,?,?,?,?,?';
             if ($this->hasCommentColumn()) {
                 $fields .= ',comment';
                 $placeholders .= ',?';
@@ -318,7 +318,6 @@ class CatalogService
                     $cat['file'] ?? '',
                     $cat['name'] ?? '',
                     $cat['description'] ?? null,
-                    $cat['qrcode_url'] ?? null,
                     $cat['raetsel_buchstabe'] ?? null,
                     $uid !== '' ? $uid : null,
                 ];

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -258,9 +258,9 @@ class TenantService
             $catalogs = json_decode(file_get_contents($catalogsFile), true) ?? [];
             $catStmt = $this->pdo->prepare(
                 'INSERT INTO catalogs(' .
-                    'uid,sort_order,slug,file,name,description,qrcode_url,' .
+                    'uid,sort_order,slug,file,name,description,' .
                     'raetsel_buchstabe,comment,event_uid' .
-                ') VALUES(?,?,?,?,?,?,?,?,?,?)'
+                ') VALUES(?,?,?,?,?,?,?,?,?)'
             );
             $qStmt = $this->hasTable('questions')
                 ? $this->pdo->prepare(
@@ -277,7 +277,6 @@ class TenantService
                     $cat['file'] ?? '',
                     $cat['name'] ?? '',
                     $cat['description'] ?? null,
-                    $cat['qrcode_url'] ?? null,
                     $cat['raetsel_buchstabe'] ?? null,
                     $cat['comment'] ?? null,
                     $activeUid,

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -26,7 +26,6 @@ class CatalogControllerTest extends TestCase
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
                 description TEXT,
-                qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
                 comment TEXT,
                 event_uid TEXT
@@ -74,7 +73,6 @@ class CatalogControllerTest extends TestCase
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
                 description TEXT,
-                qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
                 comment TEXT,
                 event_uid TEXT
@@ -126,7 +124,6 @@ class CatalogControllerTest extends TestCase
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
                 description TEXT,
-                qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
                 comment TEXT,
                 event_uid TEXT
@@ -192,7 +189,6 @@ class CatalogControllerTest extends TestCase
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
                 description TEXT,
-                qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
                 comment TEXT,
                 event_uid TEXT
@@ -269,7 +265,6 @@ class CatalogControllerTest extends TestCase
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
                 description TEXT,
-                qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
                 comment TEXT,
                 event_uid TEXT
@@ -328,7 +323,6 @@ class CatalogControllerTest extends TestCase
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
                 description TEXT,
-                qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
                 comment TEXT,
                 event_uid TEXT

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -53,7 +53,7 @@ class ResultControllerTest extends TestCase
         $pdo->exec(
             'CREATE TABLE catalogs(' .
             'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, description TEXT,' .
-            ' qrcode_url TEXT, raetsel_buchstabe TEXT, event_uid TEXT' .
+            ' raetsel_buchstabe TEXT, event_uid TEXT' .
             ');'
         );
         $pdo->exec(
@@ -167,7 +167,7 @@ class ResultControllerTest extends TestCase
         $pdo->exec(
             'CREATE TABLE catalogs(' .
             'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, description TEXT,' .
-            ' qrcode_url TEXT, raetsel_buchstabe TEXT, event_uid TEXT' .
+            ' raetsel_buchstabe TEXT, event_uid TEXT' .
             ');'
         );
         $pdo->exec(

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -26,7 +26,6 @@ class CatalogServiceTest extends TestCase
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
                 description TEXT,
-                qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
                 comment TEXT,
                 design_path TEXT,
@@ -84,7 +83,6 @@ class CatalogServiceTest extends TestCase
                 file TEXT NOT NULL,
                 name TEXT NOT NULL,
                 description TEXT,
-                qrcode_url TEXT,
                 raetsel_buchstabe TEXT,
                 design_path TEXT,
                 event_uid TEXT


### PR DESCRIPTION
## Summary
- drop obsolete `qrcode_url` column from catalog schema and services
- clean sample catalogs and docs to match schema
- update tests for new structure

## Testing
- `composer test` *(fails: EventsRouteTest, HomeControllerTest, ProfileWelcomeControllerTest)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d58b138832b8a153b90ef6f1432