### PR TITLE
style: lighten site footer

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -111,7 +111,12 @@ body .uk-icon-button {
 body .site-footer {
   background-color: #1e1e1e;
   border-color: #444;
+  color: #f5f5f5;
   padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+}
+
+body .footer-menu a {
+  color: #9dc6ff;
 }
 
 body .uk-icon-button {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -44,8 +44,8 @@ body.uk-padding {
 }
 
 .site-footer {
-  background-color: #222;
-  color: #fff;
+  background-color: #f5f5f5;
+  color: #222;
   padding: 1rem;
   text-align: center;
 }
@@ -60,7 +60,7 @@ body.uk-padding {
 }
 
 .footer-menu a {
-  color: #fff;
+  color: #222;
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- lighten footer colors for light theme
- add dark mode overrides for footer and links

## Testing
- `composer test` (fails: Missing STRIPE_SECRET_KEY and other configuration, Slim Application Error)`

------
https://chatgpt.com/codex/tasks/task_e_68ae2e04f59c832bb6819e5fff18d992