### PR TITLE
Fix dark mode background for short pages

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -1,4 +1,5 @@
 /* Zusätzliche Styles für Dark Mode */
+html.dark-mode,
 body.dark-mode {
   background-color: #000 !important;
   color: #f5f5f5;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const isDark = localStorage.getItem('darkMode') === 'true';
     if (isDark) {
       document.body.classList.add('dark-mode', 'uk-light');
+      document.documentElement.classList.add('dark-mode');
       // show sun icon when dark mode is active
       themeToggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
     } else {
@@ -16,6 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
     UIkit.icon(themeToggle);
     themeToggle.addEventListener('click', function () {
       const dark = document.body.classList.toggle('dark-mode');
+      document.documentElement.classList.toggle('dark-mode', dark);
       document.body.classList.toggle('uk-light', dark);
       if (dark) {
         localStorage.setItem('darkMode', 'true');


### PR DESCRIPTION
## Summary
- Add `dark-mode` class to `<html>` element when toggling theme
- Style `html.dark-mode` so viewport background turns black

## Testing
- `composer test` *(fails: Missing STRIPE_* env variables and Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68adedb0eda8832b85f4cc500692c797