### PR TITLE
Allow automatic service account login

### DIFF
--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -26,9 +26,10 @@ class OnboardingController
 
         $serviceUser = getenv('SERVICE_USER') ?: '';
         $servicePass = getenv('SERVICE_PASS') ?: '';
-        $appEnv = getenv('APP_ENV') ?: 'dev';
-        $allowServiceLogin = $appEnv !== 'production'
-            || getenv('ALLOW_SERVICE_LOGIN') === '1';
+        $allowServiceLogin = getenv('ALLOW_SERVICE_LOGIN');
+        $allowServiceLogin = $allowServiceLogin === false
+            ? true
+            : $allowServiceLogin === '1';
 
         if (
             $allowServiceLogin


### PR DESCRIPTION
## Summary
- automatically log in service account during onboarding when credentials exist

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a4df0e34d0832ba978382f97748daa