### PR TITLE
Load and persist landing page SEO settings

### DIFF
--- a/src/Application/Seo/PageSeoConfigService.php
+++ b/src/Application/Seo/PageSeoConfigService.php
@@ -10,13 +10,16 @@ use App\Domain\Event\SeoConfigSaved;
 use App\Domain\Event\SeoConfigUpdated;
 use App\Domain\PageSeoConfig;
 use App\Infrastructure\Cache\PageSeoCache;
+use App\Infrastructure\Database;
 use App\Infrastructure\Event\EventDispatcher;
+use PDO;
 
 /**
  * Handles loading, saving and validating SEO configuration for pages.
  */
 class PageSeoConfigService
 {
+    private PDO $pdo;
     private string $file;
     private RedirectManager $redirects;
     private SeoValidator $validator;
@@ -24,18 +27,49 @@ class PageSeoConfigService
     private EventDispatcher $dispatcher;
 
     public function __construct(
+        ?PDO $pdo = null,
         ?string $file = null,
         ?RedirectManager $redirects = null,
         ?SeoValidator $validator = null,
         ?PageSeoCache $cache = null,
         ?EventDispatcher $dispatcher = null
     ) {
+        $this->pdo = $pdo ?? Database::connectFromEnv();
         $this->file = $file ?? dirname(__DIR__, 3) . '/data/page-seo.json';
         $this->redirects = $redirects ?? new RedirectManager();
         $this->validator = $validator ?? new SeoValidator();
         $this->cache = $cache ?? new PageSeoCache();
         $this->dispatcher = $dispatcher ?? new EventDispatcher();
         SeoConfigListener::register($this->dispatcher, $this->cache);
+
+        $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $this->pdo->exec(
+                'CREATE TABLE IF NOT EXISTS page_seo_config (' .
+                'page_id INTEGER PRIMARY KEY, meta_title TEXT, meta_description TEXT, slug TEXT UNIQUE NOT NULL, ' .
+                'canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, ' .
+                'hreflang TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP, updated_at TEXT DEFAULT CURRENT_TIMESTAMP)'
+            );
+            $this->pdo->exec(
+                'CREATE TABLE IF NOT EXISTS page_seo_config_history (' .
+                'id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER NOT NULL, meta_title TEXT, meta_description TEXT, slug TEXT, ' .
+                'canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, ' .
+                'hreflang TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP)'
+            );
+        } else {
+            $this->pdo->exec(
+                'CREATE TABLE IF NOT EXISTS page_seo_config (' .
+                'page_id INTEGER PRIMARY KEY, meta_title TEXT, meta_description TEXT, slug TEXT UNIQUE NOT NULL, ' .
+                'canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json JSONB, ' .
+                'hreflang TEXT, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP)'
+            );
+            $this->pdo->exec(
+                'CREATE TABLE IF NOT EXISTS page_seo_config_history (' .
+                'id SERIAL PRIMARY KEY, page_id INTEGER NOT NULL, meta_title TEXT, meta_description TEXT, slug TEXT, canonical_url TEXT, ' .
+                'robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json JSONB, hreflang TEXT, ' .
+                'created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP)'
+            );
+        }
     }
 
     public function load(int $pageId): ?PageSeoConfig
@@ -44,6 +78,31 @@ class PageSeoConfigService
         if ($cached !== null) {
             return $cached;
         }
+
+        $stmt = $this->pdo->prepare(
+            'SELECT slug, meta_title, meta_description, canonical_url, robots_meta, og_title, og_description, og_image, schema_json, hreflang '
+            . 'FROM page_seo_config WHERE page_id = ?'
+        );
+        $stmt->execute([$pageId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row !== false) {
+            $config = new PageSeoConfig(
+                $pageId,
+                (string) ($row['slug'] ?? ''),
+                $row['meta_title'] !== null ? (string) $row['meta_title'] : null,
+                $row['meta_description'] !== null ? (string) $row['meta_description'] : null,
+                $row['canonical_url'] !== null ? (string) $row['canonical_url'] : null,
+                $row['robots_meta'] !== null ? (string) $row['robots_meta'] : null,
+                $row['og_title'] !== null ? (string) $row['og_title'] : null,
+                $row['og_description'] !== null ? (string) $row['og_description'] : null,
+                $row['og_image'] !== null ? (string) $row['og_image'] : null,
+                $row['schema_json'] !== null ? (string) $row['schema_json'] : null,
+                $row['hreflang'] !== null ? (string) $row['hreflang'] : null
+            );
+            $this->cache->set($config);
+            return $config;
+        }
+
         if (!is_file($this->file)) {
             return null;
         }
@@ -71,17 +130,13 @@ class PageSeoConfigService
 
     public function save(PageSeoConfig $config): void
     {
-        $data = [];
-        if (is_file($this->file)) {
-            $json = json_decode((string) file_get_contents($this->file), true);
-            if (is_array($json)) {
-                $data = $json;
-            }
-        }
-        $existing = $data[$config->getPageId()] ?? null;
+        $stmt = $this->pdo->prepare('SELECT slug, canonical_url FROM page_seo_config WHERE page_id = ?');
+        $stmt->execute([$config->getPageId()]);
+        $existing = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+
         if (is_array($existing)) {
             $oldSlug = $existing['slug'] ?? null;
-            $oldCanonical = $existing['canonicalUrl'] ?? null;
+            $oldCanonical = $existing['canonical_url'] ?? null;
             if ($oldSlug && $oldSlug !== $config->getSlug()) {
                 $this->redirects->register('/' . ltrim((string) $oldSlug, '/'), '/' . ltrim($config->getSlug(), '/'));
             }
@@ -89,8 +144,46 @@ class PageSeoConfigService
                 $this->redirects->register($oldCanonical, (string) $config->getCanonicalUrl());
             }
         }
+
+        $params = [
+            $config->getPageId(),
+            $config->getMetaTitle(),
+            $config->getMetaDescription(),
+            $config->getSlug(),
+            $config->getCanonicalUrl(),
+            $config->getRobotsMeta(),
+            $config->getOgTitle(),
+            $config->getOgDescription(),
+            $config->getOgImage(),
+            $config->getSchemaJson(),
+            $config->getHreflang(),
+        ];
+
+        $upsert = $this->pdo->prepare(
+            'INSERT INTO page_seo_config(page_id, meta_title, meta_description, slug, canonical_url, robots_meta, og_title, og_description, og_image, schema_json, hreflang) '
+            . 'VALUES(?,?,?,?,?,?,?,?,?,?,?) '
+            . 'ON CONFLICT(page_id) DO UPDATE SET meta_title=excluded.meta_title, meta_description=excluded.meta_description, slug=excluded.slug, '
+            . 'canonical_url=excluded.canonical_url, robots_meta=excluded.robots_meta, og_title=excluded.og_title, og_description=excluded.og_description, '
+            . 'og_image=excluded.og_image, schema_json=excluded.schema_json, hreflang=excluded.hreflang, updated_at=CURRENT_TIMESTAMP'
+        );
+        $upsert->execute($params);
+
+        $history = $this->pdo->prepare(
+            'INSERT INTO page_seo_config_history(page_id, meta_title, meta_description, slug, canonical_url, robots_meta, og_title, og_description, og_image, schema_json, hreflang) '
+            . 'VALUES(?,?,?,?,?,?,?,?,?,?,?)'
+        );
+        $history->execute($params);
+
+        $data = [];
+        if (is_file($this->file)) {
+            $json = json_decode((string) file_get_contents($this->file), true);
+            if (is_array($json)) {
+                $data = $json;
+            }
+        }
         $data[$config->getPageId()] = $config->jsonSerialize();
         file_put_contents($this->file, json_encode($data, JSON_PRETTY_PRINT) . "\n");
+
         $event = is_array($existing)
             ? new SeoConfigUpdated($config)
             : new SeoConfigSaved($config);

--- a/src/Controller/Admin/LandingpageController.php
+++ b/src/Controller/Admin/LandingpageController.php
@@ -28,7 +28,10 @@ class LandingpageController
     public function page(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'admin/landingpage/edit.html.twig');
+        $config = $this->seoService->load(1);
+        return $view->render($response, 'admin/landingpage/edit.html.twig', [
+            'config' => $config ? $config->jsonSerialize() : [],
+        ]);
     }
 
     /**

--- a/templates/admin/landingpage/edit.html.twig
+++ b/templates/admin/landingpage/edit.html.twig
@@ -19,53 +19,53 @@
       <div class="uk-margin">
         <label class="uk-form-label" for="metaTitle">Meta Title</label>
         <div class="uk-form-controls">
-          <input class="uk-input" id="metaTitle" name="meta_title" type="text" required data-maxlength="60">
+          <input class="uk-input" id="metaTitle" name="meta_title" type="text" required data-maxlength="60" value="{{ config.metaTitle|default('') }}">
           <small class="uk-text-meta char-count" data-for="metaTitle">0/60</small>
         </div>
       </div>
       <div class="uk-margin">
         <label class="uk-form-label" for="metaDescription">Meta Description</label>
         <div class="uk-form-controls">
-          <textarea class="uk-textarea" id="metaDescription" name="meta_description" required data-maxlength="160"></textarea>
+          <textarea class="uk-textarea" id="metaDescription" name="meta_description" required data-maxlength="160">{{ config.metaDescription|default('') }}</textarea>
           <small class="uk-text-meta char-count" data-for="metaDescription">0/160</small>
         </div>
       </div>
       <div class="uk-margin">
         <label class="uk-form-label" for="slug">Slug</label>
         <div class="uk-form-controls">
-          <input class="uk-input" id="slug" name="slug" type="text" required data-maxlength="100">
+          <input class="uk-input" id="slug" name="slug" type="text" required data-maxlength="100" value="{{ config.slug|default('') }}">
         </div>
       </div>
       <div class="uk-margin">
         <label class="uk-form-label" for="canonical">Canonical</label>
         <div class="uk-form-controls">
-          <input class="uk-input" id="canonical" name="canonical" type="url">
+          <input class="uk-input" id="canonical" name="canonical" type="url" value="{{ config.canonicalUrl|default('') }}">
         </div>
       </div>
       <div class="uk-margin">
         <label class="uk-form-label" for="robots">Robots</label>
         <div class="uk-form-controls">
-          <input class="uk-input" id="robots" name="robots" type="text" placeholder="index, follow">
+          <input class="uk-input" id="robots" name="robots" type="text" placeholder="index, follow" value="{{ config.robotsMeta|default('') }}">
         </div>
       </div>
       <div class="uk-margin">
         <label class="uk-form-label">OG-Tags</label>
         <div class="uk-form-controls">
-          <input class="uk-input uk-margin-small-bottom" id="ogTitle" name="og_title" type="text" placeholder="og:title" data-maxlength="60">
-          <input class="uk-input uk-margin-small-bottom" id="ogDescription" name="og_description" type="text" placeholder="og:description" data-maxlength="160">
-          <input class="uk-input" id="ogImage" name="og_image" type="url" placeholder="og:image">
+          <input class="uk-input uk-margin-small-bottom" id="ogTitle" name="og_title" type="text" placeholder="og:title" data-maxlength="60" value="{{ config.ogTitle|default('') }}">
+          <input class="uk-input uk-margin-small-bottom" id="ogDescription" name="og_description" type="text" placeholder="og:description" data-maxlength="160" value="{{ config.ogDescription|default('') }}">
+          <input class="uk-input" id="ogImage" name="og_image" type="url" placeholder="og:image" value="{{ config.ogImage|default('') }}">
         </div>
       </div>
       <div class="uk-margin">
         <label class="uk-form-label" for="schema">Schema.org</label>
         <div class="uk-form-controls">
-          <textarea class="uk-textarea" id="schema" name="schema" rows="4" placeholder="{ }"></textarea>
+          <textarea class="uk-textarea" id="schema" name="schema" rows="4" placeholder="{ }">{{ config.schemaJson|default('') }}</textarea>
         </div>
       </div>
       <div class="uk-margin">
         <label class="uk-form-label" for="hreflang">hreflang</label>
         <div class="uk-form-controls">
-          <input class="uk-input" id="hreflang" name="hreflang" type="text" placeholder="de, en, ...">
+          <input class="uk-input" id="hreflang" name="hreflang" type="text" placeholder="de, en, ..." value="{{ config.hreflang|default('') }}">
         </div>
       </div>
       <div class="uk-margin">

--- a/tests/Service/PageSeoConfigServiceTest.php
+++ b/tests/Service/PageSeoConfigServiceTest.php
@@ -8,13 +8,15 @@ use App\Application\Seo\PageSeoConfigService;
 use App\Application\Seo\SeoValidator;
 use App\Domain\PageSeoConfig;
 use App\Infrastructure\Cache\PageSeoCache;
+use PDO;
 use PHPUnit\Framework\TestCase;
 
 class PageSeoConfigServiceTest extends TestCase
 {
     public function testValidateLimitsAndUrl(): void
     {
-        $service = new PageSeoConfigService();
+        $pdo = new PDO('sqlite::memory:');
+        $service = new PageSeoConfigService($pdo);
         $errors = $service->validate([
             'slug' => 'test',
             'metaTitle' => str_repeat('a', SeoValidator::TITLE_MAX_LENGTH + 1),
@@ -28,9 +30,13 @@ class PageSeoConfigServiceTest extends TestCase
 
     public function testCacheInvalidatedOnSave(): void
     {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE page_seo_config(page_id INTEGER PRIMARY KEY, meta_title TEXT, meta_description TEXT, slug TEXT UNIQUE NOT NULL, canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, hreflang TEXT, created_at TEXT, updated_at TEXT)');
+        $pdo->exec('CREATE TABLE page_seo_config_history(id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER, meta_title TEXT, meta_description TEXT, slug TEXT, canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, hreflang TEXT, created_at TEXT)');
         $file = tempnam(sys_get_temp_dir(), 'seo');
         $cache = new PageSeoCache();
-        $service = new PageSeoConfigService($file, null, null, $cache);
+        $service = new PageSeoConfigService($pdo, $file, null, null, $cache);
         $config = new PageSeoConfig(1, 'start');
         $service->save($config);
         $first = $service->load(1);
@@ -38,12 +44,15 @@ class PageSeoConfigServiceTest extends TestCase
         $service->save(new PageSeoConfig(1, 'changed'));
         $second = $service->load(1);
         $this->assertSame('changed', $second->getSlug());
+        $row = $pdo->query('SELECT slug FROM page_seo_config WHERE page_id = 1')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('changed', $row['slug']);
         unlink($file);
     }
 
     public function testSlugAllowsSlashesAndUnderscores(): void
     {
-        $service = new PageSeoConfigService();
+        $pdo = new PDO('sqlite::memory:');
+        $service = new PageSeoConfigService($pdo);
         $valid = $service->validate(['slug' => 'foo/bar_baz-1']);
         $this->assertArrayNotHasKey('slug', $valid);
         $invalid = $service->validate(['slug' => 'Foo']);


### PR DESCRIPTION
## Summary
- store page SEO settings in database with automatic table creation
- preload landingpage SEO form with saved values
- cover database persistence with unit tests

## Testing
- `vendor/bin/phpunit tests/Service/PageSeoConfigServiceTest.php`
- `vendor/bin/phpunit` *(fails: Tests\Controller\ProfileWelcomeControllerTest::testResendWelcomeMail)*

------
https://chatgpt.com/codex/tasks/task_e_68a327d7673c832b8549ab1e2af5b6ad