### PR TITLE
Move dark mode CSS rules to dedicated file

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -103,6 +103,34 @@ body .modern-info-card {
   border-color: #444;
 }
 
+/* Sticky actions and onboarding components in Dark Mode */
+body .sticky-actions {
+  background: rgba(0, 0, 0, 0.95);
+}
+
+body .onboarding-step {
+  border-color: #444;
+  background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
+  box-shadow: 0 6px 30px rgba(0,0,0,0.5);
+}
+
+body .onboarding-timeline .timeline-step {
+  border-color: #555;
+  color: #aaa;
+}
+
+body .onboarding-timeline .timeline-step.inactive {
+  color: #444;
+  border-color: #555;
+  cursor: not-allowed;
+}
+
+body .onboarding-timeline .timeline-step.active,
+body .onboarding-timeline .timeline-step.completed {
+  border-color: #1e87f0;
+  color: #1e87f0;
+}
+
 body .uk-icon,
 body .uk-icon-button {
   color: #f5f5f5;
@@ -349,6 +377,34 @@ body.dark-mode .event-header-bar {
 
 body.dark-mode .modern-info-card {
   border-color: #444;
+}
+
+/* Sticky actions and onboarding components in Dark Mode */
+body.dark-mode .sticky-actions {
+  background: rgba(0, 0, 0, 0.95);
+}
+
+body.dark-mode .onboarding-step {
+  border-color: #444;
+  background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
+  box-shadow: 0 6px 30px rgba(0,0,0,0.5);
+}
+
+body.dark-mode .onboarding-timeline .timeline-step {
+  border-color: #555;
+  color: #aaa;
+}
+
+body.dark-mode .onboarding-timeline .timeline-step.inactive {
+  color: #444;
+  border-color: #555;
+  cursor: not-allowed;
+}
+
+body.dark-mode .onboarding-timeline .timeline-step.active,
+body.dark-mode .onboarding-timeline .timeline-step.completed {
+  border-color: #1e87f0;
+  color: #1e87f0;
 }
 
 body.dark-mode .uk-icon,

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -304,10 +304,6 @@ a.uk-accordion-title {
   padding-bottom: 8px;
 }
 
-body.dark-mode .sticky-actions {
-  background: rgba(0, 0, 0, 0.95);
-}
-
 /* Vorschau innerhalb der Fragekarte */
 .question-preview {
   min-height: 100px;
@@ -483,12 +479,6 @@ body.dark-mode .sticky-actions {
   background: linear-gradient(135deg, #ffffff 0%, #fafafa 100%);
 }
 
-body.dark-mode .onboarding-step {
-  border-color: #444;
-  background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
-  box-shadow: 0 6px 30px rgba(0,0,0,0.5);
-}
-
 /* Timeline for onboarding steps */
 .onboarding-timeline {
   list-style: none;
@@ -520,23 +510,6 @@ body.dark-mode .onboarding-step {
 .onboarding-timeline .timeline-step.completed {
   border-color: #0c86d0;
   color: #0c86d0;
-}
-
-body.dark-mode .onboarding-timeline .timeline-step {
-  border-color: #555;
-  color: #aaa;
-}
-
-body.dark-mode .onboarding-timeline .timeline-step.inactive {
-  color: #444;
-  border-color: #555;
-  cursor: not-allowed;
-}
-
-body.dark-mode .onboarding-timeline .timeline-step.active,
-body.dark-mode .onboarding-timeline .timeline-step.completed {
-  border-color: #1e87f0;
-  color: #1e87f0;
 }
 
 


### PR DESCRIPTION
## Summary
- Remove `body.dark-mode` style blocks from `main.css`
- Add corresponding dark mode styles for sticky actions and onboarding components in `dark.css`

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js` *(fails: Required code blocks not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2fb6fcd0832ba7a69a76c154db31