### PR TITLE
fix: respect flex-wrap when sizing nav placeholder

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -54,16 +54,18 @@ document.addEventListener('DOMContentLoaded', function () {
   const navPlaceholder = document.querySelector('.nav-placeholder');
 
   function updateNavPlaceholder() {
-    if (navPlaceholder && topbar) {
-      let height = topbar.offsetHeight;
-      const headerBar = document.querySelector('.event-header-bar');
-      if (headerBar) {
-        height += headerBar.offsetHeight;
-      }
-      navPlaceholder.style.height = height + 'px';
+    let height = topbar.offsetHeight;
+    const headerBar = document.querySelector('.event-header-bar');
+    if (headerBar) {
+      height += headerBar.offsetHeight;
     }
+    navPlaceholder.style.height = height + 'px';
   }
 
-  updateNavPlaceholder();
-  window.addEventListener('resize', updateNavPlaceholder);
+  if (topbar && navPlaceholder) {
+    updateNavPlaceholder();
+    if (window.getComputedStyle(topbar).flexWrap !== 'nowrap') {
+      window.addEventListener('resize', updateNavPlaceholder);
+    }
+  }
 });

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -27,17 +27,19 @@
     const navPlaceholder = document.querySelector('.nav-placeholder');
 
     function updateNavPlaceholder() {
-      if (navPlaceholder && topbar) {
-        let height = topbar.offsetHeight;
-        const headerBar = document.querySelector('.event-header-bar');
-        if (headerBar) {
-          height += headerBar.offsetHeight;
-        }
-        navPlaceholder.style.height = height + 'px';
+      let height = topbar.offsetHeight;
+      const headerBar = document.querySelector('.event-header-bar');
+      if (headerBar) {
+        height += headerBar.offsetHeight;
       }
+      navPlaceholder.style.height = height + 'px';
     }
 
-    updateNavPlaceholder();
-    window.addEventListener('resize', updateNavPlaceholder);
+    if (topbar && navPlaceholder) {
+      updateNavPlaceholder();
+      if (window.getComputedStyle(topbar).flexWrap !== 'nowrap') {
+        window.addEventListener('resize', updateNavPlaceholder);
+      }
+    }
   });
 </script>


### PR DESCRIPTION
## Summary
- ensure nav placeholder sizing only reacts to resize when topbar wraps
- align inline template script with app.js logic

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars; Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb5de98a8832b9e7b6dd84ec41885