### PR TITLE
Add admin-triggered Docker image build support

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -129,6 +129,15 @@ document.addEventListener('DOMContentLoaded', function () {
         .finally(() => {
           el.classList.remove('uk-disabled');
         });
+    } else if (action === 'build-docker') {
+      e.preventDefault();
+      apiFetch('/api/docker/build', { method: 'POST' })
+        .then(r => r.json().then(data => ({ ok: r.ok, data })))
+        .then(({ ok, data }) => {
+          if (!ok) throw new Error(data.error || 'Fehler');
+          notify(window.transBuildDocker || 'Image erstellt', 'success');
+        })
+        .catch(err => notify(err.message || 'Fehler beim Erstellen', 'danger'));
     } else if (action === 'upgrade-docker') {
       e.preventDefault();
       apiFetch('/api/tenants/' + encodeURIComponent(sub) + '/upgrade', { method: 'POST' })

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -212,6 +212,7 @@ return [
     'action_open_evaluation' => 'Auswertung öffnen',
     'action_download' => 'Herunterladen',
     'action_delete_tenant' => 'Mandant löschen',
+    'action_build_image' => 'Docker-Image bauen',
     'action_sync_tenants' => 'Fehlende Mandanten suchen',
     'action_renew_ssl' => 'SSL erneuern',
     'action_upgrade_docker' => 'Docker aktualisieren',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -211,6 +211,7 @@ return [
     'action_open_evaluation' => 'Open evaluation',
     'action_download' => 'Download',
     'action_delete_tenant' => 'Delete tenant',
+    'action_build_image' => 'Build Docker image',
     'action_sync_tenants' => 'Import missing subdomains',
     'action_renew_ssl' => 'Renew SSL',
     'action_upgrade_docker' => 'Upgrade Docker',

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+docker build -t sommerfest:latest "$(dirname "$0")/.."
+printf '{"status":"built"}\n'

--- a/scripts/upgrade_tenant.sh
+++ b/scripts/upgrade_tenant.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Upgrade tenant or main container to latest image
+# Upgrade tenant or main container using locally built image
 set -e
 
 if [ "$#" -lt 1 ]; then
@@ -32,11 +32,6 @@ fi
 
 if [ ! -f "$COMPOSE_FILE" ]; then
   echo "compose file not found: $COMPOSE_FILE" >&2
-  exit 1
-fi
-
-if ! $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" pull "$SERVICE" >/dev/null 2>&1; then
-  echo "pull failed" >&2
   exit 1
 fi
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -883,6 +883,9 @@
             <button id="tenantReportBtn" class="uk-button uk-button-default uk-button-small">Auswertung</button>
             <button id="tenantColumnBtn" class="uk-button uk-button-default uk-button-small">Spalten</button>
             <button id="tenantSyncBtn" class="uk-button uk-button-default uk-button-small">Sync</button>
+            <button class="uk-button uk-button-default uk-button-small" data-action="build-docker">
+              {{ t('action_build_image') }}
+            </button>
           </div>
         </div>
 
@@ -1117,6 +1120,7 @@
     window.transUpgradeAction = '{{ t('action_upgrade') }}';
     window.transUpgradeDocker = '{{ t('action_upgrade_docker') }}';
     window.transRestartTenant = '{{ t('action_restart_tenant') }}';
+    window.transBuildDocker = '{{ t('action_build_image') }}';
     window.stripeDashboard = '{{ stripe_sandbox ? 'https://dashboard.stripe.com/test' : 'https://dashboard.stripe.com' }}';
   </script>
   <script src="{{ basePath }}/js/dashboard.js"></script>


### PR DESCRIPTION
## Summary
- add build_image.sh to create local Docker image
- expose /api/docker/build endpoint secured with admin role
- integrate build trigger into admin interface and translations
- adjust tenant upgrade script to use local images

## Testing
- `composer test` *(fails: Database error: fail)*
- `vendor/bin/phpcs src/routes.php resources/lang/de.php resources/lang/en.php`

------
https://chatgpt.com/codex/tasks/task_e_68a5cb0c3db0832b8626dd5a224ca2c2