### PR TITLE
fix: avoid global variable conflict on landing page

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -33,35 +33,37 @@
 </section>
 
 <script>
-const words = ["unvergesslich", "spannend", "interaktiv", "einzigartig", "unterhaltsam"]; // Wörterliste
-const changeInterval = 5500; // Wechselintervall in Millisekunden
-const fadeDuration = 1000; // Dauer der Ein-/Ausblendung
+(function () {
+  const words = ["unvergesslich", "spannend", "interaktiv", "einzigartig", "unterhaltsam"]; // Wörterliste
+  const changeInterval = 5500; // Wechselintervall in Millisekunden
+  const fadeDuration = 1000; // Dauer der Ein-/Ausblendung
 
-const el = document.getElementById("rotating-word");
-let i = 0;
+  const el = document.getElementById("rotating-word");
+  let i = 0;
 
-function triggerUnderline() {
-  el.classList.remove('underline-animate');
-  void el.offsetWidth;
-  el.classList.add('underline-animate');
-}
+  function triggerUnderline() {
+    el.classList.remove('underline-animate');
+    void el.offsetWidth;
+    el.classList.add('underline-animate');
+  }
 
-// initial underline animation
-triggerUnderline();
-setInterval(() => {
-  el.style.opacity = 0;
+  // initial underline animation
+  triggerUnderline();
+  setInterval(() => {
+    el.style.opacity = 0;
 
-  setTimeout(() => {
-    i = (i + 1) % words.length;
-    el.textContent = words[i];
-    el.style.opacity = 1;
-    triggerUnderline();
-  }, fadeDuration);
-}, changeInterval);
+    setTimeout(() => {
+      i = (i + 1) % words.length;
+      el.textContent = words[i];
+      el.style.opacity = 1;
+      triggerUnderline();
+    }, fadeDuration);
+  }, changeInterval);
 
-window.addEventListener('load', () => {
-  setTimeout(triggerUnderline, 100);
-});
+  window.addEventListener('load', () => {
+    setTimeout(triggerUnderline, 100);
+  });
+})();
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
- wrap rotating-word script in an IIFE to prevent redeclaration errors

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68a2feb85648832bae73c05a58c3ebeb