### PR TITLE
Show subscription limits and plan on dashboard

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -121,7 +121,8 @@
         plan: el.dataset.labelPlan || 'Plan',
         events: el.dataset.labelEvents || 'Events',
         catalogs: el.dataset.labelCatalogs || 'Catalogs',
-        questions: el.dataset.labelQuestions || 'Questions'
+        questions: el.dataset.labelQuestions || 'Questions',
+        of: el.dataset.labelOf || '/'
       };
       const planKey = sub.plan || '';
       const planName = el.dataset['plan' + capitalize(planKey)] || planKey || '-';
@@ -136,7 +137,7 @@
         items.map(it => {
           const maxText = it.max === null || it.max === undefined ? '∞' : it.max;
           const pct = typeof it.max === 'number' ? Math.min(100, Math.round((it.used / it.max) * 100)) : 0;
-          return `<div class="uk-margin-small-top"><div class="uk-flex uk-flex-between"><span>${it.label}</span><span>${it.used}${it.max !== null && it.max !== undefined ? ' / ' + maxText : ''}</span></div>${it.max !== null && it.max !== undefined ? `<progress class="uk-progress" value="${pct}" max="100"></progress>` : ''}</div>`;
+          return `<div class="uk-margin-small-top"><div class="uk-flex uk-flex-between"><span>${it.label}</span><span>${it.used}${it.max !== null && it.max !== undefined ? ' ' + labels.of + ' ' + maxText : ''}</span></div>${it.max !== null && it.max !== undefined ? `<progress class="uk-progress" value="${pct}" max="100"></progress>` : ''}</div>`;
         }).join('');
     });
   }

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -143,6 +143,7 @@ return [
     'label_events' => 'Veranstaltungen',
     'label_catalogs' => 'Kataloge',
     'label_questions' => 'Fragen',
+    'word_of' => 'von',
     'label_competition_mode' => 'Wettkampfmodus',
     'label_team_results' => 'Ergebnisübersicht anzeigen',
     'label_photo_upload' => 'Beweisfotos aktivieren',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -142,6 +142,7 @@ return [
     'label_events' => 'Events',
     'label_catalogs' => 'Catalogs',
     'label_questions' => 'Questions',
+    'word_of' => 'of',
     'label_competition_mode' => 'Competition mode',
     'label_team_results' => 'Show results overview',
     'label_photo_upload' => 'Enable photo upload',

--- a/src/routes.php
+++ b/src/routes.php
@@ -420,8 +420,9 @@ return function (\Slim\App $app, TranslationService $translator) {
         $eventCount = (int) $usageStmt->fetchColumn();
         $catCount = (int) $pdo->query('SELECT COUNT(*) FROM catalogs')->fetchColumn();
         $qCount = (int) $pdo->query('SELECT COUNT(*) FROM questions')->fetchColumn();
+        $domainType = (string) $request->getAttribute('domainType');
         $host = $request->getUri()->getHost();
-        $sub = explode('.', $host)[0];
+        $sub = $domainType === 'main' ? 'main' : explode('.', $host)[0];
         $base = Database::connectFromEnv();
         $tenantSvc = new TenantService($base);
         $plan = $tenantSvc->getPlanBySubdomain($sub);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -148,6 +148,7 @@
                      data-label-events="{{ t('label_events') }}"
                      data-label-catalogs="{{ t('label_catalogs') }}"
                      data-label-questions="{{ t('label_questions') }}"
+                     data-label-of="{{ t('word_of') }}"
                      data-plan-starter="{{ t('plan_starter') }}"
                      data-plan-standard="{{ t('plan_standard') }}"
                      data-plan-professional="{{ t('plan_professional') }}"></div>


### PR DESCRIPTION
## Summary
- Display active plan on admin dashboard by honoring main-domain test mode
- Reveal per-plan usage limits with localized "of" label

## Testing
- `vendor/bin/phpunit` *(fails: process hangs at 27% progress)*

------
https://chatgpt.com/codex/tasks/task_e_68a352ea47c4832b9283906f6efafa55