### PR TITLE
feat: add mobile offcanvas navigation

### DIFF
--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -12,7 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}{% endblock %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
@@ -22,7 +26,6 @@
     {% block right %}
       {% include '_topbar_controls.twig' %}
     {% endblock %}
-    {% block offcanvas %}{% endblock %}
   {% endembed %}
   {{ content|raw }}
 {% endblock %}

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -13,8 +13,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}{% endblock %}
-    {% block offcanvas %}{% endblock %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">Veranstaltungen</span>
     {% endblock %}

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -12,6 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -12,6 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">{{ t('game_flow') }} <br>{{ event.name|default('Sommerfest 2025') }}</span>
     {% endblock %}

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -12,7 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}{% endblock %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
@@ -22,7 +26,6 @@
     {% block right %}
       {% include '_topbar_controls.twig' %}
     {% endblock %}
-    {% block offcanvas %}{% endblock %}
   {% endembed %}
   {{ content|raw }}
 {% endblock %}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -13,6 +13,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block center %}
       <span id="topbar-title" class="uk-navbar-title uk-text-center" data-default-title="{{ event.name|default('Sommerfest 2025') }}">{{ event.name|default('Sommerfest 2025') }}</span>
     {% endblock %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -12,7 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}{% endblock %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
@@ -22,7 +26,6 @@
     {% block right %}
       {% include '_topbar_controls.twig' %}
     {% endblock %}
-    {% block offcanvas %}{% endblock %}
   {% endembed %}
   {{ content|raw }}
 {% endblock %}

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -12,6 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block right %}
       {% include '_topbar_controls.twig' %}
     {% endblock %}

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -87,6 +87,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block left %}
       <a href="{{ basePath }}/landing" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -12,6 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block right %}
       {% include '_topbar_controls.twig' %}
     {% endblock %}

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -12,6 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block right %}
       {% include '_topbar_controls.twig' %}
     {% endblock %}

--- a/templates/register.twig
+++ b/templates/register.twig
@@ -12,6 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block right %}
       {% include '_topbar_controls.twig' %}
     {% endblock %}

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -10,6 +10,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block left %}
       <a href="{{ basePath }}/admin" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -12,6 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
         <div id="eventSelectWrap" class="uk-flex uk-flex-middle" hidden>

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -19,7 +19,15 @@
     </a>
   </div>
 </nav>
-{% block offcanvas %}{% endblock %}
+{% block offcanvas %}
+<div id="offcanvas-nav" uk-offcanvas="overlay: true">
+  <div class="uk-offcanvas-bar">
+    {% block offcanvas_nav %}
+    {% include '_topbar_controls.twig' %}
+    {% endblock %}
+  </div>
+</div>
+{% endblock %}
 {% block headerbar %}{% endblock %}
 {% block nav_placeholder %}
 <div class="nav-placeholder"></div>


### PR DESCRIPTION
## Summary
- add mobile menu toggles to page templates
- provide default offcanvas navigation in topbar

## Testing
- `composer test` *(fails: Cannot redeclare class App\Service\StripeService)*

------
https://chatgpt.com/codex/tasks/task_e_68aec656ef40832b8191b0cfaaa5645f