### PR TITLE
Increase top margin for event selector label

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -573,6 +573,11 @@ body.admin-page {
   flex: 1;
 }
 
+.admin-page #eventSelectWrap button > span:first-child {
+  display: block;
+  margin-top: 8px;
+}
+
 .admin-page .nav-placeholder {
   height: 112px;
 }


### PR DESCRIPTION
## Summary
- shift admin event selector text 4px further down for better vertical spacing

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ae332862e4832b9a751a82009fb25d