### PR TITLE
Remove redundant null coalescing in tenant export

### DIFF
--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -127,11 +127,11 @@ class TenantController
         fputcsv($handle, ['subdomain', 'plan', 'billing', 'email', 'created_at']);
         foreach ($tenants as $row) {
             fputcsv($handle, [
-                $row['subdomain'] ?? '',
+                $row['subdomain'],
                 $row['plan'] ?? '',
                 $row['billing_info'] ?? '',
                 $row['imprint_email'] ?? '',
-                $row['created_at'] ?? '',
+                $row['created_at'],
             ]);
         }
         rewind($handle);


### PR DESCRIPTION
## Summary
- remove unused null-coalescing for tenant export fields that are always present

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68a3911e8eb0832bb211d859806c091b