### PR TITLE
Add tenant status filter

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -865,11 +865,11 @@
         <!-- FILTER / TOOLBAR -->
         <div class="uk-flex uk-flex-wrap uk-flex-middle uk-margin">
           <div class="uk-margin-small-right">
-            <select class="uk-select uk-form-small" aria-label="Status filtern">
-              <option>Alle</option>
-              <option>Aktiv</option>
-              <option>Gekündigt</option>
-              <option>Simuliert</option>
+            <select id="tenantStatusFilter" class="uk-select uk-form-small" aria-label="Status filtern">
+              <option value="">Alle</option>
+              <option value="active">Aktiv</option>
+              <option value="canceled">Gekündigt</option>
+              <option value="simulated">Simuliert</option>
             </select>
           </div>
 


### PR DESCRIPTION
## Summary
- Add tenant status filter dropdown with unique ID
- Hook filter change to reload tenant list with status parameter
- Pass status to `/tenants.json` and filter tenant list

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a38ad6b590832b8c57a697d7b8d5b3