### PR TITLE
Show plus icon for add event button in desktop

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -223,9 +223,7 @@
             uk-icon="plus"
             uk-tooltip="title: {{ t('tip_event_add') }}; pos: left"
             aria-label="{{ t('tip_event_add') }}"
-          >
-            <span class="button-text uk-visible@s uk-margin-small-left">{{ t('tip_event_add') }}</span>
-          </button>
+          ></button>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- remove text from add-event FAB so only a plus icon shows on desktop

## Testing
- `composer test` *(fails: Cannot redeclare class App\Service\StripeService; Missing STRIPE environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68aebbbf22c8832bbaa82b73ed95ce54