### PR TITLE
refactor: make qr offcanvas toggle optional

### DIFF
--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -21,9 +21,7 @@
     <a class="uk-navbar-toggle" uk-toggle="target: #settings-offcanvas" aria-label="{{ t('settings') }}">
       <span uk-icon="icon: cog"></span>
     </a>
-    <a id="offcanvas-toggle" class="uk-navbar-toggle" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
-      <span uk-navbar-toggle-icon></span>
-    </a>
+    {% block qr_offcanvas_toggle %}{% endblock %}
   </div>
 </nav>
 {% block offcanvas %}


### PR DESCRIPTION
## Summary
- make QR offcanvas toggle optional via template block

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ...)*

------
https://chatgpt.com/codex/tasks/task_e_68af19169778832bae3c3aa74593db38