### PR TITLE
Integrate logs overview into admin UI and display log files

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -206,6 +206,7 @@ return [
     'text_no_catalogs' => 'Keine Kataloge',
     'text_no_data' => 'Keine Daten',
     'text_no_backups' => 'Keine Backups',
+    'text_no_logs' => 'Keine Logeinträge',
     'action_create_backup' => 'Backup erstellen',
     'action_restore_demo' => 'Demodaten wiederherstellen',
     'action_save_demo' => 'Als neue Demodaten speichern',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -208,6 +208,7 @@ return [
     'text_no_catalogs' => 'No catalogs',
     'text_no_data' => 'No data',
     'text_no_backups' => 'No backups',
+    'text_no_logs' => 'No log entries',
     'action_create_backup' => 'Create backup',
     'action_restore_demo' => 'Restore demo data',
     'action_save_demo' => 'Save as new demo data',

--- a/src/Controller/AdminLogsController.php
+++ b/src/Controller/AdminLogsController.php
@@ -19,9 +19,16 @@ class AdminLogsController
         $appLog = LogService::tail('app');
         $stripeLog = LogService::tail('stripe');
         $view = Twig::fromRequest($request);
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $role = $_SESSION['user']['role'] ?? '';
         return $view->render($response, 'admin/logs.twig', [
             'appLog' => $appLog,
             'stripeLog' => $stripeLog,
+            'role' => $role,
+            'currentPath' => $request->getUri()->getPath(),
+            'domainType' => $request->getAttribute('domainType'),
         ]);
     }
 }

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -9,14 +9,59 @@
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 
-{% block body_class %}uk-background-muted uk-padding{% endblock %}
+{% block body_class %}uk-background-muted uk-padding admin-page{% endblock %}
 
 {% block body %}
-  <div class="uk-container uk-container-expand">
-    <h1 class="uk-heading-bullet">{{ t('heading_logs') }}</h1>
+  {% embed 'topbar.twig' %}
+    {% block left %}
+      <a class="uk-navbar-toggle uk-hidden@m" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+        <span uk-navbar-toggle-icon></span>
+      </a>
+      <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">
+        QuizRace Admin
+      </a>
+    {% endblock %}
+    {% block right %}
+      <div class="theme-switch">
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="{{ t('design_toggle') }}"></button>
+      </div>
+      <div class="contrast-switch uk-margin-small-left">
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="{{ t('contrast_toggle') }}"></button>
+      </div>
+    {% endblock %}
+    {% block offcanvas %}
+      <div id="qr-offcanvas" uk-offcanvas="overlay: true">
+        <div class="uk-offcanvas-bar">
+          <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
+          <h3 class="uk-margin-small">QuizRace</h3>
+          {% include 'admin/_nav.twig' %}
+        </div>
+      </div>
+    {% endblock %}
+    {% block nav_placeholder %}
+      <div class="nav-placeholder">
+        <div class="uk-container uk-container-large">
+          <h2 class="uk-heading-bullet">{{ t('heading_logs') }}</h2>
+        </div>
+      </div>
+    {% endblock %}
+  {% endembed %}
+  <div class="uk-container uk-container-expand uk-margin">
     <h2>app.log</h2>
-    <pre class="uk-text-small">{{ appLog|e }}</pre>
+    {% if appLog %}
+      <pre class="uk-text-small">{{ appLog|e }}</pre>
+    {% else %}
+      <p class="uk-text-muted">{{ t('text_no_logs') }}</p>
+    {% endif %}
     <h2>stripe.log</h2>
-    <pre class="uk-text-small">{{ stripeLog|e }}</pre>
+    {% if stripeLog %}
+      <pre class="uk-text-small">{{ stripeLog|e }}</pre>
+    {% else %}
+      <p class="uk-text-muted">{{ t('text_no_logs') }}</p>
+    {% endif %}
   </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Embed logs page in admin interface with navigation and theming
- Load log file content with fallback text when no entries exist
- Add translations for missing log message and pass role/path context

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ae36378908832ba016b19e36d56d9d