### PR TITLE
fix: update phpstan config for v2

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+ini_set('memory_limit', '512M');
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,10 +1,11 @@
 parameters:
-  memoryLimit: '512M'
   level: 4
   paths:
     - src
   stubFiles:
     - stubs/endroid_qr.stub
+  bootstrapFiles:
+    - phpstan-bootstrap.php
   ignoreErrors:
     - '#Call to function is_callable.+will always evaluate to true#'
     - '#Method App\\Service\\AwardService::join\(\) is unused#'

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -252,20 +252,18 @@ class TenantService
                     }
                 }
                 $filtered['event_uid'] = $activeUid;
-                if ($filtered !== []) {
-                    $cols = array_keys($filtered);
-                    $place = array_map(fn($c) => ':' . $c, $cols);
-                    $sql = 'INSERT INTO config(' . implode(',', $cols) . ') VALUES(' . implode(',', $place) . ')';
-                    $stmt = $this->pdo->prepare($sql);
-                    foreach ($filtered as $k => $v) {
-                        if (is_bool($v)) {
-                            $stmt->bindValue(':' . $k, $v, PDO::PARAM_BOOL);
-                        } else {
-                            $stmt->bindValue(':' . $k, $v);
-                        }
+                $cols = array_keys($filtered);
+                $place = array_map(fn($c) => ':' . $c, $cols);
+                $sql = 'INSERT INTO config(' . implode(',', $cols) . ') VALUES(' . implode(',', $place) . ')';
+                $stmt = $this->pdo->prepare($sql);
+                foreach ($filtered as $k => $v) {
+                    if (is_bool($v)) {
+                        $stmt->bindValue(':' . $k, $v, PDO::PARAM_BOOL);
+                    } else {
+                        $stmt->bindValue(':' . $k, $v);
                     }
-                    $stmt->execute();
                 }
+                $stmt->execute();
             }
             if ($this->hasTable('active_event')) {
                 $this->pdo->prepare('INSERT INTO active_event(event_uid) VALUES(?)')->execute([$activeUid]);


### PR DESCRIPTION
## Summary
- fix phpstan config for v2
- ensure phpstan runs with increased memory limit via bootstrap
- simplify TenantService insert logic to satisfy phpstan

## Testing
- `vendor/bin/phpstan analyse`
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c50cba0c832b996fd30fb76cb336