### PR TITLE
Link tenant menu to Stripe entries

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2129,6 +2129,7 @@ document.addEventListener('DOMContentLoaded', function () {
   function loadTenants() {
     if (!tenantTableBody || window.domainType !== 'main') return;
     const mainDomain = window.mainDomain || '';
+    const stripeBase = window.stripeDashboard || 'https://dashboard.stripe.com';
     const escapeHtml = (str) =>
       (str || '').replace(/[&<>"']/g, (m) => (
         {
@@ -2148,6 +2149,8 @@ document.addEventListener('DOMContentLoaded', function () {
           const sub = t.subdomain || '';
           const plan = t.plan || '';
           const billing = t.billing_info || '';
+          const customerId = t.stripe_customer_id || '';
+          const subscriptionId = t.stripe_subscription_id || '';
           const created = (t.created_at || '').replace('T', ' ').replace(/\..*/, '');
           const status = plan ? 'Aktiv' : 'Simuliert';
           const statusClass = plan ? 'uk-label-success' : 'uk-label-warning';
@@ -2200,6 +2203,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
           const actionTd = document.createElement('td');
           actionTd.className = 'uk-text-right';
+          const customerLink = customerId ? stripeBase + '/customers/' + encodeURIComponent(customerId) : '#';
+          const subscriptionLink = subscriptionId ? stripeBase + '/subscriptions/' + encodeURIComponent(subscriptionId) : '#';
+          const customerClass = customerId ? '' : ' class="uk-disabled"';
+          const subscriptionClass = subscriptionId ? '' : ' class="uk-disabled"';
           actionTd.innerHTML = `<ul class="uk-iconnav uk-margin-remove uk-flex-right">
             <li><a href="#" uk-tooltip="Willkommensmail" uk-icon="mail" data-action="welcome" data-sub="${safeSub}"></a></li>
             <li><a href="#" uk-tooltip="${window.transUpgradeDocker || 'Docker aktualisieren'}" data-action="upgrade-docker" data-sub="${safeSub}"><span uk-icon="refresh"></span></a></li>
@@ -2217,8 +2224,8 @@ document.addEventListener('DOMContentLoaded', function () {
                   <li><a class="uk-text-danger" href="#" data-action="delete" data-uid="${safeUid}" data-sub="${safeSub}">Mandant löschen …</a></li>
                   <li class="uk-nav-divider"></li>
                   <li class="uk-nav-header">Verbindungen</li>
-                  <li><a href="#" data-action="show-customer" data-sub="${safeSub}">Kunden anzeigen</a></li>
-                  <li><a href="#" data-action="show-subscription" data-sub="${safeSub}">Abo anzeigen</a></li>
+                  <li><a href="${customerLink}"${customerClass} data-action="show-customer" data-sub="${safeSub}" target="_blank">Kunden anzeigen</a></li>
+                  <li><a href="${subscriptionLink}"${subscriptionClass} data-action="show-subscription" data-sub="${safeSub}" target="_blank">Abo anzeigen</a></li>
                 </ul>
               </div>
             </li>

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -208,6 +208,7 @@ class AdminController
               'domainType' => $request->getAttribute('domainType'),
               'tenant' => $tenant,
               'stripe_configured' => StripeService::isConfigured()['ok'],
+              'stripe_sandbox' => filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN),
               'currentPath' => $request->getUri()->getPath(),
               'username' => $_SESSION['user']['username'] ?? '',
               'csrf_token' => $csrf,

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -609,10 +609,10 @@ class TenantService
     public function getAll(): array
     {
         $stmt = $this->pdo->query(
-            'SELECT uid, subdomain, plan, billing_info, stripe_customer_id, imprint_name, '
-            . 'imprint_street, imprint_zip, imprint_city, imprint_email, custom_limits, '
-            . 'plan_started_at, plan_expires_at, created_at '
-            . 'FROM tenants ORDER BY created_at'
+            'SELECT uid, subdomain, plan, billing_info, stripe_customer_id, '
+            . 'stripe_subscription_id, imprint_name, imprint_street, imprint_zip, '
+            . 'imprint_city, imprint_email, custom_limits, plan_started_at, '
+            . 'plan_expires_at, created_at FROM tenants ORDER BY created_at'
         );
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($rows as &$row) {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1040,6 +1040,7 @@
     window.transUpgradeText = '{{ t('text_upgrade_required') }}';
     window.transUpgradeAction = '{{ t('action_upgrade') }}';
     window.transUpgradeDocker = '{{ t('action_upgrade_docker') }}';
+    window.stripeDashboard = '{{ stripe_sandbox ? 'https://dashboard.stripe.com/test' : 'https://dashboard.stripe.com' }}';
   </script>
   <script src="{{ basePath }}/js/dashboard.js"></script>
   <script src="{{ basePath }}/js/admin.js"></script>


### PR DESCRIPTION
## Summary
- expose Stripe sandbox flag to admin template and JS
- include subscription IDs in tenant listing
- link tenant actions to Stripe customer and subscription dashboards

## Testing
- `composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68a241f64cb4832b9968de190ba4837b