### PR TITLE
Use text save button in invitation text modal

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -564,7 +564,7 @@
             </div>
             <textarea id="inviteTextTextarea" class="uk-textarea" rows="5" placeholder="{{ t('placeholder_invite_text') }}"></textarea>
             <div class="uk-flex uk-flex-right uk-margin-top">
-              <button id="inviteTextSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="button"></button>
+              <button id="inviteTextSave" class="uk-button uk-button-primary" type="button">{{ t('action_save') }}</button>
               <button class="uk-button uk-button-default uk-modal-close" type="button">{{ t('action_cancel') }}</button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Show "Speichern" as a text button instead of icon in the invitation text modal

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables, nginx reload failure)*

------
https://chatgpt.com/codex/tasks/task_e_68a303b75524832baa19c076dff07fc0