### PR TITLE
feat: make database connection retries configurable

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -20,6 +20,8 @@ POSTGRES_USER=quiz                           # DB-Benutzer
 POSTGRES_PASS=quiz                           # veraltet, s. POSTGRES_PASSWORD
 POSTGRES_PASSWORD=quiz                       # Passwort des DB-Benutzers
 POSTGRES_DB=quiz                             # Datenbankname
+POSTGRES_CONNECT_RETRIES=5                   # Anzahl der Verbindungsversuche
+POSTGRES_CONNECT_RETRY_DELAY=1               # Wartezeit zwischen den Versuchen (Sekunden)
 
 # Mandantenkennung
 TENANT_ID=default

--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -14,9 +14,23 @@ class Database
 {
     /**
      * Create a PDO connection using credentials from environment variables.
+     *
+     * The number of connection attempts and the delay between retries can be
+     * overridden using the `POSTGRES_CONNECT_RETRIES` and
+     * `POSTGRES_CONNECT_RETRY_DELAY` environment variables.
      */
     public static function connectFromEnv(int $retries = 5, int $delay = 1): PDO
     {
+        $envRetries = getenv('POSTGRES_CONNECT_RETRIES');
+        if ($envRetries !== false) {
+            $retries = (int) $envRetries;
+        }
+
+        $envDelay = getenv('POSTGRES_CONNECT_RETRY_DELAY');
+        if ($envDelay !== false) {
+            $delay = (int) $envDelay;
+        }
+
         $dsn  = getenv('POSTGRES_DSN') ?: '';
         $user = getenv('POSTGRES_USER') ?: '';
         $pass = getenv('POSTGRES_PASSWORD') ?: getenv('POSTGRES_PASS') ?: '';


### PR DESCRIPTION
## Summary
- allow configuring retry attempts and delays for database connections
- document new POSTGRES_CONNECT_RETRIES and POSTGRES_CONNECT_RETRY_DELAY variables

## Testing
- `composer test` *(fails: vendor/bin/phpunit: not found)*
- `php -l src/Infrastructure/Database.php`


------
https://chatgpt.com/codex/tasks/task_e_68a247217110832b90fc2830d2b78b71