### PR TITLE
feat: enforce profile setup for random names

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -46,6 +46,19 @@
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
   </script>
+  <script>
+    function enforceProfile() {
+      if (!window.quizConfig?.randomNames) {
+        return;
+      }
+      const eventUid = window.quizConfig?.event_uid || '';
+      const nameKey = `qr_player_name:${eventUid}`;
+      if (!localStorage.getItem(nameKey)) {
+        location.replace('/profile?return=' + encodeURIComponent(location.href));
+      }
+    }
+    enforceProfile();
+  </script>
   <script id="catalogs-data" type="application/json">
     {{ catalogs|json_encode|raw }}
   </script>


### PR DESCRIPTION
## Summary
- enforce profile setup when randomNames enabled by redirecting users without a stored name

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ...; Tests: 266, Errors: 26, Failures: 6)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ee927c8832b8529dbc9e2c001b1