### PR TITLE
Add button types for event overview actions

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -980,4 +980,9 @@ body.admin-page {
   display: block;
 }
 
+/* Spacing for consecutive event action buttons */
+.event-action + .event-action {
+  margin-left: 0.5rem;
+}
+
 

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -40,11 +40,11 @@
           </div>
           <div class="uk-card-footer">
             {% if role in ['admin','event-manager'] %}
-            <button class="uk-button uk-button-primary toggle-publish" data-uid="{{ ev.uid }}" data-published="{{ ev.published ? 'true' : 'false' }}">
+            <button type="button" class="uk-button uk-button-primary event-action toggle-publish" data-uid="{{ ev.uid }}" data-published="{{ ev.published ? 'true' : 'false' }}">
               {{ ev.published ? 'Nicht veröffentlichen' : 'Veröffentlichen' }}
             </button>
             {% endif %}
-            <button class="uk-button uk-button-default copy-link" data-link="{{ basePath }}/?event={{ ev.uid }}">Link kopieren</button>
+            <button type="button" class="uk-button uk-button-default event-action copy-link" data-link="{{ basePath }}/?event={{ ev.uid }}">Link kopieren</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ensure event action buttons have explicit `type="button"`
- add common `event-action` class with spacing

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2dec908c832b8c95155f7f40a637