### PR TITLE
Use Imagick when available and limit image upload size

### DIFF
--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -55,6 +55,10 @@ class EvidenceController
             $response->getBody()->write('upload error');
             return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
+        if ($file->getSize() !== null && $file->getSize() > 20 * 1024 * 1024) {
+            $response->getBody()->write('file too large');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
+        }
         $ext = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
         if (!in_array($ext, ['jpg', 'jpeg', 'png', 'webp'], true)) {
             $response->getBody()->write('unsupported file type');
@@ -92,7 +96,7 @@ class EvidenceController
         $tmpPath = tempnam(sys_get_temp_dir(), 'upload_');
         $file->moveTo($tmpPath);
 
-        $manager = ImageManager::gd();
+        $manager = extension_loaded('imagick') ? ImageManager::imagick() : ImageManager::gd();
         $img = $manager->read($tmpPath);
 
         $orientationHandled = false;

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -80,6 +80,10 @@ class LogoController
             $response->getBody()->write('upload error');
             return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
+        if ($file->getSize() !== null && $file->getSize() > 5 * 1024 * 1024) {
+            $response->getBody()->write('file too large');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
+        }
 
         $extension = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
         if (!in_array($extension, ['png', 'webp'], true)) {
@@ -95,7 +99,7 @@ class LogoController
             return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
         }
 
-        $manager = ImageManager::gd();
+        $manager = extension_loaded('imagick') ? ImageManager::imagick() : ImageManager::gd();
         $stream = $file->getStream();
         $img = $manager->read($stream->detach());
         $img->scaleDown(512, 512);

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -339,7 +339,7 @@ class ResultController
                 if (is_readable($file)) {
                     $tmp = null;
                     if (str_ends_with(strtolower($file), '.webp')) {
-                        $manager = ImageManager::gd();
+                        $manager = extension_loaded('imagick') ? ImageManager::imagick() : ImageManager::gd();
                         $img = $manager->read($file);
                         $tmp = tempnam(sys_get_temp_dir(), 'photo') . '.png';
                         $img->save($tmp, 80);

--- a/src/Service/Pdf.php
+++ b/src/Service/Pdf.php
@@ -39,7 +39,7 @@ class Pdf extends Fpdi
 
         if (is_file($logoFile) && is_readable($logoFile)) {
             if (str_ends_with(strtolower($logoFile), '.webp')) {
-                $manager = ImageManager::gd();
+                $manager = extension_loaded('imagick') ? ImageManager::imagick() : ImageManager::gd();
                 $img = $manager->read($logoFile);
                 $logoTemp = tempnam(sys_get_temp_dir(), 'logo') . '.png';
                 $img->save($logoTemp, 80);


### PR DESCRIPTION
## Summary
- prevent memory exhaustion by rejecting evidence uploads bigger than 20MB and logos bigger than 5MB
- prefer Imagick over GD when processing images to reduce memory usage

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables, PHP unit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f9f94e54832baf20c6e34911de97