### PR TITLE
Improve onboarding error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 - Ensure page content respects dynamic topbar height
 - *(events)* Prevent table frame from clipping actions
 - Respect flex-wrap when sizing nav placeholder
+- *(onboarding)* Show detailed error messages
 
 ### Refactor
 

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -399,9 +399,17 @@ document.addEventListener('DOMContentLoaded', () => {
       if (res.status === 401 || res.status === 403 || res.redirected) {
         throw new Error('unauthorized');
       }
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || data.status !== 'queued') {
-        throw new Error('onboard');
+      const body = await res.text();
+      let data;
+      try {
+        data = JSON.parse(body);
+      } catch (_) {
+        data = undefined;
+      }
+      if (!res.ok || !data || data.status !== 'queued') {
+        const msg = data && data.error ? data.error : body || 'onboard';
+        addLog('Fehler beim Onboarding: ' + msg);
+        throw new Error(msg);
       }
       addLog('Onboarding gestartet …');
     };


### PR DESCRIPTION
## Summary
- Log onboarding API failures with returned message
- Note onboarding error details in changelog

## Testing
- `STRIPE_SECRET_KEY=1 STRIPE_PUBLISHABLE_KEY=1 STRIPE_PRICE_STARTER=1 STRIPE_PRICE_STANDARD=1 STRIPE_PRICE_PROFESSIONAL=1 STRIPE_WEBHOOK_SECRET=1 composer test` *(fails: Cannot redeclare class App\Service\StripeService)*

------
https://chatgpt.com/codex/tasks/task_e_68aec8b4bbc4832ba09e67fe431892b1