### PR TITLE
Add tenant reporting endpoint and UI trigger

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -700,6 +700,13 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('tenantController')->export($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN));
 
+    $app->get('/tenants/report', function (Request $request, Response $response) {
+        if ($request->getAttribute('domainType') !== 'main') {
+            return $response->withStatus(403);
+        }
+        return $request->getAttribute('tenantController')->report($request, $response);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN));
+
     $app->get('/tenants/{subdomain}', function (Request $request, Response $response, array $args) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(403);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -882,7 +882,7 @@
 
           <div class="uk-button-group uk-margin-small-top@s">
             <button id="tenantExportBtn" class="uk-button uk-button-default uk-button-small">Exportieren</button>
-            <button class="uk-button uk-button-default uk-button-small">Auswertung</button>
+            <button id="tenantReportBtn" class="uk-button uk-button-default uk-button-small">Auswertung</button>
             <button class="uk-button uk-button-default uk-button-small">Spalten</button>
             <button id="tenantSyncBtn" class="uk-button uk-button-default uk-button-small">Sync</button>
           </div>


### PR DESCRIPTION
## Summary
- add Auswertung button with unique ID in tenant admin
- fetch tenant report and download or open in new window
- provide backend endpoint to generate simple tenant plan report

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a39048a230832b99307d61240fc7b9