### PR TITLE
Ensure full-page dark mode coverage

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -1,4 +1,5 @@
 /* Zusätzliche Styles für Dark Mode */
+html.dark-mode,
 body.dark-mode {
   background-color: #000 !important;
   color: #f5f5f5;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const isDark = localStorage.getItem('darkMode') === 'true';
     if (isDark) {
       document.body.classList.add('dark-mode', 'uk-light');
+      document.documentElement.classList.add('dark-mode');
       // show sun icon when dark mode is active
       themeToggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
     } else {
@@ -16,6 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
     UIkit.icon(themeToggle);
     themeToggle.addEventListener('click', function () {
       const dark = document.body.classList.toggle('dark-mode');
+      document.documentElement.classList.toggle('dark-mode', dark);
       document.body.classList.toggle('uk-light', dark);
       if (dark) {
         localStorage.setItem('darkMode', 'true');


### PR DESCRIPTION
## Summary
- extend dark mode toggle to apply `dark-mode` class on the `<html>` element
- dark stylesheet also styles `html.dark-mode` for full-page dark background

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0f9d5e00832ba5afb5f34d237da4