### PR TITLE
Refactor dashboard rendering for safe event display

### DIFF
--- a/public/js/event-utils.js
+++ b/public/js/event-utils.js
@@ -1,0 +1,25 @@
+(function(){
+  function safeEventData(ev){
+    const title = String(ev.title || '');
+    const start = new Date(ev.start);
+    const end = new Date(ev.end);
+    const tOpts = { hour: '2-digit', minute: '2-digit' };
+    const startStr = start.toLocaleTimeString('de-DE', tOpts);
+    const endStr = end.toLocaleTimeString('de-DE', tOpts);
+    const shortTitle = title.length > 14 ? title.slice(0, 12) + '…' : title;
+    return {
+      id: ev.id,
+      title,
+      shortTitle,
+      rangeLabel: `${startStr}–${endStr} ${shortTitle}`,
+      when: start.toLocaleString('de-DE', {
+        weekday: 'short',
+        day: '2-digit',
+        month: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit'
+      })
+    };
+  }
+  window.safeEventData = safeEventData;
+})();


### PR DESCRIPTION
## Summary
- render dashboard calendar and upcoming list using DOM nodes instead of innerHTML
- add utility to format and sanitize event data for reuse across components
- rebuild subscription usage block with createElement and textContent

## Testing
- `STRIPE_SECRET_KEY=1 STRIPE_PUBLISHABLE_KEY=1 STRIPE_PRICE_STARTER=1 STRIPE_PRICE_STANDARD=1 STRIPE_PRICE_PROFESSIONAL=1 STRIPE_WEBHOOK_SECRET=1 composer test` *(fails: process hangs after PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68aecef574ec832b81e38015283d8356