### PR TITLE
Improve subscription limit notification

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -39,7 +39,9 @@ window.apiFetch = (path, options = {}) => {
   return fetch(withBase(path), opts).then(res => {
     if (res.status === 402) {
       showUpgradeModal();
-      throw new Error('upgrade-required');
+      const err = new Error(window.transUpgradeText || 'upgrade-required');
+      err.code = 'upgrade-required';
+      throw err;
     }
     return res;
   });

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -229,7 +229,7 @@ return [
     'action_send_link' => 'Link senden',
     'action_set_password' => 'Passwort setzen',
     'heading_limit_reached' => 'Limit erreicht',
-    'text_upgrade_required' => 'Abo-Limit erreicht. Bitte upgraden, um mehr Ressourcen anzulegen.',
+    'text_upgrade_required' => 'Das Abo ist ausgelastet. Um weitere Veranstaltungen anzulegen, upgraden Sie auf eine höhere Version.',
     'action_upgrade' => 'Upgrade',
     'text_stripe_config_missing' => 'Stripe-Konfiguration fehlt. Bitte erforderliche Umgebungsvariablen setzen.',
 ];

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -227,7 +227,7 @@ return [
     'action_send_link' => 'Send link',
     'action_set_password' => 'Set password',
     'heading_limit_reached' => 'Limit reached',
-    'text_upgrade_required' => 'Subscription limit reached. Please upgrade to add more resources.',
+    'text_upgrade_required' => 'Subscription is exhausted. To create more events, upgrade to a higher plan.',
     'action_upgrade' => 'Upgrade',
     'text_stripe_config_missing' => 'Stripe configuration missing. Please set required environment variables.',
 ];


### PR DESCRIPTION
## Summary
- clarify subscription limit message for tenants
- surface translated message when subscription upgrade required

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a59007986c832bb18704f954ea04dc