### PR TITLE
Add accessibility to event add button

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -638,17 +638,6 @@ body.admin-page {
   bottom: calc(8rem + env(safe-area-inset-bottom));
 }
 
-/* Hide button text on small screens */
-.button-text {
-  margin-left: 6px;
-  display: none;
-}
-@media (min-width: 640px) {
-  .button-text {
-    display: inline;
-  }
-}
-
 /* Toggle switch */
 .switch {
   position: relative;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -119,7 +119,7 @@
                       aria-label="{{ t('tip_event_add') }}"
                     >
                       <span uk-icon="plus"></span>
-                      <span class="button-text">{{ t('tip_event_add') }}</span>
+                      <span class="button-text uk-visible@s uk-margin-small-left">{{ t('tip_event_add') }}</span>
                     </a>
                   </div>
                 </div>
@@ -217,7 +217,15 @@
           </table>
         </div>
         <div class="uk-margin">
-          <button id="eventAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_event_add') }}; pos: left"></button>
+          <button
+            id="eventAddBtn"
+            class="uk-icon-button uk-button-primary fab"
+            uk-icon="plus"
+            uk-tooltip="title: {{ t('tip_event_add') }}; pos: left"
+            aria-label="{{ t('tip_event_add') }}"
+          >
+            <span class="button-text uk-visible@s uk-margin-small-left">{{ t('tip_event_add') }}</span>
+          </button>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- add screen reader label and visible text to event add button
- remove custom button-text CSS in favor of UIkit utilities

## Testing
- `composer test` *(fails: D..........EE...W.EE......FN....)*

------
https://chatgpt.com/codex/tasks/task_e_68ae99ee0eb8832b8335412319e1d054