### PR TITLE
Make tenant toolbar responsive

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -878,12 +878,12 @@
             </div>
           </div>
 
-          <div class="uk-button-group uk-margin-small-top@s">
-            <button id="tenantExportBtn" class="uk-button uk-button-default uk-button-small">Exportieren</button>
-            <button id="tenantReportBtn" class="uk-button uk-button-default uk-button-small">Auswertung</button>
-            <button id="tenantColumnBtn" class="uk-button uk-button-default uk-button-small">Spalten</button>
-            <button id="tenantSyncBtn" class="uk-button uk-button-default uk-button-small">Sync</button>
-            <button class="uk-button uk-button-default uk-button-small" data-action="build-docker">
+          <div class="uk-flex uk-flex-wrap uk-margin-small-top@s">
+            <button id="tenantExportBtn" class="uk-button uk-button-default uk-button-small uk-margin-small-right uk-margin-small-bottom">Exportieren</button>
+            <button id="tenantReportBtn" class="uk-button uk-button-default uk-button-small uk-margin-small-right uk-margin-small-bottom">Auswertung</button>
+            <button id="tenantColumnBtn" class="uk-button uk-button-default uk-button-small uk-margin-small-right uk-margin-small-bottom">Spalten</button>
+            <button id="tenantSyncBtn" class="uk-button uk-button-default uk-button-small uk-margin-small-right uk-margin-small-bottom">Sync</button>
+            <button class="uk-button uk-button-default uk-button-small uk-margin-small-bottom" data-action="build-docker">
               {{ t('action_build_image') }}
             </button>
           </div>


### PR DESCRIPTION
## Summary
- allow tenant toolbar buttons to wrap on small screens for better mobile layout

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f3832438832b9b5e86ac0d236414