### PR TITLE
refactor: wrap invoice return docblock

### DIFF
--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -210,7 +210,15 @@ class StripeService
     /**
      * Retrieve a list of invoices for a customer.
      *
-     * @return array<int, array{id:string, number:?string, amount:int, currency:string, status:string, created:?string, invoice_pdf:?string}>
+     * @return array<int, array{
+     *     id: string,
+     *     number: ?string,
+     *     amount: int,
+     *     currency: string,
+     *     status: string,
+     *     created: ?string,
+     *     invoice_pdf: ?string
+     * }>
      */
     public function listInvoices(string $customerId): array
     {


### PR DESCRIPTION
## Summary
- format `StripeService::listInvoices` docblock to respect line length rules

## Testing
- `vendor/bin/phpcs src/Service/StripeService.php`
- `composer test --no-interaction --no-progress` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a476049868832ba4da9b299e3da457