### PR TITLE
Adjust column label flex sizing for responsive tables

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -730,7 +730,8 @@ body.admin-page {
 }
 #eventsList td::before {
   content: attr(data-label);
-  flex: 0 0 8ch;
+  flex: 0 0 auto;
+  min-width: 6rem;
   font-weight: 600;
   margin-right: 0.5rem;
 }
@@ -804,7 +805,8 @@ body.admin-page {
 }
 #catalogList td::before {
   content: attr(data-label);
-  flex: 0 0 8ch;
+  flex: 0 0 auto;
+  min-width: 6rem;
   font-weight: 600;
   margin-right: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- ensure event and catalog tables use flexible column labels with a 6rem minimum width

## Testing
- `python3 - <<'PY'
from PIL import ImageFont
font = ImageFont.truetype('/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf', 16)
for t in ['Beschreibung','Description','Rätselwort gelöst','Puzzle solved']:
    width = font.getbbox(t)[2] - font.getbbox(t)[0]
    print(f"{t}: {width}px")
PY`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9a640dfc832b9aacb835d6bb313f