### PR TITLE
Route pricing CTAs to onboarding

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -290,7 +290,7 @@
             <li>Alle Fragetypen &amp; QR-Codes</li>
             <li>Backup &amp; editierbare Texte³</li>
           </ul>
-          <a href="{{ basePath }}/login" class="btn btn-transparent uk-width-1-1 uk-button-large uk-margin-small-top">Jetzt starten</a>
+          <a href="{{ basePath }}/onboarding" class="btn btn-transparent uk-width-1-1 uk-button-large uk-margin-small-top">Jetzt starten</a>
         </div>
       </div>
       <!-- Standard -->
@@ -308,7 +308,7 @@
             <li>Eigene Subdomain</li>
             <li>Vollständiger PDF-Export</li>
           </ul>
-          <a href="#contact-us" class="btn btn-black uk-width-1-1 uk-button-large">Jetzt upgraden</a>
+          <a href="{{ basePath }}/onboarding" class="btn btn-black uk-width-1-1 uk-button-large">Jetzt upgraden</a>
         </div>
       </div>
       <!-- Professional -->
@@ -325,7 +325,7 @@
             <li>100 Teams &amp; 50 Kataloge à 50 Fragen</li>
             <li>White-Label &amp; Rollenverwaltung</li>
           </ul>
-          <a href="#contact-us" class="btn btn-transparent uk-width-1-1 uk-button-large">Beratung anfragen</a>
+          <a href="{{ basePath }}/onboarding" class="btn btn-transparent uk-width-1-1 uk-button-large">Beratung anfragen</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Direct all landing page pricing buttons to `/onboarding`

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a46776c460832ba5007572087cf529