### PR TITLE
test: switch to postgres in tests

### DIFF
--- a/tests/RoleAccessTest.php
+++ b/tests/RoleAccessTest.php
@@ -8,21 +8,8 @@ use Tests\TestCase;
 
 class RoleAccessTest extends TestCase
 {
-    private function setupDb(): string
-    {
-        $db = tempnam(sys_get_temp_dir(), 'db');
-        putenv('POSTGRES_DSN=sqlite:' . $db);
-        putenv('POSTGRES_USER=');
-        putenv('POSTGRES_PASSWORD=');
-        $_ENV['POSTGRES_DSN'] = 'sqlite:' . $db;
-        $_ENV['POSTGRES_USER'] = '';
-        $_ENV['POSTGRES_PASSWORD'] = '';
-        return $db;
-    }
-
     public function testCatalogEditorCanEditCatalog(): void
     {
-        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
@@ -31,12 +18,10 @@ class RoleAccessTest extends TestCase
         $res = $app->handle($req);
         $this->assertEquals(204, $res->getStatusCode());
         session_destroy();
-        unlink($db);
     }
 
     public function testAnalystCannotEditCatalog(): void
     {
-        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'analyst'];
@@ -46,12 +31,10 @@ class RoleAccessTest extends TestCase
         $this->assertEquals(302, $res->getStatusCode());
         $this->assertEquals('/login', $res->getHeaderLine('Location'));
         session_destroy();
-        unlink($db);
     }
 
     public function testEventManagerCanUpdateConfig(): void
     {
-        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'event-manager'];
@@ -60,12 +43,10 @@ class RoleAccessTest extends TestCase
         $res = $app->handle($req);
         $this->assertEquals(204, $res->getStatusCode());
         session_destroy();
-        unlink($db);
     }
 
     public function testTeamManagerCanPostTeams(): void
     {
-        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'team-manager'];
@@ -77,12 +58,10 @@ class RoleAccessTest extends TestCase
         $res = $app->handle($req);
         $this->assertEquals(204, $res->getStatusCode());
         session_destroy();
-        unlink($db);
     }
 
     public function testAnalystCanAccessResults(): void
     {
-        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'analyst'];
@@ -90,12 +69,10 @@ class RoleAccessTest extends TestCase
         $res = $app->handle($req);
         $this->assertEquals(200, $res->getStatusCode());
         session_destroy();
-        unlink($db);
     }
 
     public function testAdminCanAccessSeoForm(): void
     {
-        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
@@ -107,12 +84,10 @@ class RoleAccessTest extends TestCase
         $res = $app->handle($req);
         $this->assertEquals(204, $res->getStatusCode());
         session_destroy();
-        unlink($db);
     }
 
     public function testCatalogEditorCannotAccessSeoForm(): void
     {
-        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
@@ -125,12 +100,10 @@ class RoleAccessTest extends TestCase
         $this->assertEquals(302, $res->getStatusCode());
         $this->assertEquals('/login', $res->getHeaderLine('Location'));
         session_destroy();
-        unlink($db);
     }
 
     public function testAdminCanViewSeoForm(): void
     {
-        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
@@ -138,12 +111,10 @@ class RoleAccessTest extends TestCase
         $res = $app->handle($req);
         $this->assertEquals(200, $res->getStatusCode());
         session_destroy();
-        unlink($db);
     }
 
     public function testCatalogEditorCannotViewSeoForm(): void
     {
-        $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
@@ -152,6 +123,5 @@ class RoleAccessTest extends TestCase
         $this->assertEquals(302, $res->getStatusCode());
         $this->assertEquals('/login', $res->getHeaderLine('Location'));
         session_destroy();
-        unlink($db);
     }
 }

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Service;
 
 use App\Service\MailService;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\Loader\FilesystemLoader;
@@ -16,33 +16,13 @@ use PDO;
 
 class MailServiceTest extends TestCase
 {
-    private string $db;
-
     protected function setUp(): void
     {
-        $this->db = tempnam(sys_get_temp_dir(), 'db');
-        putenv('POSTGRES_DSN=sqlite:' . $this->db);
-        putenv('POSTGRES_USER=');
-        putenv('POSTGRES_PASSWORD=');
-        $_ENV['POSTGRES_DSN'] = 'sqlite:' . $this->db;
-        $_ENV['POSTGRES_USER'] = '';
-        $_ENV['POSTGRES_PASSWORD'] = '';
-        $pdo = new PDO('sqlite:' . $this->db);
-        Migrator::migrate($pdo, dirname(__DIR__, 2) . '/migrations');
+        $pdo = $this->createDatabase();
         $pdo->exec(
             "INSERT INTO tenants(uid, subdomain, imprint_name, imprint_email) "
             . "VALUES('main','main','Example Org','admin@example.org')"
         );
-    }
-
-    protected function tearDown(): void
-    {
-        @unlink($this->db);
-        putenv('POSTGRES_DSN');
-        putenv('POSTGRES_USER');
-        putenv('POSTGRES_PASSWORD');
-        unset($_ENV['POSTGRES_DSN'], $_ENV['POSTGRES_USER'], $_ENV['POSTGRES_PASSWORD']);
-        parent::tearDown();
     }
 
     public function testUsesSmtpUserAsFrom(): void


### PR DESCRIPTION
## Summary
- replace SQLite temp databases with ephemeral PostgreSQL databases in test harness
- adjust sample tests to use PostgreSQL-backed setup

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a3874b76dc832b9648ebc0b4fa5060