### PR TITLE
feat: add tenant color variables

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -7,9 +7,20 @@ html {
   font-size: clamp(14px, 1vw + 0.5rem, 18px);
 }
 
+:root {
+  --primary-color: #0c86d0;
+  --accent-color: #39f;
+}
+
 body {
   min-height: 100vh;
   overflow-x: hidden;
+  background-color: var(--primary-color, #ffffff);
+}
+
+.uk-button-primary {
+  background-color: var(--accent-color, #1e87f0);
+  border-color: var(--accent-color, #1e87f0);
 }
 
 .about-section {
@@ -87,7 +98,7 @@ body.uk-padding {
 }
 
 .sortable-list li:focus {
-  outline: 2px solid #39f;
+  outline: 2px solid var(--accent-color);
 }
 
 .dropzone {
@@ -103,12 +114,12 @@ body.uk-padding {
 }
 
 .dropzone.over {
-  border-color: #39f;
+  border-color: var(--accent-color);
   background: #e0f7fa;
 }
 
 .dropzone:focus {
-  border-color: #39f;
+  border-color: var(--accent-color);
   outline: none;
 }
 
@@ -502,14 +513,14 @@ a.uk-accordion-title {
 }
 
 .onboarding-timeline .timeline-step.active {
-  border-color: #0c86d0;
-  color: #0c86d0;
+  border-color: var(--primary-color);
+  color: var(--primary-color);
   font-weight: 600;
 }
 
 .onboarding-timeline .timeline-step.completed {
-  border-color: #0c86d0;
-  color: #0c86d0;
+  border-color: var(--primary-color);
+  color: var(--primary-color);
 }
 
 
@@ -673,7 +684,7 @@ body.admin-page {
   border-radius: 50%;
 }
 .switch input:checked + .slider {
-  background-color: #39f;
+  background-color: var(--accent-color);
 }
 .switch input:checked + .slider:before {
   transform: translateX(18px);
@@ -954,7 +965,7 @@ body.admin-page {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #1e87f0;
+  background: var(--primary-color);
   display: block;
 }
 

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -95,9 +95,14 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       setComment('');
       // Benutzername wird nach erfolgreichem Login ergänzt
     }
-    const styleEl = document.createElement('style');
-    styleEl.textContent = `\n      body { background-color: ${cfg.backgroundColor || '#ffffff'}; }\n      .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n    `;
-    document.head.appendChild(styleEl);
+    if(cfg.colors){
+      if(cfg.colors.primary){
+        document.documentElement.style.setProperty('--primary-color', cfg.colors.primary);
+      }
+      if(cfg.colors.accent){
+        document.documentElement.style.setProperty('--accent-color', cfg.colors.accent);
+      }
+    }
   }
 
   function updateUserName(){
@@ -212,9 +217,9 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     btn.className = 'uk-button uk-button-primary uk-button-large uk-align-right';
     btn.textContent = 'Los geht es!';
     const cfg = window.quizConfig || {};
-    if(cfg.buttonColor){
-      btn.style.backgroundColor = cfg.buttonColor;
-      btn.style.borderColor = cfg.buttonColor;
+    if(cfg.colors && cfg.colors.accent){
+      btn.style.backgroundColor = cfg.colors.accent;
+      btn.style.borderColor = cfg.colors.accent;
       btn.style.color = '#fff';
     }
     btn.addEventListener('click', () => {
@@ -353,9 +358,9 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       const scanBtn = document.createElement('button');
       scanBtn.className = 'uk-button uk-button-primary uk-width-1-1';
       scanBtn.textContent = 'Name mit QR-Code scannen';
-      if(cfg.buttonColor){
-        scanBtn.style.backgroundColor = cfg.buttonColor;
-        scanBtn.style.borderColor = cfg.buttonColor;
+      if(cfg.colors && cfg.colors.accent){
+        scanBtn.style.backgroundColor = cfg.colors.accent;
+        scanBtn.style.borderColor = cfg.colors.accent;
         scanBtn.style.color = '#fff';
       }
       let bypass;
@@ -364,9 +369,9 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
         bypass.type = 'button';
         bypass.textContent = 'Kataloge anzeigen';
         bypass.className = 'uk-button uk-button-primary uk-width-1-1';
-        if(cfg.buttonColor){
-          bypass.style.backgroundColor = cfg.buttonColor;
-          bypass.style.borderColor = cfg.buttonColor;
+        if(cfg.colors && cfg.colors.accent){
+          bypass.style.backgroundColor = cfg.colors.accent;
+          bypass.style.borderColor = cfg.colors.accent;
           bypass.style.color = '#fff';
         }
         bypass.addEventListener('click', () => {
@@ -535,9 +540,9 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
         const btn = document.createElement('button');
         btn.className = 'uk-button uk-button-primary uk-align-right';
         btn.textContent = 'Los geht es!';
-        if(cfg.buttonColor){
-          btn.style.backgroundColor = cfg.buttonColor;
-          btn.style.borderColor = cfg.buttonColor;
+        if(cfg.colors && cfg.colors.accent){
+          btn.style.backgroundColor = cfg.colors.accent;
+          btn.style.borderColor = cfg.colors.accent;
           btn.style.color = '#fff';
         }
         btn.addEventListener('click', () => {

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -134,8 +134,13 @@ async function runQuiz(questions, skipIntro){
   const basePath = window.basePath || '';
   const withBase = path => basePath + path;
   const showCheck = cfg.CheckAnswerButton !== 'no';
-  if(cfg.backgroundColor){
-    document.body.style.backgroundColor = cfg.backgroundColor;
+  if(cfg.colors){
+    if(cfg.colors.primary){
+      document.documentElement.style.setProperty('--primary-color', cfg.colors.primary);
+    }
+    if(cfg.colors.accent){
+      document.documentElement.style.setProperty('--accent-color', cfg.colors.accent);
+    }
   }
 
   const container = document.getElementById('quiz');
@@ -182,10 +187,7 @@ async function runQuiz(questions, skipIntro){
     }
   }
 
-  // konfigurierbare Farben dynamisch in ein Style-Tag schreiben
-  const styleEl = document.createElement('style');
-  styleEl.textContent = `\n    body { background-color: ${cfg.backgroundColor || '#ffffff'}; }\n    .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n  `;
-  document.head.appendChild(styleEl);
+  // Farben werden über CSS-Variablen gesetzt
 
   const headerEl = document.getElementById('quiz-header');
 
@@ -242,9 +244,9 @@ async function runQuiz(questions, skipIntro){
 
   // Wendet die konfigurierte Buttonfarbe an
   function styleButton(btn){
-    if(cfg.buttonColor){
-      btn.style.backgroundColor = cfg.buttonColor;
-      btn.style.borderColor = cfg.buttonColor;
+    if(cfg.colors && cfg.colors.accent){
+      btn.style.backgroundColor = cfg.colors.accent;
+      btn.style.borderColor = cfg.colors.accent;
       btn.style.color = '#fff';
     }
   }

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -39,11 +39,5 @@
   <script src="{{ basePath }}/js/app.js"></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
-    (function(){
-      const cfg = window.quizConfig || {};
-      const styleEl = document.createElement('style');
-      styleEl.textContent = `\n        body { background-color: ${cfg.backgroundColor || '#ffffff'}; }\n        .uk-button-primary { background-color: ${cfg.buttonColor || '#1e87f0'}; border-color: ${cfg.buttonColor || '#1e87f0'}; }\n      `;
-      document.head.appendChild(styleEl);
-    })();
   </script>
 {% endblock %}

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -40,6 +40,14 @@
   <link rel="icon" href="{{ basePath }}/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="{{ basePath }}/css/uikit.min.css">
   {% block head %}{% endblock %}
+  {% if config is defined and config.colors is defined %}
+  <style>
+    :root {
+      {% if config.colors.primary is defined %}--primary-color: {{ config.colors.primary }};{% endif %}
+      {% if config.colors.accent is defined %}--accent-color: {{ config.colors.accent }};{% endif %}
+    }
+  </style>
+  {% endif %}
 </head>
 <body class="{% block body_class %}{% endblock %}">
   <div class="wrapper">


### PR DESCRIPTION
## Summary
- introduce `--primary-color` and `--accent-color` variables and replace hardcoded hues
- allow `config.colors` to override theme colors and expose them in layout
- update quiz and catalog scripts to use new color variables

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68ae95544880832ba4f2871193583ebc