### PR TITLE
Reduce dashboard side spacing on mobile

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -974,4 +974,18 @@ body.admin-page {
   margin-left: 0.5rem;
 }
 
+/* Dashboard grid spacing for mobile */
+@media (max-width: 640px) {
+  .dashboard-container {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+  .dashboard-grid {
+    margin-left: -8px;
+  }
+  .dashboard-grid > * {
+    padding-left: 8px;
+  }
+}
+
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -104,7 +104,7 @@
       {% endif %}
       <ul id="adminSwitcher" class="uk-switcher uk-margin">
     <li class="{{ activeRoute == 'dashboard' ? 'uk-active' }}">
-      <div class="uk-container uk-container-large">
+      <div class="uk-container uk-container-large dashboard-container">
         <div id="dashboard" class="uk-margin-large-top">
           <div class="uk-grid-large" uk-grid>
             <!-- Spalte 2–3: Inhalt -->
@@ -132,7 +132,7 @@
                 <span class="uk-badge" id="badge-past">0 vergangene</span>
               </div>
 
-              <div class="uk-child-width-1-2@m uk-grid-small uk-margin-small" uk-grid>
+              <div class="uk-child-width-1-2@m uk-grid-small uk-margin-small dashboard-grid" uk-grid>
                 <div>
                   <div class="uk-card uk-card-default uk-card-body">
                     <h4 class="uk-margin-remove-bottom">Teams anlegen & organisieren</h4>


### PR DESCRIPTION
## Summary
- shrink dashboard card margins on mobile by adjusting container and grid padding

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb814cca8832ba6206e57ce346424