### PR TITLE
Sync Stripe subscription when plan changes

### DIFF
--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -211,6 +211,47 @@ class StripeService
     }
 
     /**
+     * Update the price of the first subscription for the given customer.
+     */
+    public function updateSubscriptionForCustomer(string $customerId, string $priceId): void
+    {
+        $subs = $this->client->subscriptions->all([
+            'customer' => $customerId,
+            'limit' => 1,
+        ]);
+        $sub = $subs->data[0] ?? null;
+        if ($sub === null) {
+            throw new \RuntimeException('subscription-not-found');
+        }
+        $itemId = $sub->items->data[0]->id ?? null;
+        if ($itemId === null) {
+            throw new \RuntimeException('subscription-item-not-found');
+        }
+        $this->client->subscriptions->update((string) $sub->id, [
+            'items' => [
+                ['id' => $itemId, 'price' => $priceId],
+            ],
+            'cancel_at_period_end' => false,
+        ]);
+    }
+
+    /**
+     * Cancel the first subscription for the given customer.
+     */
+    public function cancelSubscriptionForCustomer(string $customerId): void
+    {
+        $subs = $this->client->subscriptions->all([
+            'customer' => $customerId,
+            'limit' => 1,
+        ]);
+        $sub = $subs->data[0] ?? null;
+        if ($sub === null) {
+            return;
+        }
+        $this->client->subscriptions->cancel((string) $sub->id, []);
+    }
+
+    /**
      * Retrieve a list of invoices for a customer.
      *
      * @return array<int, array{

--- a/tests/Service/StripeServiceStub.php
+++ b/tests/Service/StripeServiceStub.php
@@ -2,8 +2,14 @@
 
 namespace App\Service;
 
+if (class_exists(__NAMESPACE__ . '\\StripeService')) {
+    return;
+}
+
 class StripeService
 {
+    public static array $calls = [];
+
     public function __construct()
     {
     }
@@ -16,6 +22,16 @@ class StripeService
     public function createCustomer(string $email, ?string $name = null): string
     {
         return 'cus_test';
+    }
+
+    public function updateSubscriptionForCustomer(string $customerId, string $priceId): void
+    {
+        self::$calls[] = ['update', $customerId, $priceId];
+    }
+
+    public function cancelSubscriptionForCustomer(string $customerId): void
+    {
+        self::$calls[] = ['cancel', $customerId];
     }
 
     public static function isConfigured(): array


### PR DESCRIPTION
## Summary
- Update subscription toggle route to modify or cancel Stripe subscriptions before saving the new plan
- Add StripeService helpers for updating and canceling customer subscriptions
- Add integration test verifying Stripe API is called on plan change

## Testing
- `vendor/bin/phpunit --filter testStripeApiCalledOnPlanChange tests/Controller/AdminControllerTest.php`
- `vendor/bin/phpunit --filter testSetSubscriptionPlanAllowsDowngrade tests/Controller/AdminControllerTest.php`
- `vendor/bin/phpunit` *(fails: numerous environment-related errors, suite aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ae13045054832ba2d0c180e8e74fde