### PR TITLE
Fix PHPCS errors in service and test stub

### DIFF
--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -239,15 +239,15 @@ class ConfigService
                 $sql = 'INSERT INTO config(' . implode(',', $cols) . ') VALUES(' . $params . ')';
             }
             $stmt = $this->pdo->prepare($sql);
-        foreach ($filtered as $k => $v) {
-            if (is_bool($v)) {
-                $stmt->bindValue(':' . $k, $v, PDO::PARAM_BOOL);
-            } elseif ($k === 'colors') {
-                $stmt->bindValue(':' . $k, json_encode($v));
-            } else {
-                $stmt->bindValue(':' . $k, $v);
+            foreach ($filtered as $k => $v) {
+                if (is_bool($v)) {
+                    $stmt->bindValue(':' . $k, $v, PDO::PARAM_BOOL);
+                } elseif ($k === 'colors') {
+                    $stmt->bindValue(':' . $k, json_encode($v));
+                } else {
+                    $stmt->bindValue(':' . $k, $v);
+                }
             }
-        }
             $stmt->execute();
             $this->pdo->commit();
         } catch (Throwable $e) {

--- a/tests/Service/StripeServiceStub.php
+++ b/tests/Service/StripeServiceStub.php
@@ -1,10 +1,8 @@
 <?php
 
-namespace App\Service;
+declare(strict_types=1);
 
-if (class_exists(__NAMESPACE__ . '\\StripeService')) {
-    return;
-}
+namespace App\Service;
 
 class StripeService
 {


### PR DESCRIPTION
## Summary
- fix indentation in ConfigService config persistence loop
- simplify StripeServiceStub to avoid side effects and enable strict types

## Testing
- `vendor/bin/phpcs`
- `vendor/bin/phpunit tests/Service/StripeServiceTest.php`
- `vendor/bin/phpunit` *(fails: hung, missing full suite execution)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb86bffd8832b8e030fa47f63037b