### PR TITLE
Validate directory writability before file operations

### DIFF
--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -21,8 +21,11 @@ class LogService
     {
         $root = dirname(__DIR__, 2);
         $logDir = $root . '/logs';
-        if (!is_dir($logDir)) {
-            mkdir($logDir, 0777, true);
+        if (!is_dir($logDir) && !mkdir($logDir, 0777, true) && !is_dir($logDir)) {
+            throw new \RuntimeException('Unable to create log directory');
+        }
+        if (!is_writable($logDir)) {
+            throw new \RuntimeException('Log directory not writable');
         }
         $logger = new Logger($channel);
         $logger->pushHandler(new StreamHandler($logDir . '/' . $channel . '.log', Level::Debug));

--- a/src/Service/NginxService.php
+++ b/src/Service/NginxService.php
@@ -43,7 +43,13 @@ class NginxService
         if (!is_dir($this->vhostDir) && !mkdir($this->vhostDir, 0777, true) && !is_dir($this->vhostDir)) {
             throw new \RuntimeException('Unable to create vhost directory');
         }
+        if (!is_writable($this->vhostDir)) {
+            throw new \RuntimeException('Vhost directory not writable');
+        }
         $file = $this->vhostDir . '/' . $sub . '.' . $this->domain;
+        if (file_exists($file) && !is_writable($file)) {
+            throw new \RuntimeException('Vhost file not writable');
+        }
         if (file_put_contents($file, 'client_max_body_size ' . $this->clientMaxBodySize . ';') === false) {
             throw new \RuntimeException('Unable to write vhost file');
         }

--- a/tests/Service/NginxServiceTest.php
+++ b/tests/Service/NginxServiceTest.php
@@ -32,4 +32,12 @@ class NginxServiceTest extends TestCase
         $this->assertTrue($svc->called);
         $this->assertFileExists("$dir/test.example.com");
     }
+
+    public function testCreateVhostFailsOnUnwritableDir(): void
+    {
+        $svc = new NginxService('/proc/sys', 'example.com', '1m', false);
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Vhost directory not writable');
+        $svc->createVhost('test');
+    }
 }


### PR DESCRIPTION
## Summary
- ensure vhost creation checks writability of target directory and file
- validate log directory creation and permissions
- test vhost creation failure when directory is not writable

## Testing
- `composer phpunit` *(fails: Database error: fail)*
- `vendor/bin/phpunit tests/Service/NginxServiceTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68a40bec7058832ba2610a3c16d242a6