### PR TITLE
Fix QR design modal not opening

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2310,6 +2310,23 @@ document.addEventListener('DOMContentLoaded', function () {
   let currentQrTarget = '';
   let isGlobalDesign = false;
 
+  designAllBtn?.addEventListener('click', () => {
+    const eventQr = document.getElementById('summaryEventQr');
+    let target = eventQr?.dataset.target;
+    if (!target) {
+      const src = eventQr?.getAttribute('src') || '';
+      try {
+        const url = new URL(src, window.location.origin);
+        target = url.searchParams.get('t') || '';
+      } catch (_) {
+        target = '';
+      }
+    }
+    if (target) {
+      openQrDesignModal(null, '/qr/event', target, '', true);
+    }
+  });
+
   function updateQrPreview() {
     if (!currentQrEndpoint) return;
     const params = new URLSearchParams();
@@ -2391,11 +2408,6 @@ document.addEventListener('DOMContentLoaded', function () {
         if (qrDesignBtn) {
           qrDesignBtn.onclick = () => {
             openQrDesignModal(qrImg, '/qr/event', link, ev.name || '');
-          };
-        }
-        if (designAllBtn) {
-          designAllBtn.onclick = () => {
-            openQrDesignModal(null, '/qr/event', link, '', true);
           };
         }
       }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -534,7 +534,7 @@
           <div class="uk-flex">
             <button id="openInvitesBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: {{ t('tip_invitations_open') }}; pos: right">{{ t('action_open_invitations') }}</button>
             <button id="summaryPrintBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: {{ t('tip_summary_print') }}; pos: right">{{ t('action_print_summary') }}</button>
-            <button id="summaryDesignAllBtn" class="uk-button uk-button-default">{{ t('action_design_qrcodes') }}</button>
+            <button id="summaryDesignAllBtn" class="uk-button uk-button-default" type="button">{{ t('action_design_qrcodes') }}</button>
           </div>
         </div>
         <div id="inviteTextModal" uk-modal>


### PR DESCRIPTION
## Summary
- ensure "QR-Codes gestalten" button opens the design modal by binding a click handler that reads the current event QR data
- mark the button as type="button" to avoid unintended form submission

## Testing
- `composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68a2feb43a00832ba4f7fe05059912a7