### PR TITLE
Add CSRF token and submission target for landing page SEO form

### DIFF
--- a/templates/admin/landingpage/edit.html.twig
+++ b/templates/admin/landingpage/edit.html.twig
@@ -13,8 +13,9 @@
 {% block body %}
   <div class="uk-container uk-container-small">
     <h1 class="uk-heading-bullet">Landingpage bearbeiten</h1>
-    <form class="uk-form-stacked seo-form">
+    <form class="uk-form-stacked seo-form" action="{{ basePath }}/admin/landingpage/seo" method="post">
       <input type="hidden" name="pageId" value="1">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
       <h2>SEO</h2>
       <div class="uk-margin">
         <label class="uk-form-label" for="metaTitle">Meta Title</label>


### PR DESCRIPTION
## Summary
- Post landing page SEO form to backend with explicit action and method
- Include CSRF token in landing page editor form

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a388fb3cc8832bbf7eb1fe651fd8f1