### PR TITLE
Fix admin topbar overlap when event selector loads

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1707,6 +1707,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const sel = eventSelect.options[eventSelect.selectedIndex];
       btnSpan.textContent = sel ? sel.textContent : '';
     }
+    window.dispatchEvent(new Event('resize'));
   }
 
   function setActiveEvent(uid, name) {


### PR DESCRIPTION
## Summary
- ensure topbar placeholder recalculates after event selector updates to avoid overlapping headings on mobile

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables and Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3b8cbff0832ba2767de2cc734eaa