### PR TITLE
Move topbar controls into offcanvas menu

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3,12 +3,6 @@ document.addEventListener('DOMContentLoaded', function () {
   const themeToggle = document.getElementById('theme-toggle');
   const contrastToggle = document.getElementById('contrast-toggle');
   const darkStylesheet = document.querySelector('link[href$="dark.css"]');
-  const themeSwitch = document.querySelector('.theme-switch');
-  const contrastSwitch = document.querySelector('.contrast-switch');
-  const helpBtn = document.getElementById('helpBtn');
-  const offcanvasToggle = document.getElementById('offcanvas-toggle');
-  const offcanvasButtons = document.getElementById('offcanvas-buttons');
-  const topbarRight = document.querySelector('.topbar .uk-navbar-right .uk-navbar-item');
 
   const storedTheme = localStorage.getItem('darkMode');
   const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -24,23 +18,15 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   if (themeToggle) {
-    themeToggle.setAttribute('uk-icon', isDark ? 'icon: sun; ratio: 2' : 'icon: moon; ratio: 2');
-    UIkit.icon(themeToggle);
-    themeToggle.addEventListener('click', function () {
+    themeToggle.addEventListener('click', function (event) {
+      event.preventDefault();
       const dark = document.body.classList.toggle('dark-mode');
       document.documentElement.classList.toggle('dark-mode', dark);
       document.body.classList.toggle('uk-light', dark);
       if (darkStylesheet) {
         darkStylesheet.disabled = !dark;
       }
-      if (dark) {
-        localStorage.setItem('darkMode', 'true');
-        themeToggle.setAttribute('uk-icon', 'icon: sun; ratio: 2');
-      } else {
-        localStorage.setItem('darkMode', 'false');
-        themeToggle.setAttribute('uk-icon', 'icon: moon; ratio: 2');
-      }
-      UIkit.icon(themeToggle);
+      localStorage.setItem('darkMode', dark ? 'true' : 'false');
     });
   }
 
@@ -49,8 +35,8 @@ document.addEventListener('DOMContentLoaded', function () {
     if (isHigh) {
       document.body.classList.add('high-contrast');
     }
-    UIkit.icon(contrastToggle);
-    contrastToggle.addEventListener('click', function () {
+    contrastToggle.addEventListener('click', function (event) {
+      event.preventDefault();
       const hc = document.body.classList.toggle('high-contrast');
       localStorage.setItem('highContrast', hc ? 'true' : 'false');
     });
@@ -68,39 +54,13 @@ document.addEventListener('DOMContentLoaded', function () {
     navPlaceholder.style.height = height + 'px';
   }
 
-  function handleTopbarOverflow() {
-    if (!topbar || !topbarRight || !offcanvasToggle || !offcanvasButtons) {
-      return;
-    }
-    const overflowing = topbar.scrollWidth > topbar.clientWidth;
-    const elements = [themeSwitch, contrastSwitch, helpBtn];
-    if (overflowing) {
-      elements.forEach(el => {
-        if (el && offcanvasButtons.contains(el) === false) {
-          offcanvasButtons.appendChild(el);
-        }
-      });
-      offcanvasToggle.hidden = false;
-    } else {
-      elements.forEach(el => {
-        if (el && topbarRight.contains(el) === false) {
-          topbarRight.appendChild(el);
-        }
-      });
-      if (offcanvasButtons.children.length === 0) {
-        offcanvasToggle.hidden = true;
-      }
-    }
-  }
-
   if (topbar && navPlaceholder) {
     updateNavPlaceholder();
   }
-  handleTopbarOverflow();
+
   window.addEventListener('resize', () => {
     if (topbar && navPlaceholder) {
       updateNavPlaceholder();
     }
-    handleTopbarOverflow();
   });
 });

--- a/public/js/custom-icons.js
+++ b/public/js/custom-icons.js
@@ -7,13 +7,5 @@ document.addEventListener('DOMContentLoaded', function () {
       handbook: '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4.5A2.5 2.5 0 0 1 5.5 2H10v13H5.5A2.5 2.5 0 0 0 3 17.5V4.5z"/><path d="M17 17.5A2.5 2.5 0 0 0 14.5 15H10V2h4.5A2.5 2.5 0 0 1 17 4.5v13z"/></svg>',
       key: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>'
     });
-    const themeToggle = document.getElementById('theme-toggle');
-    if (themeToggle) {
-      UIkit.icon(themeToggle);
-    }
-    const contrastToggle = document.getElementById('contrast-toggle');
-    if (contrastToggle) {
-      UIkit.icon(contrastToggle);
-    }
   }
 });

--- a/templates/_topbar_controls.twig
+++ b/templates/_topbar_controls.twig
@@ -1,7 +1,11 @@
-<div class="theme-switch">
-  <button id="theme-toggle" class="uk-icon-button" uk-icon="icon: moon; ratio: 2" aria-label="{{ t('design_toggle') }}"></button>
-</div>
-<div class="contrast-switch uk-margin-small-left">
-  <button id="contrast-toggle" class="uk-icon-button" uk-icon="icon: paint-bucket; ratio: 2" aria-label="{{ t('contrast_toggle') }}"></button>
-</div>
-<a href="{{ basePath }}/faq" class="uk-icon-button uk-margin-small-left" uk-icon="icon: question; ratio: 2" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
+<ul class="uk-nav uk-nav-default">
+  <li>
+    <a id="theme-toggle" href="#">{{ t('design_toggle') }}</a>
+  </li>
+  <li>
+    <a id="contrast-toggle" href="#">{{ t('contrast_toggle') }}</a>
+  </li>
+  <li>
+    <a href="{{ basePath }}/faq">{{ t('help') }}</a>
+  </li>
+</ul>

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -31,7 +31,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a class="uk-navbar-toggle uk-hidden@m" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+      <a class="uk-navbar-toggle" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
         <span uk-navbar-toggle-icon></span>
       </a>
       <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">
@@ -51,9 +51,7 @@
         <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
       </div>
     {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
-    {% endblock %}
+    {% block right %}{% endblock %}
     {% block nav_placeholder %}
       {% set activeRoute = currentPath|split('/admin/')|last %}
       {% if activeRoute == '' %}

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -14,15 +14,12 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a class="uk-navbar-toggle uk-hidden@m" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+      <a class="uk-navbar-toggle" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
         <span uk-navbar-toggle-icon></span>
       </a>
       <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">
         QuizRace Admin
       </a>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
     {% endblock %}
     {% block offcanvas %}
       <div id="qr-offcanvas" uk-offcanvas="overlay: true">

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -12,19 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">Datenschutz</span>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   {{ content|raw }}

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -13,16 +13,8 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">Veranstaltungen</span>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-large">

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -12,19 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">FAQ</span>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   {{ content|raw }}

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -12,16 +12,8 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">{{ t('game_flow') }} <br>{{ event.name|default('Sommerfest 2025') }}</span>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small">

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -12,19 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">Impressum</span>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   {{ content|raw }}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -13,16 +13,8 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block center %}
       <span id="topbar-title" class="uk-navbar-title uk-text-center" data-default-title="{{ event.name|default('Sommerfest 2025') }}">{{ event.name|default('Sommerfest 2025') }}</span>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
     {% endblock %}
     {% block headerbar %}
       {% if event.description %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -12,19 +12,11 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block left %}
       <a href="." class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block center %}
       <span class="uk-navbar-title uk-text-center">Lizenz</span>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   {{ content|raw }}

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -11,16 +11,7 @@
 {% block body_class %}uk-padding{% endblock %}
 
 {% block body %}
-  {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
-    {% endblock %}
-  {% endembed %}
+  {% embed 'topbar.twig' %}{% endembed %}
 <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
   <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
     <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -11,16 +11,7 @@
 {% block body_class %}uk-padding{% endblock %}
 
 {% block body %}
-  {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
-    {% endblock %}
-  {% endembed %}
+  {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
     <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
       <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -11,16 +11,7 @@
 {% block body_class %}uk-padding{% endblock %}
 
 {% block body %}
-  {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
-    {% endblock %}
-  {% endembed %}
+  {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
     <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
       <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">

--- a/templates/register.twig
+++ b/templates/register.twig
@@ -11,16 +11,7 @@
 {% block body_class %}uk-padding{% endblock %}
 
 {% block body %}
-  {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
-    {% endblock %}
-  {% endembed %}
+  {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
     <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
       <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -12,11 +12,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
         <div id="eventSelectWrap" class="uk-flex uk-flex-middle" hidden>
@@ -31,9 +26,6 @@
         </div>
         <span id="eventTitle" class="uk-navbar-title uk-text-center">{{ event.name|default('Sommerfest 2025') }}</span>
       </div>
-    {% endblock %}
-    {% block right %}
-      {% include '_topbar_controls.twig' %}
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-small uk-text-center">

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,6 +1,10 @@
 <nav class="uk-navbar-container uk-padding-small topbar" uk-navbar>
   <div class="uk-navbar-left">
-    {% block mobile_menu_toggle %}{% endblock %}
+    {% block mobile_menu_toggle %}
+      <a class="uk-navbar-toggle" href="#offcanvas-nav" uk-toggle aria-label="{{ t('menu') }}">
+        <span uk-navbar-toggle-icon></span>
+      </a>
+    {% endblock %}
     <div class="uk-navbar-item">
       {% block left %}{% endblock %}
     </div>
@@ -14,9 +18,6 @@
     <div class="uk-navbar-item">
       {% block right %}{% endblock %}
     </div>
-    <a id="offcanvas-toggle" class="uk-navbar-toggle" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
-      <span uk-navbar-toggle-icon></span>
-    </a>
   </div>
 </nav>
 {% block offcanvas %}


### PR DESCRIPTION
## Summary
- Replace topbar icons with text links inside a shared off-canvas menu
- Add default hamburger toggle to access the menu on all pages
- Simplify theme and contrast toggle scripts to work with menu entries

## Testing
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec9836764832b83a905a1dc824981