### PR TITLE
Fix subdomain handling for main domain

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -129,7 +129,8 @@ return function (\Slim\App $app, TranslationService $translator) {
         Migrator::migrate($base, __DIR__ . '/../migrations');
 
         $host = $request->getUri()->getHost();
-        $sub = explode('.', $host)[0];
+        $domainType = $request->getAttribute('domainType');
+        $sub = $domainType === 'main' ? 'main' : explode('.', $host)[0];
         $stmt = $base->prepare('SELECT subdomain FROM tenants WHERE subdomain = ?');
         $stmt->execute([$sub]);
         $schema = $stmt->fetchColumn();


### PR DESCRIPTION
## Summary
- Ensure request middleware uses `domainType` to resolve `main` as subdomain
- Test that main-domain requests enforce plan limits

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f8d32a0832ba8e883b0d76ca15d