### PR TITLE
Improve tenant availability feedback

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -508,7 +508,12 @@ document.addEventListener('DOMContentLoaded', () => {
       window.location.href = `https://${subdomain}.${window.mainDomain}/`;
       return;
     } catch (e) {
-      const msg = 'Fehler: ' + e.message;
+      if (taskEls.wait && !taskEls.wait.spinner.hidden && !taskEls.wait.li.querySelector('span:not([uk-spinner])')) {
+        mark('wait', false);
+      }
+      const msg = e.message === 'timeout'
+        ? 'Mandant wurde erstellt, ist jedoch noch nicht verfügbar. Bitte später erneut versuchen.'
+        : 'Fehler: ' + e.message;
       addLog(msg);
       alert(msg);
     }


### PR DESCRIPTION
## Summary
- provide clearer onboarding message when tenant is created but not yet available
- mark waiting task as failed on timeout

## Testing
- `composer test` *(fails: Database error: fail)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js` *(fails: Required code blocks not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a507905258832bb1e3240b302a1aa3