### PR TITLE
Fix indentation in ConfigService

### DIFF
--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -239,15 +239,15 @@ class ConfigService
                 $sql = 'INSERT INTO config(' . implode(',', $cols) . ') VALUES(' . $params . ')';
             }
             $stmt = $this->pdo->prepare($sql);
-        foreach ($filtered as $k => $v) {
-            if (is_bool($v)) {
-                $stmt->bindValue(':' . $k, $v, PDO::PARAM_BOOL);
-            } elseif ($k === 'colors') {
-                $stmt->bindValue(':' . $k, json_encode($v));
-            } else {
-                $stmt->bindValue(':' . $k, $v);
+            foreach ($filtered as $k => $v) {
+                if (is_bool($v)) {
+                    $stmt->bindValue(':' . $k, $v, PDO::PARAM_BOOL);
+                } elseif ($k === 'colors') {
+                    $stmt->bindValue(':' . $k, json_encode($v));
+                } else {
+                    $stmt->bindValue(':' . $k, $v);
+                }
             }
-        }
             $stmt->execute();
             $this->pdo->commit();
         } catch (Throwable $e) {


### PR DESCRIPTION
## Summary
- fix indentation in ConfigService's saveConfig method to meet coding standards

## Testing
- `vendor/bin/phpcs src/Service/ConfigService.php`
- `composer test` *(fails: 27 errors, 6 failures, 5 warnings, 1 notice)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js` *(fails: Required code blocks not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb8e1d59c832bb04355e210f0f921