### PR TITLE
Fix missing moon icon on initial admin login

### DIFF
--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -33,6 +33,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -31,6 +31,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -35,8 +35,8 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
     (function(){

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -33,6 +33,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -33,6 +33,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -76,6 +76,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -68,8 +68,8 @@
 {% endblock %}
 
   {% block scripts %}
-    <script src="{{ basePath }}/js/app.js"></script>
     <script src="{{ basePath }}/js/custom-icons.js"></script>
+    <script src="{{ basePath }}/js/app.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', function () {
         const form = document.querySelector('form');

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -55,6 +55,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}

--- a/templates/register.twig
+++ b/templates/register.twig
@@ -76,6 +76,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure custom icons are loaded before app script so moon icon renders on first load
- reorder script tags across templates

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ae311c7b74832b8902695c182928d0