### PR TITLE
Improve onboarding timeline contrast in dark mode

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -116,7 +116,7 @@ body .onboarding-step {
 
 body .onboarding-timeline .timeline-step {
   border-color: #555;
-  color: #aaa;
+  color: #ddd;
 }
 
 body .onboarding-timeline .timeline-step.inactive {
@@ -392,7 +392,7 @@ body.dark-mode .onboarding-step {
 
 body.dark-mode .onboarding-timeline .timeline-step {
   border-color: #555;
-  color: #aaa;
+  color: #ddd;
 }
 
 body.dark-mode .onboarding-timeline .timeline-step.inactive {


### PR DESCRIPTION
## Summary
- lighten onboarding timeline step text in dark mode for better readability

## Testing
- `composer test` *(fails: Cannot redeclare class App\Service\StripeService)*

------
https://chatgpt.com/codex/tasks/task_e_68aec79d3040832bb6d675f50cde6fa3