### PR TITLE
Allow unlimited runtime for docker build process

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -1205,6 +1205,9 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
         $process = new Process([$script]);
+        $process->setTimeout(null);
+        $process->setIdleTimeout(null);
+        $process->disableOutput();
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
## Summary
- Disable process timeouts and output buffering for docker image build

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68aed0bbce28832b83697b5a9b138a71