### PR TITLE
feat: add profile name management

### DIFF
--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -1,0 +1,52 @@
+// Profile page logic for handling player names
+
+let nameInput;
+let nameKey;
+let uidKey;
+
+function generateRandomName() {
+  const adjectives = [
+    'Flinker', 'Lustiger', 'Mutiger', 'Schneller', 'Starker',
+    'Schlauer', 'Kreativer', 'Tapferer', 'Fröhlicher', 'Geschickter'
+  ];
+  const animals = [
+    'Fuchs', 'Panda', 'Tiger', 'Bär', 'Adler',
+    'Löwe', 'Delfin', 'Eule', 'Wal', 'Drache'
+  ];
+  const adj = adjectives[Math.floor(Math.random() * adjectives.length)];
+  const animal = animals[Math.floor(Math.random() * animals.length)];
+  const number = Math.floor(Math.random() * 100);
+  return `${adj}${animal}${number}`;
+}
+
+function saveName(e) {
+  e?.preventDefault();
+  const name = nameInput.value.trim();
+  if (name) {
+    localStorage.setItem(nameKey, name);
+  } else {
+    localStorage.removeItem(nameKey);
+  }
+  if (typeof returnUrl !== 'undefined' && returnUrl) {
+    window.location.href = returnUrl;
+  }
+}
+
+function deleteName(e) {
+  e?.preventDefault();
+  localStorage.removeItem(nameKey);
+  localStorage.removeItem(uidKey);
+  nameInput.value = generateRandomName();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  nameInput = document.getElementById('playerName');
+  const eventUid = window.quizConfig?.event_uid || '';
+  nameKey = `qr_player_name:${eventUid}`;
+  uidKey = `qr_player_uid:${eventUid}`;
+  const storedName = localStorage.getItem(nameKey);
+  nameInput.value = storedName || generateRandomName();
+  document.getElementById('save-name')?.addEventListener('click', saveName);
+  document.getElementById('delete-name')?.addEventListener('click', deleteName);
+});
+

--- a/templates/profile.twig
+++ b/templates/profile.twig
@@ -38,28 +38,7 @@
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
     const returnUrl = '{{ return }}';
-    document.addEventListener('DOMContentLoaded', () => {
-      const nameInput = document.getElementById('playerName');
-      const saveBtn = document.getElementById('save-name');
-      const deleteBtn = document.getElementById('delete-name');
-      const key = 'playerName:' + (window.quizConfig.event_uid || '');
-      const stored = localStorage.getItem(key);
-      if (stored) {
-        nameInput.value = stored;
-      }
-      saveBtn.addEventListener('click', (e) => {
-        e.preventDefault();
-        localStorage.setItem(key, nameInput.value.trim());
-        if (returnUrl) {
-          window.location.href = returnUrl;
-        }
-      });
-      deleteBtn.addEventListener('click', (e) => {
-        e.preventDefault();
-        localStorage.removeItem(key);
-        nameInput.value = '';
-      });
-    });
   </script>
+  <script src="{{ basePath }}/js/profile.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add `profile.js` for random player name generation and local storage
- load new script on profile page

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*
- `node tests/test_random_name_prompt.js` *(fails: Required code blocks not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6614cbc0832b80817c508296aaab