### PR TITLE
feat: support configurable QR designs

### DIFF
--- a/migrations/20250220_add_qr_design_fields.sql
+++ b/migrations/20250220_add_qr_design_fields.sql
@@ -1,0 +1,6 @@
+-- Add QR design configuration fields
+ALTER TABLE config ADD COLUMN IF NOT EXISTS qr_label_line1 TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS qr_label_line2 TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS qr_logo_path TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS qr_round_mode TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS qr_logo_punchout BOOLEAN;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -932,6 +932,7 @@ body.admin-page {
   padding: 2px 6px;
   border: 0.5px solid #ccc;
   border-radius: 0 0 4px 4px;
+  white-space: pre-line;
 }
 
 /* Dashboard calendar */

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -136,6 +136,7 @@ return [
     'label_check_button' => 'Antwort-Prüfen-Button anzeigen',
     'label_qr_login' => 'QR-Code-Login verwenden',
     'label_qr_remember' => 'Einmaliges Einscannen merken',
+    'label_custom_logo' => 'Eigenes Logo',
     'label_random_names' => 'Teamnamen eingeben lassen',
     'label_team_restrict' => 'Nur Teams/Personen aus der Liste dürfen teilnehmen.',
     'label_plan' => 'Abo',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -135,6 +135,7 @@ return [
     'label_check_button' => 'Show check answer button',
     'label_qr_login' => 'Use QR code login',
     'label_qr_remember' => 'Remember scanned login',
+    'label_custom_logo' => 'Custom logo',
     'label_random_names' => 'Prompt for team names',
     'label_team_restrict' => 'Only listed teams may join',
     'label_plan' => 'Plan',

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -55,7 +55,8 @@ class QrController
      */
     public function catalog(Request $request, Response $response): Response
     {
-        $out = $this->qrService->generateCatalog($request->getQueryParams());
+        $cfg = $this->config->getConfig();
+        $out = $this->qrService->generateCatalog($request->getQueryParams(), $cfg);
         $response->getBody()->write($out['body']);
         return $response
             ->withHeader('Content-Type', $out['mime'])
@@ -67,7 +68,8 @@ class QrController
      */
     public function team(Request $request, Response $response): Response
     {
-        $out = $this->qrService->generateTeam($request->getQueryParams());
+        $cfg = $this->config->getConfig();
+        $out = $this->qrService->generateTeam($request->getQueryParams(), $cfg);
         $response->getBody()->write($out['body']);
         return $response
             ->withHeader('Content-Type', $out['mime'])
@@ -79,7 +81,8 @@ class QrController
      */
     public function event(Request $request, Response $response): Response
     {
-        $out = $this->qrService->generateEvent($request->getQueryParams());
+        $cfg = $this->config->getConfig();
+        $out = $this->qrService->generateEvent($request->getQueryParams(), $cfg);
         $response->getBody()->write($out['body']);
         return $response
             ->withHeader('Content-Type', $out['mime'])

--- a/src/Controller/QrLogoController.php
+++ b/src/Controller/QrLogoController.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\ConfigService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Intervention\Image\ImageManager;
+
+/**
+ * Handles uploading and serving QR code logo images.
+ */
+class QrLogoController
+{
+    private ConfigService $config;
+
+    public function __construct(ConfigService $config)
+    {
+        $this->config = $config;
+    }
+
+    public function get(Request $request, Response $response): Response
+    {
+        $file = (string)($request->getAttribute('file') ?? '');
+        $ext = strtolower((string)($request->getAttribute('ext') ?? 'png'));
+        $uid = '';
+        if (preg_match('/^qrlogo-([\w-]+)\.' . preg_quote($ext, '/') . '$/', $file, $m)) {
+            $uid = $m[1];
+        }
+
+        $cfg = $uid !== ''
+            ? $this->config->getConfigForEvent($uid)
+            : $this->config->getConfig();
+
+        $relPath = $cfg['qrLogoPath'] ?? '';
+        $path = '';
+        $contentType = 'image/png';
+
+        if ($relPath !== '') {
+            $path = __DIR__ . '/../../data' . $relPath;
+            if (file_exists($path)) {
+                $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+                $contentType = $ext === 'webp' ? 'image/webp' : 'image/png';
+            } else {
+                $path = '';
+            }
+        }
+
+        if ($path === '') {
+            // fallback to site logo if QR logo missing
+            $cfgLogo = $cfg['logoPath'] ?? '';
+            if ($cfgLogo !== '') {
+                $path = __DIR__ . '/../../data' . $cfgLogo;
+                $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+                $contentType = $ext === 'webp' ? 'image/webp' : 'image/png';
+            }
+        }
+
+        if ($path === '' || !file_exists($path)) {
+            $path = __DIR__ . '/../../public/favicon.svg';
+            $contentType = 'image/svg+xml';
+        }
+
+        $response->getBody()->write((string)file_get_contents($path));
+        return $response->withHeader('Content-Type', $contentType);
+    }
+
+    public function post(Request $request, Response $response): Response
+    {
+        $files = $request->getUploadedFiles();
+        if (!isset($files['file'])) {
+            $response->getBody()->write('missing file');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
+        }
+
+        $file = $files['file'];
+        if ($file->getError() !== UPLOAD_ERR_OK) {
+            $response->getBody()->write('upload error');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
+        }
+        if ($file->getSize() !== null && $file->getSize() > 5 * 1024 * 1024) {
+            $response->getBody()->write('file too large');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
+        }
+
+        $extension = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
+        if (!in_array($extension, ['png', 'webp'], true)) {
+            $response->getBody()->write('unsupported file type');
+            return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
+        }
+
+        $uid = $this->config->getActiveEventUid();
+        $base = $uid !== '' ? "qrlogo-$uid.$extension" : "qrlogo.$extension";
+        $target = __DIR__ . "/../../data/" . $base;
+        if (!class_exists('\\Intervention\\Image\\ImageManager')) {
+            $response->getBody()->write('Intervention Image NICHT installiert');
+            return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
+        }
+
+        $manager = extension_loaded('imagick') ? ImageManager::imagick() : ImageManager::gd();
+        $stream = $file->getStream();
+        $img = $manager->read($stream->detach());
+        $img->scaleDown(512, 512);
+        $img->save($target, 80);
+
+        $cfg = $this->config->getConfig();
+        $cfg['qrLogoPath'] = '/' . $base;
+        $this->config->saveConfig($cfg);
+
+        return $response->withStatus(204);
+    }
+}
+

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -29,6 +29,7 @@ class ConfigService
         'teamResults',
         'photoUpload',
         'puzzleWordEnabled',
+        'qrLogoPunchout',
     ];
 
     /**
@@ -176,6 +177,11 @@ class ConfigService
             'puzzleFeedback',
             'inviteText',
             'event_uid',
+            'qrLabelLine1',
+            'qrLabelLine2',
+            'qrLogoPath',
+            'qrRoundMode',
+            'qrLogoPunchout',
         ];
         $filtered = array_intersect_key($data, array_flip($keys));
         $uid = (string)($filtered['event_uid'] ?? $this->getActiveEventUid());
@@ -299,6 +305,11 @@ class ConfigService
             'puzzleFeedback',
             'inviteText',
             'event_uid',
+            'qrLabelLine1',
+            'qrLabelLine2',
+            'qrLogoPath',
+            'qrRoundMode',
+            'qrLogoPunchout',
         ];
         $map = [];
         foreach ($keys as $k) {

--- a/src/routes.php
+++ b/src/routes.php
@@ -50,6 +50,7 @@ use App\Controller\ImportController;
 use App\Controller\ExportController;
 use App\Controller\QrController;
 use App\Controller\LogoController;
+use App\Controller\QrLogoController;
 use App\Controller\CatalogDesignController;
 use App\Controller\SummaryController;
 use App\Controller\EvidenceController;
@@ -205,6 +206,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             ->withAttribute('onboardingEmailController', new OnboardingEmailController($emailConfirmService))
             ->withAttribute('catalogDesignController', new CatalogDesignController($catalogService))
             ->withAttribute('logoController', new LogoController($configService))
+            ->withAttribute('qrLogoController', new QrLogoController($configService))
             ->withAttribute('summaryController', new SummaryController($configService, $eventService))
             ->withAttribute('importController', new ImportController(
                 $catalogService,
@@ -845,6 +847,19 @@ return function (\Slim\App $app, TranslationService $translator) {
     });
     $app->post('/logo.webp', function (Request $request, Response $response) {
         return $request->getAttribute('logoController')->post($request, $response);
+    })->add(new RoleAuthMiddleware('admin'));
+
+    $app->get('/{file:qrlogo(?:-[\w-]+)?\.png}', function (Request $request, Response $response) {
+        return $request->getAttribute('qrLogoController')->get($request->withAttribute('ext', 'png'), $response);
+    });
+    $app->post('/qrlogo.png', function (Request $request, Response $response) {
+        return $request->getAttribute('qrLogoController')->post($request, $response);
+    })->add(new RoleAuthMiddleware('admin'));
+    $app->get('/{file:qrlogo(?:-[\w-]+)?\.webp}', function (Request $request, Response $response) {
+        return $request->getAttribute('qrLogoController')->get($request->withAttribute('ext', 'webp'), $response);
+    });
+    $app->post('/qrlogo.webp', function (Request $request, Response $response) {
+        return $request->getAttribute('qrLogoController')->post($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
 
     $app->get('/catalog/{slug}/design', function (Request $request, Response $response, array $args) {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -574,7 +574,11 @@
             <h2 class="uk-modal-title">QR-Design</h2>
             <div class="uk-margin">
               <label class="uk-form-label" for="qrLabelInput">Label</label>
-              <input class="uk-input" id="qrLabelInput" type="text">
+              <textarea class="uk-textarea" id="qrLabelInput" rows="2"></textarea>
+            </div>
+            <div class="uk-margin">
+              <label class="uk-form-label" for="qrLogoFile">{{ t('label_custom_logo') }}</label>
+              <input class="uk-input" id="qrLogoFile" type="file" accept="image/png,image/webp">
             </div>
             <div class="uk-margin">
               <label><input class="uk-checkbox" id="qrPunchoutInput" type="checkbox"> Logo-Hintergrund ausstanzen</label>

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -143,6 +143,11 @@ class QrControllerTest extends TestCase
                 puzzleWord TEXT,
                 puzzleFeedback TEXT,
                 inviteText TEXT,
+                qrLabelLine1 TEXT,
+                qrLabelLine2 TEXT,
+                qrLogoPath TEXT,
+                qrRoundMode TEXT,
+                qrLogoPunchout INTEGER,
                 event_uid TEXT
             );
             SQL
@@ -210,6 +215,11 @@ class QrControllerTest extends TestCase
                 puzzleWord TEXT,
                 puzzleFeedback TEXT,
                 inviteText TEXT,
+                qrLabelLine1 TEXT,
+                qrLabelLine2 TEXT,
+                qrLogoPath TEXT,
+                qrRoundMode TEXT,
+                qrLogoPunchout INTEGER,
                 event_uid TEXT
             );
             SQL
@@ -254,6 +264,11 @@ class QrControllerTest extends TestCase
             <<<'SQL'
             CREATE TABLE config(
                 inviteText TEXT,
+                qrLabelLine1 TEXT,
+                qrLabelLine2 TEXT,
+                qrLogoPath TEXT,
+                qrRoundMode TEXT,
+                qrLogoPunchout INTEGER,
                 event_uid TEXT
             );
             SQL
@@ -307,6 +322,11 @@ class QrControllerTest extends TestCase
                 puzzleWord TEXT,
                 puzzleFeedback TEXT,
                 inviteText TEXT,
+                qrLabelLine1 TEXT,
+                qrLabelLine2 TEXT,
+                qrLogoPath TEXT,
+                qrRoundMode TEXT,
+                qrLogoPunchout INTEGER,
                 event_uid TEXT
             );
             SQL
@@ -368,6 +388,11 @@ class QrControllerTest extends TestCase
                 puzzleWord TEXT,
                 puzzleFeedback TEXT,
                 inviteText TEXT,
+                qrLabelLine1 TEXT,
+                qrLabelLine2 TEXT,
+                qrLogoPath TEXT,
+                qrRoundMode TEXT,
+                qrLogoPunchout INTEGER,
                 event_uid TEXT
             );
             SQL

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -40,6 +40,11 @@ class ResultControllerTest extends TestCase
                 puzzleWord TEXT,
                 puzzleFeedback TEXT,
                 inviteText TEXT,
+                qrLabelLine1 TEXT,
+                qrLabelLine2 TEXT,
+                qrLogoPath TEXT,
+                qrRoundMode TEXT,
+                qrLogoPunchout INTEGER,
                 event_uid TEXT
             );
             SQL
@@ -151,6 +156,11 @@ class ResultControllerTest extends TestCase
                 puzzleWord TEXT,
                 puzzleFeedback TEXT,
                 inviteText TEXT,
+                qrLabelLine1 TEXT,
+                qrLabelLine2 TEXT,
+                qrLogoPath TEXT,
+                qrRoundMode TEXT,
+                qrLogoPunchout INTEGER,
                 event_uid TEXT
             );
             SQL


### PR DESCRIPTION
## Summary
- allow multi-line labels and custom logo uploads when designing QR codes
- persist QR design settings and apply them when generating catalog, team, and event QR codes
- add migration and endpoints for storing QR logo assets

## Testing
- `composer test` *(fails: Tests\Controller\EventsRouteTest::testEventsListAccessibleForCatalogEditor, Tests\Controller\HomeControllerTest::testEventsAsHomePage, Tests\Controller\ProfileWelcomeControllerTest::testResendWelcomeMail)*

------
https://chatgpt.com/codex/tasks/task_e_68a30285c5cc832bbc891fe9065de633