### PR TITLE
feat: defer template scripts

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -50,17 +50,17 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/custom-icons.js"></script>
-  <script src="https://unpkg.com/html5-qrcode@2.3.7/html5-qrcode.min.js"></script>
+  <script src="{{ basePath }}/js/custom-icons.js" defer></script>
+  <script src="https://unpkg.com/html5-qrcode@2.3.7/html5-qrcode.min.js" defer></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
   </script>
   <script id="catalogs-data" type="application/json">
     {{ catalogs|json_encode|raw }}
   </script>
-  <script src="{{ basePath }}/js/catalog.js"></script>
-  <script src="{{ basePath }}/js/confetti.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-  <script src="{{ basePath }}/js/quiz.js"></script>
-  <script src="{{ basePath }}/js/app.js"></script>
+  <script src="{{ basePath }}/js/catalog.js" defer></script>
+  <script src="{{ basePath }}/js/confetti.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js" defer></script>
+  <script src="{{ basePath }}/js/quiz.js" defer></script>
+  <script src="{{ basePath }}/js/app.js" defer></script>
 {% endblock %}

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -56,10 +56,10 @@
       </nav>
     </footer>
   </div>
-  <script src="{{ basePath }}/js/uikit.min.js"></script>
-  <script src="{{ basePath }}/js/uikit-icons.min.js"></script>
+  <script src="{{ basePath }}/js/uikit.min.js" defer></script>
+  <script src="{{ basePath }}/js/uikit-icons.min.js" defer></script>
   <script>window.basePath = '{{ basePath }}';</script>
-  <script src="{{ basePath }}/js/i18n/{{ locale() == 'en' ? 'en-us' : 'de-de' }}.js"></script>
+  <script src="{{ basePath }}/js/i18n/{{ locale() == 'en' ? 'en-us' : 'de-de' }}.js" defer></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `defer` to layout scripts to avoid blocking render
- load index page libraries with `defer`

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*
- `lighthouse public/index.html --output=json --quiet --chrome-flags="--headless --no-sandbox"` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable no older than Chrome stable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1dfa51fc832bb54ba2528456677a