### PR TITLE
Add top margin to event selector label

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -573,6 +573,11 @@ body.admin-page {
   flex: 1;
 }
 
+.admin-page #eventSelectWrap button > span:first-child {
+  display: block;
+  margin-top: 4px;
+}
+
 .admin-page .nav-placeholder {
   height: 112px;
 }


### PR DESCRIPTION
## Summary
- add small top margin to event name in admin event switcher to improve spacing

## Testing
- `composer test` *(fails: Missing STRIPE environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68ae332862e4832b9a751a82009fb25d