### PR TITLE
Fix code style issues

### DIFF
--- a/src/Application/Middleware/CsrfMiddleware.php
+++ b/src/Application/Middleware/CsrfMiddleware.php
@@ -33,7 +33,9 @@ class CsrfMiddleware implements MiddlewareInterface
                 $accept = $request->getHeaderLine('Accept');
                 $xhr = $request->getHeaderLine('X-Requested-With');
                 $path = $request->getUri()->getPath();
-                $isApi = str_starts_with($path, '/api/') || str_contains($accept, 'application/json') || $xhr === 'fetch';
+                $isApi = str_starts_with($path, '/api/')
+                    || str_contains($accept, 'application/json')
+                    || $xhr === 'fetch';
                 if ($isApi) {
                     $resp = new SlimResponse(419);
                     $resp->getBody()->write(json_encode(['error' => 'csrf']));

--- a/tests/HealthzEndpointTest.php
+++ b/tests/HealthzEndpointTest.php
@@ -77,47 +77,47 @@ class HealthzEndpointTest extends TestCase
         $this->assertSame($expected, $data['version'] ?? null);
     }
 
-public function testHealthzEndpointAccessibleForTenantHost(): void
-{
-    // Backup current env
-    $old = getenv('MAIN_DOMAIN');
-    $oldEnv = $_ENV['MAIN_DOMAIN'] ?? null;
+    public function testHealthzEndpointAccessibleForTenantHost(): void
+    {
+        // Backup current env
+        $old = getenv('MAIN_DOMAIN');
+        $oldEnv = $_ENV['MAIN_DOMAIN'] ?? null;
 
-    // Set test env
-    putenv('MAIN_DOMAIN=example.com');
-    $_ENV['MAIN_DOMAIN'] = 'example.com';
+        // Set test env
+        putenv('MAIN_DOMAIN=example.com');
+        $_ENV['MAIN_DOMAIN'] = 'example.com';
 
-    $app = $this->getAppInstance();
+        $app = $this->getAppInstance();
 
-    // Erzeuge Request für Tenant-Domain und JSON
-    $request = $this->createRequest('GET', '/healthz', [
-        'HTTP_HOST'   => 'tenant.example.com',
-        'HTTP_ACCEPT' => 'application/json',
-    ]);
-    // Stelle sicher, dass auch die URI den Host trägt (je nach Helper-Implementation)
-    $request = $request->withUri($request->getUri()->withHost('tenant.example.com'));
+        // Erzeuge Request für Tenant-Domain und JSON
+        $request = $this->createRequest('GET', '/healthz', [
+            'HTTP_HOST'   => 'tenant.example.com',
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+        // Stelle sicher, dass auch die URI den Host trägt (je nach Helper-Implementation)
+        $request = $request->withUri($request->getUri()->withHost('tenant.example.com'));
 
-    $response = $app->handle($request);
+        $response = $app->handle($request);
 
-    // Status OK & JSON-Header
-    $this->assertSame(200, $response->getStatusCode());
-    $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+        // Status OK & JSON-Header
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
 
-    // Body inhaltlich prüfen
-    $data = json_decode((string) $response->getBody(), true);
-    $this->assertSame('ok', $data['status'] ?? null);
+        // Body inhaltlich prüfen
+        $data = json_decode((string) $response->getBody(), true);
+        $this->assertSame('ok', $data['status'] ?? null);
 
-    // Restore env
-    if ($old === false) {
-        putenv('MAIN_DOMAIN');
-        unset($_ENV['MAIN_DOMAIN']);
-    } else {
-        putenv('MAIN_DOMAIN=' . $old);
-        if ($oldEnv === null) {
+        // Restore env
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
             unset($_ENV['MAIN_DOMAIN']);
         } else {
-            $_ENV['MAIN_DOMAIN'] = $oldEnv;
+            putenv('MAIN_DOMAIN=' . $old);
+            if ($oldEnv === null) {
+                unset($_ENV['MAIN_DOMAIN']);
+            } else {
+                $_ENV['MAIN_DOMAIN'] = $oldEnv;
+            }
         }
     }
-}
 }

--- a/tests/SessionDependentMiddlewareTest.php
+++ b/tests/SessionDependentMiddlewareTest.php
@@ -126,7 +126,6 @@ class SessionDependentMiddlewareTest extends TestCase
         $this->assertSame('application/json', $res->getHeaderLine('Content-Type'));
     }
 
-    
     public function testAdminAuthMiddlewareReturnsJsonForApiRequests(): void
     {
         $app = AppFactory::create();


### PR DESCRIPTION
## Summary
- reformat CSRF middleware line to respect PSR-12 line length
- fix indentation of tenant health check test
- remove stray whitespace in session middleware test

## Testing
- `vendor/bin/phpcs`
- `composer test` *(fails: PDOException: SQLSTATE[HY000]: General error: 1 near "DO" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c1b0bba4832bbd2aa06c0f57e3f4