### PR TITLE
Fix active menu item visibility in light mode

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -242,6 +242,7 @@ body.uk-padding {
   background: var(--uk-background-muted, #f8f8f8);
   border-radius: 6px;
   font-weight: 600;
+  color: #222;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- Ensure active sidebar menu items display dark text in light mode

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables, Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2d0157d4832baa6f4d9b96b7a36e