### PR TITLE
Display subdomain validation feedback inline

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const emailStatus = document.getElementById('emailStatus');
   const subdomainInput = document.getElementById('subdomain');
   const subdomainPreview = document.getElementById('subdomainPreview');
+  const subdomainStatus = document.getElementById('subdomainStatus');
   const saveSubdomainBtn = document.getElementById('saveSubdomain');
   const planButtons = document.querySelectorAll('.plan-select');
   const verifiedHint = document.getElementById('verifiedHint');
@@ -136,31 +137,58 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  if (saveSubdomainBtn) {
-    saveSubdomainBtn.addEventListener('click', async () => {
-      const subdomain = subdomainInput.value.trim().toLowerCase();
-      if (!subdomain) return;
-      if (!isValidSubdomain(subdomain)) {
-        alert('Ungültige Subdomain.');
-        return;
-      }
-      const res = await fetch(withBase('/tenants/' + encodeURIComponent(subdomain)), {
-        credentials: 'same-origin',
-        headers: { 'X-Requested-With': 'fetch' }
+    if (saveSubdomainBtn) {
+      saveSubdomainBtn.addEventListener('click', async () => {
+        const subdomain = subdomainInput.value.trim().toLowerCase();
+        if (!subdomain) return;
+        if (subdomainStatus) {
+          subdomainStatus.textContent = '';
+          subdomainStatus.hidden = true;
+          subdomainStatus.classList.remove('uk-text-danger', 'uk-text-success');
+        }
+        subdomainInput.classList.remove('uk-form-danger', 'uk-form-success');
+        if (!isValidSubdomain(subdomain)) {
+          if (subdomainStatus) {
+            subdomainStatus.textContent = 'Ungültige Subdomain.';
+            subdomainStatus.classList.add('uk-text-danger');
+            subdomainStatus.hidden = false;
+          }
+          subdomainInput.classList.add('uk-form-danger');
+          return;
+        }
+        const res = await fetch(withBase('/tenants/' + encodeURIComponent(subdomain)), {
+          credentials: 'same-origin',
+          headers: { 'X-Requested-With': 'fetch' }
+        });
+        if (res.ok) {
+          if (subdomainStatus) {
+            subdomainStatus.textContent = 'Subdomain bereits vergeben.';
+            subdomainStatus.classList.add('uk-text-danger');
+            subdomainStatus.hidden = false;
+          }
+          subdomainInput.classList.add('uk-form-danger');
+          return;
+        }
+        if (res.status !== 404) {
+          if (subdomainStatus) {
+            subdomainStatus.textContent = 'Fehler bei der Prüfung der Subdomain.';
+            subdomainStatus.classList.add('uk-text-danger');
+            subdomainStatus.hidden = false;
+          }
+          subdomainInput.classList.add('uk-form-danger');
+          return;
+        }
+        if (subdomainStatus) {
+          subdomainStatus.textContent = 'Subdomain verfügbar.';
+          subdomainStatus.classList.add('uk-text-success');
+          subdomainStatus.hidden = false;
+        }
+        subdomainInput.classList.add('uk-form-success');
+        localStorage.setItem('onboard_subdomain', subdomain);
+        subdomainStored = subdomain;
+        showStep(3);
       });
-      if (res.ok) {
-        alert('Subdomain bereits vergeben.');
-        return;
-      }
-      if (res.status !== 404) {
-        alert('Fehler bei der Prüfung der Subdomain.');
-        return;
-      }
-      localStorage.setItem('onboard_subdomain', subdomain);
-      subdomainStored = subdomain;
-      showStep(3);
-    });
-  }
+    }
 
   if (saveImprintBtn) {
     saveImprintBtn.addEventListener('click', () => {

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -144,6 +144,7 @@
       </div>
       <div class="uk-margin">
         <input id="subdomain" class="uk-input" type="text" placeholder="gewünschte Subdomain" required>
+        <div id="subdomainStatus" class="uk-margin-small-top" hidden></div>
         <div class="uk-margin-small-top uk-text-meta">Die vollständige Adresse lautet: <span id="subdomainPreview"></span>.{{ main_domain }}</div>
       </div>
       <p>Gib eine gewünschte Subdomain ein (z.&nbsp;B. <code>meine-seite</code>) und bestätige mit der Schaltfläche. Wir prüfen die Verfügbarkeit und reservieren sie für dich.</p>


### PR DESCRIPTION
## Summary
- show subdomain availability status below input
- validate subdomain without alerts, toggling UIkit form classes

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET, Slim Application Error, Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68ae38ea5150832b8c2b2f3e50033449