### PR TITLE
Fix config menu not opening

### DIFF
--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -74,7 +74,6 @@
     color:var(--text);
     min-width:auto !important;
     width:fit-content !important;
-    display:none;
   }
   .uk-dropdown-nav{
     display:flex;
@@ -113,7 +112,7 @@
               <path d="M19.14 12.94a7.5 7.5 0 0 0 .05-.94 7.5 7.5 0 0 0-.05-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.33a.5.5 0 0 0-.6-.22l-2.39.96a7.6 7.6 0 0 0-1.63-.94l-.36-2.54a.5.5 0 0 0-.5-.43h-3.84a.5.5 0 0 0-.5.43l-.36 2.54c-.57.24-1.12.55-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.7 7.84a.5.5 0 0 0 .12.64l2.03 1.58c-.03.31-.05.63-.05.94s.02.63.05.94L2.82 13.5a.5.5 0 0 0-.12.64l1.92 3.33a.5.5 0 0 0 .6.22l2.39-.96c.51.39 1.06.7 1.63.94l.36 2.54a.5.5 0 0 0 .5.43h3.84a.5.5 0 0 0 .5-.43l.36-2.54c.57-.24 1.12-.55 1.63-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.33a.5.5 0 0 0-.12-.64l-2.03-1.58ZM12 15.5A3.5 3.5 0 1 1 12 8.5a3.5 3.5 0 0 1 0 7Z" fill="currentColor"/>
             </svg>
           </button>
-          <div id="menuDrop" class="uk-dropdown" uk-dropdown="mode: click; pos: bottom-right; animation: uk-animation-slide-top-small">
+          <div id="menuDrop" class="uk-dropdown" hidden uk-dropdown="mode: click; pos: bottom-right; animation: uk-animation-slide-top-small">
             <ul class="uk-nav uk-dropdown-nav">
               <li>
                 <button id="themeToggle" class="uk-button uk-button-default git-btn theme-toggle" aria-label="{{ t('design_toggle') }}">


### PR DESCRIPTION
## Summary
- allow UIkit to toggle the configuration menu by removing forced display style
- mark dropdown as hidden so it stays invisible until activated

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js` *(fails: playerNameKey is not defined)*
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js` *(fails: Required code blocks not found)*
- `vendor/bin/phpunit` *(fails: Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68af7bf296b8832bad91aec740c6017a