### PR TITLE
Refactor admin lists with responsive grid layout

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -718,26 +718,31 @@ body.admin-page {
 #eventsTable thead {
   display: none;
 }
-#eventsList,
-#eventsList tr,
-#eventsList td {
+#eventsList {
   display: block;
 }
 #eventsList tr {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.25rem;
   border: 1px solid #ddd;
   border-radius: 8px;
   padding: 0.5rem;
   margin-bottom: 0.75rem;
-  position: relative;
 }
 #eventsList td {
-  padding: 8px 0;
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
 }
-#eventsList td:first-child {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  display: block;
+#eventsList td::before {
+  content: attr(data-label);
+  flex: 0 0 8ch;
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+#eventsList td:first-child::before {
+  content: '';
 }
 #eventsList input[type="text"],
 #eventsList input[type="datetime-local"] {
@@ -758,17 +763,13 @@ body.admin-page {
     border-radius: 0;
     padding: 0;
     margin-bottom: 0;
-    position: static;
   }
   #eventsList td {
     display: table-cell;
     padding: 12px 4px;
   }
-  #eventsList td:first-child {
-    position: static;
-    top: auto;
-    right: auto;
-    display: table-cell;
+  #eventsList td::before {
+    content: none;
   }
   #eventsList input[type="text"],
   #eventsList input[type="datetime-local"] {
@@ -791,26 +792,31 @@ body.admin-page {
 #catalogTable thead {
   display: none;
 }
-#catalogList,
-#catalogList tr,
-#catalogList td {
+#catalogList {
   display: block;
 }
 #catalogList tr {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.25rem;
   border: 1px solid #ddd;
   border-radius: 8px;
   padding: 0.5rem;
   margin-bottom: 0.75rem;
-  position: relative;
 }
 #catalogList td {
+  display: flex;
+  align-items: center;
   padding: 4px 0;
 }
-#catalogList td:first-child {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  display: block;
+#catalogList td::before {
+  content: attr(data-label);
+  flex: 0 0 8ch;
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+#catalogList td:first-child::before {
+  content: '';
 }
 #catalogList input[type="text"] {
   width: 100%;
@@ -829,17 +835,13 @@ body.admin-page {
     border-radius: 0;
     padding: 0;
     margin-bottom: 0;
-    position: static;
   }
   #catalogList td {
     display: table-cell;
     padding: 8px 4px;
   }
-  #catalogList td:first-child {
-    position: static;
-    top: auto;
-    right: auto;
-    display: table-cell;
+  #catalogList td::before {
+    content: none;
   }
   #catalogList input[type="text"] {
     width: auto;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -783,6 +783,7 @@ document.addEventListener('DOMContentLoaded', function () {
   function createCatalogRow(cat) {
     const row = document.createElement('tr');
     row.className = 'catalog-row';
+    row.setAttribute('role', 'row');
     if (cat.new) row.dataset.new = 'true';
     row.dataset.sortOrder = cat.sort_order !== undefined ? String(cat.sort_order) : '';
     row.dataset.slug = cat.slug || '';
@@ -792,8 +793,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const rowId = 'cat-' + catalogRowIndex++;
 
+    const labels = catalogList?.dataset || {};
+
     const idCell = document.createElement('td');
+    idCell.setAttribute('role', 'cell');
+    idCell.setAttribute('data-label', labels.labelSlug || '');
     const handleCell = document.createElement('td');
+    handleCell.setAttribute('role', 'cell');
+    handleCell.setAttribute('data-label', labels.labelActions || '');
     const handleSpan = document.createElement('span');
     handleSpan.className = 'uk-sortable-handle uk-icon';
     handleSpan.setAttribute('uk-icon', 'icon: table');
@@ -808,6 +815,8 @@ document.addEventListener('DOMContentLoaded', function () {
     idCell.appendChild(idInput);
 
     const nameCell = document.createElement('td');
+    nameCell.setAttribute('role', 'cell');
+    nameCell.setAttribute('data-label', labels.labelName || '');
     const name = document.createElement('input');
     name.type = 'text';
     name.className = 'uk-input cat-name';
@@ -823,6 +832,8 @@ document.addEventListener('DOMContentLoaded', function () {
     nameCell.appendChild(name);
 
     const descCell = document.createElement('td');
+    descCell.setAttribute('role', 'cell');
+    descCell.setAttribute('data-label', labels.labelDescription || '');
     const desc = document.createElement('input');
     desc.type = 'text';
     desc.className = 'uk-input cat-desc';
@@ -832,6 +843,8 @@ document.addEventListener('DOMContentLoaded', function () {
     descCell.appendChild(desc);
 
     const letterCell = document.createElement('td');
+    letterCell.setAttribute('role', 'cell');
+    letterCell.setAttribute('data-label', labels.labelLetter || '');
     const letter = document.createElement('input');
     letter.type = 'text';
     letter.className = 'uk-input cat-letter';
@@ -842,6 +855,8 @@ document.addEventListener('DOMContentLoaded', function () {
     letterCell.appendChild(letter);
 
     const commentCell = document.createElement('td');
+    commentCell.setAttribute('role', 'cell');
+    commentCell.setAttribute('data-label', labels.labelComment || '');
     const commentBtn = document.createElement('button');
     commentBtn.className = 'uk-button uk-button-default';
     const commentField = document.createElement('input');
@@ -861,6 +876,8 @@ document.addEventListener('DOMContentLoaded', function () {
     commentCell.appendChild(commentField);
 
     const delCell = document.createElement('td');
+    delCell.setAttribute('role', 'cell');
+    delCell.setAttribute('data-label', labels.labelActions || '');
     const del = document.createElement('button');
     del.className = 'uk-icon-button uk-button-danger';
     del.setAttribute('uk-icon', 'trash');
@@ -1553,6 +1570,7 @@ document.addEventListener('DOMContentLoaded', function () {
   function createEventRow(ev = {}) {
     const row = document.createElement('tr');
     row.className = 'event-row';
+    row.setAttribute('role', 'row');
     row.dataset.uid = ev.uid || crypto.randomUUID();
     row.dataset.published = ev.published ? 'true' : 'false';
 
@@ -1560,7 +1578,11 @@ document.addEventListener('DOMContentLoaded', function () {
       row.classList.add('active-event');
     }
 
+    const labels = eventsListEl?.dataset || {};
+
     const handleCell = document.createElement('td');
+    handleCell.setAttribute('role', 'cell');
+    handleCell.setAttribute('data-label', labels.labelActions || '');
     const handleSpan = document.createElement('span');
     handleSpan.className = 'uk-sortable-handle uk-icon';
     handleSpan.setAttribute('uk-icon', 'icon: table');
@@ -1568,9 +1590,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const indexCell = document.createElement('td');
     indexCell.className = 'row-num';
+    indexCell.setAttribute('role', 'cell');
+    indexCell.setAttribute('data-label', labels.labelNumber || '');
     indexCell.textContent = '';
 
     const nameCell = document.createElement('td');
+    nameCell.setAttribute('role', 'cell');
+    nameCell.setAttribute('data-label', labels.labelName || '');
     const nameInput = document.createElement('input');
     nameInput.type = 'text';
     nameInput.className = 'uk-input event-name';
@@ -1579,6 +1605,8 @@ document.addEventListener('DOMContentLoaded', function () {
     nameCell.appendChild(nameInput);
 
     const startCell = document.createElement('td');
+    startCell.setAttribute('role', 'cell');
+    startCell.setAttribute('data-label', labels.labelStart || '');
     const startWrapper = document.createElement('div');
     startWrapper.className = 'uk-inline';
     const startIcon = document.createElement('span');
@@ -1595,6 +1623,8 @@ document.addEventListener('DOMContentLoaded', function () {
     startCell.appendChild(startWrapper);
 
     const endCell = document.createElement('td');
+    endCell.setAttribute('role', 'cell');
+    endCell.setAttribute('data-label', labels.labelEnd || '');
     const endWrapper = document.createElement('div');
     endWrapper.className = 'uk-inline';
     const endIcon = document.createElement('span');
@@ -1610,6 +1640,8 @@ document.addEventListener('DOMContentLoaded', function () {
     endCell.appendChild(endWrapper);
 
     const descCell = document.createElement('td');
+    descCell.setAttribute('role', 'cell');
+    descCell.setAttribute('data-label', labels.labelDescription || '');
     const descInput = document.createElement('input');
     descInput.type = 'text';
     descInput.className = 'uk-input event-desc';
@@ -1618,6 +1650,8 @@ document.addEventListener('DOMContentLoaded', function () {
     descCell.appendChild(descInput);
 
     const activateCell = document.createElement('td');
+    activateCell.setAttribute('role', 'cell');
+    activateCell.setAttribute('data-label', labels.labelActive || '');
     const activateLabel = document.createElement('label');
     activateLabel.className = 'switch';
     activateLabel.setAttribute('uk-tooltip', 'title: Aktivieren; pos: top');
@@ -1640,6 +1674,8 @@ document.addEventListener('DOMContentLoaded', function () {
     activateCell.appendChild(activateLabel);
 
     const delCell = document.createElement('td');
+    delCell.setAttribute('role', 'cell');
+    delCell.setAttribute('data-label', labels.labelActions || '');
     const del = document.createElement('button');
     del.className = 'uk-icon-button uk-button-danger';
     del.setAttribute('uk-icon', 'trash');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -192,7 +192,7 @@
         <h2 class="uk-heading-bullet">{{ t('heading_events') }}</h2>
         <p class="uk-hidden">Professionelles Quiz-Hosting</p>
         <div class="uk-overflow-auto">
-          <table id="eventsTable" class="uk-table uk-table-divider uk-table-small">
+          <table id="eventsTable" class="uk-table uk-table-divider uk-table-small" role="table" aria-label="{{ t('heading_events') }}">
             <thead class="table-headings">
               <tr>
                 <th><span uk-icon="icon: question" uk-tooltip="title: {{ t('tip_sort_rows') }}; pos: top"></span></th>
@@ -205,7 +205,15 @@
                 <th><span uk-icon="icon: question" uk-tooltip="title: {{ t('tip_event_remove') }}; pos: top"></span></th>
               </tr>
             </thead>
-            <tbody id="eventsList" uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
+            <tbody id="eventsList" role="rowgroup"
+              data-label-number="{{ t('column_number') }}"
+              data-label-name="{{ t('column_name') }}"
+              data-label-start="{{ t('column_start') }}"
+              data-label-end="{{ t('column_end') }}"
+              data-label-description="{{ t('column_description') }}"
+              data-label-active="{{ t('column_active') }}"
+              data-label-actions="{{ t('column_actions') }}"
+              uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
           </table>
         </div>
         <div class="uk-margin">
@@ -403,7 +411,7 @@
         <div>
           <h2 class="uk-heading-bullet">{{ t('heading_catalogs') }}</h2>
           <div class="uk-overflow-auto">
-          <table id="catalogTable" class="uk-table uk-table-divider uk-table-small">
+          <table id="catalogTable" class="uk-table uk-table-divider uk-table-small" role="table" aria-label="{{ t('heading_catalogs') }}">
             <thead class="table-headings">
               <tr>
                 <th>
@@ -429,7 +437,14 @@
                   </th>
               </tr>
             </thead>
-            <tbody id="catalogList" uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
+            <tbody id="catalogList" role="rowgroup"
+              data-label-slug="{{ t('column_slug') }}"
+              data-label-name="{{ t('column_name') }}"
+              data-label-description="{{ t('column_description') }}"
+              data-label-letter="{{ t('column_letter') }}"
+              data-label-comment="{{ t('column_comment') }}"
+              data-label-actions="{{ t('column_actions') }}"
+              uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
           </table>
         </div>
         <div class="uk-margin">

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -28,7 +28,7 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-large">
-    <div class="uk-grid-match uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m" uk-grid>
+    <div class="uk-grid-match uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m" uk-grid aria-label="Veranstaltungsliste">
       {% for ev in events %}
       <div>
         <div class="uk-card uk-card-default uk-card-hover">

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -6,12 +6,12 @@
 {% block content %}
 <div class="uk-container uk-container-large">
     <div>
-        <h2 class="uk-heading-bullet">Kataloge</h2>
+        <h2 id="catalogs-heading" class="uk-heading-bullet">Kataloge</h2>
         <div class="uk-margin">
             <button class="uk-button uk-button-primary">Neuer Katalog</button>
         </div>
 
-        <div class="uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid>
+        <div class="uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid aria-labelledby="catalogs-heading">
             {% for katalog in kataloge %}
             <div>
                 <div class="uk-card uk-card-default uk-card-hover uk-card-body custom-card uk-margin-small-bottom">


### PR DESCRIPTION
## Summary
- replace events and catalogs tables with mobile-friendly CSS grid layout
- expose column headers via `data-label` and ARIA roles for better accessibility
- add ARIA labels to event and catalog overview grids

## Testing
- `npx -y @axe-core/cli file://$PWD/templates/events_overview.twig` *(no output)*
- `composer test` *(missing STRIPE keys, tests incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e3fa00c832b8818081e10eb1349