### PR TITLE
Render admin subscription plans as comparison table

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1012,58 +1012,67 @@
             <div class="uk-text-meta">Wird für Stripe-Kund*in verwendet.</div>
           </div>
           {% endif %}
-        <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-small uk-margin-top" uk-grid>
-          <div>
-            <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
-              <span class="uk-label uk-label-success uk-label-large">Kostenlos testen</span>
-              <h3 class="uk-card-title uk-text-primary uk-margin-small-top">{{ t('plan_starter') }}</h3>
-              <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">9&nbsp;€/Monat</div>
-              <div class="uk-text-meta uk-margin-small-bottom">Für kleine Events &amp; Einsteiger</div>
-              <ul class="uk-list uk-text-left uk-margin-small-bottom">
-                <li><b>7 Tage kostenlos testen</b></li>
-                <li><b>1 Event gleichzeitig</b></li>
-                <li>5 Teams &amp; 5 Kataloge à 5 Fragen</li>
-                <li>Unbegrenzte Teilnehmende pro Team¹</li>
-                <li>Live-Ranking &amp; Basis-PDF-Export²</li>
-                <li>Alle Fragetypen &amp; QR-Codes</li>
-                <li>Backup &amp; editierbare Texte³</li>
-              </ul>
-              <button class="uk-button uk-button-default uk-width-1-1 plan-select" data-plan="starter">{{ t('action_start_subscription') }}</button>
-            </div>
-          </div>
-          <div>
-            <div class="uk-card uk-card-popular uk-card-quizrace uk-text-center">
-              <span class="uk-label uk-label-large">Meist gewählt</span>
-              <h3 class="uk-card-title uk-margin-small-top" style="color:#fff;">{{ t('plan_standard') }}</h3>
-              <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700; color:#fff;">39&nbsp;€/Monat</div>
-              <div class="uk-text-meta uk-margin-small-bottom" style="color:#fff;">Beliebt bei Schulen &amp; Teams</div>
-              <ul class="uk-list uk-text-left uk-margin-small-bottom" style="color:#fff;">
-                <li><b>7 Tage kostenlos testen</b></li>
-                <li><b>Alle Starter-Funktionen</b></li>
-                <li>Bis zu 3 Events gleichzeitig</li>
-                <li>10 Teams &amp; 10 Kataloge à 10 Fragen</li>
-                <li>Eigene Subdomain</li>
-                <li>Vollständiger PDF-Export</li>
-              </ul>
-              <button class="uk-button uk-button-primary uk-width-1-1 plan-select" data-plan="standard">{{ t('action_start_subscription') }}</button>
-            </div>
-          </div>
-          <div>
-            <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
-              <span class="uk-label uk-label-primary uk-label-large">Professional</span>
-              <h3 class="uk-card-title uk-text-primary uk-margin-small-top">{{ t('plan_professional') }}</h3>
-              <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">79&nbsp;€/Monat</div>
-              <div class="uk-text-meta uk-margin-small-bottom">Für Agenturen &amp; Unternehmen</div>
-              <ul class="uk-list uk-text-left uk-margin-small-bottom">
-                <li><b>7 Tage kostenlos testen</b></li>
-                <li><b>Alle Standard-Funktionen</b></li>
-                <li>20 Events gleichzeitig (mehr auf Anfrage)</li>
-                <li>100 Teams &amp; 50 Kataloge à 50 Fragen</li>
-                <li>White-Label &amp; Rollenverwaltung</li>
-              </ul>
-              <button class="uk-button uk-button-default uk-width-1-1 plan-select" data-plan="professional">{{ t('action_start_subscription') }}</button>
-            </div>
-          </div>
+        <div class="uk-overflow-auto uk-margin-top">
+          <table class="uk-table uk-table-divider uk-table-small uk-text-center">
+            <thead>
+              <tr>
+                <th></th>
+                <th>
+                  {{ t('plan_starter') }}<br>
+                  <div class="uk-text-large">9&nbsp;€/Monat</div>
+                  <div class="uk-text-meta">7 Tage kostenlos testen</div>
+                </th>
+                <th>
+                  {{ t('plan_standard') }}<br>
+                  <div class="uk-text-large">39&nbsp;€/Monat</div>
+                  <div class="uk-text-meta">7 Tage kostenlos testen</div>
+                </th>
+                <th>
+                  {{ t('plan_professional') }}<br>
+                  <div class="uk-text-large">79&nbsp;€/Monat</div>
+                  <div class="uk-text-meta">7 Tage kostenlos testen</div>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th>Gleichzeitige Events</th>
+                <td>1</td>
+                <td>3</td>
+                <td>20</td>
+              </tr>
+              <tr>
+                <th>Teams &amp; Kataloge</th>
+                <td>5 Teams &amp; 5 Kataloge à 5 Fragen</td>
+                <td>10 Teams &amp; 10 Kataloge à 10 Fragen</td>
+                <td>100 Teams &amp; 50 Kataloge à 50 Fragen</td>
+              </tr>
+              <tr>
+                <th>Subdomain</th>
+                <td>–</td>
+                <td>&#10003;</td>
+                <td>&#10003;</td>
+              </tr>
+              <tr>
+                <th>PDF-Export</th>
+                <td>Basis</td>
+                <td>Vollständig</td>
+                <td>Vollständig</td>
+              </tr>
+              <tr>
+                <th>White-Label &amp; Rollenverwaltung</th>
+                <td>–</td>
+                <td>–</td>
+                <td>&#10003;</td>
+              </tr>
+              <tr>
+                <th></th>
+                <td><button class="uk-button uk-button-default uk-width-1-1 plan-select" data-plan="starter">{{ t('action_start_subscription') }}</button></td>
+                <td><button class="uk-button uk-button-primary uk-width-1-1 plan-select" data-plan="standard">{{ t('action_start_subscription') }}</button></td>
+                <td><button class="uk-button uk-button-default uk-width-1-1 plan-select" data-plan="professional">{{ t('action_start_subscription') }}</button></td>
+              </tr>
+            </tbody>
+          </table>
         </div>
         {% endif %}
         {% if domainType == 'tenant' and hasCustomer %}


### PR DESCRIPTION
## Summary
- Replace subscription plan cards with a comparison table under the admin subscription page

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c920fd04832bb703fef3f6015fd7