### PR TITLE
feat: increase icon button tap size

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -140,6 +140,11 @@ body.uk-padding {
   padding: 4px;
 }
 
+.uk-icon-button {
+  width: 44px;
+  height: 44px;
+}
+
 .result-slide {
   position: absolute;
   width: 100%;


### PR DESCRIPTION
## Summary
- set `.uk-icon-button` size to 44px for larger tap targets
- reviewed templates using `uk-icon-button`; no markup changes required

## Testing
- `vendor/bin/phpcs src/`
- `vendor/bin/phpstan analyse src/`
- `./vendor/bin/phpunit` *(fails: database locked, missing STRIPE_* env)*

------
https://chatgpt.com/codex/tasks/task_e_68ae14a3afac832bb548b3b9a6c9003e