### PR TITLE
Load SEO config in admin dashboard

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -19,6 +19,7 @@ use App\Domain\Roles;
 use App\Infrastructure\Database;
 use App\Service\StripeService;
 use App\Service\VersionService;
+use App\Application\Seo\PageSeoConfigService;
 use PDO;
 
 /**
@@ -192,6 +193,9 @@ class AdminController
             ?: getenv('DOMAIN')
             ?: $uri->getHost();
 
+        $seoSvc    = new PageSeoConfigService($pdo);
+        $seoConfig = $seoSvc->load(1);
+
           return $view->render($response, 'admin.twig', [
               'config' => $cfg,
               'settings' => $settings,
@@ -205,6 +209,7 @@ class AdminController
               'event' => $event,
               'role' => $role,
               'pages' => $pages,
+              'seo_config' => $seoConfig ? $seoConfig->jsonSerialize() : [],
               'domainType' => $request->getAttribute('domainType'),
               'tenant' => $tenant,
               'stripe_configured' => StripeService::isConfigured()['ok'],

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -715,53 +715,53 @@
                 <div class="uk-margin">
                   <label class="uk-form-label" for="metaTitle">Meta Title</label>
                   <div class="uk-form-controls">
-                    <input class="uk-input" id="metaTitle" name="meta_title" type="text" required data-maxlength="60">
+                    <input class="uk-input" id="metaTitle" name="meta_title" type="text" required data-maxlength="60" value="{{ seo_config.metaTitle|default('') }}">
                     <small class="uk-text-meta char-count" data-for="metaTitle">0/60</small>
                   </div>
                 </div>
                 <div class="uk-margin">
                   <label class="uk-form-label" for="metaDescription">Meta Description</label>
                   <div class="uk-form-controls">
-                    <textarea class="uk-textarea" id="metaDescription" name="meta_description" required data-maxlength="160"></textarea>
+                    <textarea class="uk-textarea" id="metaDescription" name="meta_description" required data-maxlength="160">{{ seo_config.metaDescription|default('') }}</textarea>
                     <small class="uk-text-meta char-count" data-for="metaDescription">0/160</small>
                   </div>
                 </div>
                 <div class="uk-margin">
                   <label class="uk-form-label" for="slug">Slug</label>
                   <div class="uk-form-controls">
-                    <input class="uk-input" id="slug" name="slug" type="text" required data-maxlength="100">
+                    <input class="uk-input" id="slug" name="slug" type="text" required data-maxlength="100" value="{{ seo_config.slug|default('') }}">
                   </div>
                 </div>
                 <div class="uk-margin">
                   <label class="uk-form-label" for="canonical">Canonical</label>
                   <div class="uk-form-controls">
-                    <input class="uk-input" id="canonical" name="canonical" type="url">
+                    <input class="uk-input" id="canonical" name="canonical" type="url" value="{{ seo_config.canonicalUrl|default('') }}">
                   </div>
                 </div>
                 <div class="uk-margin">
                   <label class="uk-form-label" for="robots">Robots</label>
                   <div class="uk-form-controls">
-                    <input class="uk-input" id="robots" name="robots" type="text" placeholder="index, follow">
+                    <input class="uk-input" id="robots" name="robots" type="text" placeholder="index, follow" value="{{ seo_config.robotsMeta|default('') }}">
                   </div>
                 </div>
                 <div class="uk-margin">
                   <label class="uk-form-label">OG-Tags</label>
                   <div class="uk-form-controls">
-                    <input class="uk-input uk-margin-small-bottom" id="ogTitle" name="og_title" type="text" placeholder="og:title" data-maxlength="60">
-                    <input class="uk-input uk-margin-small-bottom" id="ogDescription" name="og_description" type="text" placeholder="og:description" data-maxlength="160">
-                    <input class="uk-input" id="ogImage" name="og_image" type="url" placeholder="og:image">
+                    <input class="uk-input uk-margin-small-bottom" id="ogTitle" name="og_title" type="text" placeholder="og:title" data-maxlength="60" value="{{ seo_config.ogTitle|default('') }}">
+                    <input class="uk-input uk-margin-small-bottom" id="ogDescription" name="og_description" type="text" placeholder="og:description" data-maxlength="160" value="{{ seo_config.ogDescription|default('') }}">
+                    <input class="uk-input" id="ogImage" name="og_image" type="url" placeholder="og:image" value="{{ seo_config.ogImage|default('') }}">
                   </div>
                 </div>
                 <div class="uk-margin">
                   <label class="uk-form-label" for="schema">Schema.org</label>
                   <div class="uk-form-controls">
-                    <textarea class="uk-textarea" id="schema" name="schema" rows="4" placeholder="{ }"></textarea>
+                    <textarea class="uk-textarea" id="schema" name="schema" rows="4" placeholder="{ }">{{ seo_config.schemaJson|default('') }}</textarea>
                   </div>
                 </div>
                 <div class="uk-margin">
                   <label class="uk-form-label" for="hreflang">hreflang</label>
                   <div class="uk-form-controls">
-                    <input class="uk-input" id="hreflang" name="hreflang" type="text" placeholder="de, en, ...">
+                    <input class="uk-input" id="hreflang" name="hreflang" type="text" placeholder="de, en, ..." value="{{ seo_config.hreflang|default('') }}">
                   </div>
                 </div>
                 <div class="uk-margin">


### PR DESCRIPTION
## Summary
- Load landing page SEO configuration in the admin controller
- Prefill SEO form fields in admin dashboard from stored configuration

## Testing
- `composer test` *(fails: Database error: fail; Error creating tenant: boom)*

------
https://chatgpt.com/codex/tasks/task_e_68a38ac0d978832bafeae77462b05c92