### PR TITLE
Fix subdomain action menu clipping

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2529,7 +2529,7 @@ document.addEventListener('DOMContentLoaded', function () {
           actionTd.innerHTML = `
             <div class="uk-inline">
               <a class="uk-icon-button" uk-icon="more-vertical" href="#"></a>
-              <div uk-dropdown="mode: click; pos: bottom-right">
+              <div uk-dropdown="mode: click; pos: bottom-right; container: body">
                 <ul class="uk-nav uk-dropdown-nav">
                   <li class="uk-nav-header">Aktionen</li>
                   <li><a href="#" data-action="welcome" data-sub="${safeSub}"><span uk-icon="mail" class="uk-margin-small-right"></span>Willkommensmail</a></li>
@@ -2565,7 +2565,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 </div>
                 <div>
                   <a class="uk-icon-button" uk-icon="more-vertical" href="#"></a>
-                  <div uk-dropdown="mode: click; pos: bottom-right">
+                  <div uk-dropdown="mode: click; pos: bottom-right; container: body">
                     <ul class="uk-nav uk-dropdown-nav">
                       <li class="uk-nav-header">Aktionen</li>
                       <li><a href="#" data-action="welcome" data-sub="${safeSub}">Willkommensmail</a></li>


### PR DESCRIPTION
## Summary
- prevent tenant action dropdown from being clipped by container

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY; Tests: 267, Assertions: 568, Errors: 26, Failures: 6)*

------
https://chatgpt.com/codex/tasks/task_e_68afe2f02d90832bb736de08ebf13d85