### PR TITLE
Reduce event switcher line spacing on mobile

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -632,7 +632,8 @@ body.admin-page {
 
 .admin-page #eventSelectWrap button > span:first-child {
   display: block;
-  margin-top: 4px;
+  line-height: 1.2;
+  margin-top: 0;
 }
 
 .admin-page .nav-placeholder {


### PR DESCRIPTION
## Summary
- tighten event switcher dropdown text spacing in mobile topbar

## Testing
- `vendor/bin/phpunit` *(hangs after running initial tests)*
- `python3 tests/test_html_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`


------
https://chatgpt.com/codex/tasks/task_e_68aff09e2fe0832b924f3a4d7fae51b1