### PR TITLE
Handle SEO form save responses

### DIFF
--- a/public/js/seo-form.js
+++ b/public/js/seo-form.js
@@ -1,3 +1,5 @@
+/* global apiFetch, notify */
+
 export function initSeoForm() {
   const form = document.querySelector('.seo-form');
   if (!form) return;
@@ -62,6 +64,7 @@ export function initSeoForm() {
   }
 
   form.addEventListener('submit', e => {
+    e.preventDefault();
     let valid = true;
     inputs.forEach(input => {
       const max = parseInt(input.dataset.maxlength, 10);
@@ -80,9 +83,25 @@ export function initSeoForm() {
         field.classList.remove('uk-form-danger');
       }
     });
-    if (!valid) {
-      e.preventDefault();
-    }
+    if (!valid) return;
+    const body = new URLSearchParams(new FormData(form));
+    apiFetch('/admin/landingpage/seo', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json'
+      },
+      body
+    })
+      .then(r => {
+        if (!r.ok) throw new Error('save-failed');
+        return r.json().catch(() => ({}));
+      })
+      .then(() => {
+        notify('Einstellungen gespeichert', 'success');
+        window.location.reload();
+      })
+      .catch(() => notify('Fehler beim Speichern', 'danger'));
   });
 }
 

--- a/src/Controller/Admin/LandingpageController.php
+++ b/src/Controller/Admin/LandingpageController.php
@@ -8,6 +8,7 @@ use App\Application\Seo\PageSeoConfigService;
 use App\Domain\PageSeoConfig;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Routing\RouteContext;
 use Slim\Views\Twig;
 
 /**
@@ -84,6 +85,15 @@ class LandingpageController
 
         $this->seoService->save($config);
 
-        return $response->withStatus(204);
+        $accept = $request->getHeaderLine('Accept');
+        if (str_contains($accept, 'application/json')) {
+            $response->getBody()->write(json_encode(['status' => 'ok']));
+            return $response->withHeader('Content-Type', 'application/json');
+        }
+
+        $base = RouteContext::fromRequest($request)->getBasePath();
+        return $response
+            ->withHeader('Location', $base . '/admin/landingpage/seo')
+            ->withStatus(303);
     }
 }


### PR DESCRIPTION
## Summary
- Return JSON success or redirect after saving landing page SEO settings
- Submit SEO form via fetch, notify user, and reload on success

## Testing
- `vendor/bin/phpunit` *(fails: Database error: fail)*
- `vendor/bin/phpcs src/Controller/Admin/LandingpageController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a38cbe0ec8832baa2244ede4342d7d