### PR TITLE
Add responsive email layout with tenant footer links

### DIFF
--- a/templates/emails/contact.twig
+++ b/templates/emails/contact.twig
@@ -1,2 +1,6 @@
+{% extends 'emails/layout.twig' %}
+
+{% block content %}
 <p>Kontaktanfrage von {{ name }} ({{ email }}):</p>
 <p>{{ message|nl2br }}</p>
+{% endblock %}

--- a/templates/emails/contact_copy.twig
+++ b/templates/emails/contact_copy.twig
@@ -1,4 +1,8 @@
+{% extends 'emails/layout.twig' %}
+
+{% block content %}
 <p>Hallo {{ name }},</p>
 <p>vielen Dank für Ihre Nachricht. Hier ist eine Kopie Ihrer Anfrage:</p>
 <p>{{ message|nl2br }}</p>
 <p>Wir melden uns in Kürze.</p>
+{% endblock %}

--- a/templates/emails/double_optin.twig
+++ b/templates/emails/double_optin.twig
@@ -1,4 +1,8 @@
+{% extends 'emails/layout.twig' %}
+
+{% block content %}
 <p>Hallo,</p>
 <p>bitte bestätige deine E-Mail-Adresse durch Klick auf den folgenden Link:</p>
 <p><a href="{{ link }}">{{ link }}</a></p>
 <p>Wenn du diese Anfrage nicht gestellt hast, kannst du diese E-Mail ignorieren.</p>
+{% endblock %}

--- a/templates/emails/invitation.twig
+++ b/templates/emails/invitation.twig
@@ -1,4 +1,8 @@
+{% extends 'emails/layout.twig' %}
+
+{% block content %}
 <p>Hallo {{ name }},</p>
 <p>du bist eingeladen, bei QuizRace mitzumachen. Klicke auf den folgenden Link, um dich zu registrieren:</p>
 <p><a href="{{ link }}">{{ link }}</a></p>
 <p>Viel Erfolg!</p>
+{% endblock %}

--- a/templates/emails/layout.twig
+++ b/templates/emails/layout.twig
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ subject|default('') }}</title>
+  <style>
+    body { margin:0; padding:0; }
+    table { border-collapse:collapse; }
+    img { border:0; height:auto; line-height:100%; outline:none; text-decoration:none; }
+    @media screen and (max-width: 600px) {
+      .container { width:100% !important; }
+      .padding { padding:10px !important; }
+    }
+  </style>
+</head>
+<body style="margin:0;padding:0;">
+  <table border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+      <td align="center" bgcolor="#f7f7f7">
+        <table border="0" cellpadding="0" cellspacing="0" width="600" class="container">
+          <tr>
+            <td align="left" class="padding" style="padding:40px 30px;">
+              {% block content %}{% endblock %}
+            </td>
+          </tr>
+          <tr>
+            <td align="center" bgcolor="#222" class="padding" style="padding:20px 30px; color:#ccc; font-size:12px;">
+              <a href="{{ base_url }}/impressum" style="color:#ccc; text-decoration:none;">Impressum</a>
+              &nbsp;|&nbsp;
+              <a href="{{ base_url }}/datenschutz" style="color:#ccc; text-decoration:none;">Datenschutz</a>
+              &nbsp;|&nbsp;
+              <a href="{{ base_url }}/lizenz" style="color:#ccc; text-decoration:none;">Lizenz</a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/templates/emails/password_reset.twig
+++ b/templates/emails/password_reset.twig
@@ -1,4 +1,8 @@
+{% extends 'emails/layout.twig' %}
+
+{% block content %}
 <p>Hallo,</p>
 <p>zum Zurücksetzen deines Passworts klicke auf den folgenden Link:</p>
 <p><a href="{{ link }}">{{ link }}</a></p>
 <p>Wenn du diese Anfrage nicht gestellt hast, kannst du diese E-Mail ignorieren.</p>
+{% endblock %}

--- a/templates/emails/welcome.twig
+++ b/templates/emails/welcome.twig
@@ -1,3 +1,6 @@
+{% extends 'emails/layout.twig' %}
+
+{% block content %}
 <p>Hallo,</p>
 <p>Ihr QuizRace wurde unter <a href="https://{{ domain }}">{{ domain }}</a> eingerichtet.</p>
 <p>Verwalten Sie Ihre Fragenkataloge hier:</p>
@@ -5,3 +8,4 @@
 <p>Um das Admin-Passwort Ihrer Domain zu setzen oder zurückzusetzen, verwenden Sie folgenden Link:</p>
 <p><a href="{{ link }}">{{ link }}</a></p>
 <p>Viel Erfolg!</p>
+{% endblock %}

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -195,10 +195,7 @@ class MailServiceTest extends TestCase
         $_ENV['SMTP_PORT'] = '587';
         unset($_ENV['SMTP_FROM'], $_ENV['SMTP_FROM_NAME']);
 
-        $twig = new Environment(new ArrayLoader([
-            'emails/contact.twig' => '',
-            'emails/contact_copy.twig' => '',
-        ]));
+        $twig = new Environment(new FilesystemLoader(dirname(__DIR__, 2) . '/templates'));
 
         $svc = new class ($twig) extends MailService {
             /** @var Email[] */


### PR DESCRIPTION
## Summary
- Introduce shared responsive `emails/layout.twig` with tenant footer links
- Refactor email templates to extend the new layout
- Inject base URL into `MailService` so footer links resolve correctly
- Adapt mail service tests to load templates from filesystem

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars, nginx reload failure)*
- `vendor/bin/phpcs src/Service/MailService.php tests/Service/MailServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a2f5a16660832ba41791487730cd4e