### PR TITLE
Refine topbar menus

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -203,9 +203,11 @@ body.uk-padding {
   white-space: nowrap;
 }
 
-.theme-switch {
+.theme-switch,
+.contrast-switch,
+.help-switch {
   display: inline-block;
-  margin-left: 8px;
+  margin-left: 0;
   margin-top: 0;
 }
 
@@ -214,21 +216,9 @@ body.uk-padding {
   background: transparent;
 }
 
-.contrast-switch {
-  display: inline-block;
-  margin-left: 8px;
-  margin-top: 0;
-}
-
 .contrast-switch button {
   border: none;
   background: transparent;
-}
-
-.help-switch {
-  display: inline-block;
-  margin-left: 8px;
-  margin-top: 0;
 }
 
 .help-switch a {
@@ -261,6 +251,12 @@ body.uk-padding {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+.topbar .theme-switch,
+.topbar .contrast-switch,
+.topbar .help-switch {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
 }
 .topbar .uk-navbar-center {
   flex: 1;

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,7 +1,7 @@
 <nav class="uk-navbar-container uk-padding-small topbar" uk-navbar>
   <div class="uk-navbar-left">
     {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle" href="#offcanvas-nav" uk-toggle aria-label="{{ t('menu') }}">
+      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle aria-label="{{ t('menu') }}">
         <span uk-navbar-toggle-icon></span>
       </a>
     {% endblock %}
@@ -30,7 +30,7 @@
       <a class="uk-navbar-toggle options-toggle" uk-toggle="target: #settings-offcanvas" aria-label="{{ t('settings') }}">
         <span uk-icon="icon: cog"></span>
       </a>
-      <a id="offcanvas-toggle" class="uk-navbar-toggle" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+      <a id="offcanvas-toggle" class="uk-navbar-toggle uk-hidden@m" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
         <span uk-navbar-toggle-icon></span>
       </a>
     </div>


### PR DESCRIPTION
## Summary
- Reduce spacing between topbar control icons
- Hide hamburger toggles on desktop

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68af1e69866c832bad2de680fe4a7c11