### PR TITLE
Add profile flow tests and player API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,9 @@ Unter `/admin` stehen folgende Tabs zur Verfügung:
 ### Teams und QR-Code-Login
 In `data/teams.json` können Teilnehmernamen gespeichert werden. `GET /teams.json` ruft die Liste ab, `POST /teams.json` speichert sie. Ein optionales Häkchen „Nur Teams/Personen aus der Liste dürfen teilnehmen“ aktiviert eine Zugangsbeschränkung via QR-Code. QR-Codes lassen sich direkt in der Oberfläche generieren.
 
+### Spielerprofil
+Auf `/profile` legen Teilnehmende ihren Anzeigenamen fest. Ist die Option für Zufallsnamen aktiv und noch kein Name hinterlegt, leitet die Startseite automatisch auf diese Profilseite weiter. Nach dem Speichern werden Name und eine zufällige Kennung lokal gespeichert und über `/api/players` an den Server gemeldet.
+
 ### Ergebnisse
 Alle Resultate werden in der Datenbank abgelegt. Die API bietet folgende Endpunkte:
 - `GET /results.json` – liefert alle gespeicherten Ergebnisse.

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -16,6 +16,14 @@ CREATE TABLE IF NOT EXISTS events (
     sort_order INTEGER NOT NULL DEFAULT 0
 );
 
+-- Players
+CREATE TABLE IF NOT EXISTS players (
+    event_uid TEXT NOT NULL,
+    player_name TEXT NOT NULL,
+    player_uid TEXT NOT NULL,
+    PRIMARY KEY (event_uid, player_uid)
+);
+
 -- Config
 CREATE TABLE IF NOT EXISTS config (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/routes.php
+++ b/src/routes.php
@@ -131,7 +131,8 @@ use App\Infrastructure\Migrations\Migrator;
 use Psr\Http\Server\RequestHandlerInterface;
 
 return function (\Slim\App $app, TranslationService $translator) {
-    $app->add(function (Request $request, RequestHandlerInterface $handler) use ($translator) {
+    $playerService = null;
+    $app->add(function (Request $request, RequestHandlerInterface $handler) use ($translator, &$playerService) {
         if ($request->getUri()->getPath() === '/healthz') {
             return $handler->handle($request);
         }
@@ -725,12 +726,12 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('resultController')->post($request, $response);
     });
 
-    $app->post('/api/players', function (Request $request, Response $response) use ($playerService) {
+    $app->post('/api/players', function (Request $request, Response $response) use (&$playerService) {
         $data = (array) $request->getParsedBody();
         $playerService->save(
-            (string)($data['event_uid'] ?? ''),
-            (string)($data['player_name'] ?? ''),
-            (string)($data['player_uid'] ?? '')
+            (string) ($data['event_uid'] ?? ''),
+            (string) ($data['player_name'] ?? ''),
+            (string) ($data['player_uid'] ?? '')
         );
         return $response->withStatus(204);
     });

--- a/tests/Controller/PlayerProfileTest.php
+++ b/tests/Controller/PlayerProfileTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+use Slim\Psr7\Factory\StreamFactory;
+
+class PlayerProfileTest extends TestCase
+{
+    public function testProfilePageAndApiPlayers(): void
+    {
+        $pdo = $this->getDatabase();
+        $pdo->exec("INSERT INTO events(uid, name) VALUES('ev1','Test')");
+
+        $app = $this->getAppInstance();
+
+        $response = $app->handle($this->createRequest('GET', '/profile'));
+        $this->assertSame(200, $response->getStatusCode());
+
+        $request = $this->createRequest('POST', '/api/players');
+        $request = $request->withParsedBody([
+            'event_uid' => 'ev1',
+            'player_name' => 'Alice',
+            'player_uid' => 'uid1',
+        ]);
+        $res = $app->handle($request);
+        $this->assertSame(204, $res->getStatusCode());
+
+        $name = $pdo->query("SELECT player_name FROM players WHERE event_uid='ev1' AND player_uid='uid1'")?->fetchColumn();
+        $this->assertSame('Alice', $name);
+    }
+}

--- a/tests/test_profile_flow.js
+++ b/tests/test_profile_flow.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Test profile enforcement redirect
+const indexCode = fs.readFileSync('templates/index.twig', 'utf8');
+const match = indexCode.match(/function enforceProfile\(\)\s*{[\s\S]*?}\s*enforceProfile\(\);/);
+if (!match) {
+  throw new Error('enforceProfile script not found');
+}
+const ctx1 = {
+  window: { quizConfig: { randomNames: true, event_uid: '' } },
+  localStorage: {
+    data: {},
+    getItem(k) { return this.data[k] ?? null; },
+    setItem(k, v) { this.data[k] = String(v); },
+  },
+  location: {
+    href: '/quiz',
+    replaced: null,
+    replace(url) { this.replaced = url; }
+  }
+};
+vm.runInNewContext(match[0], ctx1);
+assert.strictEqual(ctx1.location.replaced, '/profile?return=' + encodeURIComponent('/quiz'));
+
+// Test saving profile name
+const profileCode = fs.readFileSync('public/js/profile.js', 'utf8');
+const ctx2 = {
+  window: { quizConfig: { event_uid: '' } },
+  nameInput: { value: '' },
+  localStorage: {
+    data: {},
+    getItem(k) { return this.data[k] ?? null; },
+    setItem(k, v) { this.data[k] = String(v); },
+    removeItem(k) { delete this.data[k]; }
+  },
+  fetchCalls: [],
+  self: { crypto: { randomUUID: () => 'uid-123' } },
+  returnUrl: '/quiz',
+  location: { href: '' },
+  console,
+  document: {
+    getElementById(id) {
+      if (id === 'playerName') return ctx2.nameInput;
+      if (id === 'save-name') return { addEventListener: (ev, fn) => { ctx2.saveHandler = fn; } };
+      if (id === 'delete-name') return { addEventListener: () => {} };
+      return null;
+    },
+    addEventListener(ev, fn) {
+      if (ev === 'DOMContentLoaded') fn();
+    }
+  }
+};
+ctx2.fetch = (url, opts) => { ctx2.fetchCalls.push({ url, opts }); return Promise.resolve(); };
+ctx2.window.location = ctx2.location;
+vm.runInNewContext(profileCode, ctx2);
+ctx2.nameInput.value = 'Alice';
+ctx2.nameKey = 'qr_player_name:';
+ctx2.uidKey = 'qr_player_uid:';
+ctx2.eventUid = '';
+(async () => {
+  await ctx2.saveHandler?.({ preventDefault() {} });
+  assert.strictEqual(ctx2.localStorage.getItem('qr_player_name:'), 'Alice');
+  assert.strictEqual(ctx2.localStorage.getItem('qr_player_uid:'), 'uid-123');
+  assert.strictEqual(ctx2.fetchCalls[0].url, '/api/players');
+  assert(ctx2.fetchCalls[0].opts.body.includes('Alice'));
+  assert.strictEqual(ctx2.location.href, '/quiz');
+  console.log('ok');
+})().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- test profile flow redirects and saves player name
- verify player profile page and new /api/players endpoint
- document player profile feature

## Testing
- `node tests/test_profile_flow.js`
- `vendor/bin/phpunit tests/Controller/PlayerProfileTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68af7c77e580832b995603bb6b84625b