### PR TITLE
feat: show overall event counts on dashboard

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -101,9 +101,9 @@
 
   function renderBadges() {
     const s = state.stats || {};
-    const total = (s.draftCount || 0) + (s.scheduledCount || 0) + (s.runningCount || 0) + (s.finishedCount || 0);
-    const upcoming = (s.scheduledCount || 0) + (s.runningCount || 0);
-    const past = s.finishedCount || 0;
+    const total = s.eventCount || 0;
+    const upcoming = s.upcomingCount || 0;
+    const past = s.pastCount || 0;
     const e = document.getElementById('badge-events');
     const u = document.getElementById('badge-upcoming');
     const p = document.getElementById('badge-past');


### PR DESCRIPTION
## Summary
- report total, upcoming, and past event counts in dashboard JSON
- display updated event statistics in admin dashboard badges

## Testing
- `vendor/bin/phpunit` *(fails: hangs at 28% despite dummy Stripe env; see log)*

------
https://chatgpt.com/codex/tasks/task_e_68a322992674832bb0de682416ef2481