### PR TITLE
style: match hamburger menu toggle to options button

### DIFF
--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -87,9 +87,17 @@
 <nav class="uk-navbar-container uk-padding-small topbar" uk-navbar>
     <div class="uk-navbar-left">
       <div class="uk-navbar-item">
-        <a id="offcanvas-toggle" class="uk-navbar-toggle uk-hidden@m" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
-          <span uk-navbar-toggle-icon></span>
-        </a>
+        <button id="offcanvas-toggle"
+                type="button"
+                class="uk-button uk-button-default git-btn uk-hidden@m"
+                uk-toggle="target: #qr-offcanvas"
+                aria-label="{{ t('menu') }}">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <line x1="4" y1="6" x2="20" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            <line x1="4" y1="12" x2="20" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            <line x1="4" y1="18" x2="20" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          </svg>
+        </button>
         {% block left %}{% endblock %}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- style hamburger offcanvas toggle like configuration button with matching border

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68afefe04e04832b9dba69bd87ff5a9f