### PR TITLE
Add responsive admin topbar offcanvas menu

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -578,7 +578,7 @@ body.admin-page {
 
 .admin-page .topbar {
   height: auto;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .admin-page .topbar .uk-navbar-left {
@@ -618,7 +618,6 @@ body.admin-page {
   }
   .admin-page .topbar {
     height: 56px;
-    flex-wrap: nowrap;
   }
   .admin-page .topbar .uk-navbar-left,
   .admin-page .topbar .uk-navbar-right,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3,6 +3,12 @@ document.addEventListener('DOMContentLoaded', function () {
   const themeToggle = document.getElementById('theme-toggle');
   const contrastToggle = document.getElementById('contrast-toggle');
   const darkStylesheet = document.querySelector('link[href$="dark.css"]');
+  const themeSwitch = document.querySelector('.theme-switch');
+  const contrastSwitch = document.querySelector('.contrast-switch');
+  const helpBtn = document.getElementById('helpBtn');
+  const offcanvasToggle = document.getElementById('offcanvas-toggle');
+  const offcanvasButtons = document.getElementById('offcanvas-buttons');
+  const topbarRight = document.querySelector('.topbar .uk-navbar-right .uk-navbar-item');
 
   const storedTheme = localStorage.getItem('darkMode');
   const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -62,10 +68,39 @@ document.addEventListener('DOMContentLoaded', function () {
     navPlaceholder.style.height = height + 'px';
   }
 
-  if (topbar && navPlaceholder) {
-    updateNavPlaceholder();
-    if (window.getComputedStyle(topbar).flexWrap !== 'nowrap') {
-      window.addEventListener('resize', updateNavPlaceholder);
+  function handleTopbarOverflow() {
+    if (!topbar || !topbarRight || !offcanvasToggle || !offcanvasButtons) {
+      return;
+    }
+    const overflowing = topbar.scrollWidth > topbar.clientWidth;
+    const elements = [themeSwitch, contrastSwitch, helpBtn];
+    if (overflowing) {
+      elements.forEach(el => {
+        if (el && offcanvasButtons.contains(el) === false) {
+          offcanvasButtons.appendChild(el);
+        }
+      });
+      offcanvasToggle.hidden = false;
+    } else {
+      elements.forEach(el => {
+        if (el && topbarRight.contains(el) === false) {
+          topbarRight.appendChild(el);
+        }
+      });
+      if (offcanvasButtons.children.length === 0) {
+        offcanvasToggle.hidden = true;
+      }
     }
   }
+
+  if (topbar && navPlaceholder) {
+    updateNavPlaceholder();
+  }
+  handleTopbarOverflow();
+  window.addEventListener('resize', () => {
+    if (topbar && navPlaceholder) {
+      updateNavPlaceholder();
+    }
+    handleTopbarOverflow();
+  });
 });

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -53,12 +53,12 @@
     {% endblock %}
     {% block right %}
       <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
+        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="{{ t('design_toggle') }}"></button>
       </div>
       <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
+        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="{{ t('contrast_toggle') }}"></button>
       </div>
-      <button id="helpBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" aria-label="Hilfe"></button>
+      <button id="helpBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" aria-label="{{ t('help') }}"></button>
     {% endblock %}
     {% block nav_placeholder %}
       {% set activeRoute = currentPath|split('/admin/')|last %}
@@ -1159,6 +1159,7 @@
       <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
       <h3 class="uk-margin-small">QuizRace</h3>
       {% include 'admin/_nav.twig' %}
+      <div id="offcanvas-buttons" class="uk-margin-top uk-flex uk-flex-middle"></div>
     </div>
   </div>
 {% endblock %}

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -14,6 +14,9 @@
     <div class="uk-navbar-item">
       {% block right %}{% endblock %}
     </div>
+    <a id="offcanvas-toggle" class="uk-navbar-toggle" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+      <span uk-navbar-toggle-icon></span>
+    </a>
   </div>
 </nav>
 {% block offcanvas %}{% endblock %}


### PR DESCRIPTION
## Summary
- keep admin topbar from wrapping and provide toggle for an offcanvas menu
- move theme/contrast/help buttons into an offcanvas section when space runs short

## Testing
- `composer test` (fails: Missing STRIPE_* env vars; Fatal error: Cannot redeclare class App\Service\StripeService)


------
https://chatgpt.com/codex/tasks/task_e_68aebeca87d4832b96c0effa5b683ee7