### PR TITLE
style: remove trailing blank line from QrLogoController

### DIFF
--- a/src/Controller/QrLogoController.php
+++ b/src/Controller/QrLogoController.php
@@ -112,4 +112,3 @@ class QrLogoController
         return $response->withStatus(204);
     }
 }
-


### PR DESCRIPTION
## Summary
- remove extra trailing blank line from `QrLogoController`

## Testing
- `vendor/bin/phpcs src/Controller/QrLogoController.php`
- `composer test` *(fails: Failed asserting that 500 is identical to 204; missing STRIPE_* env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68a323f71a70832b9342b13721d2fbd4