### PR TITLE
Check QR flags before enforcing profile redirect

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -48,10 +48,11 @@
   </script>
   <script>
     function enforceProfile() {
-      if (!window.quizConfig?.randomNames) {
+      const cfg = window.quizConfig || {};
+      if (!cfg.randomNames || cfg.QRUser || cfg.QRRestrict) {
         return;
       }
-      const eventUid = window.quizConfig?.event_uid || '';
+      const eventUid = cfg.event_uid || '';
       const nameKey = `qr_player_name:${eventUid}`;
       if (!localStorage.getItem(nameKey)) {
         location.replace('/profile?return=' + encodeURIComponent(location.href));


### PR DESCRIPTION
## Summary
- Expand `enforceProfile` to respect QRUser and QRRestrict flags before redirecting to `/profile`.

## Testing
- `composer test` *(fails: Missing STRIPE_* keys and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68afea13e9d8832ba4dbe9b025686ca2