### PR TITLE
Require password repeat when resetting password

### DIFF
--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -30,6 +30,10 @@
           <div class="uk-alert-success" uk-alert>
             <p>Passwort erfolgreich geändert.</p>
           </div>
+          {% elseif mismatch %}
+          <div class="uk-alert-danger" uk-alert>
+            <p>Passwörter stimmen nicht überein.</p>
+          </div>
           {% elseif error %}
           <div class="uk-alert-danger" uk-alert>
             <p>Passwort konnte nicht geändert werden.</p>

--- a/tests/Controller/PasswordResetFlowTest.php
+++ b/tests/Controller/PasswordResetFlowTest.php
@@ -79,6 +79,7 @@ class PasswordResetFlowTest extends TestCase
             ->withParsedBody([
                 'token' => $token,
                 'password' => 'Str0ngPass1',
+                'password_repeat' => 'Str0ngPass1',
                 'csrf_token' => 'tok',
             ]);
         $_POST['csrf_token'] = 'tok';
@@ -150,6 +151,7 @@ class PasswordResetFlowTest extends TestCase
             ->withParsedBody([
                 'token' => $token,
                 'password' => 'weak',
+                'password_repeat' => 'weak',
                 'csrf_token' => 'tok',
             ]);
         $_POST['csrf_token'] = 'tok';
@@ -225,7 +227,74 @@ class PasswordResetFlowTest extends TestCase
         $_POST = [];
         $this->assertSame(400, $resp2->getStatusCode());
         $body = (string) $resp2->getBody();
-        $this->assertStringContainsString('Passwort konnte nicht geändert werden.', $body);
+        $this->assertStringContainsString('Passwörter stimmen nicht überein.', $body);
+
+        $updated = $userService->getByUsername('alice');
+        $this->assertIsArray($updated);
+        $this->assertTrue(password_verify('oldpass', (string)$updated['password']));
+    }
+
+    public function testRejectMissingPasswordRepeat(): void
+    {
+        putenv('PASSWORD_RESET_SECRET=secret');
+        $_ENV['PASSWORD_RESET_SECRET'] = 'secret';
+        putenv('POSTGRES_DSN=');
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        unset($_ENV['POSTGRES_DSN'], $_ENV['POSTGRES_USER'], $_ENV['POSTGRES_PASSWORD']);
+        $app = $this->getAppInstance();
+        $pdo = Database::connectFromEnv();
+        Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        try {
+            $pdo->exec(
+                'CREATE TABLE password_resets(' .
+                'user_id INTEGER NOT NULL, token_hash TEXT NOT NULL, expires_at TEXT NOT NULL)'
+            );
+        } catch (\PDOException $e) {
+        }
+        $userService = new UserService($pdo);
+        $userService->create('alice', 'oldpass', 'alice@example.com', Roles::ADMIN);
+
+        $mailer = new class extends MailService
+        {
+            public array $sent = [];
+
+            public function __construct()
+            {
+            }
+
+            public function sendPasswordReset(string $to, string $link): void
+            {
+                $this->sent[] = ['to' => $to, 'link' => $link];
+            }
+        };
+
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+        $request = $this->createRequest('POST', '/password/reset/request')
+            ->withAttribute('mailService', $mailer)
+            ->withParsedBody(['username' => 'alice', 'csrf_token' => 'tok']);
+        $response = $app->handle($request);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertCount(1, $mailer->sent);
+
+        $link = $mailer->sent[0]['link'];
+        $pos = strrpos($link, 'token=');
+        $token = $pos === false ? '' : substr($link, $pos + 6);
+        $this->assertNotSame('', $token, 'Token not found in link: ' . $link);
+
+        $confirm = $this->createRequest('POST', '/password/reset/confirm')
+            ->withParsedBody([
+                'token' => $token,
+                'password' => 'Str0ngPass1',
+                'csrf_token' => 'tok',
+            ]);
+        $_POST['csrf_token'] = 'tok';
+        $resp2 = $app->handle($confirm);
+        $_POST = [];
+        $this->assertSame(400, $resp2->getStatusCode());
+        $body = (string) $resp2->getBody();
+        $this->assertStringContainsString('Passwörter stimmen nicht überein.', $body);
 
         $updated = $userService->getByUsername('alice');
         $this->assertIsArray($updated);


### PR DESCRIPTION
## Summary
- Require `password_repeat` in PasswordResetController and trim before comparison
- Display mismatch error when repeated password is missing or differs
- Update password reset flow tests for new requirement and add coverage for missing repeat

## Testing
- `vendor/bin/phpunit tests/Controller/PasswordResetFlowTest.php`
- `vendor/bin/phpcs src/Controller/PasswordResetController.php tests/Controller/PasswordResetFlowTest.php`
- `vendor/bin/phpstan analyse src/Controller/PasswordResetController.php`
- `vendor/bin/phpstan analyse tests/Controller/PasswordResetFlowTest.php`
- `vendor/bin/phpunit` *(fails: 27 errors, 11 failures, Warnings 5, PHPUnit Deprecations 3)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0d519bb4832b83670af5a13c4460