### PR TITLE
fix: remove empty hamburger menu and align settings toggle

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -292,11 +292,6 @@
 {% block body %}
   <div class="landing-content">
     {% embed 'topbar.twig' %}
-      {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-      {% endblock %}
       {% block left %}
         <a class="uk-logo" href="{{ basePath }}/landing">QuizRace</a>
         {% endblock %}
@@ -311,19 +306,6 @@
       {% endblock %}
       {% block right %}
         <a class="top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt testen</a>
-      {% endblock %}
-      {% block offcanvas %}
-      <div id="offcanvas-nav" uk-offcanvas="overlay: true">
-        <div class="uk-offcanvas-bar">
-          <ul class="uk-nav uk-nav-primary">
-            <li><a href="#features">Features</a></li>
-            <li><a href="#pricing">Preise</a></li>
-            <li><a href="#contact-us">Kontakt</a></li>
-            <li><a href="{{ basePath }}/faq">FAQ</a></li>
-            <li><a href="{{ basePath }}/login">Login</a></li>
-          </ul>
-        </div>
-      </div>
       {% endblock %}
     {% endembed %}
 

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -87,11 +87,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block left %}
       <a href="{{ basePath }}/landing" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -10,11 +10,6 @@
 
 {% block body %}
   {% embed 'topbar.twig' %}
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle>
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
     {% block left %}
       <a href="{{ basePath }}/admin" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,10 +1,5 @@
 <nav class="uk-navbar-container uk-padding-small topbar" uk-navbar>
     <div class="uk-navbar-left">
-    {% block mobile_menu_toggle %}
-      <a class="uk-navbar-toggle uk-hidden@m" href="#offcanvas-nav" uk-toggle aria-label="{{ t('menu') }}">
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    {% endblock %}
       <div class="uk-navbar-item">
         {% block left %}{% endblock %}
       </div>
@@ -14,35 +9,28 @@
       {% block center %}{% endblock %}
     </div>
   </div>
-    <div class="uk-navbar-right">
-      <div class="uk-navbar-item">
-        {% block right %}{% endblock %}
-      </div>
-      <div class="uk-navbar-item theme-switch">
+      <div class="uk-navbar-right">
+        <a class="uk-navbar-toggle options-toggle" uk-toggle="target: #settings-offcanvas" aria-label="{{ t('settings') }}">
+          <span uk-icon="icon: cog"></span>
+        </a>
+        <div class="uk-navbar-item">
+          {% block right %}{% endblock %}
+        </div>
+        <div class="uk-navbar-item theme-switch">
         <button class="theme-toggle uk-button uk-button-link" uk-icon="icon: moon; ratio: 0.95" title="{{ t('design_toggle') }}" aria-label="{{ t('design_toggle') }}"></button>
       </div>
       <div class="uk-navbar-item contrast-switch">
         <button class="contrast-toggle uk-button uk-button-link" uk-icon="icon: paint-bucket; ratio: 0.95" title="{{ t('contrast_toggle') }}" aria-label="{{ t('contrast_toggle') }}"></button>
       </div>
-      <div class="uk-navbar-item help-switch">
-        <a href="{{ basePath }}/faq" class="uk-button uk-button-link" uk-icon="icon: question; ratio: 0.95" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
+        <div class="uk-navbar-item help-switch">
+          <a href="{{ basePath }}/faq" class="uk-button uk-button-link" uk-icon="icon: question; ratio: 0.95" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
+        </div>
+        <a id="offcanvas-toggle" class="uk-navbar-toggle uk-hidden@m" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+          <span uk-navbar-toggle-icon></span>
+        </a>
       </div>
-      <a class="uk-navbar-toggle options-toggle" uk-toggle="target: #settings-offcanvas" aria-label="{{ t('settings') }}">
-        <span uk-icon="icon: cog"></span>
-      </a>
-      <a id="offcanvas-toggle" class="uk-navbar-toggle uk-hidden@m" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
-        <span uk-navbar-toggle-icon></span>
-      </a>
-    </div>
-  </nav>
-{% block offcanvas %}
-<div id="offcanvas-nav" uk-offcanvas="overlay: true">
-  <div class="uk-offcanvas-bar">
-    {% block offcanvas_nav %}{% endblock %}
-  </div>
-</div>
-{% endblock %}
-{% include 'partials/settings-offcanvas.twig' %}
+    </nav>
+  {% include 'partials/settings-offcanvas.twig' %}
 {% block headerbar %}{% endblock %}
 {% block nav_placeholder %}
 <div class="nav-placeholder"></div>


### PR DESCRIPTION
## Summary
- remove unused hamburger menu and offcanvas markup
- move settings toggle to the far right in the top bar
- clean templates of leftover mobile menu blocks

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET, Slim Application Error, Failed to reload nginx: reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_68af264855a4832bab52a8ffe5fa4633