### PR TITLE
Show spinner while building Docker image

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -131,13 +131,20 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     } else if (action === 'build-docker') {
       e.preventDefault();
+      const original = el.innerHTML;
+      el.disabled = true;
+      el.innerHTML = '<div uk-spinner></div>';
       apiFetch('/api/docker/build', { method: 'POST' })
         .then(r => r.json().then(data => ({ ok: r.ok, data })))
         .then(({ ok, data }) => {
           if (!ok) throw new Error(data.error || 'Fehler');
-          notify(window.transBuildDocker || 'Image erstellt', 'success');
+          notify(window.transImageReady || 'Image bereit', 'success');
         })
-        .catch(err => notify(err.message || 'Fehler beim Erstellen', 'danger'));
+        .catch(err => notify(err.message || 'Fehler beim Erstellen', 'danger'))
+        .finally(() => {
+          el.disabled = false;
+          el.innerHTML = original;
+        });
     } else if (action === 'upgrade-docker') {
       e.preventDefault();
       apiFetch('/api/tenants/' + encodeURIComponent(sub) + '/upgrade', { method: 'POST' })

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -218,6 +218,7 @@ return [
     'action_upgrade_docker' => 'Docker aktualisieren',
     'action_restart_tenant' => 'Docker neu starten',
     'action_send_welcome_mail' => 'Willkommensmail senden',
+    'text_image_ready' => 'Docker-Image bereit',
     'help_admin_pass' => 'Definiert das Admin-Passwort des neuen Mandanten. Bleibt das Feld leer, ' .
         'wird ein zufälliges Passwort erzeugt',
     'info_admin_email' => 'Der Link zum Setzen des Admin-Passworts wird per E-Mail verschickt.',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -217,6 +217,7 @@ return [
     'action_upgrade_docker' => 'Upgrade Docker',
     'action_restart_tenant' => 'Restart Docker',
     'action_send_welcome_mail' => 'Send welcome email',
+    'text_image_ready' => 'Docker image ready',
     'help_admin_pass' => 'Defines the admin password for the new tenant. Leave empty to generate a random one',
     'info_admin_email' => 'The link to set the admin password will be sent by email.',
     'text_admin_email_sent' => 'A link to set the admin password has been sent to %s.',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1120,7 +1120,7 @@
     window.transUpgradeAction = '{{ t('action_upgrade') }}';
     window.transUpgradeDocker = '{{ t('action_upgrade_docker') }}';
     window.transRestartTenant = '{{ t('action_restart_tenant') }}';
-    window.transBuildDocker = '{{ t('action_build_image') }}';
+    window.transImageReady = '{{ t('text_image_ready') }}';
     window.stripeDashboard = '{{ stripe_sandbox ? 'https://dashboard.stripe.com/test' : 'https://dashboard.stripe.com' }}';
   </script>
   <script src="{{ basePath }}/js/dashboard.js"></script>


### PR DESCRIPTION
## Summary
- Show loading spinner when building Docker image and notify once ready
- Add translation for image-ready message

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d618657c832b8b7f9e3e77bab699