### PR TITLE
Harden router against path traversal

### DIFF
--- a/public/router.php
+++ b/public/router.php
@@ -1,7 +1,27 @@
 <?php
 
-$path = __DIR__ . parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-if (file_exists($path) && !is_dir($path)) {
+declare(strict_types=1);
+
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '';
+$decoded = rawurldecode($uri);
+
+// deny traversal attempts
+if (str_contains($decoded, '..') || str_contains($decoded, '\\')) {
+    http_response_code(400);
+    exit('Invalid path');
+}
+
+$publicDir = realpath(__DIR__);
+$path = realpath($publicDir . $decoded);
+$allowedExt = ['css', 'js', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'ico', 'html', 'json', 'map', 'webp', 'woff', 'woff2', 'ttf'];
+
+if (
+    $path !== false
+    && str_starts_with($path, $publicDir)
+    && is_file($path)
+    && in_array(strtolower(pathinfo($path, PATHINFO_EXTENSION)), $allowedExt, true)
+) {
     return false;
 }
+
 require __DIR__ . '/index.php';


### PR DESCRIPTION
## Summary
- Harden built-in router by denying traversal patterns and verifying resolved paths stay inside the public directory
- Serve only allowed static file types via a whitelist and fall back to the main application otherwise

## Testing
- `composer test` *(fails: Controller tests and others, see log for errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aeceffa508832b9756f93a58acd391