### PR TITLE
Add accessibility toggle and help drawer

### DIFF
--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -2,6 +2,7 @@
 body.high-contrast {
   background-color: #ffffff !important;
   color: #000000 !important;
+  font-size: 1.125em;
 }
 body.high-contrast a {
   color: #0000ee;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,10 +1,10 @@
 /* global UIkit */
 document.addEventListener('DOMContentLoaded', function () {
   const themeToggles = document.querySelectorAll('.theme-toggle');
-  const contrastToggles = document.querySelectorAll('.contrast-toggle');
+  const accessibilityToggles = document.querySelectorAll('.accessibility-toggle');
   const darkStylesheet = document.querySelector('link[href$="dark.css"]');
   const themeIcon = document.getElementById('themeIcon');
-  const contrastIcon = document.getElementById('contrastIcon');
+  const accessibilityIcon = document.getElementById('accessibilityIcon');
   const helpBtn = document.getElementById('helpBtn');
 
   const storedTheme = localStorage.getItem('darkMode');
@@ -37,12 +37,12 @@ document.addEventListener('DOMContentLoaded', function () {
       <svg viewBox="0 0 24 24">
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="currentColor"></path>
       </svg>`;
-  const contrastOnSVG = `
+  const accessibilityOnSVG = `
       <svg viewBox="0 0 24 24">
         <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/>
         <path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor"/>
       </svg>`;
-  const contrastOffSVG = `
+  const accessibilityOffSVG = `
       <svg viewBox="0 0 24 24">
         <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/>
         <path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor" opacity="0.4"/>
@@ -52,12 +52,12 @@ document.addEventListener('DOMContentLoaded', function () {
     themeIcon.innerHTML = dark ? sunSVG : moonSVG;
   }
 
-  let hc = localStorage.getItem('highContrast') === 'true';
-  if (hc) {
+  let accessible = localStorage.getItem('barrierFree') === 'true';
+  if (accessible) {
     document.body.classList.add('high-contrast');
   }
-  if (contrastIcon) {
-    contrastIcon.innerHTML = hc ? contrastOnSVG : contrastOffSVG;
+  if (accessibilityIcon) {
+    accessibilityIcon.innerHTML = accessible ? accessibilityOnSVG : accessibilityOffSVG;
   }
 
   if (themeToggles.length) {
@@ -79,14 +79,14 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  if (contrastToggles.length) {
-    contrastToggles.forEach((toggle) => {
+  if (accessibilityToggles.length) {
+    accessibilityToggles.forEach((toggle) => {
       toggle.addEventListener('click', function (event) {
         event.preventDefault();
-        hc = document.body.classList.toggle('high-contrast');
-        localStorage.setItem('highContrast', hc ? 'true' : 'false');
-        if (contrastIcon) {
-          contrastIcon.innerHTML = hc ? contrastOnSVG : contrastOffSVG;
+        accessible = document.body.classList.toggle('high-contrast');
+        localStorage.setItem('barrierFree', accessible ? 'true' : 'false');
+        if (accessibilityIcon) {
+          accessibilityIcon.innerHTML = accessible ? accessibilityOnSVG : accessibilityOffSVG;
         }
         try { UIkit.drop('#menuDrop').hide(); } catch (e) {}
       });
@@ -96,7 +96,7 @@ document.addEventListener('DOMContentLoaded', function () {
   if (helpBtn) {
     helpBtn.addEventListener('click', function () {
       try { UIkit.drop('#menuDrop').hide(); } catch (e) {}
-      UIkit.modal('#helpModal').show();
+      UIkit.offcanvas('#helpDrawer').show();
     });
   }
 

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -3,9 +3,9 @@
 return [
     'help' => 'Hilfe',
     'design_toggle' => 'Design wechseln',
-    'contrast_toggle' => 'Kontrastmodus',
+    'contrast_toggle' => 'Barrierefrei',
     'configuration' => 'Konfiguration',
-    'help_modal_text' => 'Dark-Mode und High-Contrast lassen sich hier oben im Menü umschalten. Passe Farben zentral über CSS-Variablen an (<code>--text</code>, <code>--drop-bg</code> …).',
+    'help_modal_text' => 'Dark-Mode und Barrierefrei-Modus lassen sich hier im Menü umschalten. Der Barrierefrei-Modus vergrößert die Schrift für bessere Lesbarkeit. Passe Farben zentral über CSS-Variablen an (<code>--text</code>, <code>--drop-bg</code> …).',
     'quiz_progress' => 'Fortschritt des Quiz',
     'manual_open' => 'Handbuch öffnen',
     'privacy' => 'Datenschutz',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -3,9 +3,9 @@
 return [
     'help' => 'Help',
     'design_toggle' => 'Toggle theme',
-    'contrast_toggle' => 'High contrast',
+    'contrast_toggle' => 'Barrier-free mode',
     'configuration' => 'Configuration',
-    'help_modal_text' => 'Dark mode and high contrast can be toggled here in the menu. Adjust colors via CSS variables (<code>--text</code>, <code>--drop-bg</code> …).',
+    'help_modal_text' => 'Dark mode and barrier-free mode can be toggled in this menu. The barrier-free mode enlarges fonts for better readability. Adjust colors via CSS variables (<code>--text</code>, <code>--drop-bg</code> …).',
     'quiz_progress' => 'Quiz progress',
     'manual_open' => 'Open manual',
     'privacy' => 'Privacy',

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -124,8 +124,8 @@
                 </button>
               </li>
               <li>
-                <button id="contrastToggle" class="uk-button uk-button-default git-btn contrast-toggle" aria-label="{{ t('contrast_toggle') }}">
-                  <span id="contrastIcon" aria-hidden="true">
+                <button id="accessibilityToggle" class="uk-button uk-button-default git-btn accessibility-toggle" aria-label="{{ t('contrast_toggle') }}">
+                  <span id="accessibilityIcon" aria-hidden="true">
                     <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor" opacity="0.4"/></svg>
                   </span>
                 </button>
@@ -143,10 +143,10 @@
         {% endblock %}
       </div>
     </nav>
-<div id="helpModal" class="uk-flex-top" uk-modal>
-  <div class="uk-modal-dialog uk-modal-body uk-margin-auto-vertical">
-    <button class="uk-modal-close-default" type="button" uk-close></button>
-    <h3 class="uk-modal-title">{{ t('help') }}</h3>
+<div id="helpDrawer" uk-offcanvas="flip: true; overlay: true">
+  <div class="uk-offcanvas-bar">
+    <button class="uk-offcanvas-close" type="button" uk-close></button>
+    <h3 class="uk-offcanvas-title">{{ t('help') }}</h3>
     <p>{{ t('help_modal_text')|raw }}</p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Replace always-visible icons with gear menu containing theme and barrier-free toggles plus help entry
- Show help content in a right-side drawer
- Persist barrier-free mode state and enlarge fonts when enabled

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68af69b27e04832b91a338dbd4b334f8