### PR TITLE
Add back link from onboarding to landing page

### DIFF
--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -86,7 +86,11 @@
 {% block body_class %}uk-padding{% endblock %}
 
 {% block body %}
-  {% embed 'topbar.twig' %}{% endembed %}
+  {% embed 'topbar.twig' %}
+    {% block left %}
+      <a href="{{ basePath }}/landing" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+    {% endblock %}
+  {% endembed %}
   <div class="uk-container uk-margin-large-top">
     {% if stripe_error %}
       <div class="uk-alert-danger" uk-alert>


### PR DESCRIPTION
## Summary
- add navigation link on onboarding page to return to landing

## Testing
- `vendor/bin/phpunit` *(fails: Slim Application Error)*
- `pytest tests/test_html_validity.py::TestHTMLValidity::test_onboarding_html_is_valid -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab70aa06b8832b8ac79335d2809b21