### PR TITLE
Add tenant search with backend filtering

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -120,7 +120,7 @@ document.addEventListener('DOMContentLoaded', function () {
         })
         .then(() => {
           notify('Mandant entfernt', 'success');
-          loadTenants(tenantStatusFilter?.value);
+          loadTenants(tenantStatusFilter?.value, tenantSearchInput?.value);
         })
         .catch(() => notify('Fehler beim Löschen', 'danger'))
         .finally(() => {
@@ -2018,9 +2018,14 @@ document.addEventListener('DOMContentLoaded', function () {
   const tenantCards = document.getElementById('tenantCards');
   const tenantSyncBtn = document.getElementById('tenantSyncBtn');
   const tenantStatusFilter = document.getElementById('tenantStatusFilter');
+  const tenantSearchInput = document.getElementById('tenantSearchInput');
 
   tenantStatusFilter?.addEventListener('change', () => {
-    loadTenants(tenantStatusFilter.value);
+    loadTenants(tenantStatusFilter.value, tenantSearchInput?.value);
+  });
+
+  tenantSearchInput?.addEventListener('input', () => {
+    loadTenants(tenantStatusFilter?.value, tenantSearchInput.value);
   });
 
   function loadBackups() {
@@ -2146,7 +2151,7 @@ document.addEventListener('DOMContentLoaded', function () {
       .then(r => r.json())
       .then(() => {
         notify('Mandanten eingelesen', 'success');
-        loadTenants(tenantStatusFilter?.value);
+        loadTenants(tenantStatusFilter?.value, tenantSearchInput?.value);
       })
       .catch(() => notify('Fehler beim Synchronisieren', 'danger'))
       .finally(() => {
@@ -2155,7 +2160,7 @@ document.addEventListener('DOMContentLoaded', function () {
       });
   });
 
-  function loadTenants(status = tenantStatusFilter?.value || '') {
+  function loadTenants(status = tenantStatusFilter?.value || '', query = tenantSearchInput?.value || '') {
     if (!tenantTableBody || window.domainType !== 'main') return;
     const mainDomain = window.mainDomain || '';
     const stripeBase = window.stripeDashboard || 'https://dashboard.stripe.com';
@@ -2169,7 +2174,10 @@ document.addEventListener('DOMContentLoaded', function () {
           "'": '&#39;',
         }[m]
       ));
-    const url = '/tenants.json' + (status ? ('?status=' + encodeURIComponent(status)) : '');
+    const params = new URLSearchParams();
+    if (status) params.set('status', status);
+    if (query) params.set('query', query);
+    const url = '/tenants.json' + (params.toString() ? ('?' + params.toString()) : '');
     apiFetch(url, { headers: { 'Accept': 'application/json' } })
       .then(r => r.json())
       .then(list => {
@@ -2700,7 +2708,7 @@ document.addEventListener('DOMContentLoaded', function () {
         loadSummary();
       }
       if (index === tenantIdx) {
-        loadTenants(tenantStatusFilter?.value);
+        loadTenants(tenantStatusFilter?.value, tenantSearchInput?.value);
       }
     });
     if (summaryIdx >= 0) {
@@ -2710,7 +2718,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     if (tenantIdx >= 0) {
       adminTabs.children[tenantIdx]?.addEventListener('click', () => {
-        loadTenants(tenantStatusFilter?.value);
+        loadTenants(tenantStatusFilter?.value, tenantSearchInput?.value);
       });
     }
     adminMenu.querySelectorAll('[data-tab]').forEach(item => {
@@ -2728,7 +2736,7 @@ document.addEventListener('DOMContentLoaded', function () {
             loadSummary();
           }
           if (idx === tenantIdx) {
-            loadTenants(tenantStatusFilter?.value);
+            loadTenants(tenantStatusFilter?.value, tenantSearchInput?.value);
           }
         }
       });
@@ -2789,7 +2797,7 @@ document.addEventListener('DOMContentLoaded', function () {
       tenantSyncBtn.click();
       sessionStorage.setItem(syncFlag, '1');
     } else {
-      loadTenants(tenantStatusFilter?.value);
+      loadTenants(tenantStatusFilter?.value, tenantSearchInput?.value);
     }
   }
 });

--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -122,7 +122,9 @@ class TenantController
      */
     public function list(Request $request, Response $response): Response
     {
-        $list = $this->service->getAll();
+        $params = $request->getQueryParams();
+        $query = isset($params['query']) ? (string) $params['query'] : '';
+        $list = $this->service->getAll($query);
         $response->getBody()->write(json_encode($list));
         return $response->withHeader('Content-Type', 'application/json');
     }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -876,7 +876,7 @@
           <div class="uk-margin-small-right uk-width-expand">
             <div class="uk-inline uk-width-1-1">
               <span class="uk-form-icon" uk-icon="icon: search"></span>
-              <input class="uk-input uk-form-small" type="search" placeholder="Suchen (Subdomain, Kunde, E-Mail)">
+              <input id="tenantSearchInput" class="uk-input uk-form-small" type="search" placeholder="Suchen (Subdomain, Kunde, E-Mail)">
             </div>
           </div>
 

--- a/tests/Controller/TenantControllerTest.php
+++ b/tests/Controller/TenantControllerTest.php
@@ -416,4 +416,26 @@ class TenantControllerTest extends TestCase
         $this->assertEquals(500, $res->getStatusCode());
         $this->assertStringContainsString('boom', (string) $res->getBody());
     }
+
+    public function testListPassesQueryToService(): void
+    {
+        $service = new class extends TenantService {
+            public string $received = '';
+            public function __construct()
+            {
+            }
+
+            public function getAll(string $query = ''): array
+            {
+                $this->received = $query;
+                return [];
+            }
+        };
+        $controller = new TenantController($service);
+        $req = $this->createRequest('GET', '/tenants.json?query=foo');
+        $res = $controller->list($req, new Response());
+        $this->assertSame('foo', $service->received);
+        $this->assertSame('application/json', $res->getHeaderLine('Content-Type'));
+        $this->assertSame('[]', (string) $res->getBody());
+    }
 }

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -111,6 +111,18 @@ SQL;
         $this->assertSame(0, (int) $pdo->query('SELECT COUNT(*) FROM tenants')->fetchColumn());
     }
 
+    public function testGetAllFiltersByQuery(): void
+    {
+        $dir = sys_get_temp_dir() . '/mig' . uniqid();
+        $pdo = new PDO('sqlite::memory:');
+        $service = $this->createService($dir, $pdo);
+        $pdo->exec("INSERT INTO tenants(uid, subdomain, imprint_name, imprint_email, created_at) VALUES('u1','alpha','Alpha GmbH','a@example.com','2024-01-01')");
+        $pdo->exec("INSERT INTO tenants(uid, subdomain, imprint_name, imprint_email, created_at) VALUES('u2','beta','Beta AG','b@example.com','2024-01-02')");
+        $list = $service->getAll('beta');
+        $this->assertCount(1, $list);
+        $this->assertSame('beta', $list[0]['subdomain']);
+    }
+
     public function testCreateTenantThrowsOnNginxFailure(): void
     {
         $dir = sys_get_temp_dir() . '/mig' . uniqid();


### PR DESCRIPTION
## Summary
- add `tenantSearchInput` to tenant list filter
- forward search term to `loadTenants` and backend
- support `query` filter in tenant endpoints and tests

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*
- `vendor/bin/phpunit --filter testGetAllFiltersByQuery`
- `vendor/bin/phpunit --filter testListPassesQueryToService`


------
https://chatgpt.com/codex/tasks/task_e_68a38cc75ca4832b8f739d2c80ab5886