### PR TITLE
Add player tracking endpoint and service

### DIFF
--- a/migrations/20250221_create_players_table.sql
+++ b/migrations/20250221_create_players_table.sql
@@ -1,0 +1,8 @@
+-- Create players table
+CREATE TABLE IF NOT EXISTS players (
+    event_uid TEXT NOT NULL,
+    player_name TEXT NOT NULL,
+    player_uid TEXT NOT NULL,
+    PRIMARY KEY (event_uid, player_uid),
+    CONSTRAINT fk_players_event FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
+);

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -3,6 +3,7 @@
 let nameInput;
 let nameKey;
 let uidKey;
+let eventUid;
 
 function generateRandomName() {
   const adjectives = [
@@ -27,6 +28,16 @@ function saveName(e) {
   } else {
     localStorage.removeItem(nameKey);
   }
+  let uid = localStorage.getItem(uidKey);
+  if (!uid) {
+    uid = self.crypto?.randomUUID ? self.crypto.randomUUID() : Math.random().toString(36).slice(2);
+    localStorage.setItem(uidKey, uid);
+  }
+  fetch('/api/players', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ event_uid: eventUid, player_name: name, player_uid: uid })
+  }).catch(() => {});
   if (typeof returnUrl !== 'undefined' && returnUrl) {
     window.location.href = returnUrl;
   }
@@ -41,7 +52,7 @@ function deleteName(e) {
 
 document.addEventListener('DOMContentLoaded', () => {
   nameInput = document.getElementById('playerName');
-  const eventUid = window.quizConfig?.event_uid || '';
+  eventUid = window.quizConfig?.event_uid || '';
   nameKey = `qr_player_name:${eventUid}`;
   uidKey = `qr_player_uid:${eventUid}`;
   const storedName = localStorage.getItem(nameKey);

--- a/src/Service/PlayerService.php
+++ b/src/Service/PlayerService.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use PDO;
+
+/**
+ * Service for persisting player information.
+ */
+class PlayerService
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * Store a player's data in the database.
+     */
+    public function save(string $eventUid, string $playerName, string $playerUid): void
+    {
+        if ($eventUid === '' || $playerName === '' || $playerUid === '') {
+            return;
+        }
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO players(event_uid, player_name, player_uid) VALUES(?,?,?) ON CONFLICT DO NOTHING'
+        );
+        $stmt->execute([$eventUid, $playerName, $playerUid]);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -23,6 +23,7 @@ use App\Service\TeamService;
 use App\Service\PhotoConsentService;
 use App\Service\EventService;
 use App\Service\SummaryPhotoService;
+use App\Service\PlayerService;
 use App\Service\UserService;
 use App\Service\TenantService;
 use App\Service\NginxService;
@@ -171,6 +172,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $emailConfirmService = new EmailConfirmationService($pdo);
         $auditLogger = new AuditLogger($pdo);
         $sessionService = new SessionService($pdo);
+        $playerService = new PlayerService($pdo);
 
         $request = $request
             ->withAttribute('plan', $plan)
@@ -721,6 +723,16 @@ return function (\Slim\App $app, TranslationService $translator) {
 
     $app->post('/results', function (Request $request, Response $response) {
         return $request->getAttribute('resultController')->post($request, $response);
+    });
+
+    $app->post('/api/players', function (Request $request, Response $response) use ($playerService) {
+        $data = (array) $request->getParsedBody();
+        $playerService->save(
+            (string)($data['event_uid'] ?? ''),
+            (string)($data['player_name'] ?? ''),
+            (string)($data['player_uid'] ?? '')
+        );
+        return $response->withStatus(204);
     });
 
     $app->delete('/results', function (Request $request, Response $response) {


### PR DESCRIPTION
## Summary
- add PlayerService to store player info
- expose /api/players endpoint
- persist player names from profile page and create players table

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY etc.)*
- `node --check public/js/profile.js`


------
https://chatgpt.com/codex/tasks/task_e_68af784e0254832b92418250d20d7dc7