### PR TITLE
Make topbar help link overridable for admin sidebar

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -49,6 +49,9 @@
       </div>
     {% endblock %}
     {% block right %}{% endblock %}
+    {% block help_button %}
+      <a id="helpBtn" href="#" class="uk-button uk-button-link" uk-icon="icon: question; ratio: 0.95" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
+    {% endblock %}
     {% block nav_placeholder %}
       {% set activeRoute = currentPath|split('/admin/')|last %}
       {% if activeRoute == '' %}

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -24,7 +24,9 @@
         <button class="contrast-toggle uk-button uk-button-link" uk-icon="icon: paint-bucket; ratio: 0.95" title="{{ t('contrast_toggle') }}" aria-label="{{ t('contrast_toggle') }}"></button>
       </div>
         <div class="uk-navbar-item help-switch">
-          <a href="{{ basePath }}/faq" class="uk-button uk-button-link" uk-icon="icon: question; ratio: 0.95" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
+          {% block help_button %}
+          <a id="helpBtn" href="{{ basePath }}/faq" class="uk-button uk-button-link" uk-icon="icon: question; ratio: 0.95" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
+          {% endblock %}
         </div>
         {% endblock %}
       </div>


### PR DESCRIPTION
## Summary
- Expose topbar help link as `help_button` block with `id="helpBtn"`
- Override block in admin layout with inert help button for JS sidebar toggle

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68af443e4820832b9adbda81717239cf