### PR TITLE
Fix PHPStan null coalesce warnings

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -143,7 +143,7 @@ class QrController
         $qrParams['format'] = 'png';
         if (isset($qrParams['logoText'])) {
             $parts = explode("\n", (string)$qrParams['logoText']);
-            $qrParams['text1'] = $parts[0] ?? '';
+            $qrParams['text1'] = $parts[0];
             $qrParams['text2'] = $parts[1] ?? '';
             unset($qrParams['logoText']);
         }
@@ -263,7 +263,7 @@ class QrController
             $q['format'] = 'png';
             if (isset($q['logoText'])) {
                 $parts = explode("\n", (string)$q['logoText']);
-                $q['text1'] = $parts[0] ?? '';
+                $q['text1'] = $parts[0];
                 $q['text2'] = $parts[1] ?? '';
                 unset($q['logoText']);
             }

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -200,7 +200,15 @@ class QrCodeService
 
     /**
      * @param array<string,mixed> $q
-     * @param array{t:string,fg:string} $defaults
+     * @param array{
+     *     t:string,
+     *     fg:string,
+     *     text1?:string,
+     *     text2?:string,
+     *     round_mode?:string,
+     *     logo_punchout?:bool,
+     *     logo_path?:string
+     * } $defaults
      * @return array{mime:string,body:string}
      */
     private function buildQrWithCenterLogoParam(array $q, array $defaults): array


### PR DESCRIPTION
## Summary
- avoid unnecessary null coalesce on explode results in QR controller
- expand defaults array phpdoc for optional keys in QR code service

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `vendor/bin/phpunit` *(fails: hangs after partial progress)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js` *(fails: Required code blocks not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a31f6dc7ec832b8759c2a9a2934696