### PR TITLE
Send welcome mail directly and update content

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -161,18 +161,7 @@ document.addEventListener('DOMContentLoaded', function () {
       apiFetch('/tenants/' + encodeURIComponent(sub) + '/welcome', { method: 'POST' })
         .then(r => {
           if (!r.ok) throw new Error('Fehler');
-          return apiFetch('/tenants/' + encodeURIComponent(sub) + '/welcome');
-        })
-        .then(r => {
-          if (!r.ok) throw new Error('Fehler');
-          return r.text();
-        })
-        .then(html => {
-          const w = window.open('', '_blank');
-          if (w) {
-            w.document.write(html);
-            w.document.close();
-          }
+          notify('Willkommensmail gesendet', 'success');
         })
         .catch(() => notify('Willkommensmail nicht verfügbar', 'danger'));
     }

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -194,14 +194,14 @@ class MailService
      */
     public function sendWelcome(string $to, string $domain, string $link): string
     {
-        $catalogLink = sprintf('https://%s/admin/catalogs', $domain);
+        $adminLink = sprintf('https://%s/admin', $domain);
 
         $baseUrl = 'https://' . $domain;
         $html = $this->twig->render('emails/welcome.twig', [
-            'domain'       => $domain,
-            'link'         => $link,
-            'catalog_link' => $catalogLink,
-            'base_url'     => $baseUrl,
+            'domain'     => $domain,
+            'link'       => $link,
+            'admin_link' => $adminLink,
+            'base_url'   => $baseUrl,
         ]);
 
         $email = (new Email())

--- a/src/routes.php
+++ b/src/routes.php
@@ -601,13 +601,8 @@ return function (\Slim\App $app, TranslationService $translator) {
         $mainDomain = getenv('MAIN_DOMAIN') ?: getenv('DOMAIN');
         $domain = $mainDomain ? sprintf('%s.%s', $sub, $mainDomain) : $uri->getHost();
         $link = sprintf('https://%s/password/set?token=%s&next=%%2Fadmin', $domain, urlencode($token));
-        $html = $mailer->sendWelcome($email, $domain, $link);
-        $baseDir = dirname(__DIR__, 1);
-        $dir = $baseDir . '/data/' . $sub;
-        if (!is_dir($dir)) {
-            mkdir($dir, 0777, true);
-        }
-        file_put_contents($dir . '/welcome_email.html', $html);
+        $mailer->sendWelcome($email, $domain, $link);
+
         return $response->withStatus(204);
     })->add(new RoleAuthMiddleware(Roles::ADMIN))->add(new CsrfMiddleware());
     $app->get('/admin/tenants', function (Request $request, Response $response) {
@@ -828,29 +823,10 @@ return function (\Slim\App $app, TranslationService $translator) {
         $mainDomain = getenv('MAIN_DOMAIN') ?: getenv('DOMAIN');
         $domain = $mainDomain ? sprintf('%s.%s', $sub, $mainDomain) : $request->getUri()->getHost();
         $link = sprintf('https://%s/password/set?token=%s&next=%%2Fadmin', $domain, urlencode($token));
-        $html = $mailer->sendWelcome($email, $domain, $link);
-        $baseDir = dirname(__DIR__, 1);
-        $dir = $baseDir . '/data/' . $sub;
-        if (!is_dir($dir)) {
-            mkdir($dir, 0777, true);
-        }
-        file_put_contents($dir . '/welcome_email.html', $html);
+        $mailer->sendWelcome($email, $domain, $link);
+
         return $response->withStatus(204);
     })->add(new RoleAuthMiddleware(Roles::ADMIN))->add(new CsrfMiddleware());
-
-    $app->get('/tenants/{subdomain}/welcome', function (Request $request, Response $response, array $args) {
-        if ($request->getAttribute('domainType') !== 'main') {
-            return $response->withStatus(403);
-        }
-        $sub = preg_replace('/[^a-z0-9\-]/', '-', strtolower((string) ($args['subdomain'] ?? '')));
-        $base = dirname(__DIR__, 1);
-        $file = $base . '/data/' . $sub . '/welcome_email.html';
-        if (!is_readable($file)) {
-            return $response->withStatus(404);
-        }
-        $response->getBody()->write((string) file_get_contents($file));
-        return $response->withHeader('Content-Type', 'text/html');
-    })->add(new RoleAuthMiddleware(Roles::ADMIN));
 
     $app->get('/teams.json', function (Request $request, Response $response) {
         return $request->getAttribute('teamController')->get($request, $response);
@@ -925,13 +901,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $mailer = new MailService($twig, $auditLogger);
         $domain = $mainDomain ? sprintf('%s.%s', $schema, $mainDomain) : $request->getUri()->getHost();
         $link = sprintf('https://%s/password/set?token=%s&next=%%2Fadmin', $domain, urlencode($token));
-        $html = $mailer->sendWelcome($email, $domain, $link);
-        $base = dirname(__DIR__, 1);
-        $dir = $base . '/data/' . $schema;
-        if (!is_dir($dir)) {
-            mkdir($dir, 0777, true);
-        }
-        file_put_contents($dir . '/welcome_email.html', $html);
+        $mailer->sendWelcome($email, $domain, $link);
 
         return $response->withStatus(204);
     })->add(new RoleAuthMiddleware(Roles::SERVICE_ACCOUNT));

--- a/templates/emails/welcome.twig
+++ b/templates/emails/welcome.twig
@@ -3,8 +3,8 @@
 {% block content %}
 <p>Hallo,</p>
 <p>Ihr QuizRace wurde unter <a href="https://{{ domain }}">{{ domain }}</a> eingerichtet.</p>
-<p>Verwalten Sie Ihre Fragenkataloge hier:</p>
-<p><a href="{{ catalog_link }}">{{ catalog_link }}</a></p>
+<p>Passen Sie Ihre Veranstaltung hier an:</p>
+<p><a href="{{ admin_link }}">{{ admin_link }}</a></p>
 <p>Um das Admin-Passwort Ihrer Domain zu setzen oder zurückzusetzen, verwenden Sie folgenden Link:</p>
 <p><a href="{{ link }}">{{ link }}</a></p>
 <p>Viel Erfolg!</p>


### PR DESCRIPTION
## Summary
- send tenant welcome mail without storing preview
- reference admin area in welcome email content
- avoid browser preview when triggering welcome mail

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c791ed40832ba626016231b98160