### PR TITLE
Allow slashes in SEO slug

### DIFF
--- a/src/Application/Seo/SeoValidator.php
+++ b/src/Application/Seo/SeoValidator.php
@@ -25,8 +25,8 @@ class SeoValidator
         $slug = (string)($data['slug'] ?? '');
         if ($slug === '') {
             $errors['slug'] = 'Slug is required';
-        } elseif (!preg_match('/^[a-z0-9\-]+$/', $slug)) {
-            $errors['slug'] = 'Slug must contain lowercase letters, numbers and dashes only';
+        } elseif (!preg_match('/^[a-z0-9\/_-]+$/', $slug)) {
+            $errors['slug'] = 'Slug must contain lowercase letters, numbers, dashes, underscores or slashes only';
         }
 
         $title = $data['metaTitle'] ?? null;

--- a/tests/Service/PageSeoConfigServiceTest.php
+++ b/tests/Service/PageSeoConfigServiceTest.php
@@ -40,4 +40,13 @@ class PageSeoConfigServiceTest extends TestCase
         $this->assertSame('changed', $second->getSlug());
         unlink($file);
     }
+
+    public function testSlugAllowsSlashesAndUnderscores(): void
+    {
+        $service = new PageSeoConfigService();
+        $valid = $service->validate(['slug' => 'foo/bar_baz-1']);
+        $this->assertArrayNotHasKey('slug', $valid);
+        $invalid = $service->validate(['slug' => 'Foo']);
+        $this->assertArrayHasKey('slug', $invalid);
+    }
 }


### PR DESCRIPTION
## Summary
- allow forward slashes and underscores in SEO slug validation
- test slug validation for slashes and underscores

## Testing
- `composer test` *(fails: Slim Application Error)*
- `vendor/bin/phpcs src/Application/Seo/SeoValidator.php tests/Service/PageSeoConfigServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a2fdb47fb0832b839bbbe044b6c650