### PR TITLE
Ensure summary loads when opening admin

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2517,28 +2517,31 @@ document.addEventListener('DOMContentLoaded', function () {
     });
     const path = window.location.pathname.replace(basePath + '/admin/', '');
     const initRoute = path === '' ? 'dashboard' : path.replace(/^\/?/, '');
+    const summaryIdx = adminRoutes.indexOf('summary');
+    const tenantIdx = adminRoutes.indexOf('tenants');
     const initIdx = adminRoutes.indexOf(initRoute);
     if (initIdx >= 0) {
       tabControl.show(initIdx);
+      if (initRoute === 'summary') {
+        loadSummary();
+      }
     }
-      UIkit.util.on(adminTabs, 'shown', (e, tab) => {
-        const index = Array.prototype.indexOf.call(adminTabs.children, tab);
-        const route = adminRoutes[index];
-        if (route) {
-          const url = basePath + '/admin/' + route;
-          if (window.history && window.history.replaceState) {
-            window.history.replaceState(null, '', url);
-          }
+    UIkit.util.on(adminTabs, 'shown', (e, tab) => {
+      const index = Array.prototype.indexOf.call(adminTabs.children, tab);
+      const route = adminRoutes[index];
+      if (route) {
+        const url = basePath + '/admin/' + route;
+        if (window.history && window.history.replaceState) {
+          window.history.replaceState(null, '', url);
         }
-        if (index === summaryIdx) {
-          loadSummary();
-        }
-        if (index === tenantIdx) {
-          loadTenants();
-        }
-      });
-      const summaryIdx = adminRoutes.indexOf('summary');
-      const tenantIdx = adminRoutes.indexOf('tenants');
+      }
+      if (index === summaryIdx) {
+        loadSummary();
+      }
+      if (index === tenantIdx) {
+        loadTenants();
+      }
+    });
     if (summaryIdx >= 0) {
       adminTabs.children[summaryIdx]?.addEventListener('click', () => {
         loadSummary();


### PR DESCRIPTION
## Summary
- Determine summary and tenant tab indices before showing initial tab
- Load summary data when opening summary route directly
- Keep summary loading on tab change via `shown` events

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f46f1348832ba77167d15fbda92f