### PR TITLE
Add missing columns to base schema

### DIFF
--- a/migrations/20240910_base_schema.sql
+++ b/migrations/20240910_base_schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS events (
     start_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     end_date TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     description TEXT,
+    published BOOLEAN NOT NULL DEFAULT FALSE,
     sort_order INTEGER NOT NULL DEFAULT 0
 );
 
@@ -171,6 +172,8 @@ CREATE TABLE IF NOT EXISTS users (
     id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     username TEXT UNIQUE NOT NULL,
     password TEXT NOT NULL,
+    email TEXT UNIQUE,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
     role user_role NOT NULL DEFAULT 'catalog-editor'
 );
 
@@ -180,6 +183,15 @@ CREATE TABLE IF NOT EXISTS user_sessions (
     session_id TEXT PRIMARY KEY,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Password reset tokens
+CREATE TABLE IF NOT EXISTS password_resets (
+    user_id INTEGER NOT NULL,
+    token_hash TEXT NOT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT fk_password_resets_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_password_resets_token ON password_resets(token_hash);
 
 -- Tenant definitions
 CREATE TABLE IF NOT EXISTS tenants (
@@ -218,10 +230,3 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs(action);
-
--- Persisted user sessions
-CREATE TABLE IF NOT EXISTS user_sessions (
-    user_id INTEGER NOT NULL,
-    session_id TEXT PRIMARY KEY,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-);

--- a/tests/Controller/PasswordControllerTest.php
+++ b/tests/Controller/PasswordControllerTest.php
@@ -16,14 +16,6 @@ class PasswordControllerTest extends TestCase
     {
         $pdo = Database::connectFromEnv();
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
-        try {
-            $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
-        } catch (\PDOException $e) {
-        }
-        try {
-            $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        } catch (\PDOException $e) {
-        }
         $service = new UserService($pdo);
         $service->create('alice', 'OldPass1', null, Roles::ADMIN);
         return $service;

--- a/tests/Controller/PasswordResetFlowTest.php
+++ b/tests/Controller/PasswordResetFlowTest.php
@@ -25,14 +25,6 @@ class PasswordResetFlowTest extends TestCase
         $pdo = Database::connectFromEnv();
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
         try {
-            $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
-        } catch (\PDOException $e) {
-        }
-        try {
-            $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        } catch (\PDOException $e) {
-        }
-        try {
             $pdo->exec(
                 'CREATE TABLE password_resets(' .
                 'user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)'
@@ -115,14 +107,6 @@ class PasswordResetFlowTest extends TestCase
         $pdo = Database::connectFromEnv();
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
         try {
-            $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
-        } catch (\PDOException $e) {
-        }
-        try {
-            $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        } catch (\PDOException $e) {
-        }
-        try {
             $pdo->exec(
                 'CREATE TABLE password_resets(' .
                 'user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)'
@@ -185,14 +169,6 @@ class PasswordResetFlowTest extends TestCase
         $app = $this->getAppInstance();
         $pdo = Database::connectFromEnv();
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
-        try {
-            $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
-        } catch (\PDOException $e) {
-        }
-        try {
-            $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        } catch (\PDOException $e) {
-        }
         try {
             $pdo->exec(
                 'CREATE TABLE password_resets(' .

--- a/tests/Controller/ProfileWelcomeControllerTest.php
+++ b/tests/Controller/ProfileWelcomeControllerTest.php
@@ -23,6 +23,8 @@ class ProfileWelcomeControllerTest extends TestCase
         $_ENV['SMTP_HOST'] = 'localhost';
         $_ENV['SMTP_USER'] = 'user';
         $_ENV['SMTP_PASS'] = 'pass';
+        putenv('PASSWORD_RESET_SECRET=secret');
+        $_ENV['PASSWORD_RESET_SECRET'] = 'secret';
 
         $app = $this->getAppInstance();
         $pdo = new PDO(getenv('POSTGRES_DSN'));

--- a/tests/Service/PasswordResetServiceTest.php
+++ b/tests/Service/PasswordResetServiceTest.php
@@ -13,14 +13,6 @@ class PasswordResetServiceTest extends TestCase
     public function testCreateAndConsumeToken(): void
     {
         $pdo = $this->createDatabase();
-        $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
-        $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        $pdo->exec(
-            'CREATE TABLE password_resets('
-            . 'user_id INTEGER NOT NULL, '
-            . 'token_hash TEXT NOT NULL, '
-            . 'expires_at TEXT NOT NULL)'
-        );
         $users = new UserService($pdo);
         $users->create('alice', 'secret', 'alice@example.com');
 
@@ -43,14 +35,6 @@ class PasswordResetServiceTest extends TestCase
     public function testTokenExpires(): void
     {
         $pdo = $this->createDatabase();
-        $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
-        $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        $pdo->exec(
-            'CREATE TABLE password_resets('
-            . 'user_id INTEGER NOT NULL, '
-            . 'token_hash TEXT NOT NULL, '
-            . 'expires_at TEXT NOT NULL)'
-        );
         $users = new UserService($pdo);
         $users->create('bob', 'secret', 'bob@example.com');
 
@@ -69,14 +53,6 @@ class PasswordResetServiceTest extends TestCase
     public function testOldTokenInvalidated(): void
     {
         $pdo = $this->createDatabase();
-        $pdo->exec('ALTER TABLE users ADD COLUMN email TEXT');
-        $pdo->exec('ALTER TABLE users ADD COLUMN active INTEGER DEFAULT 1');
-        $pdo->exec(
-            'CREATE TABLE password_resets('
-            . 'user_id INTEGER NOT NULL, '
-            . 'token_hash TEXT NOT NULL, '
-            . 'expires_at TEXT NOT NULL)'
-        );
         $users = new UserService($pdo);
         $users->create('carol', 'secret', 'carol@example.com');
 


### PR DESCRIPTION
## Summary
- ensure events table includes `published` flag
- include user `email` and `active` fields in base schema
- add `password_resets` table to base schema
- drop obsolete column setup in password-related tests
- configure welcome-mail test with password reset secret

## Testing
- `vendor/bin/phpunit` *(fails: Tests\Controller\ProfileWelcomeControllerTest::testResendWelcomeMail)*

------
https://chatgpt.com/codex/tasks/task_e_68a30c3b43d8832b8426c2b1d5531ad8