### PR TITLE
Run Stripe API test in separate process

### DIFF
--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -251,6 +251,10 @@ class AdminControllerTest extends TestCase
         unset($_ENV['MAIN_DOMAIN']);
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testStripeApiCalledOnPlanChange(): void
     {
         require_once __DIR__ . '/../Service/StripeServiceStub.php';


### PR DESCRIPTION
## Summary
- prevent class name conflicts by running Stripe API plan change test in isolated process

## Testing
- `vendor/bin/phpunit --coverage-clover clover.xml` *(fails: D..........E....W.EE......FN....E...EEFEE..)*

------
https://chatgpt.com/codex/tasks/task_e_68aec60958f0832baaae67a2fada0e9f