### PR TITLE
Remove SQLite-specific logic from tenant service

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Mit dieser App zeigen wir, was heute schon möglich ist, wenn Menschen und versc
 - **Sechs Fragetypen**: Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten bieten Abwechslung f\u00fcr jede Zielgruppe.
 - **QR-Code-Login & Dunkelmodus**: Optionaler QR-Code-Login für schnelles Anmelden und ein zuschaltbares dunkles Design steigern den Komfort.
 - **Persistente Speicherung**: Konfigurationen, Kataloge und Ergebnisse liegen in einer PostgreSQL-Datenbank.
+- **Mandantenverwaltung**: Tenant-Daten werden über PostgreSQL-Schemata isoliert; SQLite wird nicht unterstützt.
 
 ## Highlights
 


### PR DESCRIPTION
## Summary
- streamline tenant creation and deletion to rely solely on PostgreSQL schemas
- update tests to stub PostgreSQL-specific schema commands when using in-memory databases
- document that tenant management now requires PostgreSQL

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000]: General error: 1 near "DO": syntax error; no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a383c39240832ba9db0de8ceed2294