### PR TITLE
Add subdomain length limit

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function isValidSubdomain(subdomain) {
-    return /^[a-z0-9-]{3,}$/.test(subdomain);
+    return /^[a-z0-9-]{3,63}$/.test(subdomain);
   }
 
   const params = new URLSearchParams(window.location.search);

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -143,7 +143,8 @@
         <p>Deine E-Mail-Adresse wurde erfolgreich bestätigt.</p>
       </div>
       <div class="uk-margin">
-        <input id="subdomain" class="uk-input" type="text" placeholder="gewünschte Subdomain" required>
+        <label for="subdomain" class="uk-form-label">Subdomain</label>
+        <input id="subdomain" class="uk-input" type="text" placeholder="gewünschte Subdomain" maxlength="63" required>
         <div id="subdomainStatus" class="uk-margin-small-top" hidden></div>
         <div class="uk-margin-small-top uk-text-meta">Die vollständige Adresse lautet: <span id="subdomainPreview"></span>.{{ main_domain }}</div>
       </div>


### PR DESCRIPTION
## Summary
- Add label and maxlength=63 to onboarding subdomain field
- Restrict client-side subdomain validation to 63 characters

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ae951c017c832b9a220ddcdf1d9e1f