### PR TITLE
Show spinner during docker upgrade and force container recreation

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -140,13 +140,21 @@ document.addEventListener('DOMContentLoaded', function () {
         .catch(err => notify(err.message || 'Fehler beim Erstellen', 'danger'));
     } else if (action === 'upgrade-docker') {
       e.preventDefault();
+      el.classList.add('uk-disabled');
+      const originalHtml = el.innerHTML;
+      const text = (el.textContent || '').trim();
+      el.innerHTML = text ? `<span class="uk-margin-small-right" uk-spinner></span>${text}` : '<span uk-spinner></span>';
       apiFetch('/api/tenants/' + encodeURIComponent(sub) + '/upgrade', { method: 'POST' })
         .then(r => r.json().then(data => ({ ok: r.ok, data })))
         .then(({ ok, data }) => {
           if (!ok) throw new Error(data.error || 'Fehler');
           notify(window.transUpgradeDocker || 'Docker aktualisiert', 'success');
         })
-        .catch(err => notify(err.message || 'Fehler beim Aktualisieren', 'danger'));
+        .catch(err => notify(err.message || 'Fehler beim Aktualisieren', 'danger'))
+        .finally(() => {
+          el.innerHTML = originalHtml;
+          el.classList.remove('uk-disabled');
+        });
     } else if (action === 'restart') {
       e.preventDefault();
       apiFetch('/api/tenants/' + encodeURIComponent(sub) + '/restart', { method: 'POST' })

--- a/scripts/upgrade_tenant.sh
+++ b/scripts/upgrade_tenant.sh
@@ -35,7 +35,7 @@ if [ ! -f "$COMPOSE_FILE" ]; then
   exit 1
 fi
 
-if ! $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" up -d --no-deps "$SERVICE" >/dev/null 2>&1; then
+if ! $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" up -d --no-deps --force-recreate "$SERVICE" >/dev/null 2>&1; then
   echo "upgrade failed" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Ensure `docker compose` recreates containers when upgrading a tenant, pulling in the newly built image
- Display a spinner on the Docker upgrade button while the upgrade script runs

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d67ed824832b9187d57b30a7ea57