### PR TITLE
Fix admin options menu toggle

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (themeIcon) {
           themeIcon.innerHTML = dark ? sunSVG : moonSVG;
         }
-        try { UIkit.drop('#menuDrop').hide(); } catch (e) {}
+        try { UIkit.dropdown('#menuDrop').hide(); } catch (e) {}
       });
     });
   }
@@ -88,14 +88,14 @@ document.addEventListener('DOMContentLoaded', function () {
         if (accessibilityIcon) {
           accessibilityIcon.innerHTML = accessible ? accessibilityOnSVG : accessibilityOffSVG;
         }
-        try { UIkit.drop('#menuDrop').hide(); } catch (e) {}
+        try { UIkit.dropdown('#menuDrop').hide(); } catch (e) {}
       });
     });
   }
 
   if (helpBtn) {
     helpBtn.addEventListener('click', function () {
-      try { UIkit.drop('#menuDrop').hide(); } catch (e) {}
+      try { UIkit.dropdown('#menuDrop').hide(); } catch (e) {}
       UIkit.offcanvas('#helpDrawer').show();
     });
   }

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -104,17 +104,16 @@
           {% block right %}{% endblock %}
         </div>
         {% block switches %}
-        <div class="uk-navbar-item config-menu">
-          <button type="button"
+        <div class="uk-navbar-item config-menu uk-inline">
+          <button id="configMenuToggle" type="button"
                   class="uk-button uk-button-default git-btn"
                   aria-label="{{ t('configuration') }}"
-                  uk-toggle="target: #menuDrop"
                   aria-expanded="false">
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path d="M19.14 12.94a7.5 7.5 0 0 0 .05-.94 7.5 7.5 0 0 0-.05-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.33a.5.5 0 0 0-.6-.22l-2.39.96a7.6 7.6 0 0 0-1.63-.94l-.36-2.54a.5.5 0 0 0-.5-.43h-3.84a.5.5 0 0 0-.5.43l-.36 2.54c-.57.24-1.12.55-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.7 7.84a.5.5 0 0 0 .12.64l2.03 1.58c-.03.31-.05.63-.05.94s.02.63.05.94L2.82 13.5a.5.5 0 0 0-.12.64l1.92 3.33a.5.5 0 0 0 .6.22l2.39-.96c.51.39 1.06.7 1.63.94l.36 2.54a.5.5 0 0 0 .5.43h3.84a.5.5 0 0 0 .5-.43l.36-2.54c.57-.24 1.12-.55 1.63-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.33a.5.5 0 0 0-.12-.64l-2.03-1.58ZM12 15.5A3.5 3.5 0 1 1 12 8.5a3.5 3.5 0 0 1 0 7Z" fill="currentColor"/>
             </svg>
           </button>
-          <div id="menuDrop" class="uk-drop" uk-drop="mode: click; pos: bottom-right; animation: uk-animation-slide-top-small">
+          <div id="menuDrop" class="uk-dropdown" uk-dropdown="mode: click; pos: bottom-right; animation: uk-animation-slide-top-small">
             <ul class="uk-nav uk-dropdown-nav">
               <li>
                 <button id="themeToggle" class="uk-button uk-button-default git-btn theme-toggle" aria-label="{{ t('design_toggle') }}">


### PR DESCRIPTION
## Summary
- Use UIkit dropdown for configuration menu in topbar
- Update script to hide dropdown via UIkit.dropdown API

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68af793d2268832b9df593b2ff7835fe