### PR TITLE
Align options button to top bar edge

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -305,7 +305,7 @@
         </ul>
       {% endblock %}
       {% block right %}
-        <a class="top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt testen</a>
+        <a class="uk-navbar-item top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt testen</a>
       {% endblock %}
       {% block switches %}{% endblock %}
     {% endembed %}

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -107,9 +107,7 @@
     </div>
   </div>
       <div class="uk-navbar-right">
-        <div class="uk-navbar-item">
-          {% block right %}{% endblock %}
-        </div>
+        {% block right %}{% endblock %}
         {% block switches %}
         <div class="uk-navbar-item config-menu uk-inline">
           <button id="configMenuToggle" type="button"


### PR DESCRIPTION
## Summary
- ensure options/config menu sits at the far right of the top bar
- keep marketing CTA aligned by adding `uk-navbar-item`

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68aff4ae5110832ba15627bae8551210