### PR TITLE
Handle API requests with JSON auth responses

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -27,6 +27,7 @@ window.apiFetch = (path, options = {}) => {
   const token = getCsrfToken();
   const headers = {
     ...(token ? { 'X-CSRF-Token': token } : {}),
+    'X-Requested-With': 'fetch',
     ...(options.headers || {})
   };
   const opts = {

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -23,6 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const withBase = p => basePath + p;
   const timelineSteps = document.querySelectorAll('.timeline-step');
   const restartBtn = document.getElementById('restartOnboarding');
+  let tenantFinalizing = false;
 
   function isValidEmail(email) {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -116,7 +117,8 @@ document.addEventListener('DOMContentLoaded', () => {
         credentials: 'same-origin',
         headers: {
           'Content-Type': 'application/json',
-          'X-CSRF-Token': window.csrfToken || ''
+          'X-CSRF-Token': window.csrfToken || '',
+          'X-Requested-With': 'fetch'
         },
         body: JSON.stringify({ email })
       });
@@ -142,7 +144,10 @@ document.addEventListener('DOMContentLoaded', () => {
         alert('Ungültige Subdomain.');
         return;
       }
-      const res = await fetch(withBase('/tenants/' + encodeURIComponent(subdomain)));
+      const res = await fetch(withBase('/tenants/' + encodeURIComponent(subdomain)), {
+        credentials: 'same-origin',
+        headers: { 'X-Requested-With': 'fetch' }
+      });
       if (res.ok) {
         alert('Subdomain bereits vergeben.');
         return;
@@ -186,6 +191,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (planButtons.length) {
     planButtons.forEach(btn => {
       btn.addEventListener('click', async () => {
+        btn.disabled = true;
         const plan = btn.dataset.plan;
         const email = localStorage.getItem('onboard_email') || emailInput.value.trim();
         const subdomain = localStorage.getItem('onboard_subdomain') || '';
@@ -215,7 +221,8 @@ document.addEventListener('DOMContentLoaded', () => {
             credentials: 'same-origin',
             headers: {
               'Content-Type': 'application/json',
-              'X-CSRF-Token': window.csrfToken || ''
+              'X-CSRF-Token': window.csrfToken || '',
+              'X-Requested-With': 'fetch'
             },
             body: JSON.stringify({ plan, email, subdomain })
           });
@@ -270,6 +277,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   async function finalizeTenant() {
+    if (tenantFinalizing) { return; }
+    tenantFinalizing = true;
     const subdomain = localStorage.getItem('onboard_subdomain') || '';
     const plan = localStorage.getItem('onboard_plan') || '';
     const email = localStorage.getItem('onboard_email') || '';
@@ -354,7 +363,8 @@ document.addEventListener('DOMContentLoaded', () => {
         credentials: 'same-origin',
         headers: {
           'Content-Type': 'application/json',
-          'X-CSRF-Token': window.csrfToken || ''
+          'X-CSRF-Token': window.csrfToken || '',
+          'X-Requested-With': 'fetch'
         },
         body: JSON.stringify({ mode: 'full' })
       });
@@ -395,7 +405,8 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       if (sessionId) {
         const res = await fetch(withBase('/onboarding/checkout/' + encodeURIComponent(sessionId)), {
-          credentials: 'same-origin'
+          credentials: 'same-origin',
+          headers: { 'X-Requested-With': 'fetch' }
         });
         if (!res.ok) {
           throw new Error('checkout');
@@ -411,7 +422,8 @@ document.addEventListener('DOMContentLoaded', () => {
         credentials: 'same-origin',
         headers: {
           'Content-Type': 'application/json',
-          'X-CSRF-Token': window.csrfToken || ''
+          'X-CSRF-Token': window.csrfToken || '',
+          'X-Requested-With': 'fetch'
         },
         body: JSON.stringify({
           uid: subdomain,
@@ -476,7 +488,8 @@ document.addEventListener('DOMContentLoaded', () => {
         credentials: 'same-origin',
         headers: {
           'Content-Type': 'application/json',
-          'X-CSRF-Token': window.csrfToken || ''
+          'X-CSRF-Token': window.csrfToken || '',
+          'X-Requested-With': 'fetch'
         },
         body: JSON.stringify({ schema: subdomain, email })
       });

--- a/scripts/offboard_tenant.sh
+++ b/scripts/offboard_tenant.sh
@@ -21,12 +21,11 @@ else
   exit 1
 fi
 
-if [ ! -f "$COMPOSE_FILE" ]; then
-  echo "Compose file '$COMPOSE_FILE' not found" >&2
-else
+if [ -f "$COMPOSE_FILE" ]; then
   $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" down -v || true
+else
+  echo "skip down: $COMPOSE_FILE missing"
 fi
 
 rm -rf "$TENANT_DIR"
-
 printf '{"status":"removed","slug":"%s"}\n' "$SLUG"

--- a/src/Application/Middleware/AdminAuthMiddleware.php
+++ b/src/Application/Middleware/AdminAuthMiddleware.php
@@ -22,6 +22,18 @@ class AdminAuthMiddleware implements MiddlewareInterface
     {
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
+            $accept = $request->getHeaderLine('Accept');
+            $xhr = $request->getHeaderLine('X-Requested-With');
+            $path = $request->getUri()->getPath();
+            $isApi = str_starts_with($path, '/api/') || str_contains($accept, 'application/json') || $xhr === 'fetch';
+
+            if ($isApi) {
+                $response = new SlimResponse(401);
+                $response->getBody()->write(json_encode(['error' => 'unauthorized']));
+
+                return $response->withHeader('Content-Type', 'application/json');
+            }
+
             $response = new SlimResponse();
             return $response->withHeader('Location', '/login')->withStatus(302);
         }

--- a/src/Application/Middleware/CsrfMiddleware.php
+++ b/src/Application/Middleware/CsrfMiddleware.php
@@ -32,7 +32,9 @@ class CsrfMiddleware implements MiddlewareInterface
             if ($token === null || ($header !== $token && $bodyToken !== $token)) {
                 $accept = $request->getHeaderLine('Accept');
                 $xhr = $request->getHeaderLine('X-Requested-With');
-                if (str_contains($accept, 'application/json') || $xhr === 'fetch') {
+                $path = $request->getUri()->getPath();
+                $isApi = str_starts_with($path, '/api/') || str_contains($accept, 'application/json') || $xhr === 'fetch';
+                if ($isApi) {
                     $resp = new SlimResponse(419);
                     $resp->getBody()->write(json_encode(['error' => 'csrf']));
 

--- a/src/Application/Middleware/RoleAuthMiddleware.php
+++ b/src/Application/Middleware/RoleAuthMiddleware.php
@@ -34,8 +34,10 @@ class RoleAuthMiddleware implements MiddlewareInterface
         if ($role === null || !in_array($role, $this->roles, true)) {
             $accept = $request->getHeaderLine('Accept');
             $xhr = $request->getHeaderLine('X-Requested-With');
+            $path = $request->getUri()->getPath();
+            $isApi = str_starts_with($path, '/api/') || str_contains($accept, 'application/json') || $xhr === 'fetch';
 
-            if (str_contains($accept, 'application/json') || $xhr === 'fetch') {
+            if ($isApi) {
                 $response = new SlimResponse(401);
                 $response->getBody()->write(json_encode(['error' => 'unauthorized']));
 


### PR DESCRIPTION
## Summary
- ensure admin and onboarding fetch requests include `X-Requested-With` and session credentials
- return JSON 401 for unauthorized API calls in role, admin, and CSRF middleware
- avoid errors when tenant compose files are missing

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fa9c53cc832b98c926803c7d0232