### PR TITLE
Hide topbar config menu by default

### DIFF
--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -74,7 +74,7 @@
     color:var(--text);
     min-width:auto !important;
     width:fit-content !important;
-    display:inline-block;
+    display:none;
   }
   .uk-dropdown-nav{
     display:flex;


### PR DESCRIPTION
## Summary
- hide topbar dropdown until toggled by replacing inline-block with display: none

## Testing
- `node - <<'NODE'
const fs = require('fs');
const {JSDOM} = require('jsdom');
const html = fs.readFileSync('templates/topbar.twig','utf8');
const dom = new JSDOM(html, { pretendToBeVisual: true });
const document = dom.window.document;
const window = dom.window;
const menuDrop = document.querySelector('#menuDrop');
console.log('Initial display:', window.getComputedStyle(menuDrop).display);
menuDrop.style.display = 'block';
console.log('After opening:', window.getComputedStyle(menuDrop).display);
menuDrop.style.display = 'none';
console.log('After closing:', window.getComputedStyle(menuDrop).display);
NODE`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68af75ec161c832bbefa0caf09690744