### PR TITLE
Add label and length validation for subdomain field

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function isValidSubdomain(subdomain) {
-    return /^[a-z0-9-]{3,}$/.test(subdomain);
+    return subdomain.length <= 63 && /^[a-z0-9-]{3,}$/.test(subdomain);
   }
 
   const params = new URLSearchParams(window.location.search);

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -143,7 +143,8 @@
         <p>Deine E-Mail-Adresse wurde erfolgreich bestätigt.</p>
       </div>
       <div class="uk-margin">
-        <input id="subdomain" class="uk-input" type="text" placeholder="gewünschte Subdomain" required>
+        <label for="subdomain">Subdomain</label>
+        <input id="subdomain" class="uk-input" type="text" placeholder="gewünschte Subdomain" maxlength="63" required>
         <div class="uk-margin-small-top uk-text-meta">Die vollständige Adresse lautet: <span id="subdomainPreview"></span>.{{ main_domain }}</div>
       </div>
       <p>Gib eine gewünschte Subdomain ein (z.&nbsp;B. <code>meine-seite</code>) und bestätige mit der Schaltfläche. Wir prüfen die Verfügbarkeit und reservieren sie für dich.</p>


### PR DESCRIPTION
## Summary
- Add label and maxlength attribute to subdomain input on onboarding page
- Limit subdomain length to 63 characters in client-side validation

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3905f8ec832ba7f693803de98c34