### PR TITLE
feat: enable automatic dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Mit dieser App zeigen wir, was heute schon möglich ist, wenn Menschen und versc
 
 - **Flexibel einsetzbar**: Fragenkataloge im JSON-Format lassen sich bequem austauschen oder erweitern.
 - **Sechs Fragetypen**: Sortieren, Zuordnen, Multiple Choice, Swipe-Karten, Foto mit Texteingabe und "Hätten Sie es gewusst?"-Karten bieten Abwechslung f\u00fcr jede Zielgruppe.
-- **QR-Code-Login & Dunkelmodus**: Optionaler QR-Code-Login für schnelles Anmelden und ein zuschaltbares dunkles Design steigern den Komfort.
+- **QR-Code-Login & Dunkelmodus**: Optionaler QR-Code-Login für schnelles Anmelden und ein dunkles Design, das sich automatisch der Systemeinstellung anpasst oder manuell umgeschaltet werden kann, steigern den Komfort.
 - **Persistente Speicherung**: Konfigurationen, Kataloge und Ergebnisse liegen in einer PostgreSQL-Datenbank.
 - **Mandantenverwaltung**: Tenant-Daten werden über PostgreSQL-Schemata isoliert; SQLite wird nicht unterstützt.
 
@@ -423,7 +423,7 @@ Das Frontend bringt mehrere Funktionen mit, die die Nutzung erleichtern:
 - Ausführliche ARIA-Beschriftungen auf Bedienelementen und Formularfeldern.
 - Tastatursteuerung für Sortier- und Zuordnungsfragen samt versteckten Hinweisen.
 - Fortschrittsbalken mit `aria-valuenow` und Live-Ansage der aktuellen Frage.
-- Umschaltbarer Dunkel- und Hochkontrastmodus.
+- Automatische Dark-Mode-Erkennung sowie umschaltbarer Dunkel- und Hochkontrastmodus.
 
 
 ## Anwenderhandbuch

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -1,4 +1,244 @@
 /* Zusätzliche Styles für Dark Mode */
+@media (prefers-color-scheme: dark) {
+html,
+body {
+  background-color: #000 !important;
+  color: #f5f5f5;
+}
+body a {
+  color: #9dc6ff;
+}
+body h1,
+body h2,
+body h3,
+body h4,
+body h5,
+body h6 {
+  color: #f5f5f5;
+}
+body .uk-card-title {
+  color: #f5f5f5;
+}
+body .uk-card-default {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+body .uk-card-default a {
+  color: #9dc6ff;
+}
+body .uk-card h3,
+body .uk-card p {
+  color: #f5f5f5;
+}
+body .uk-progress {
+  background-color: #333;
+  color: #1e87f0;
+}
+body .uk-button-primary {
+  background-color: #1e87f0;
+  border-color: #1e87f0;
+}
+body .uk-button,
+body .uk-button-default {
+  color: #fff;
+  background-color: #333;
+  border-color: #555;
+}
+body input,
+body textarea,
+body select {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+  border-color: #555;
+}
+body .sortable-list li,
+body .terms li,
+body .dropzone,
+body .mc-option {
+  background-color: #1e1e1e;
+  border-color: #444;
+  color: #f5f5f5;
+  font-size: 1rem;
+  padding: 16px;
+  white-space: normal;
+}
+body .dropzone.over {
+  background-color: #2a2a2a;
+}
+body .uk-alert-success {
+  background-color: #145214;
+  color: #fff;
+}
+body .uk-alert-danger {
+  background-color: #5a1a1a;
+  color: #fff;
+}
+body .uk-alert-primary {
+  background-color: #003366;
+  color: #fff;
+}
+
+body .mc-option input {
+  transform: scale(1.3);
+  margin-right: 8px;
+}
+
+/* Einheitlicher Kartenrahmen fuer Admin-Tabs im Dunkelmodus */
+body .tab-card {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+
+body .topbar {
+  background-color: #1e1e1e;
+  border-color: #444;
+  padding-top: env(safe-area-inset-top);
+}
+body .event-header-bar {
+  background-color: #1e1e1e;
+  border-color: #444;
+}
+
+body .modern-info-card {
+  border-color: #444;
+}
+
+body .uk-icon,
+body .uk-icon-button {
+  color: #f5f5f5;
+}
+
+body .site-footer {
+  background-color: #1e1e1e;
+  border-color: #444;
+  padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+}
+
+body .uk-icon-button {
+  color: #fff;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Active state for navigation items in dark off-canvas menus */
+.uk-offcanvas-bar .uk-nav-default > li.uk-active > a {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+/* Active state for navigation items in dark mode */
+body .uk-navbar-nav > li.uk-active > a,
+body .uk-nav-default > li.uk-active > a {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+/* Styles for Trumbowyg editor in Dark Mode */
+body .trumbowyg-box,
+body .trumbowyg-editor {
+  background-color: #1e1e1e !important;
+  color: #f5f5f5 !important;
+}
+
+body .trumbowyg-button-pane {
+  background-color: #2a2a2a;
+  border-color: #444;
+}
+
+body .trumbowyg-button-pane button {
+  color: #f5f5f5;
+}
+
+body .trumbowyg-button-pane button svg {
+  fill: #f5f5f5;
+}
+
+body .trumbowyg-button-pane button:hover {
+  background-color: #333;
+}
+
+/* Styles fuer QR-Scan-Popup im Dunkelmodus */
+body .uk-modal-dialog {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+
+/* Hoverfarbe für Katalogkarten im Dunkelmodus */
+body .uk-card-hover:hover {
+  background-color: #333;
+  color: #f5f5f5;
+}
+
+/* Tabellenlesbarkeit im Dunkelmodus verbessern */
+body .uk-table th,
+body .uk-table td {
+  color: #f5f5f5;
+  background-color: #1e1e1e;
+  border-color: #444;
+}
+body .uk-table thead th {
+  background-color: #333;
+}
+body .uk-table tr {
+  border-color: #444;
+}
+
+@media (min-width: 640px) {
+  body .sortable-list li,
+  body .terms li,
+  body .dropzone,
+  body .mc-option {
+    font-size: 1.3rem;
+  }
+}
+
+@media (min-width: 960px) {
+  body .sortable-list li,
+  body .terms li,
+  body .dropzone,
+  body .mc-option {
+    font-size: 1.5rem;
+  }
+body .mc-option input {
+  transform: scale(1.3);
+}
+}
+
+body .flip-card-front,
+body .flip-card-back {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+  border: 1px solid #444;
+}
+
+/* FAQ page elements in Dark Mode */
+body .uk-heading-divider {
+  border-bottom-color: #444;
+  color: #f5f5f5;
+}
+
+body .uk-heading-bullet {
+  color: #f5f5f5;
+}
+
+body .uk-heading-bullet::before {
+  border-color: #444;
+}
+
+body .uk-accordion-title {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+
+body .uk-accordion-title::before {
+  filter: invert(1);
+}
+
+body .uk-accordion-content {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+}
+
 html.dark-mode,
 body.dark-mode {
   background-color: #000 !important;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3,17 +3,16 @@ document.addEventListener('DOMContentLoaded', function () {
   const themeToggle = document.getElementById('theme-toggle');
   const contrastToggle = document.getElementById('contrast-toggle');
 
+  const storedTheme = localStorage.getItem('darkMode');
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const isDark = storedTheme === 'true' || (storedTheme === null && prefersDark);
+  if (isDark) {
+    document.body.classList.add('dark-mode', 'uk-light');
+    document.documentElement.classList.add('dark-mode');
+  }
+
   if (themeToggle) {
-    const isDark = localStorage.getItem('darkMode') === 'true';
-    if (isDark) {
-      document.body.classList.add('dark-mode', 'uk-light');
-      document.documentElement.classList.add('dark-mode');
-      // show sun icon when dark mode is active
-      themeToggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
-    } else {
-      // show moon icon when light mode is active
-      themeToggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
-    }
+    themeToggle.setAttribute('uk-icon', isDark ? 'icon: sun; ratio: 2' : 'icon: moon; ratio: 2');
     UIkit.icon(themeToggle);
     themeToggle.addEventListener('click', function () {
       const dark = document.body.classList.toggle('dark-mode');


### PR DESCRIPTION
## Summary
- add `@media (prefers-color-scheme: dark)` to apply dark theme automatically
- detect system dark preference on startup via `window.matchMedia`
- document automatic theme selection in README

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ae14e033e4832b8110ffb29ae0ce84