### PR TITLE
Fix test code style for PHPCS compliance

### DIFF
--- a/tests/Controller/AdminCatalogControllerTest.php
+++ b/tests/Controller/AdminCatalogControllerTest.php
@@ -29,7 +29,14 @@ class AdminCatalogControllerTest extends TestCase
         $cfgSvc = new ConfigService($pdo);
         $service = $this->createMock(CatalogService::class);
         $service->method('read')->willReturn(json_encode([
-            ['uid' => 'c1', 'sort_order' => 1, 'slug' => 'slug', 'file' => 'file', 'name' => 'Cat', 'beschreibung' => '']
+            [
+                'uid' => 'c1',
+                'sort_order' => 1,
+                'slug' => 'slug',
+                'file' => 'file',
+                'name' => 'Cat',
+                'beschreibung' => '',
+            ],
         ]));
         $controller = new AdminCatalogController($service);
         $twig = Twig::create(dirname(__DIR__, 2) . '/templates', ['cache' => false]);

--- a/tests/Controller/ProfileWelcomeControllerTest.php
+++ b/tests/Controller/ProfileWelcomeControllerTest.php
@@ -29,15 +29,23 @@ class ProfileWelcomeControllerTest extends TestCase
         $pdo->exec("INSERT INTO tenants(uid, subdomain, imprint_email) VALUES('t1','foo','admin@example.com')");
 
         $twig = new Environment(new FilesystemLoader(__DIR__ . '/../../templates'));
-        $mailer = new class($twig) extends MailService {
+        $mailer = new class ($twig) extends MailService {
             public array $messages = [];
+
             protected function createTransport(string $dsn): \Symfony\Component\Mailer\MailerInterface
             {
-                return new class($this) implements \Symfony\Component\Mailer\MailerInterface {
+                return new class ($this) implements \Symfony\Component\Mailer\MailerInterface {
                     private $outer;
-                    public function __construct($outer) { $this->outer = $outer; }
-                    public function send(\Symfony\Component\Mime\RawMessage $message, ?\Symfony\Component\Mailer\Envelope $envelope = null): void
+
+                    public function __construct($outer)
                     {
+                        $this->outer = $outer;
+                    }
+
+                    public function send(
+                        \Symfony\Component\Mime\RawMessage $message,
+                        ?\Symfony\Component\Mailer\Envelope $envelope = null
+                    ): void {
                         $this->outer->messages[] = $message;
                     }
                 };

--- a/tests/test_random_name_prompt.js
+++ b/tests/test_random_name_prompt.js
@@ -4,46 +4,46 @@ const assert = require('assert');
 
 const code = fs.readFileSync('public/js/quiz.js', 'utf8');
 if (!/if\(cfg.randomNames\)\s*\{\n\s*const nameBtn/.test(code)) {
-  throw new Error('Team name button not found for randomNames');
+    throw new Error('Team name button not found for randomNames');
 }
 const initMatch = code.match(/if\(!getStored\('quizUser'\) && !cfg\.QRRestrict && !cfg\.QRUser\)\{[\s\S]*?\n\s*\}\n\s*\}/);
-const handlerMatch = code.match(/startBtn.addEventListener\('click', async \(\) => \{([\s\S]*?)\n\s*\}\);/);
+const handlerMatch = code.match(/startBtn.addEventListener\('click', async\(\) => \{([\s\S]*?)\n\s*\}\);/);
 if (!initMatch || !handlerMatch) {
-  throw new Error('Required code blocks not found');
+    throw new Error('Required code blocks not found');
 }
 
-(async () => {
-  const initCtx = {
-    cfg: { randomNames: true },
-    quizUser: null,
-    promptCalled: false,
-    randomCalled: false,
-    getStored() { return this.quizUser; },
-    setStored(k, v) { this.quizUser = v; },
-    promptTeamName: async () => { initCtx.promptCalled = true; initCtx.setStored('quizUser', 'Team A'); },
-    generateUserName: () => { initCtx.randomCalled = true; return 'R'; }
-  };
-  await vm.runInNewContext('(async () => {' + initMatch[0] + '})()', initCtx);
-  assert(initCtx.promptCalled);
-  assert(!initCtx.randomCalled);
-  assert.strictEqual(initCtx.quizUser, 'Team A');
+(async() => {
+    const initCtx = {
+        cfg: { randomNames: true },
+        quizUser: null,
+        promptCalled: false,
+        randomCalled: false,
+        getStored() { return this.quizUser; },
+        setStored(k, v) { this.quizUser = v; },
+        promptTeamName: async() => { initCtx.promptCalled = true; initCtx.setStored('quizUser', 'Team A'); },
+        generateUserName: () => { initCtx.randomCalled = true; return 'R'; }
+    };
+    await vm.runInNewContext('(async () => {' + initMatch[0] + '})()', initCtx);
+    assert(initCtx.promptCalled);
+    assert(!initCtx.randomCalled);
+    assert.strictEqual(initCtx.quizUser, 'Team A');
 
-  const body = handlerMatch[1];
-  const ctx = {
-    cfg: { randomNames: true },
-    promptCalled: false,
-    randomCalled: false,
-    nextCalled: false,
-    getStored: () => null,
-    setStored: () => {},
-    promptTeamName: async () => { ctx.promptCalled = true; },
-    generateUserName: () => { ctx.randomCalled = true; return 'R'; },
-    next: () => { ctx.nextCalled = true; },
-    alert: () => {}
-  };
-  await vm.runInNewContext('(async () => {' + body + '})()', ctx);
-  assert(ctx.promptCalled);
-  assert(!ctx.randomCalled);
-  assert(ctx.nextCalled);
-  console.log('ok');
+    const body = handlerMatch[1];
+    const ctx = {
+        cfg: { randomNames: true },
+        promptCalled: false,
+        randomCalled: false,
+        nextCalled: false,
+        getStored: () => null,
+        setStored: () => {},
+        promptTeamName: async() => { ctx.promptCalled = true; },
+        generateUserName: () => { ctx.randomCalled = true; return 'R'; },
+        next: () => { ctx.nextCalled = true; },
+        alert: () => {}
+    };
+    await vm.runInNewContext('(async () => {' + body + '})()', ctx);
+    assert(ctx.promptCalled);
+    assert(!ctx.randomCalled);
+    assert(ctx.nextCalled);
+    console.log('ok');
 })().catch(err => { console.error(err); process.exit(1); });

--- a/tests/test_team_restrict.js
+++ b/tests/test_team_restrict.js
@@ -2,12 +2,12 @@ const fs = require('fs');
 const code = fs.readFileSync('public/js/catalog.js', 'utf8');
 
 if (!/allowed = allowed\.map\(t => String\(t\)\.toLowerCase\(\)\);/.test(code)) {
-  throw new Error('allowed normalization missing');
+    throw new Error('allowed normalization missing');
 }
 if (!/allowed.indexOf\(name.toLowerCase\(\)\) === -1/.test(code)) {
-  throw new Error('case-insensitive check missing');
+    throw new Error('case-insensitive check missing');
 }
 if (!/cfg.QRRestrict && allowed.indexOf\(name.toLowerCase\(\)\) === -1\)\{\n\s*alert\('Unbekanntes oder nicht berechtigtes Team\/Person'\)/.test(code)) {
-  throw new Error('manual entry validation missing');
+    throw new Error('manual entry validation missing');
 }
 console.log('ok');


### PR DESCRIPTION
## Summary
- align JS test indentation and remove extra async spacing
- reformat AdminCatalogControllerTest array to avoid long line
- tidy ProfileWelcomeControllerTest anonymous class formatting

## Testing
- `vendor/bin/phpcs`
- `composer test` *(fails: SQLSTATE[HY000]: no such column: published)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f242cff0832ba0ca627ee0c38d5e