### PR TITLE
Capture process output and surface errors

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -1111,8 +1111,13 @@ return function (\Slim\App $app, TranslationService $translator) {
             return $response->withHeader('Content-Type', 'application/json')->withStatus(500);
         }
 
-        if (!runSyncProcess($script, [$slug])) {
-            $response->getBody()->write(json_encode(['error' => 'Failed to remove tenant']));
+        $result = runSyncProcess($script, [$slug]);
+        if (!$result['success']) {
+            $message = trim($result['stderr'] !== '' ? $result['stderr'] : $result['stdout']);
+            $response->getBody()->write(json_encode([
+                'error' => 'Failed to remove tenant',
+                'message' => $message,
+            ]));
 
             return $response->withHeader('Content-Type', 'application/json')->withStatus(500);
         }
@@ -1136,8 +1141,13 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        if (!runSyncProcess($script, ['--main'])) {
-            $response->getBody()->write(json_encode(['error' => 'Failed to renew certificate']));
+        $result = runSyncProcess($script, ['--main']);
+        if (!$result['success']) {
+            $message = trim($result['stderr'] !== '' ? $result['stderr'] : $result['stdout']);
+            $response->getBody()->write(json_encode([
+                'error' => 'Failed to renew certificate',
+                'message' => $message,
+            ]));
 
             return $response
                 ->withHeader('Content-Type', 'application/json')
@@ -1169,8 +1179,13 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        if (!runSyncProcess($script, [$slug])) {
-            $response->getBody()->write(json_encode(['error' => 'Failed to renew certificate']));
+        $result = runSyncProcess($script, [$slug]);
+        if (!$result['success']) {
+            $message = trim($result['stderr'] !== '' ? $result['stderr'] : $result['stdout']);
+            $response->getBody()->write(json_encode([
+                'error' => 'Failed to renew certificate',
+                'message' => $message,
+            ]));
 
             return $response
                 ->withHeader('Content-Type', 'application/json')
@@ -1195,8 +1210,13 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withHeader('Content-Type', 'application/json')
                 ->withStatus(500);
         }
-        if (!runSyncProcess($script)) {
-            $response->getBody()->write(json_encode(['error' => 'Failed to build image']));
+        $result = runSyncProcess($script);
+        if (!$result['success']) {
+            $message = trim($result['stderr'] !== '' ? $result['stderr'] : $result['stdout']);
+            $response->getBody()->write(json_encode([
+                'error' => 'Failed to build image',
+                'message' => $message,
+            ]));
 
             return $response
                 ->withHeader('Content-Type', 'application/json')
@@ -1227,8 +1247,13 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        if (!runSyncProcess($script, [$slug])) {
-            $response->getBody()->write(json_encode(['error' => 'Failed to upgrade tenant']));
+        $result = runSyncProcess($script, [$slug]);
+        if (!$result['success']) {
+            $message = trim($result['stderr'] !== '' ? $result['stderr'] : $result['stdout']);
+            $response->getBody()->write(json_encode([
+                'error' => 'Failed to upgrade tenant',
+                'message' => $message,
+            ]));
 
             return $response
                 ->withHeader('Content-Type', 'application/json')
@@ -1260,8 +1285,13 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        if (!runSyncProcess($script, [$slug])) {
-            $response->getBody()->write(json_encode(['error' => 'Failed to restart tenant']));
+        $result = runSyncProcess($script, [$slug]);
+        if (!$result['success']) {
+            $message = trim($result['stderr'] !== '' ? $result['stderr'] : $result['stdout']);
+            $response->getBody()->write(json_encode([
+                'error' => 'Failed to restart tenant',
+                'message' => $message,
+            ]));
 
             return $response
                 ->withHeader('Content-Type', 'application/json')

--- a/tests/ProcessHelpersTest.php
+++ b/tests/ProcessHelpersTest.php
@@ -17,7 +17,23 @@ class ProcessHelpersTest extends TestCase
         chmod($script, 0755);
 
         $result = \App\runSyncProcess($script);
-        $this->assertTrue($result);
+        $this->assertTrue($result['success']);
+
+        unlink($script);
+        rmdir($dir);
+    }
+
+    public function testRunSyncProcessReturnsErrorOutputOnFailure(): void
+    {
+        $dir = sys_get_temp_dir() . '/space dir ' . uniqid();
+        mkdir($dir);
+        $script = $dir . '/test script.sh';
+        file_put_contents($script, "#!/bin/sh\necho 'boom' 1>&2\nexit 1\n");
+        chmod($script, 0755);
+
+        $result = \App\runSyncProcess($script);
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('boom', $result['stderr']);
 
         unlink($script);
         rmdir($dir);


### PR DESCRIPTION
## Summary
- collect stdout/stderr when running sync processes and optionally throw errors
- propagate process error messages through API routes
- add regression tests for process helper output handling

## Testing
- `vendor/bin/phpunit tests/ProcessHelpersTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68af28d8a25c832b97ca0d37a5bb3b84