### PR TITLE
Process health checks for all domains

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -126,6 +126,10 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 return function (\Slim\App $app, TranslationService $translator) {
     $app->add(function (Request $request, RequestHandlerInterface $handler) use ($translator) {
+        if ($request->getUri()->getPath() === '/healthz') {
+            return $handler->handle($request);
+        }
+
         $base = Database::connectFromEnv();
         Migrator::migrate($base, __DIR__ . '/../migrations');
 

--- a/tests/HealthzEndpointTest.php
+++ b/tests/HealthzEndpointTest.php
@@ -72,4 +72,25 @@ class HealthzEndpointTest extends TestCase
 
         $this->assertSame($expected, $data['version'] ?? null);
     }
+
+    public function testHealthzEndpointAccessibleForTenantDomain(): void
+    {
+        putenv('MAIN_DOMAIN=example');
+        $_ENV['MAIN_DOMAIN'] = 'example';
+
+        $app = parent::getAppInstance();
+        $request = $this->createRequest('GET', '/healthz', [
+            'HTTP_HOST' => 'tenant.example',
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+        $data = json_decode((string) $response->getBody(), true);
+        $this->assertSame('ok', $data['status'] ?? null);
+
+        putenv('MAIN_DOMAIN');
+        unset($_ENV['MAIN_DOMAIN']);
+    }
 }


### PR DESCRIPTION
## Summary
- Skip tenant bootstrap logic for `/healthz` so the health check works on any domain
- Add integration test ensuring `/healthz` responds for tenant subdomains

## Testing
- `composer test` *(fails: Database error: fail, no such function to_regclass)*
- `vendor/bin/phpunit tests/HealthzEndpointTest.php` *(fails: SQL near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68a55eae787c832b9433a5648ff9699d