### PR TITLE
Ensure mobile topbar layout and hide admin theme switches

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -602,6 +602,11 @@ body.admin-page {
   flex-wrap: nowrap;
 }
 
+.admin-page .topbar .theme-switch,
+.admin-page .topbar .contrast-switch {
+  display: none;
+}
+
 .admin-page .topbar .uk-navbar-left {
   order: 1;
 }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -31,9 +31,6 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a class="uk-navbar-toggle" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
-        <span uk-navbar-toggle-icon></span>
-      </a>
       <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">
         QuizRace Admin
         <div class="uk-text-meta uk-text-small">v{{ version }}</div>

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,6 +1,9 @@
 <nav class="uk-navbar-container uk-padding-small topbar" uk-navbar>
     <div class="uk-navbar-left">
       <div class="uk-navbar-item">
+        <a id="offcanvas-toggle" class="uk-navbar-toggle uk-hidden@m" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+          <span uk-navbar-toggle-icon></span>
+        </a>
         {% block left %}{% endblock %}
       </div>
     </div>
@@ -22,9 +25,6 @@
         <div class="uk-navbar-item help-switch">
           <a href="{{ basePath }}/faq" class="uk-button uk-button-link" uk-icon="icon: question; ratio: 0.95" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
         </div>
-        <a id="offcanvas-toggle" class="uk-navbar-toggle uk-hidden@m" hidden uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
-          <span uk-navbar-toggle-icon></span>
-        </a>
       </div>
     </nav>
 {% block headerbar %}{% endblock %}


### PR DESCRIPTION
## Summary
- Move hamburger menu to the left of the topbar for mobile
- Hide dark mode and contrast switches on admin pages while keeping help visible
- Simplify admin topbar left block to use shared menu toggle

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68af32b1b86c832ba18fbf369dfc3c59