### PR TITLE
Handle password reset validation errors gracefully

### DIFF
--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -126,7 +126,20 @@ class PasswordResetController
             || ($repeat !== '' && $repeat !== $pass)
             || !$this->policy->validate($pass)
         ) {
-            return $response->withStatus(400);
+            $view = Twig::fromRequest($request);
+            $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
+            $_SESSION['csrf_token'] = $csrf;
+
+            return $view->render(
+                $response->withStatus(400),
+                'password_confirm.twig',
+                [
+                    'error'      => true,
+                    'token'      => $token,
+                    'csrf_token' => $csrf,
+                    'next'       => $next,
+                ]
+            );
         }
 
         $userId = $this->resets->consumeToken($token);

--- a/tests/Controller/PasswordResetFlowTest.php
+++ b/tests/Controller/PasswordResetFlowTest.php
@@ -152,6 +152,8 @@ class PasswordResetFlowTest extends TestCase
             ]);
         $resp2 = $app->handle($confirm);
         $this->assertSame(400, $resp2->getStatusCode());
+        $body = (string) $resp2->getBody();
+        $this->assertStringContainsString('Passwort konnte nicht geändert werden.', $body);
 
         $updated = $userService->getByUsername('alice');
         $this->assertIsArray($updated);
@@ -216,6 +218,8 @@ class PasswordResetFlowTest extends TestCase
             ]);
         $resp2 = $app->handle($confirm);
         $this->assertSame(400, $resp2->getStatusCode());
+        $body = (string) $resp2->getBody();
+        $this->assertStringContainsString('Passwort konnte nicht geändert werden.', $body);
 
         $updated = $userService->getByUsername('alice');
         $this->assertIsArray($updated);


### PR DESCRIPTION
## Summary
- Render the password reset form again with an error when the new password fails validation
- Verify that weak or mismatched passwords show an error message during the reset flow

## Testing
- `vendor/bin/phpunit tests/Controller/PasswordResetFlowTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*
- `vendor/bin/phpcs src/Controller/PasswordResetController.php tests/Controller/PasswordResetFlowTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68ab8f7a4c54832b9f9086478b74ea06