### PR TITLE
Prevent caching issues for config requests

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -26,14 +26,16 @@ function showUpgradeModal() {
 window.apiFetch = (path, options = {}) => {
   const token = getCsrfToken();
   const headers = {
-    'X-CSRF-Token': token,
+    ...(token ? { 'X-CSRF-Token': token } : {}),
     ...(options.headers || {})
   };
-  return fetch(withBase(path), {
+  const opts = {
     credentials: 'same-origin',
+    cache: 'no-store',
     ...options,
     headers
-  }).then(res => {
+  };
+  return fetch(withBase(path), opts).then(res => {
     if (res.status === 402) {
       showUpgradeModal();
       throw new Error('upgrade-required');


### PR DESCRIPTION
## Summary
- disable browser caching in `apiFetch` to always fetch fresh configuration
- send CSRF header only when a token is present

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68a3080e0f60832ba012a73babf16c7d