### PR TITLE
Add mobile bottom navigation bar

### DIFF
--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -64,6 +64,14 @@
       </nav>
     </footer>
   </div>
+  {% include 'partials/bottom-nav.twig' with {
+    links: [
+      { href: basePath ~ '/', text: t('tab_dashboard') },
+      { href: basePath ~ '/faq', text: t('help') },
+      { href: basePath ~ '/impressum', text: t('imprint') },
+      { href: basePath ~ '/datenschutz', text: t('privacy') }
+    ]
+  } %}
   <script src="{{ basePath }}/js/uikit.min.js" defer></script>
   <script src="{{ basePath }}/js/uikit-icons.min.js" defer></script>
   <script>window.basePath = '{{ basePath }}';</script>

--- a/templates/partials/bottom-nav.twig
+++ b/templates/partials/bottom-nav.twig
@@ -1,0 +1,24 @@
+{% set links = links|default([]) %}
+<nav class="uk-navbar-container bottom-nav uk-hidden@m" uk-navbar>
+  <div class="uk-navbar-center">
+    <ul class="uk-navbar-nav">
+      {% for link in links %}
+      <li><a href="{{ link.href }}">{{ link.text }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+</nav>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const bottomNav = document.querySelector('.bottom-nav');
+    function toggleBottomNav() {
+      if (window.innerWidth >= 960) {
+        bottomNav.classList.add('uk-hidden');
+      } else {
+        bottomNav.classList.remove('uk-hidden');
+      }
+    }
+    toggleBottomNav();
+    window.addEventListener('resize', toggleBottomNav);
+  });
+</script>


### PR DESCRIPTION
## Summary
- add bottom navigation twig partial with responsive uk-navbar and JS hide on large screens
- include mobile bottom navigation in layout with links to dashboard, help, imprint and privacy pages

## Testing
- `STRIPE_SECRET_KEY=1 STRIPE_PUBLISHABLE_KEY=1 STRIPE_PRICE_STARTER=1 STRIPE_PRICE_STANDARD=1 STRIPE_PRICE_PROFESSIONAL=1 STRIPE_WEBHOOK_SECRET=1 composer test` *(fails: Tests: 264, Assertions: 562, Errors: 26, Failures: 6, Warnings: 5, PHPUnit Deprecations: 3, Notices: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aecc6501b8832b95b2aed8a7a3c908