### PR TITLE
Handle missing Stripe webhook secret

### DIFF
--- a/src/Controller/StripeWebhookController.php
+++ b/src/Controller/StripeWebhookController.php
@@ -21,12 +21,15 @@ class StripeWebhookController
         $sigHeader = $request->getHeaderLine('Stripe-Signature');
         $webhookSecret = getenv('STRIPE_WEBHOOK_SECRET') ?: '';
 
-        if ($webhookSecret !== '') {
-            try {
-                Webhook::constructEvent($payload, $sigHeader, $webhookSecret);
-            } catch (\UnexpectedValueException | \Stripe\Exception\SignatureVerificationException) {
-                return $response->withStatus(400);
-            }
+        if ($webhookSecret === '') {
+            error_log('Missing STRIPE_WEBHOOK_SECRET environment variable');
+            return $response->withStatus(500);
+        }
+
+        try {
+            Webhook::constructEvent($payload, $sigHeader, $webhookSecret);
+        } catch (\UnexpectedValueException | \Stripe\Exception\SignatureVerificationException) {
+            return $response->withStatus(400);
         }
 
         $data = json_decode($payload, true);


### PR DESCRIPTION
## Summary
- return HTTP 500 and log when STRIPE_WEBHOOK_SECRET is missing
- compute signatures in Stripe webhook tests and add coverage for missing secret

## Testing
- `vendor/bin/phpunit tests/Controller/StripeWebhookControllerTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Stripe configuration, Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae12fff094832badb88ab4df23fb68