### PR TITLE
Restore topbar theme, contrast and help icons

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -225,6 +225,17 @@ body.uk-padding {
   background: transparent;
 }
 
+.help-switch {
+  display: inline-block;
+  margin-left: 8px;
+  margin-top: 0;
+}
+
+.help-switch a {
+  border: none;
+  background: transparent;
+}
+
 .topbar .uk-navbar-item,
 .topbar .uk-navbar-nav > li > a,
 .topbar .uk-navbar-toggle {
@@ -253,9 +264,18 @@ body.uk-padding {
   height: 56px;
 }
 
-@media (max-width: 360px) {
-  .topbar .contrast-switch {
+.topbar .options-toggle {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  .topbar .theme-switch,
+  .topbar .contrast-switch,
+  .topbar .help-switch {
     display: none;
+  }
+  .topbar .options-toggle {
+    display: flex;
   }
 }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,7 +1,7 @@
 /* global UIkit */
 document.addEventListener('DOMContentLoaded', function () {
-  const themeToggle = document.getElementById('theme-toggle');
-  const contrastToggle = document.getElementById('contrast-toggle');
+  const themeToggles = document.querySelectorAll('.theme-toggle');
+  const contrastToggles = document.querySelectorAll('.contrast-toggle');
   const darkStylesheet = document.querySelector('link[href$="dark.css"]');
 
   const storedTheme = localStorage.getItem('darkMode');
@@ -17,28 +17,32 @@ document.addEventListener('DOMContentLoaded', function () {
     document.documentElement.classList.add('dark-mode');
   }
 
-  if (themeToggle) {
-    themeToggle.addEventListener('click', function (event) {
-      event.preventDefault();
-      const dark = document.body.classList.toggle('dark-mode');
-      document.documentElement.classList.toggle('dark-mode', dark);
-      document.body.classList.toggle('uk-light', dark);
-      if (darkStylesheet) {
-        darkStylesheet.disabled = !dark;
-      }
-      localStorage.setItem('darkMode', dark ? 'true' : 'false');
+  if (themeToggles.length) {
+    themeToggles.forEach((toggle) => {
+      toggle.addEventListener('click', function (event) {
+        event.preventDefault();
+        const dark = document.body.classList.toggle('dark-mode');
+        document.documentElement.classList.toggle('dark-mode', dark);
+        document.body.classList.toggle('uk-light', dark);
+        if (darkStylesheet) {
+          darkStylesheet.disabled = !dark;
+        }
+        localStorage.setItem('darkMode', dark ? 'true' : 'false');
+      });
     });
   }
 
-  if (contrastToggle) {
+  if (contrastToggles.length) {
     const isHigh = localStorage.getItem('highContrast') === 'true';
     if (isHigh) {
       document.body.classList.add('high-contrast');
     }
-    contrastToggle.addEventListener('click', function (event) {
-      event.preventDefault();
-      const hc = document.body.classList.toggle('high-contrast');
-      localStorage.setItem('highContrast', hc ? 'true' : 'false');
+    contrastToggles.forEach((toggle) => {
+      toggle.addEventListener('click', function (event) {
+        event.preventDefault();
+        const hc = document.body.classList.toggle('high-contrast');
+        localStorage.setItem('highContrast', hc ? 'true' : 'false');
+      });
     });
   }
 

--- a/templates/_topbar_controls.twig
+++ b/templates/_topbar_controls.twig
@@ -1,9 +1,9 @@
 <ul class="uk-nav uk-nav-default">
   <li>
-    <a id="theme-toggle" href="#">{{ t('design_toggle') }}</a>
+    <a class="theme-toggle" href="#">{{ t('design_toggle') }}</a>
   </li>
   <li>
-    <a id="contrast-toggle" href="#">{{ t('contrast_toggle') }}</a>
+    <a class="contrast-toggle" href="#">{{ t('contrast_toggle') }}</a>
   </li>
   <li>
     <a href="{{ basePath }}/faq">{{ t('help') }}</a>

--- a/templates/partials/settings-offcanvas.twig
+++ b/templates/partials/settings-offcanvas.twig
@@ -2,12 +2,12 @@
   <div class="uk-offcanvas-bar">
     <ul class="uk-nav uk-nav-default">
       <li>
-        <button id="theme-toggle" class="uk-button uk-button-link uk-text-left" uk-icon="icon: moon; ratio: 0.95">
+        <button class="theme-toggle uk-button uk-button-link uk-text-left" uk-icon="icon: moon; ratio: 0.95">
           <span class="qr-nav-text">{{ t('design_toggle') }}</span>
         </button>
       </li>
       <li>
-        <button id="contrast-toggle" class="uk-button uk-button-link uk-text-left" uk-icon="icon: paint-bucket; ratio: 0.95">
+        <button class="contrast-toggle uk-button uk-button-link uk-text-left" uk-icon="icon: paint-bucket; ratio: 0.95">
           <span class="qr-nav-text">{{ t('contrast_toggle') }}</span>
         </button>
       </li>

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -14,18 +14,27 @@
       {% block center %}{% endblock %}
     </div>
   </div>
-  <div class="uk-navbar-right">
-    <div class="uk-navbar-item">
-      {% block right %}{% endblock %}
+    <div class="uk-navbar-right">
+      <div class="uk-navbar-item">
+        {% block right %}{% endblock %}
+      </div>
+      <div class="uk-navbar-item theme-switch">
+        <button class="theme-toggle uk-button uk-button-link" uk-icon="icon: moon; ratio: 0.95" title="{{ t('design_toggle') }}" aria-label="{{ t('design_toggle') }}"></button>
+      </div>
+      <div class="uk-navbar-item contrast-switch">
+        <button class="contrast-toggle uk-button uk-button-link" uk-icon="icon: paint-bucket; ratio: 0.95" title="{{ t('contrast_toggle') }}" aria-label="{{ t('contrast_toggle') }}"></button>
+      </div>
+      <div class="uk-navbar-item help-switch">
+        <a href="{{ basePath }}/faq" class="uk-button uk-button-link" uk-icon="icon: question; ratio: 0.95" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
+      </div>
+      <a class="uk-navbar-toggle options-toggle" uk-toggle="target: #settings-offcanvas" aria-label="{{ t('settings') }}">
+        <span uk-icon="icon: cog"></span>
+      </a>
+      <a id="offcanvas-toggle" class="uk-navbar-toggle" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+        <span uk-navbar-toggle-icon></span>
+      </a>
     </div>
-    <a class="uk-navbar-toggle" uk-toggle="target: #settings-offcanvas" aria-label="{{ t('settings') }}">
-      <span uk-icon="icon: cog"></span>
-    </a>
-    <a id="offcanvas-toggle" class="uk-navbar-toggle" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
-      <span uk-navbar-toggle-icon></span>
-    </a>
-  </div>
-</nav>
+  </nav>
 {% block offcanvas %}
 <div id="offcanvas-nav" uk-offcanvas="overlay: true">
   <div class="uk-offcanvas-bar">


### PR DESCRIPTION
## Summary
- Reintroduce desktop topbar icons for theme, contrast and help and move them to a mobile-only options menu
- Support multiple toggles in settings by handling theme/contrast switches via shared classes
- Add responsive styling for new controls and show settings cog only on small screens

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68af18ecccb0832bbb528de34755a168