### PR TITLE
Remove topbar buttons from landing page

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -307,6 +307,7 @@
       {% block right %}
         <a class="top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt testen</a>
       {% endblock %}
+      {% block switches %}{% endblock %}
     {% endembed %}
 
     {{ content|raw }}

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -16,6 +16,7 @@
         <div class="uk-navbar-item">
           {% block right %}{% endblock %}
         </div>
+        {% block switches %}
         <div class="uk-navbar-item theme-switch">
         <button class="theme-toggle uk-button uk-button-link" uk-icon="icon: moon; ratio: 0.95" title="{{ t('design_toggle') }}" aria-label="{{ t('design_toggle') }}"></button>
       </div>
@@ -25,6 +26,7 @@
         <div class="uk-navbar-item help-switch">
           <a href="{{ basePath }}/faq" class="uk-button uk-button-link" uk-icon="icon: question; ratio: 0.95" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
         </div>
+        {% endblock %}
       </div>
     </nav>
 {% block headerbar %}{% endblock %}


### PR DESCRIPTION
## Summary
- Allow topbar buttons to be overridable
- Hide theme, contrast, and help icons on landing page

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68af418e432c832b99baf3e9302891d3