### PR TITLE
Add top menu icon buttons

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -99,15 +99,7 @@ body .topbar .theme-switch button,
 body .topbar .contrast-switch button,
 body .topbar .help-switch a {
   background-color: rgba(255, 255, 255, 0.1);
-}
-
-body .topbar .top-menu .nav-button {
-  background-color: rgba(255, 255, 255, 0.1);
-  border-color: #444;
-}
-
-body .topbar .top-menu .nav-button .notification-dot {
-  background-color: #1e87f0;
+  border: 1px solid #444;
 }
 body .event-header-bar {
   background-color: #1e1e1e;

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -100,6 +100,15 @@ body .topbar .contrast-switch button,
 body .topbar .help-switch a {
   background-color: rgba(255, 255, 255, 0.1);
 }
+
+body .topbar .top-menu .nav-button {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: #444;
+}
+
+body .topbar .top-menu .nav-button .notification-dot {
+  background-color: #1e87f0;
+}
 body .event-header-bar {
   background-color: #1e1e1e;
   border-color: #444;

--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -108,13 +108,17 @@ body.dark-mode.high-contrast .onboarding-timeline .timeline-step.completed {
   border-color: #ffffff;
   color: #ffffff;
 }
-
-body.high-contrast .topbar .top-menu .nav-button {
-  border-color: #000000;
+body.high-contrast .topbar .theme-switch button,
+body.high-contrast .topbar .contrast-switch button,
+body.high-contrast .topbar .help-switch a {
+  border: 2px solid #000000;
+  background-color: #ffffff;
 }
 
-body.dark-mode.high-contrast .topbar .top-menu .nav-button {
-  border-color: #ffffff;
+body.dark-mode.high-contrast .topbar .theme-switch button,
+body.dark-mode.high-contrast .topbar .contrast-switch button,
+body.dark-mode.high-contrast .topbar .help-switch a {
+  border: 2px solid #ffffff;
   background-color: #000000;
 }
 body.dark-mode.high-contrast .onboarding-timeline .timeline-step.inactive {

--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -108,6 +108,15 @@ body.dark-mode.high-contrast .onboarding-timeline .timeline-step.completed {
   border-color: #ffffff;
   color: #ffffff;
 }
+
+body.high-contrast .topbar .top-menu .nav-button {
+  border-color: #000000;
+}
+
+body.dark-mode.high-contrast .topbar .top-menu .nav-button {
+  border-color: #ffffff;
+  background-color: #000000;
+}
 body.dark-mode.high-contrast .onboarding-timeline .timeline-step.inactive {
   border-color: #999999;
   color: #999999;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -226,34 +226,6 @@ body.uk-padding {
   background: transparent;
 }
 
-.topbar .top-menu {
-  display: flex;
-  gap: 4px;
-  margin-right: 8px;
-}
-
-.topbar .top-menu .nav-button {
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  border-radius: 6px;
-  background-color: rgba(0, 0, 0, 0.05);
-  position: relative;
-}
-
-.topbar .top-menu .nav-button .notification-dot {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background-color: #1e87f0;
-}
-
 .topbar .theme-switch button,
 .topbar .contrast-switch button,
 .topbar .help-switch a {
@@ -265,6 +237,7 @@ body.uk-padding {
   justify-content: center;
   border-radius: 50%;
   background-color: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 .topbar .uk-navbar-item,

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -226,6 +226,34 @@ body.uk-padding {
   background: transparent;
 }
 
+.topbar .top-menu {
+  display: flex;
+  gap: 4px;
+  margin-right: 8px;
+}
+
+.topbar .top-menu .nav-button {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  background-color: rgba(0, 0, 0, 0.05);
+  position: relative;
+}
+
+.topbar .top-menu .nav-button .notification-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: #1e87f0;
+}
+
 .topbar .theme-switch button,
 .topbar .contrast-switch button,
 .topbar .help-switch a {

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,14 +1,14 @@
 <nav class="uk-navbar-container uk-padding-small topbar" uk-navbar>
-  <div class="uk-navbar-left">
+    <div class="uk-navbar-left">
     {% block mobile_menu_toggle %}
       <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle aria-label="{{ t('menu') }}">
         <span uk-navbar-toggle-icon></span>
       </a>
     {% endblock %}
-    <div class="uk-navbar-item">
-      {% block left %}{% endblock %}
+      <div class="uk-navbar-item">
+        {% block left %}{% endblock %}
+      </div>
     </div>
-  </div>
   <div class="uk-navbar-center">
     <div class="uk-navbar-item">
       {% block center %}{% endblock %}
@@ -17,6 +17,15 @@
     <div class="uk-navbar-right">
       <div class="uk-navbar-item">
         {% block right %}{% endblock %}
+      </div>
+      <div class="uk-navbar-item top-menu">
+        <a href="#" class="nav-button" uk-icon="icon: users" aria-label="Users"></a>
+        <a href="#" class="nav-button" uk-icon="icon: plus" aria-label="Add"></a>
+        <a href="#" class="nav-button" uk-icon="icon: circle" aria-label="Status"></a>
+        <a href="#" class="nav-button" uk-icon="icon: git-branch" aria-label="Branches"></a>
+        <a href="#" class="nav-button" uk-icon="icon: mail" aria-label="Inbox">
+          <span class="notification-dot"></span>
+        </a>
       </div>
       <div class="uk-navbar-item theme-switch">
         <button class="theme-toggle uk-button uk-button-link" uk-icon="icon: moon; ratio: 0.95" title="{{ t('design_toggle') }}" aria-label="{{ t('design_toggle') }}"></button>

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -18,15 +18,6 @@
       <div class="uk-navbar-item">
         {% block right %}{% endblock %}
       </div>
-      <div class="uk-navbar-item top-menu">
-        <a href="#" class="nav-button" uk-icon="icon: users" aria-label="Users"></a>
-        <a href="#" class="nav-button" uk-icon="icon: plus" aria-label="Add"></a>
-        <a href="#" class="nav-button" uk-icon="icon: circle" aria-label="Status"></a>
-        <a href="#" class="nav-button" uk-icon="icon: git-branch" aria-label="Branches"></a>
-        <a href="#" class="nav-button" uk-icon="icon: mail" aria-label="Inbox">
-          <span class="notification-dot"></span>
-        </a>
-      </div>
       <div class="uk-navbar-item theme-switch">
         <button class="theme-toggle uk-button uk-button-link" uk-icon="icon: moon; ratio: 0.95" title="{{ t('design_toggle') }}" aria-label="{{ t('design_toggle') }}"></button>
       </div>


### PR DESCRIPTION
## Summary
- add icon-based navigation buttons to top bar
- style top menu buttons for light, dark, and high-contrast themes

## Testing
- `composer test` *(fails: hung after PHPUnit output)*

------
https://chatgpt.com/codex/tasks/task_e_68af203874c4832bad01fb41031146ad