### PR TITLE
Initialize EventService with tenant context

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -144,9 +144,9 @@ return function (\Slim\App $app, TranslationService $translator) {
         $teamService = new TeamService($pdo, $configService);
         $consentService = new PhotoConsentService($pdo, $configService);
         $summaryService = new SummaryPhotoService($pdo, $configService);
-        $eventService = new EventService($pdo);
         $nginxService = new NginxService();
         $tenantService = new TenantService($base, null, $nginxService);
+        $eventService = new EventService($pdo, $configService, $tenantService, $sub);
         $plan = $tenantService->getPlanBySubdomain($sub);
         $userService = new \App\Service\UserService($pdo);
         $settingsService = new \App\Service\SettingsService($pdo);


### PR DESCRIPTION
## Summary
- construct NginxService and TenantService before EventService
- pass configuration, tenant service and subdomain to EventService

## Testing
- `vendor/bin/phpunit tests/Service/EventServiceTest.php`
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py -q`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js` *(fails: Required code blocks not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a341127594832b9148d251974b0e52