### PR TITLE
Fix PSR-12 style issues

### DIFF
--- a/src/Application/Seo/PageSeoConfigService.php
+++ b/src/Application/Seo/PageSeoConfigService.php
@@ -51,7 +51,8 @@ class PageSeoConfigService
         }
 
         $stmt = $this->pdo->prepare(
-            'SELECT slug, meta_title, meta_description, canonical_url, robots_meta, og_title, og_description, og_image, schema_json, hreflang '
+            'SELECT slug, meta_title, meta_description, canonical_url, robots_meta, '
+            . 'og_title, og_description, og_image, schema_json, hreflang '
             . 'FROM page_seo_config WHERE page_id = ?'
         );
         $stmt->execute([$pageId]);
@@ -131,16 +132,23 @@ class PageSeoConfigService
         ];
 
         $upsert = $this->pdo->prepare(
-            'INSERT INTO page_seo_config(page_id, meta_title, meta_description, slug, canonical_url, robots_meta, og_title, og_description, og_image, schema_json, hreflang) '
+            'INSERT INTO page_seo_config('
+            . 'page_id, meta_title, meta_description, slug, canonical_url, robots_meta, '
+            . 'og_title, og_description, og_image, schema_json, hreflang) '
             . 'VALUES(?,?,?,?,?,?,?,?,?,?,?) '
-            . 'ON CONFLICT(page_id) DO UPDATE SET meta_title=excluded.meta_title, meta_description=excluded.meta_description, slug=excluded.slug, '
-            . 'canonical_url=excluded.canonical_url, robots_meta=excluded.robots_meta, og_title=excluded.og_title, og_description=excluded.og_description, '
-            . 'og_image=excluded.og_image, schema_json=excluded.schema_json, hreflang=excluded.hreflang, updated_at=CURRENT_TIMESTAMP'
+            . 'ON CONFLICT(page_id) DO UPDATE SET meta_title=excluded.meta_title, '
+            . 'meta_description=excluded.meta_description, slug=excluded.slug, '
+            . 'canonical_url=excluded.canonical_url, robots_meta=excluded.robots_meta, '
+            . 'og_title=excluded.og_title, og_description=excluded.og_description, '
+            . 'og_image=excluded.og_image, schema_json=excluded.schema_json, '
+            . 'hreflang=excluded.hreflang, updated_at=CURRENT_TIMESTAMP'
         );
         $upsert->execute($params);
 
         $history = $this->pdo->prepare(
-            'INSERT INTO page_seo_config_history(page_id, meta_title, meta_description, slug, canonical_url, robots_meta, og_title, og_description, og_image, schema_json, hreflang) '
+            'INSERT INTO page_seo_config_history('
+            . 'page_id, meta_title, meta_description, slug, canonical_url, robots_meta, '
+            . 'og_title, og_description, og_image, schema_json, hreflang) '
             . 'VALUES(?,?,?,?,?,?,?,?,?,?,?)'
         );
         $history->execute($params);

--- a/tests/Controller/TenantWelcomeRouteTest.php
+++ b/tests/Controller/TenantWelcomeRouteTest.php
@@ -44,8 +44,10 @@ class TenantWelcomeRouteTest extends TestCase
                         $this->outer = $outer;
                     }
 
-                    public function send(\Symfony\Component\Mime\RawMessage $message, ?\Symfony\Component\Mailer\Envelope $envelope = null): void
-                    {
+                    public function send(
+                        \Symfony\Component\Mime\RawMessage $message,
+                        ?\Symfony\Component\Mailer\Envelope $envelope = null
+                    ): void {
                         $this->outer->messages[] = $message;
                     }
                 };
@@ -72,4 +74,3 @@ class TenantWelcomeRouteTest extends TestCase
         unset($_ENV['MAIN_DOMAIN'], $_ENV['SMTP_HOST'], $_ENV['SMTP_USER'], $_ENV['SMTP_PASS']);
     }
 }
-

--- a/tests/Service/PageSeoConfigServiceTest.php
+++ b/tests/Service/PageSeoConfigServiceTest.php
@@ -32,8 +32,20 @@ class PageSeoConfigServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE page_seo_config(page_id INTEGER PRIMARY KEY, meta_title TEXT, meta_description TEXT, slug TEXT UNIQUE NOT NULL, canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, hreflang TEXT, created_at TEXT, updated_at TEXT)');
-        $pdo->exec('CREATE TABLE page_seo_config_history(id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER, meta_title TEXT, meta_description TEXT, slug TEXT, canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, hreflang TEXT, created_at TEXT)');
+        $pdo->exec(
+            'CREATE TABLE page_seo_config('
+            . 'page_id INTEGER PRIMARY KEY, meta_title TEXT, meta_description TEXT, '
+            . 'slug TEXT UNIQUE NOT NULL, canonical_url TEXT, robots_meta TEXT, '
+            . 'og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, '
+            . 'hreflang TEXT, created_at TEXT, updated_at TEXT)'
+        );
+        $pdo->exec(
+            'CREATE TABLE page_seo_config_history('
+            . 'id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER, meta_title TEXT, '
+            . 'meta_description TEXT, slug TEXT, canonical_url TEXT, robots_meta TEXT, '
+            . 'og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, '
+            . 'hreflang TEXT, created_at TEXT)'
+        );
         $file = tempnam(sys_get_temp_dir(), 'seo');
         $cache = new PageSeoCache();
         $service = new PageSeoConfigService($pdo, $file, null, null, $cache);
@@ -63,8 +75,20 @@ class PageSeoConfigServiceTest extends TestCase
     {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE page_seo_config(page_id INTEGER PRIMARY KEY, meta_title TEXT, meta_description TEXT, slug TEXT UNIQUE NOT NULL, canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, hreflang TEXT, created_at TEXT, updated_at TEXT)');
-        $pdo->exec('CREATE TABLE page_seo_config_history(id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER, meta_title TEXT, meta_description TEXT, slug TEXT, canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, hreflang TEXT, created_at TEXT)');
+        $pdo->exec(
+            'CREATE TABLE page_seo_config('
+            . 'page_id INTEGER PRIMARY KEY, meta_title TEXT, meta_description TEXT, '
+            . 'slug TEXT UNIQUE NOT NULL, canonical_url TEXT, robots_meta TEXT, '
+            . 'og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, '
+            . 'hreflang TEXT, created_at TEXT, updated_at TEXT)'
+        );
+        $pdo->exec(
+            'CREATE TABLE page_seo_config_history('
+            . 'id INTEGER PRIMARY KEY AUTOINCREMENT, page_id INTEGER, meta_title TEXT, '
+            . 'meta_description TEXT, slug TEXT, canonical_url TEXT, robots_meta TEXT, '
+            . 'og_title TEXT, og_description TEXT, og_image TEXT, schema_json TEXT, '
+            . 'hreflang TEXT, created_at TEXT)'
+        );
         $file = tempnam(sys_get_temp_dir(), 'seo');
         $service = new PageSeoConfigService($pdo, $file);
         $config = new PageSeoConfig(1, 'slug', schemaJson: '');

--- a/tests/Service/TenantServiceTest.php
+++ b/tests/Service/TenantServiceTest.php
@@ -21,7 +21,10 @@ class TenantServiceTest extends TestCase
 
             public function exec($statement): int|false
             {
-                if (preg_match('/^(CREATE|DROP) SCHEMA/i', $statement) || str_starts_with($statement, 'SET search_path')) {
+                if (
+                    preg_match('/^(CREATE|DROP) SCHEMA/i', $statement)
+                    || str_starts_with($statement, 'SET search_path')
+                ) {
                     return 0;
                 }
                 return parent::exec($statement);
@@ -116,8 +119,14 @@ SQL;
         $dir = sys_get_temp_dir() . '/mig' . uniqid();
         $pdo = new PDO('sqlite::memory:');
         $service = $this->createService($dir, $pdo);
-        $pdo->exec("INSERT INTO tenants(uid, subdomain, imprint_name, imprint_email, created_at) VALUES('u1','alpha','Alpha GmbH','a@example.com','2024-01-01')");
-        $pdo->exec("INSERT INTO tenants(uid, subdomain, imprint_name, imprint_email, created_at) VALUES('u2','beta','Beta AG','b@example.com','2024-01-02')");
+        $pdo->exec(
+            "INSERT INTO tenants(uid, subdomain, imprint_name, imprint_email, created_at) "
+            . "VALUES('u1','alpha','Alpha GmbH','a@example.com','2024-01-01')"
+        );
+        $pdo->exec(
+            "INSERT INTO tenants(uid, subdomain, imprint_name, imprint_email, created_at) "
+            . "VALUES('u2','beta','Beta AG','b@example.com','2024-01-02')"
+        );
         $list = $service->getAll('beta');
         $this->assertCount(1, $list);
         $this->assertSame('beta', $list[0]['subdomain']);


### PR DESCRIPTION
## Summary
- Break up long SQL strings in PageSeoConfigService and related tests
- Reformat test utilities and method signatures to respect PSR-12 line length and indentation

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a40602abbc832b9c53d7d1c7357fd1