### PR TITLE
Add SQLite schema and cross-database migration support

### DIFF
--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -57,7 +57,10 @@ class Database
     public static function connectWithSchema(string $schema): PDO
     {
         $pdo = self::connectFromEnv();
-        $pdo->exec('SET search_path TO ' . $pdo->quote($schema));
+        if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
+            $pdo->exec('SET search_path TO ' . $pdo->quote($schema));
+        }
+
         return $pdo;
     }
 }

--- a/src/Infrastructure/Migrations/Migrator.php
+++ b/src/Infrastructure/Migrations/Migrator.php
@@ -16,6 +16,22 @@ class Migrator
         $files = glob(rtrim($dir, '/') . '/*.sql');
         sort($files);
         $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'sqlite') {
+            $schema = __DIR__ . '/sqlite-schema.sql';
+            $sql = file_get_contents($schema);
+            if ($sql !== false) {
+                $pdo->exec($sql);
+            }
+            foreach ($files as $file) {
+                $version = basename($file);
+                $ins = $pdo->prepare('INSERT OR IGNORE INTO migrations(version) VALUES(?)');
+                $ins->execute([$version]);
+            }
+
+            return;
+        }
+
         foreach ($files as $file) {
             $version = basename($file);
             if (in_array($version, $applied, true)) {

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -1,0 +1,285 @@
+-- SQLite schema for tests
+-- This script sets up the database schema in a SQLite-compatible way
+
+CREATE TABLE IF NOT EXISTS migrations (
+    version TEXT PRIMARY KEY
+);
+
+-- Events
+CREATE TABLE IF NOT EXISTS events (
+    uid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
+    description TEXT,
+    published BOOLEAN NOT NULL DEFAULT FALSE,
+    sort_order INTEGER NOT NULL DEFAULT 0
+);
+
+-- Config
+CREATE TABLE IF NOT EXISTS config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    displayErrorDetails BOOLEAN,
+    QRUser BOOLEAN,
+    logoPath TEXT,
+    pageTitle TEXT,
+    backgroundColor TEXT,
+    buttonColor TEXT,
+    CheckAnswerButton TEXT,
+    QRRestrict BOOLEAN,
+    randomNames BOOLEAN DEFAULT TRUE,
+    competitionMode BOOLEAN,
+    teamResults BOOLEAN,
+    photoUpload BOOLEAN,
+    puzzleWordEnabled BOOLEAN,
+    puzzleWord TEXT,
+    puzzleFeedback TEXT,
+    inviteText TEXT,
+    qrremember BOOLEAN DEFAULT FALSE,
+    event_uid TEXT,
+    qrLabelLine1 TEXT,
+    qrLabelLine2 TEXT,
+    qrLogoPath TEXT,
+    qrRoundMode TEXT,
+    qrLogoPunchout BOOLEAN,
+    qrRounded BOOLEAN,
+    qrColorTeam TEXT,
+    qrColorCatalog TEXT,
+    qrColorEvent TEXT,
+    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
+);
+
+-- Settings
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+INSERT OR IGNORE INTO settings(key, value) VALUES('home_page', 'help');
+INSERT OR IGNORE INTO settings(key, value) VALUES('registration_enabled', '0');
+
+-- Teams
+CREATE TABLE IF NOT EXISTS teams (
+    sort_order INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    uid TEXT PRIMARY KEY,
+    event_uid TEXT,
+    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE,
+    UNIQUE(event_uid, sort_order)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_name ON teams(name);
+
+-- Results
+CREATE TABLE IF NOT EXISTS results (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    catalog TEXT NOT NULL,
+    attempt INTEGER NOT NULL,
+    correct INTEGER NOT NULL,
+    answer_text TEXT,
+    consent BOOLEAN,
+    total INTEGER NOT NULL,
+    time INTEGER NOT NULL,
+    puzzleTime INTEGER,
+    photo TEXT,
+    event_uid TEXT,
+    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_results_catalog ON results(catalog);
+CREATE INDEX IF NOT EXISTS idx_results_name ON results(name);
+
+-- Question results
+CREATE TABLE IF NOT EXISTS question_results (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    catalog TEXT NOT NULL,
+    question_id INTEGER NOT NULL,
+    attempt INTEGER NOT NULL,
+    correct INTEGER NOT NULL,
+    answer_text TEXT,
+    photo TEXT,
+    consent BOOLEAN,
+    event_uid TEXT,
+    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_qresults_catalog ON question_results(catalog);
+CREATE INDEX IF NOT EXISTS idx_qresults_name ON question_results(name);
+CREATE INDEX IF NOT EXISTS idx_qresults_question ON question_results(question_id);
+
+-- Catalogs
+CREATE TABLE IF NOT EXISTS catalogs (
+    uid TEXT PRIMARY KEY,
+    sort_order INTEGER NOT NULL,
+    slug TEXT UNIQUE NOT NULL,
+    file TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    raetsel_buchstabe TEXT,
+    comment TEXT,
+    design_path TEXT,
+    event_uid TEXT,
+    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE,
+    UNIQUE(event_uid, sort_order)
+);
+
+-- Questions
+CREATE TABLE IF NOT EXISTS questions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    catalog_uid TEXT NOT NULL,
+    sort_order INTEGER,
+    type TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    options TEXT DEFAULT '{}',
+    answers TEXT DEFAULT '[]',
+    terms TEXT DEFAULT '{}',
+    items TEXT DEFAULT '{}',
+    FOREIGN KEY (catalog_uid) REFERENCES catalogs(uid) ON DELETE CASCADE,
+    UNIQUE(catalog_uid, sort_order)
+);
+CREATE INDEX IF NOT EXISTS idx_questions_catalog ON questions(catalog_uid);
+
+-- Photo consents
+CREATE TABLE IF NOT EXISTS photo_consents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    team TEXT NOT NULL,
+    time INTEGER NOT NULL,
+    event_uid TEXT,
+    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_photo_consents_team ON photo_consents(team);
+
+-- Summary photos
+CREATE TABLE IF NOT EXISTS summary_photos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    path TEXT NOT NULL,
+    time INTEGER NOT NULL,
+    event_uid TEXT,
+    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_summary_photos_name ON summary_photos(name);
+
+-- Users
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL,
+    email TEXT UNIQUE,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    role TEXT NOT NULL DEFAULT 'catalog-editor'
+);
+
+-- User sessions
+CREATE TABLE IF NOT EXISTS user_sessions (
+    user_id INTEGER NOT NULL,
+    session_id TEXT PRIMARY KEY,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Password resets
+CREATE TABLE IF NOT EXISTS password_resets (
+    user_id INTEGER NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    expires_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Tenants
+CREATE TABLE IF NOT EXISTS tenants (
+    uid TEXT PRIMARY KEY,
+    subdomain TEXT UNIQUE NOT NULL,
+    plan TEXT,
+    billing_info TEXT,
+    stripe_customer_id TEXT,
+    stripe_subscription_id TEXT,
+    stripe_price_id TEXT,
+    stripe_status TEXT,
+    stripe_current_period_end TEXT,
+    stripe_cancel_at_period_end BOOLEAN,
+    imprint_name TEXT,
+    imprint_street TEXT,
+    imprint_zip TEXT,
+    imprint_city TEXT,
+    imprint_email TEXT,
+    custom_limits TEXT,
+    plan_started_at TEXT,
+    plan_expires_at TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Active event
+CREATE TABLE IF NOT EXISTS active_event (
+    event_uid TEXT PRIMARY KEY,
+    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
+);
+
+-- Audit log
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    action TEXT NOT NULL,
+    context TEXT DEFAULT '{}' NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs(action);
+
+-- Email confirmations
+CREATE TABLE IF NOT EXISTS email_confirmations (
+    email TEXT NOT NULL,
+    token TEXT NOT NULL,
+    confirmed INTEGER NOT NULL DEFAULT 0,
+    expires_at TEXT NOT NULL,
+    UNIQUE(token),
+    UNIQUE(email)
+);
+
+-- Invitations
+CREATE TABLE IF NOT EXISTS invitations (
+    email TEXT NOT NULL,
+    token TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    UNIQUE(token),
+    UNIQUE(email)
+);
+
+-- Pages
+CREATE TABLE IF NOT EXISTS pages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Page SEO config
+CREATE TABLE IF NOT EXISTS page_seo_config (
+    page_id INTEGER PRIMARY KEY REFERENCES pages(id) ON DELETE CASCADE,
+    meta_title TEXT,
+    meta_description TEXT,
+    slug TEXT UNIQUE NOT NULL,
+    canonical_url TEXT,
+    robots_meta TEXT,
+    og_title TEXT,
+    og_description TEXT,
+    og_image TEXT,
+    schema_json TEXT,
+    hreflang TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_page_seo_config_slug ON page_seo_config(slug);
+
+CREATE TABLE IF NOT EXISTS page_seo_config_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+    meta_title TEXT,
+    meta_description TEXT,
+    slug TEXT,
+    canonical_url TEXT,
+    robots_meta TEXT,
+    og_title TEXT,
+    og_description TEXT,
+    og_image TEXT,
+    schema_json TEXT,
+    hreflang TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- Add SQLite-compatible schema for tests with default settings
- Detect SQLite driver in Migrator and load dedicated schema
- Avoid running `SET search_path` on non-PostgreSQL connections

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-error` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f38b1e44832b835691d89239721e