### PR TITLE
Refactor topbar controls into reusable Twig partial

### DIFF
--- a/templates/_topbar_controls.twig
+++ b/templates/_topbar_controls.twig
@@ -1,0 +1,7 @@
+<div class="theme-switch">
+  <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="{{ t('design_toggle') }}"></button>
+</div>
+<div class="contrast-switch uk-margin-small-left">
+  <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="{{ t('contrast_toggle') }}"></button>
+</div>
+<a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -52,13 +52,7 @@
       </div>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
-      <button id="helpBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" aria-label="Hilfe"></button>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
     {% block nav_placeholder %}
       {% set activeRoute = currentPath|split('/admin/')|last %}
@@ -1159,6 +1153,7 @@
       <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
       <h3 class="uk-margin-small">QuizRace</h3>
       {% include 'admin/_nav.twig' %}
+      {% include '_topbar_controls.twig' %}
     </div>
   </div>
 {% endblock %}

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -22,12 +22,7 @@
       </a>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="{{ t('design_toggle') }}"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="{{ t('contrast_toggle') }}"></button>
-      </div>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
     {% block offcanvas %}
       <div id="qr-offcanvas" uk-offcanvas="overlay: true">
@@ -35,6 +30,7 @@
           <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
           <h3 class="uk-margin-small">QuizRace</h3>
           {% include 'admin/_nav.twig' %}
+          {% include '_topbar_controls.twig' %}
         </div>
       </div>
     {% endblock %}

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -20,12 +20,7 @@
       <span class="uk-navbar-title uk-text-center">Datenschutz</span>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
     {% block offcanvas %}{% endblock %}
   {% endembed %}

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -19,13 +19,7 @@
       <span class="uk-navbar-title uk-text-center">Veranstaltungen</span>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
-      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-large">

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -19,12 +19,7 @@
       <span class="uk-navbar-title uk-text-center">FAQ</span>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   {{ content|raw }}

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -16,13 +16,7 @@
       <span class="uk-navbar-title uk-text-center">{{ t('game_flow') }} <br>{{ event.name|default('Sommerfest 2025') }}</span>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="{{ t('design_toggle') }}"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="{{ t('contrast_toggle') }}"></button>
-      </div>
-      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small">

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -20,12 +20,7 @@
       <span class="uk-navbar-title uk-text-center">Impressum</span>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
     {% block offcanvas %}{% endblock %}
   {% endembed %}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -17,13 +17,7 @@
       <span id="topbar-title" class="uk-navbar-title uk-text-center" data-default-title="{{ event.name|default('Sommerfest 2025') }}">{{ event.name|default('Sommerfest 2025') }}</span>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="{{ t('design_toggle') }}"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="{{ t('contrast_toggle') }}"></button>
-      </div>
-      <a href="faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
     {% block headerbar %}
       {% if event.description %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -20,12 +20,7 @@
       <span class="uk-navbar-title uk-text-center">Lizenz</span>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
     {% block offcanvas %}{% endblock %}
   {% endembed %}

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -13,13 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
-      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
 <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -13,13 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
-      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -13,13 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
-      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">

--- a/templates/register.twig
+++ b/templates/register.twig
@@ -13,13 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
-      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -28,13 +28,7 @@
       </div>
     {% endblock %}
     {% block right %}
-      <div class="theme-switch">
-        <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="Design wechseln"></button>
-      </div>
-      <div class="contrast-switch uk-margin-small-left">
-        <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="Kontrastmodus"></button>
-      </div>
-      <a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="Hilfe" aria-label="Hilfe"></a>
+      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small uk-text-center">


### PR DESCRIPTION
## Summary
- Extract reusable `_topbar_controls.twig` with theme, contrast, and help controls
- Include new partial in all templates that previously duplicated the controls
- Provide offcanvas access to controls for admin layouts

## Testing
- `composer test` *(fails: Cannot redeclare class App\Service\StripeService)*

------
https://chatgpt.com/codex/tasks/task_e_68aebeddc9a4832b9eaf9ca2af7f5e87