### PR TITLE
Remove inline dark mode scripts from legal templates

### DIFF
--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -35,25 +35,4 @@
 {% block scripts %}
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function(){
-      const toggle = document.getElementById('theme-toggle');
-      const isDark = localStorage.getItem('darkMode') === 'true';
-      if(isDark){
-        document.body.classList.add('dark-mode','uk-light');
-        if(toggle) toggle.checked = true;
-      }
-      if(toggle){
-        toggle.addEventListener('change', function(){
-          if(this.checked){
-            document.body.classList.add('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'true');
-          } else {
-            document.body.classList.remove('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'false');
-          }
-        });
-      }
-    });
-  </script>
 {% endblock %}

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -35,25 +35,4 @@
 {% block scripts %}
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function(){
-      const toggle = document.getElementById('theme-toggle');
-      const isDark = localStorage.getItem('darkMode') === 'true';
-      if(isDark){
-        document.body.classList.add('dark-mode','uk-light');
-        if(toggle) toggle.checked = true;
-      }
-      if(toggle){
-        toggle.addEventListener('change', function(){
-          if(this.checked){
-            document.body.classList.add('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'true');
-          } else {
-            document.body.classList.remove('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'false');
-          }
-        });
-      }
-    });
-  </script>
 {% endblock %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -35,25 +35,4 @@
 {% block scripts %}
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function(){
-      const toggle = document.getElementById('theme-toggle');
-      const isDark = localStorage.getItem('darkMode') === 'true';
-      if(isDark){
-        document.body.classList.add('dark-mode','uk-light');
-        if(toggle) toggle.checked = true;
-      }
-      if(toggle){
-        toggle.addEventListener('change', function(){
-          if(this.checked){
-            document.body.classList.add('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'true');
-          } else {
-            document.body.classList.remove('dark-mode','uk-light');
-            localStorage.setItem('darkMode', 'false');
-          }
-        });
-      }
-    });
-  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove obsolete inline theme toggle scripts from legal templates
- ensure dark mode toggling handled solely by public/js/app.js

## Testing
- `vendor/bin/phpcs src/`
- `vendor/bin/phpstan analyse src/`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_* env vars, database errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2dc23958832b80a1b4942b1e8a69