### PR TITLE
Handle safe area for notched devices

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -91,6 +91,7 @@ body.dark-mode .tab-card {
 body.dark-mode .topbar {
   background-color: #1e1e1e;
   border-color: #444;
+  padding-top: env(safe-area-inset-top);
 }
 body.dark-mode .event-header-bar {
   background-color: #1e1e1e;
@@ -109,7 +110,7 @@ body.dark-mode .uk-icon-button {
 body.dark-mode .site-footer {
   background-color: #1e1e1e;
   border-color: #444;
-  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: calc(1rem + env(safe-area-inset-bottom));
 }
 
 body.dark-mode .uk-icon-button {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -154,6 +154,7 @@ body.uk-padding {
   right: 0;
   min-height: 56px;
   padding: 0 0.5rem;
+  padding-top: env(safe-area-inset-top);
   box-sizing: border-box;
   z-index: 1000;
   display: flex;


### PR DESCRIPTION
## Summary
- Add safe-area top padding to main and dark topbars
- Respect safe-area bottom padding in dark-mode footer

## Testing
- `composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae132f6f9c832bb3ba72c0744dbdc0