### PR TITLE
Add missing closing brace to HealthzEndpointTest

### DIFF
--- a/tests/HealthzEndpointTest.php
+++ b/tests/HealthzEndpointTest.php
@@ -120,3 +120,4 @@ public function testHealthzEndpointAccessibleForTenantHost(): void
         }
     }
 }
+}


### PR DESCRIPTION
## Summary
- close `HealthzEndpointTest` class with final brace

## Testing
- `composer test` *(fails: Database error: fail; Error creating tenant: boom)*

------
https://chatgpt.com/codex/tasks/task_e_68a574788120832b957e7e146a4fd20f