### PR TITLE
feat: show version on admin login

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use App\Service\UserService;
 use App\Infrastructure\Database;
+use App\Service\VersionService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
@@ -30,9 +31,14 @@ class LoginController
         $view = Twig::fromRequest($request);
         $query = $request->getQueryParams();
         $resetSuccess = array_key_exists('reset', $query);
+        $version = getenv('APP_VERSION');
+        if ($version === false || $version === '') {
+            $version = (new VersionService())->getCurrentVersion();
+        }
         return $view->render($response, 'login.twig', [
             'registration_allowed' => $allowed,
             'reset_success' => $resetSuccess,
+            'version' => $version,
         ]);
     }
 

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -66,6 +66,9 @@
             {% endif %}
           </form>
       </div>
+      {% if version %}
+      <div class="uk-text-center uk-text-meta uk-margin-small-top">Version {{ version }}</div>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class LoginControllerTest extends TestCase
+{
+    public function testLoginPageShowsVersion(): void
+    {
+        putenv('APP_VERSION=1.2.3');
+        $_ENV['APP_VERSION'] = '1.2.3';
+
+        $app = $this->getAppInstance();
+        $response = $app->handle($this->createRequest('GET', '/login'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('Version 1.2.3', (string) $response->getBody());
+
+        putenv('APP_VERSION');
+        unset($_ENV['APP_VERSION']);
+    }
+}


### PR DESCRIPTION
## Summary
- display app version on login screen
- test version display on login

## Testing
- `composer test` *(fails: SQLSTATE[HY000]: General error: 1 no such function: to_regclass)*

------
https://chatgpt.com/codex/tasks/task_e_68a590d8133c832ba9ad25925aa34468