### PR TITLE
Use escapeshellarg for script path in process helpers

### DIFF
--- a/src/process_helpers.php
+++ b/src/process_helpers.php
@@ -21,7 +21,7 @@ function runBackgroundProcess(string $script, array $args = []): void
         return;
     }
 
-    $command = escapeshellcmd($script);
+    $command = escapeshellarg($script);
     foreach ($args as $arg) {
         $command .= ' ' . escapeshellarg($arg);
     }
@@ -45,7 +45,7 @@ function runSyncProcess(string $script, array $args = []): bool
         return $process->isSuccessful();
     }
 
-    $command = escapeshellcmd($script);
+    $command = escapeshellarg($script);
     foreach ($args as $arg) {
         $command .= ' ' . escapeshellarg($arg);
     }


### PR DESCRIPTION
## Summary
- ensure background and synchronous process fallbacks quote script paths with `escapeshellarg`

## Testing
- `vendor/bin/phpcs src/process_helpers.php`
- `php -r 'require "vendor/autoload.php"; App\\runSyncProcess("/tmp/test dir/test.sh");'` (script with spaces)
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, database error)*
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68af24762f80832bb57414b261cab4fb