### PR TITLE
Remove start page padding on mobile

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
 {% endblock %}
 
-{% block body_class %}index-page uk-padding{% endblock %}
+{% block body_class %}index-page uk-padding@m{% endblock %}
 
 {% block body %}
   {% embed 'topbar.twig' %}


### PR DESCRIPTION
## Summary
- avoid unnecessary 30px body padding on start page by applying uk-padding only from medium screens

## Testing
- `composer test` *(fails: Cannot redeclare class App\Service\StripeService)*

------
https://chatgpt.com/codex/tasks/task_e_68aebfb2f26c832bb47bcb5664bdfa94