### PR TITLE
feat: add exponential backoff for db connection

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -21,7 +21,7 @@ POSTGRES_PASS=quiz                           # veraltet, s. POSTGRES_PASSWORD
 POSTGRES_PASSWORD=quiz                       # Passwort des DB-Benutzers
 POSTGRES_DB=quiz                             # Datenbankname
 POSTGRES_CONNECT_RETRIES=5                   # Anzahl der Verbindungsversuche
-POSTGRES_CONNECT_RETRY_DELAY=1               # Wartezeit zwischen den Versuchen (Sekunden)
+POSTGRES_CONNECT_RETRY_DELAY=1               # Startverzögerung (Sekunden, verdoppelt sich nach jedem Fehlversuch)
 
 # Mandantenkennung
 TENANT_ID=default

--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -15,9 +15,10 @@ class Database
     /**
      * Create a PDO connection using credentials from environment variables.
      *
-     * The number of connection attempts and the delay between retries can be
-     * overridden using the `POSTGRES_CONNECT_RETRIES` and
-     * `POSTGRES_CONNECT_RETRY_DELAY` environment variables.
+     * The number of connection attempts and the initial delay between retries
+     * can be overridden using the `POSTGRES_CONNECT_RETRIES` and
+     * `POSTGRES_CONNECT_RETRY_DELAY` environment variables. The delay doubles
+     * after each failed attempt to give the database more time to recover.
      */
     public static function connectFromEnv(int $retries = 5, int $delay = 1): PDO
     {
@@ -43,7 +44,9 @@ class Database
                 if ($retries-- <= 0) {
                     throw $e;
                 }
+
                 sleep($delay);
+                $delay *= 2; // exponential backoff
             }
         }
     }


### PR DESCRIPTION
## Summary
- add exponential backoff to database connection retries
- document new retry behavior in sample environment

## Testing
- `vendor/bin/phpcs src/Infrastructure/Database.php sample.env`
- `vendor/bin/phpstan analyse src/Infrastructure/Database.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY; Failed to reload nginx: reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_68af7d03a324832b93a04b9a94d30b0f