### PR TITLE
Ensure middleware sessions handled centrally

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -62,9 +62,9 @@ $twig->addExtension(new UikitExtension());
 $twig->addExtension(new TranslationExtension($translator));
 $twig->getEnvironment()->addGlobal('basePath', $basePath);
 $app->add(TwigMiddleware::create($app, $twig));
-$app->add(new SessionMiddleware());
 $app->add(new DomainMiddleware());
 $app->add(new ProxyMiddleware());
+$app->add(new SessionMiddleware());
 $errorMiddleware = new \App\Application\Middleware\ErrorMiddleware(
     $app->getCallableResolver(),
     $app->getResponseFactory(),

--- a/src/Application/Middleware/AdminAuthMiddleware.php
+++ b/src/Application/Middleware/AdminAuthMiddleware.php
@@ -20,9 +20,6 @@ class AdminAuthMiddleware implements MiddlewareInterface
      */
     public function process(Request $request, RequestHandler $handler): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
             $response = new SlimResponse();

--- a/src/Application/Middleware/CsrfMiddleware.php
+++ b/src/Application/Middleware/CsrfMiddleware.php
@@ -20,10 +20,6 @@ class CsrfMiddleware implements MiddlewareInterface
      */
     public function process(Request $request, RequestHandler $handler): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
-
         $token = $_SESSION['csrf_token'] ?? null;
 
         if ($request->getMethod() === 'POST') {

--- a/src/Application/Middleware/RateLimitMiddleware.php
+++ b/src/Application/Middleware/RateLimitMiddleware.php
@@ -29,10 +29,6 @@ class RateLimitMiddleware implements MiddlewareInterface
      */
     public function process(Request $request, RequestHandler $handler): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
-
         $key = 'rate:' . $request->getUri()->getPath();
         $entry = $_SESSION[$key] ?? ['count' => 0, 'start' => time()];
 

--- a/src/Application/Middleware/RoleAuthMiddleware.php
+++ b/src/Application/Middleware/RoleAuthMiddleware.php
@@ -30,9 +30,6 @@ class RoleAuthMiddleware implements MiddlewareInterface
         if ($this->roles === []) {
             return $handler->handle($request);
         }
-        if (session_status() === PHP_SESSION_NONE && !headers_sent()) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role === null || !in_array($role, $this->roles, true)) {
             $response = new SlimResponse();

--- a/tests/SessionDependentMiddlewareTest.php
+++ b/tests/SessionDependentMiddlewareTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Application\Middleware\AdminAuthMiddleware;
+use App\Application\Middleware\CsrfMiddleware;
+use App\Application\Middleware\RateLimitMiddleware;
+use App\Application\Middleware\RoleAuthMiddleware;
+use App\Application\Middleware\SessionMiddleware;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response;
+
+class SessionDependentMiddlewareTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_unset();
+            session_destroy();
+        }
+        parent::tearDown();
+    }
+
+    public function testCsrfMiddlewareSetsAndValidatesToken(): void
+    {
+        $app = AppFactory::create();
+        $app->add(new SessionMiddleware());
+        $app->map(['GET', 'POST'], '/csrf', fn (Request $request, Response $response): Response => $response)
+            ->add(new CsrfMiddleware());
+
+        $factory = new ServerRequestFactory();
+        $get = $factory->createServerRequest('GET', '/csrf');
+        $app->handle($get);
+        $this->assertNotEmpty($_SESSION['csrf_token']);
+        $token = $_SESSION['csrf_token'];
+        $sid = session_id();
+        session_write_close();
+
+        $post = $factory->createServerRequest('POST', '/csrf')
+            ->withHeader('X-CSRF-Token', $token)
+            ->withCookieParams([session_name() => $sid]);
+        $response = $app->handle($post);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRateLimitMiddlewareUsesSession(): void
+    {
+        $app = AppFactory::create();
+        $app->add(new SessionMiddleware());
+        $app->get('/limited', fn (Request $request, Response $response): Response => $response)
+            ->add(new RateLimitMiddleware(1, 60));
+
+        $factory = new ServerRequestFactory();
+        $req1 = $factory->createServerRequest('GET', '/limited');
+        $res1 = $app->handle($req1);
+        $this->assertSame(200, $res1->getStatusCode());
+        $sid = session_id();
+        session_write_close();
+
+        $req2 = $factory->createServerRequest('GET', '/limited')
+            ->withCookieParams([session_name() => $sid]);
+        $res2 = $app->handle($req2);
+        $this->assertSame(429, $res2->getStatusCode());
+    }
+
+    public function testRoleAuthMiddlewareRedirectsWithoutRole(): void
+    {
+        $app = AppFactory::create();
+        $app->add(new SessionMiddleware());
+        $app->get('/protected', fn (Request $request, Response $response): Response => $response)
+            ->add(new RoleAuthMiddleware('admin'));
+
+        $factory = new ServerRequestFactory();
+        $req = $factory->createServerRequest('GET', '/protected');
+        $res = $app->handle($req);
+        $this->assertSame(302, $res->getStatusCode());
+        $this->assertSame('/login', $res->getHeaderLine('Location'));
+    }
+
+    public function testAdminAuthMiddlewareAllowsAdmin(): void
+    {
+        $app = AppFactory::create();
+        $app->add(new SessionMiddleware());
+        $app->get('/set', function (Request $request, Response $response): Response {
+            $_SESSION['user'] = ['role' => 'admin'];
+            return $response;
+        });
+        $app->get('/admin', fn (Request $request, Response $response): Response => $response)
+            ->add(new AdminAuthMiddleware());
+
+        $factory = new ServerRequestFactory();
+        $app->handle($factory->createServerRequest('GET', '/set'));
+        $sid = session_id();
+        session_write_close();
+
+        $req = $factory->createServerRequest('GET', '/admin')
+            ->withCookieParams([session_name() => $sid]);
+        $res = $app->handle($req);
+        $this->assertSame(200, $res->getStatusCode());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -70,10 +70,10 @@ class TestCase extends PHPUnit_TestCase
         $twig->getEnvironment()->addGlobal('basePath', $basePath);
         $app->setBasePath($basePath);
         $app->add(TwigMiddleware::create($app, $twig));
-        $app->add(new SessionMiddleware());
         $app->add(new \App\Application\Middleware\DomainMiddleware());
         $app->add(new \App\Application\Middleware\LanguageMiddleware($translator));
         $app->add(new ProxyMiddleware());
+        $app->add(new SessionMiddleware());
 
         // Register error middleware
         $errorMiddleware = new \App\Application\Middleware\ErrorMiddleware(


### PR DESCRIPTION
## Summary
- Remove direct session_start calls from authentication, CSRF, and rate-limit middlewares
- Register SessionMiddleware ahead of route middlewares to initialize sessions
- Add tests to confirm session-dependent middlewares operate with SessionMiddleware

## Testing
- `vendor/bin/phpunit tests/SessionDependentMiddlewareTest.php`
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a4060774ec832b882ffb30dc09abc3