### PR TITLE
Add CORS header to health endpoint

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -267,7 +267,11 @@ return function (\Slim\App $app, TranslationService $translator) {
         ];
         $response->getBody()->write(json_encode($payload));
 
-        return $response->withHeader('Content-Type', 'application/json');
+        $response = $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Access-Control-Allow-Origin', '*');
+
+        return $response;
     });
 
     $app->get('/', HomeController::class);


### PR DESCRIPTION
## Summary
- include CORS header on `/healthz` endpoint responses

## Testing
- `composer test` *(fails: Unclosed `{` in `tests/HealthzEndpointTest.php`)*

------
https://chatgpt.com/codex/tasks/task_e_68a5745858b4832b8bede55cf79f71c2