### PR TITLE
Use shell helpers when Symfony Process is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 - Bump version to 0.2.26 [skip ci]
 - Bump version to 0.2.27 [skip ci]
 - Bump version to 0.2.28 [skip ci]
+
+### Fix
+
+- Prevent fatal errors when Symfony Process is missing
 - Bump version to 0.2.29 [skip ci]
 - Bump version to 0.2.30 [skip ci]
 - Bump version to 0.2.31 [skip ci]

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,10 @@
     "autoload": {
         "psr-4": {
             "App\\": "src/"
-        }
+        },
+        "files": [
+            "src/process_helpers.php"
+        ]
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/src/process_helpers.php
+++ b/src/process_helpers.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Run a shell script in the background.
+ * Falls back to exec if the Symfony Process component is unavailable.
+ */
+function runBackgroundProcess(string $script, array $args = []): void
+{
+    $cmd = array_merge([$script], $args);
+
+    if (class_exists(Process::class)) {
+        $process = new Process($cmd);
+        $process->disableOutput();
+        $process->start();
+        return;
+    }
+
+    $command = escapeshellcmd($script);
+    foreach ($args as $arg) {
+        $command .= ' ' . escapeshellarg($arg);
+    }
+    exec($command . ' > /dev/null 2>&1 &');
+}
+
+/**
+ * Run a shell script synchronously and return success.
+ * Falls back to exec if the Symfony Process component is unavailable.
+ */
+function runSyncProcess(string $script, array $args = []): bool
+{
+    $cmd = array_merge([$script], $args);
+
+    if (class_exists(Process::class)) {
+        $process = new Process($cmd);
+        $process->setTimeout(null);
+        $process->setIdleTimeout(null);
+        $process->disableOutput();
+        $process->run();
+        return $process->isSuccessful();
+    }
+
+    $command = escapeshellcmd($script);
+    foreach ($args as $arg) {
+        $command .= ' ' . escapeshellarg($arg);
+    }
+    exec($command, $output, $exitCode);
+    return $exitCode === 0;
+}
+

--- a/src/routes.php
+++ b/src/routes.php
@@ -79,7 +79,8 @@ use Psr\Log\NullLogger;
 use App\Controller\BackupController;
 use App\Domain\Roles;
 use App\Domain\Plan;
-use Symfony\Component\Process\Process;
+use function App\runBackgroundProcess;
+use function App\runSyncProcess;
 
 require_once __DIR__ . '/Controller/HomeController.php';
 require_once __DIR__ . '/Controller/FaqController.php';
@@ -1083,9 +1084,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             return $response->withHeader('Content-Type', 'application/json')->withStatus(500);
         }
 
-        $process = new Process([$script, $slug]);
-        $process->disableOutput();
-        $process->start();
+        runBackgroundProcess($script, [$slug]);
 
         $payload = ['status' => 'queued', 'tenant' => $slug];
         $response->getBody()->write(json_encode($payload));
@@ -1111,10 +1110,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             return $response->withHeader('Content-Type', 'application/json')->withStatus(500);
         }
 
-        $process = new Process([$script, $slug]);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
+        if (!runSyncProcess($script, [$slug])) {
             $response->getBody()->write(json_encode(['error' => 'Failed to remove tenant']));
 
             return $response->withHeader('Content-Type', 'application/json')->withStatus(500);
@@ -1139,10 +1135,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        $process = new Process([$script, '--main']);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
+        if (!runSyncProcess($script, ['--main'])) {
             $response->getBody()->write(json_encode(['error' => 'Failed to renew certificate']));
 
             return $response
@@ -1175,10 +1168,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        $process = new Process([$script, $slug]);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
+        if (!runSyncProcess($script, [$slug])) {
             $response->getBody()->write(json_encode(['error' => 'Failed to renew certificate']));
 
             return $response
@@ -1204,13 +1194,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withHeader('Content-Type', 'application/json')
                 ->withStatus(500);
         }
-        $process = new Process([$script]);
-        $process->setTimeout(null);
-        $process->setIdleTimeout(null);
-        $process->disableOutput();
-        $process->run();
-
-        if (!$process->isSuccessful()) {
+        if (!runSyncProcess($script)) {
             $response->getBody()->write(json_encode(['error' => 'Failed to build image']));
 
             return $response
@@ -1242,10 +1226,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        $process = new Process([$script, $slug]);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
+        if (!runSyncProcess($script, [$slug])) {
             $response->getBody()->write(json_encode(['error' => 'Failed to upgrade tenant']));
 
             return $response
@@ -1278,10 +1259,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        $process = new Process([$script, $slug]);
-        $process->run();
-
-        if (!$process->isSuccessful()) {
+        if (!runSyncProcess($script, [$slug])) {
             $response->getBody()->write(json_encode(['error' => 'Failed to restart tenant']));
 
             return $response


### PR DESCRIPTION
## Summary
- add runBackgroundProcess and runSyncProcess helpers with exec fallback
- call helpers from onboarding and maintenance routes to avoid fatal errors
- document Process fallback in changelog

## Testing
- `composer test` *(fails: vendor/bin/phpunit not found)*
- `vendor/bin/phpcs src/process_helpers.php src/routes.php` *(fails: vendor/bin/phpcs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed2618cd0832b8aa75149a6af2254