### PR TITLE
Remove Vivid Vision prefix from landing page heading

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -201,7 +201,7 @@
 <section id="vivid-vision" class="uk-section uk-section-muted">
   <div class="uk-container">
     <div class="uk-text-center uk-margin-medium-bottom">
-      <h2 class="uk-heading-line"><span>Vivid Vision: So fühlt sich Ihr Event mit QuizRace an</span></h2>
+      <h2 class="uk-heading-line"><span>So fühlt sich Ihr Event mit QuizRace an</span></h2>
       <p class="uk-text-lead">
         In unter einer Stunde vom Login zur Siegerehrung – ohne App, datensicher, mit Live-Spannung.
         Jede Organisation erhält ihre eigene Instanz für maximale Kontrolle und Compliance.


### PR DESCRIPTION
## Summary
- clean up landing page by dropping "Vivid Vision:" prefix from section heading

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars, Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68adf23dafbc832b80f83d225c49c7eb