### PR TITLE
Handle missing Stripe webhook secret

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -559,7 +559,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                         'standard' => getenv($prefix . 'PRICE_STANDARD') ?: '',
                         'professional' => getenv($prefix . 'PRICE_PROFESSIONAL') ?: '',
                     ];
-                    $priceId = $map[$plan] ?? '';
+                    $priceId = $map[$plan];
                     if ($priceId === '') {
                         throw new \RuntimeException('price-id-missing');
                     }


### PR DESCRIPTION
## Summary
- return 500 and log when STRIPE_WEBHOOK_SECRET is missing
- sign Stripe webhook test payloads and cover missing secret
- tidy subscription route price lookup for static analysis

## Testing
- `vendor/bin/phpcs src/Controller/StripeWebhookController.php src/routes.php tests/Controller/StripeWebhookControllerTest.php`
- `vendor/bin/phpstan analyse src/ --no-progress`
- `./vendor/bin/phpunit tests/Controller/StripeWebhookControllerTest.php`
- `./vendor/bin/phpunit --stop-on-failure` *(fails: PDOException: UNIQUE constraint failed: tenants.uid)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1eb34254832bb3003e77a016732d