### PR TITLE
Use inline cell labels for responsive tables

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -723,19 +723,19 @@ body.admin-page {
   padding: 0.5rem;
   margin-bottom: 0.75rem;
 }
+
+.cell-label {
+  display: block;
+}
 #eventsList td {
   display: flex;
   align-items: center;
   padding: 4px 0;
 }
-#eventsList td::before {
-  content: attr(data-label);
+#eventsList .cell-label {
   flex: 0 0 8ch;
   font-weight: 600;
   margin-right: 0.5rem;
-}
-#eventsList td:first-child::before {
-  content: '';
 }
 #eventsList input[type="text"],
 #eventsList input[type="datetime-local"] {
@@ -761,8 +761,8 @@ body.admin-page {
     display: table-cell;
     padding: 12px 4px;
   }
-  #eventsList td::before {
-    content: none;
+  .cell-label {
+    display: none;
   }
   #eventsList input[type="text"],
   #eventsList input[type="datetime-local"] {
@@ -802,14 +802,10 @@ body.admin-page {
   align-items: center;
   padding: 4px 0;
 }
-#catalogList td::before {
-  content: attr(data-label);
+#catalogList .cell-label {
   flex: 0 0 8ch;
   font-weight: 600;
   margin-right: 0.5rem;
-}
-#catalogList td:first-child::before {
-  content: '';
 }
 #catalogList input[type="text"] {
   width: 100%;
@@ -829,17 +825,14 @@ body.admin-page {
     padding: 0;
     margin-bottom: 0;
   }
-  #catalogList td {
-    display: table-cell;
-    padding: 8px 4px;
+    #catalogList td {
+      display: table-cell;
+      padding: 8px 4px;
+    }
+    #catalogList input[type="text"] {
+      width: auto;
+    }
   }
-  #catalogList td::before {
-    content: none;
-  }
-  #catalogList input[type="text"] {
-    width: auto;
-  }
-}
 
 /* Team list enhancements */
 #teamsList td {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -797,10 +797,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const idCell = document.createElement('td');
     idCell.setAttribute('role', 'cell');
-    idCell.setAttribute('data-label', labels.labelSlug || '');
+    const idLabel = document.createElement('span');
+    idLabel.className = 'cell-label uk-hidden@s';
+    idLabel.textContent = labels.labelSlug || '';
+    idCell.appendChild(idLabel);
     const handleCell = document.createElement('td');
     handleCell.setAttribute('role', 'cell');
-    handleCell.setAttribute('data-label', labels.labelActions || '');
+    const handleLabel = document.createElement('span');
+    handleLabel.className = 'cell-label uk-hidden@s';
+    handleLabel.textContent = labels.labelActions || '';
+    handleCell.appendChild(handleLabel);
     const handleSpan = document.createElement('span');
     handleSpan.className = 'uk-sortable-handle uk-icon';
     handleSpan.setAttribute('uk-icon', 'icon: table');
@@ -816,7 +822,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const nameCell = document.createElement('td');
     nameCell.setAttribute('role', 'cell');
-    nameCell.setAttribute('data-label', labels.labelName || '');
+    const nameLabel = document.createElement('span');
+    nameLabel.className = 'cell-label uk-hidden@s';
+    nameLabel.textContent = labels.labelName || '';
+    nameCell.appendChild(nameLabel);
     const name = document.createElement('input');
     name.type = 'text';
     name.className = 'uk-input cat-name';
@@ -833,7 +842,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const descCell = document.createElement('td');
     descCell.setAttribute('role', 'cell');
-    descCell.setAttribute('data-label', labels.labelDescription || '');
+    const descLabel = document.createElement('span');
+    descLabel.className = 'cell-label uk-hidden@s';
+    descLabel.textContent = labels.labelDescription || '';
+    descCell.appendChild(descLabel);
     const desc = document.createElement('input');
     desc.type = 'text';
     desc.className = 'uk-input cat-desc';
@@ -844,7 +856,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const letterCell = document.createElement('td');
     letterCell.setAttribute('role', 'cell');
-    letterCell.setAttribute('data-label', labels.labelLetter || '');
+    const letterLabel = document.createElement('span');
+    letterLabel.className = 'cell-label uk-hidden@s';
+    letterLabel.textContent = labels.labelLetter || '';
+    letterCell.appendChild(letterLabel);
     const letter = document.createElement('input');
     letter.type = 'text';
     letter.className = 'uk-input cat-letter';
@@ -856,7 +871,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const commentCell = document.createElement('td');
     commentCell.setAttribute('role', 'cell');
-    commentCell.setAttribute('data-label', labels.labelComment || '');
+    const commentLabel = document.createElement('span');
+    commentLabel.className = 'cell-label uk-hidden@s';
+    commentLabel.textContent = labels.labelComment || '';
+    commentCell.appendChild(commentLabel);
     const commentBtn = document.createElement('button');
     commentBtn.className = 'uk-button uk-button-default';
     const commentField = document.createElement('input');
@@ -877,7 +895,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const delCell = document.createElement('td');
     delCell.setAttribute('role', 'cell');
-    delCell.setAttribute('data-label', labels.labelActions || '');
+    const delLabel = document.createElement('span');
+    delLabel.className = 'cell-label uk-hidden@s';
+    delLabel.textContent = labels.labelActions || '';
+    delCell.appendChild(delLabel);
     const del = document.createElement('button');
     del.className = 'uk-icon-button uk-button-danger';
     del.setAttribute('uk-icon', 'trash');
@@ -1562,7 +1583,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function updateEventRowNumbers() {
     Array.from(eventsListEl.querySelectorAll('.event-row')).forEach((row, idx) => {
-      const cell = row.querySelector('.row-num');
+      const cell = row.querySelector('.row-num .row-number');
       if (cell) cell.textContent = idx + 1;
     });
   }
@@ -1582,7 +1603,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const handleCell = document.createElement('td');
     handleCell.setAttribute('role', 'cell');
-    handleCell.setAttribute('data-label', labels.labelActions || '');
+    const handleLabel = document.createElement('span');
+    handleLabel.className = 'cell-label uk-hidden@s';
+    handleLabel.textContent = labels.labelActions || '';
+    handleCell.appendChild(handleLabel);
     const handleSpan = document.createElement('span');
     handleSpan.className = 'uk-sortable-handle uk-icon';
     handleSpan.setAttribute('uk-icon', 'icon: table');
@@ -1591,12 +1615,20 @@ document.addEventListener('DOMContentLoaded', function () {
     const indexCell = document.createElement('td');
     indexCell.className = 'row-num';
     indexCell.setAttribute('role', 'cell');
-    indexCell.setAttribute('data-label', labels.labelNumber || '');
-    indexCell.textContent = '';
+    const indexLabel = document.createElement('span');
+    indexLabel.className = 'cell-label uk-hidden@s';
+    indexLabel.textContent = labels.labelNumber || '';
+    const indexValue = document.createElement('span');
+    indexValue.className = 'row-number';
+    indexCell.appendChild(indexLabel);
+    indexCell.appendChild(indexValue);
 
     const nameCell = document.createElement('td');
     nameCell.setAttribute('role', 'cell');
-    nameCell.setAttribute('data-label', labels.labelName || '');
+    const nameLabel = document.createElement('span');
+    nameLabel.className = 'cell-label uk-hidden@s';
+    nameLabel.textContent = labels.labelName || '';
+    nameCell.appendChild(nameLabel);
     const nameInput = document.createElement('input');
     nameInput.type = 'text';
     nameInput.className = 'uk-input event-name';
@@ -1606,7 +1638,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const startCell = document.createElement('td');
     startCell.setAttribute('role', 'cell');
-    startCell.setAttribute('data-label', labels.labelStart || '');
+    const startLabel = document.createElement('span');
+    startLabel.className = 'cell-label uk-hidden@s';
+    startLabel.textContent = labels.labelStart || '';
+    startCell.appendChild(startLabel);
     const startWrapper = document.createElement('div');
     startWrapper.className = 'uk-inline';
     const startIcon = document.createElement('span');
@@ -1624,7 +1659,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const endCell = document.createElement('td');
     endCell.setAttribute('role', 'cell');
-    endCell.setAttribute('data-label', labels.labelEnd || '');
+    const endLabel = document.createElement('span');
+    endLabel.className = 'cell-label uk-hidden@s';
+    endLabel.textContent = labels.labelEnd || '';
+    endCell.appendChild(endLabel);
     const endWrapper = document.createElement('div');
     endWrapper.className = 'uk-inline';
     const endIcon = document.createElement('span');
@@ -1641,7 +1679,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const descCell = document.createElement('td');
     descCell.setAttribute('role', 'cell');
-    descCell.setAttribute('data-label', labels.labelDescription || '');
+    const descLabel = document.createElement('span');
+    descLabel.className = 'cell-label uk-hidden@s';
+    descLabel.textContent = labels.labelDescription || '';
+    descCell.appendChild(descLabel);
     const descInput = document.createElement('input');
     descInput.type = 'text';
     descInput.className = 'uk-input event-desc';
@@ -1651,7 +1692,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const activateCell = document.createElement('td');
     activateCell.setAttribute('role', 'cell');
-    activateCell.setAttribute('data-label', labels.labelActive || '');
+    const activateCellLabel = document.createElement('span');
+    activateCellLabel.className = 'cell-label uk-hidden@s';
+    activateCellLabel.textContent = labels.labelActive || '';
+    activateCell.appendChild(activateCellLabel);
     const activateLabel = document.createElement('label');
     activateLabel.className = 'switch';
     activateLabel.setAttribute('uk-tooltip', 'title: Aktivieren; pos: top');
@@ -1675,7 +1719,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const delCell = document.createElement('td');
     delCell.setAttribute('role', 'cell');
-    delCell.setAttribute('data-label', labels.labelActions || '');
+    const delLabel = document.createElement('span');
+    delLabel.className = 'cell-label uk-hidden@s';
+    delLabel.textContent = labels.labelActions || '';
+    delCell.appendChild(delLabel);
     const del = document.createElement('button');
     del.className = 'uk-icon-button uk-button-danger';
     del.setAttribute('uk-icon', 'trash');


### PR DESCRIPTION
## Summary
- replace data-label pseudo-elements with inline `<span class="cell-label uk-hidden@s">` for event and catalog rows
- hide `.cell-label` above 640px and drop obsolete `td::before` rules

## Testing
- `./vendor/bin/phpunit` *(fails: Missing STRIPE_* env vars)*
- `npx -p puppeteer node /tmp/test-cell-label.js` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68ae9a20a2c4832b8e89242027d2f7c2