### PR TITLE
Fix mobile topbar options alignment

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -193,6 +193,10 @@ body.uk-padding {
   align-items: center;
 }
 
+.topbar .uk-navbar-right {
+  margin-left: auto;
+}
+
 .topbar .uk-navbar-right > * {
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- Ensure topbar options menu is right-aligned on mobile

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET, Slim Application Error, Database error, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68afe59957f0832bb2a865113e924451