### PR TITLE
Allow admin role to start tenant onboarding

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -1072,7 +1072,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $response->getBody()->write(json_encode($payload));
 
         return $response->withHeader('Content-Type', 'application/json')->withStatus(202);
-    })->add(new RoleAuthMiddleware(Roles::SERVICE_ACCOUNT))->add(new CsrfMiddleware());
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT))->add(new CsrfMiddleware());
 
     $app->delete('/api/tenants/{slug}', function (Request $request, Response $response, array $args) {
         if ($request->getAttribute('domainType') !== 'main') {


### PR DESCRIPTION
## Summary
- allow admins to trigger tenant onboarding so onboarding import step no longer gets unauthorized

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a5024fe3c0832bba7c08e88a7605ef