### PR TITLE
Fix dark mode visibility for onboarding pricing cards

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -407,6 +407,22 @@ body.dark-mode .onboarding-timeline .timeline-step.completed {
   color: #1e87f0;
 }
 
+body.dark-mode .pricing-grid .uk-card-quizrace {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+
+body.dark-mode .pricing-grid .uk-card-quizrace.uk-card-popular {
+  background-color: #0c86d0;
+  color: #fff;
+}
+
+body.dark-mode .pricing-grid .uk-card-quizrace .uk-text-meta,
+body.dark-mode .pricing-grid .uk-card-quizrace li,
+body.dark-mode .pricing-grid .uk-card-quizrace h3 {
+  color: #f5f5f5;
+}
+
 body.dark-mode .uk-icon,
 body.dark-mode .uk-icon-button {
   color: #f5f5f5;


### PR DESCRIPTION
## Summary
- ensure onboarding pricing cards use dark backgrounds and light text in dark mode for readability

## Testing
- `composer test` *(fails: missing Stripe environment variables; Cannot redeclare class App\Service\StripeService)*

------
https://chatgpt.com/codex/tasks/task_e_68aec87262f0832bb851f7a280f3915b