### PR TITLE
Handle spaces in script paths for process helpers

### DIFF
--- a/src/process_helpers.php
+++ b/src/process_helpers.php
@@ -26,7 +26,7 @@ function runBackgroundProcess(string $script, array $args = []): void
     } catch (\Throwable $e) {
         error_log('runBackgroundProcess failed: ' . $e->getMessage());
 
-        $command = escapeshellcmd($script);
+        $command = escapeshellarg($script);
         foreach ($args as $arg) {
             $command .= ' ' . escapeshellarg($arg);
         }
@@ -56,7 +56,7 @@ function runSyncProcess(string $script, array $args = []): bool
     } catch (\Throwable $e) {
         error_log('runSyncProcess failed: ' . $e->getMessage());
 
-        $command = escapeshellcmd($script);
+        $command = escapeshellarg($script);
         foreach ($args as $arg) {
             $command .= ' ' . escapeshellarg($arg);
         }

--- a/tests/ProcessHelpersTest.php
+++ b/tests/ProcessHelpersTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class ProcessHelpersTest extends TestCase
+{
+    public function testRunSyncProcessHandlesSpacesInScriptPath(): void
+    {
+        $dir = sys_get_temp_dir() . '/space dir ' . uniqid();
+        mkdir($dir);
+        $script = $dir . '/test script.sh';
+        file_put_contents($script, "#!/bin/sh\nexit 0\n");
+        chmod($script, 0755);
+
+        $result = \App\runSyncProcess($script);
+        $this->assertTrue($result);
+
+        unlink($script);
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary
- use `escapeshellarg` instead of `escapeshellcmd` when building shell commands
- add regression test ensuring `runSyncProcess` works with spaces in script path

## Testing
- `php -r 'require "vendor/autoload.php"; $dir=sys_get_temp_dir()."/space dir"; @mkdir($dir); $script=$dir."/test script.sh"; file_put_contents($script, "#!/bin/sh\nexit 0\n"); chmod($script,0755); var_dump(\App\runSyncProcess($script)); unlink($script); rmdir($dir);'`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*
- `vendor/bin/phpunit tests/ProcessHelpersTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68af273365c4832b93fc3b87000dd3e8