### PR TITLE
Respect QRRemember in catalog init

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -622,7 +622,8 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
 
   async function init(){
     const cfg = window.quizConfig || {};
-    if(cfg.QRRestrict){
+    if(cfg.QRRestrict && !cfg.QRRemember){
+      // Ohne Namensübernahme gespeicherte Daten löschen
       sessionStorage.removeItem(playerNameKey);
       sessionStorage.removeItem('quizSolved');
       localStorage.removeItem(playerNameKey);


### PR DESCRIPTION
## Summary
- Preserve player name and progress when QRRestrict is active but QRRemember allows carry-over

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68afea39d2f4832b810b0d6ccff68531