### PR TITLE
Fix light mode toggle by disabling dark stylesheet

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2,10 +2,16 @@
 document.addEventListener('DOMContentLoaded', function () {
   const themeToggle = document.getElementById('theme-toggle');
   const contrastToggle = document.getElementById('contrast-toggle');
+  const darkStylesheet = document.querySelector('link[href$="dark.css"]');
 
   const storedTheme = localStorage.getItem('darkMode');
   const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   const isDark = storedTheme === 'true' || (storedTheme === null && prefersDark);
+
+  if (darkStylesheet) {
+    darkStylesheet.disabled = !isDark;
+  }
+
   if (isDark) {
     document.body.classList.add('dark-mode', 'uk-light');
     document.documentElement.classList.add('dark-mode');
@@ -18,6 +24,9 @@ document.addEventListener('DOMContentLoaded', function () {
       const dark = document.body.classList.toggle('dark-mode');
       document.documentElement.classList.toggle('dark-mode', dark);
       document.body.classList.toggle('uk-light', dark);
+      if (darkStylesheet) {
+        darkStylesheet.disabled = !dark;
+      }
       if (dark) {
         localStorage.setItem('darkMode', 'true');
         themeToggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');


### PR DESCRIPTION
## Summary
- Ensure the dark stylesheet is disabled when light mode is active
- Toggle dark stylesheet alongside theme changes so light mode works again

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py` *(no output)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js` *(fails: Required code blocks not found)*
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2a6917dc832b9db74ee67bf97fc4