### PR TITLE
fix: ensure page content respects dynamic topbar height

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -152,12 +152,13 @@ body.uk-padding {
   top: 0;
   left: 0;
   right: 0;
-  height: 56px;
+  min-height: 56px;
   padding: 0 0.5rem;
   box-sizing: border-box;
   z-index: 1000;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .topbar .uk-navbar-left,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -39,4 +39,21 @@ document.addEventListener('DOMContentLoaded', function () {
       localStorage.setItem('highContrast', hc ? 'true' : 'false');
     });
   }
+
+  const topbar = document.querySelector('.topbar');
+  const navPlaceholder = document.querySelector('.nav-placeholder');
+
+  function updateNavPlaceholder() {
+    if (navPlaceholder && topbar) {
+      let height = topbar.offsetHeight;
+      const headerBar = document.querySelector('.event-header-bar');
+      if (headerBar) {
+        height += headerBar.offsetHeight;
+      }
+      navPlaceholder.style.height = height + 'px';
+    }
+  }
+
+  updateNavPlaceholder();
+  window.addEventListener('resize', updateNavPlaceholder);
 });


### PR DESCRIPTION
## Summary
- allow topbar to wrap and grow with content
- update nav placeholder height via script so page content starts below multi-line topbar

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2171989c832b908102e12b5f36a8