### PR TITLE
Open demo links in new tab

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -18,7 +18,7 @@
         <div class="separator width-100 bottom-border border-2px border-color-gray-light margin-top-bottom-30px uk-width-1-2@s" uk-scrollspy="cls: uk-animation-fade; delay: 250"></div>
         <div class="hero-buttons uk-margin-top" uk-scrollspy="cls: uk-animation-scale-up; delay: 300">
           <a class="cta-main" href="{{ basePath }}/onboarding">Event starten</a>
-          <a class="btn btn-black" href="{{ basePath }}/kataloge">Demo anschauen</a>
+          <a class="btn btn-black" href="https://demo.quizrace.app" target="_blank" rel="noopener">Demo anschauen</a>
         </div>
       </div>
       <div>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -310,7 +310,7 @@
         </ul>
       {% endblock %}
       {% block right %}
-        <a class="top-cta" href="{{ basePath }}/onboarding">Jetzt testen</a>
+        <a class="top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt testen</a>
       {% endblock %}
       {% block offcanvas %}
       <div id="offcanvas-nav" uk-offcanvas="overlay: true">


### PR DESCRIPTION
## Summary
- Ensure landing page demo button opens demo.quizrace.app in a new tab
- Update top navigation CTA to launch the demo in a separate window

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, database error)*

------
https://chatgpt.com/codex/tasks/task_e_68adf2cbc3d4832ba966d247cdeab515