### PR TITLE
Remove unsupported subscription actions for subdomains

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2240,11 +2240,6 @@ document.addEventListener('DOMContentLoaded', function () {
               <div uk-dropdown="mode: click; pos: bottom-right">
                 <ul class="uk-nav uk-dropdown-nav">
                   <li class="uk-nav-header">Aktionen</li>
-                  <li><a href="#" data-action="update" data-sub="${safeSub}">Abo aktualisieren</a></li>
-                  <li><a href="#" data-action="pause" data-sub="${safeSub}">Zahlung pausieren</a></li>
-                  <li><a href="#" data-action="paylink" data-sub="${safeSub}">Zahlungslink senden</a></li>
-                  <li><a href="#" data-action="invoice" data-sub="${safeSub}">Einmalige Rechnung</a></li>
-                  <li class="uk-nav-divider"></li>
                   <li><a class="uk-text-danger" href="#" data-action="delete" data-uid="${safeUid}" data-sub="${safeSub}">Mandant löschen …</a></li>
                   <li class="uk-nav-divider"></li>
                   <li class="uk-nav-header">Verbindungen</li>


### PR DESCRIPTION
## Summary
- remove Stripe subscription management actions from subdomain admin menu where they weren't functional

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a38898fcd4832ba3fe524970a7a9df