### PR TITLE
Ensure PostgreSQL schema selection during DB connection

### DIFF
--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -50,13 +50,14 @@ class Database
 
     /**
      * Create a PDO connection and switch to the given schema.
+     *
+     * This method is intended for PostgreSQL databases and will always
+     * execute a `SET search_path` statement to select the provided schema.
      */
     public static function connectWithSchema(string $schema): PDO
     {
         $pdo = self::connectFromEnv();
-        if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'sqlite') {
-            $pdo->exec('SET search_path TO ' . $pdo->quote($schema));
-        }
+        $pdo->exec('SET search_path TO ' . $pdo->quote($schema));
         return $pdo;
     }
 }


### PR DESCRIPTION
## Summary
- Always run `SET search_path` when connecting with a schema
- Clarify that schema selection is PostgreSQL-specific

## Testing
- `composer test` *(fails: SQL error near "DO")*

------
https://chatgpt.com/codex/tasks/task_e_68a37f21c040832b997bbdf3cb083399