### PR TITLE
Refactor tenant script execution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "guzzlehttp/guzzle": "^7",
         "symfony/mailer": "^7.3",
         "stripe/stripe-php": "^17.5",
-        "monolog/monolog": "^3"
+        "monolog/monolog": "^3",
+        "symfony/process": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9570057d56245d0b8504f9a6c0f126e",
+    "content-hash": "449b2885bffef046439ba9d6cc251d9b",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -2788,6 +2788,67 @@
                 }
             ],
             "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
+                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-17T09:11:12+00:00"
         },
         {
             "name": "symfony/service-contracts",


### PR DESCRIPTION
## Summary
- replace shell exec/proc_open with Symfony\Process
- validate tenant slugs and remove shell background ops
- add symfony/process dependency

## Testing
- `./vendor/bin/phpcs src/routes.php`
- `composer test` *(fails: Cannot redeclare class App\Service\StripeService)*

------
https://chatgpt.com/codex/tasks/task_e_68aebfcbebf8832ba83d1fc2117d1bae