### PR TITLE
Improve onboarding security

### DIFF
--- a/tests/SessionDependentMiddlewareTest.php
+++ b/tests/SessionDependentMiddlewareTest.php
@@ -82,6 +82,22 @@ class SessionDependentMiddlewareTest extends TestCase
         $this->assertSame('/login', $res->getHeaderLine('Location'));
     }
 
+    public function testRoleAuthMiddlewareReturnsJsonForApiRequests(): void
+    {
+        $app = AppFactory::create();
+        $app->add(new SessionMiddleware());
+        $app->get('/protected', fn (Request $request, Response $response): Response => $response)
+            ->add(new RoleAuthMiddleware('admin'));
+
+        $factory = new ServerRequestFactory();
+        $req = $factory->createServerRequest('GET', '/protected')
+            ->withHeader('Accept', 'application/json')
+            ->withHeader('X-Requested-With', 'fetch');
+        $res = $app->handle($req);
+        $this->assertSame(401, $res->getStatusCode());
+        $this->assertSame('application/json', $res->getHeaderLine('Content-Type'));
+    }
+
     public function testAdminAuthMiddlewareAllowsAdmin(): void
     {
         $app = AppFactory::create();


### PR DESCRIPTION
## Summary
- Handle API auth failures with JSON 401 instead of login redirects
- Accept CSRF header or token and return JSON 419 on failure
- Queue tenant onboarding asynchronously and protect route with CSRF
- Send credentials and CSRF tokens during onboarding requests
- Add regression test for API auth middleware

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ed769f30832b93c5177e67612b10