### PR TITLE
Add CSRF token handling for events overview

### DIFF
--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -3,6 +3,7 @@
 {% block title %}Veranstaltungen{% endblock %}
 
 {% block head %}
+  <meta name="csrf-token" content="{{ csrf_token }}">
   <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">


### PR DESCRIPTION
## Summary
- add CSRF meta tag to events overview template
- include CSRF token and error handling in events.js
- provide clipboard fallback notification

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2dd23568832ba3f6b53b40a2a4c3