### PR TITLE
Remove goals and CTA section from landing page

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -249,22 +249,6 @@
       </div>
     </div>
 
-    <!-- Ziele/Kennzahlen -->
-    <div class="uk-margin-large-top">
-      <h4 class="uk-heading-bullet">Unsere Ziele bis Q4 2025</h4>
-      <div class="uk-grid-small uk-child-width-auto" uk-grid>
-        <div><span class="uk-label">Setup &lt; 5 min</span></div>
-        <div><span class="uk-label">Teilnahmequote ≥ 90 %</span></div>
-        <div><span class="uk-label">NPS &gt; 70</span></div>
-        <div><span class="uk-label">First Response &lt; 2 h</span></div>
-      </div>
-    </div>
-
-    <!-- CTA -->
-    <div class="uk-margin-large-top uk-text-center">
-      <a href="/signup" class="uk-button uk-button-primary uk-button-large">Jetzt kostenlos testen</a>
-      <a href="#demo" class="uk-button uk-button-default uk-button-large" uk-toggle>Demo ansehen</a>
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- drop goals/metrics subsection from landing content
- remove call-to-action buttons for signup and demo

## Testing
- `composer test` *(fails: Unclosed '{' on line 14 in tests/HealthzEndpointTest.php)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js` *(fails: Required code blocks not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5639cdaf0832ba46f814470cf68ad