### PR TITLE
Ensure main CSS loads before dark theme across templates

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -4,8 +4,8 @@
 
 {% block head %}
   <meta name="csrf-token" content="{{ csrf_token }}">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/ui/trumbowyg.min.css">
   <script src="https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js"></script>

--- a/templates/admin/landingpage/edit.html.twig
+++ b/templates/admin/landingpage/edit.html.twig
@@ -3,8 +3,8 @@
 {% block title %}Landingpage bearbeiten{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -4,8 +4,8 @@
 
 {% block head %}
   <meta http-equiv="refresh" content="5">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/admin/pages/edit.twig
+++ b/templates/admin/pages/edit.twig
@@ -3,8 +3,8 @@
 {% block title %}Seite bearbeiten{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/ui/trumbowyg.min.css">
   <script src="https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js"></script>

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -3,8 +3,8 @@
 {% block title %}Datenschutz{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -4,8 +4,8 @@
 
 {% block head %}
   <meta name="csrf-token" content="{{ csrf_token }}">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -3,8 +3,8 @@
 {% block title %}FAQ{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -3,8 +3,8 @@
 {% block title %}{{ t('title_help') }}{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -3,8 +3,8 @@
 {% block title %}Impressum{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -3,8 +3,8 @@
 {% block title %}{{ config.pageTitle|default('Modernes Quiz mit UIkit') }}{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
 {% endblock %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -3,8 +3,8 @@
 {% block title %}Lizenz{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -3,8 +3,8 @@
 {% block title %}Login{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -3,8 +3,8 @@
 {% block title %}Onboarding{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <style>
     .btn {

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -3,8 +3,8 @@
 {% block title %}Neues Passwort{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -3,8 +3,8 @@
 {% block title %}Passwort zurücksetzen{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/register.twig
+++ b/templates/register.twig
@@ -3,8 +3,8 @@
 {% block title %}Registrieren{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -3,8 +3,8 @@
 {% block title %}Auswertung{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Load `main.css` before `dark.css` in events overview and all other Twig templates
- Keep high-contrast stylesheet last for proper override behavior

## Testing
- `node -e "const fs=require('fs');const dark=fs.readFileSync('public/css/dark.css','utf8');const main=fs.readFileSync('public/css/main.css','utf8');console.log('dark.css length',dark.length);console.log('main.css length',main.length);console.log('dark has body background #000',/background-color:\s*#000\s*!important/.test(dark));console.log('main has body background #000',/body\s*{[^}]*background-color:\s*#000/.test(main));"`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2fbc9ff0832b9d9889e24d561aea