### PR TITLE
Improve button border contrast

### DIFF
--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,8 +1,8 @@
 <style>
   :root{
     --btn-bg: transparent;
-    --btn-border: rgba(27,31,35,0.12);
-    --btn-border-hover: rgba(27,31,35,0.2);
+    --btn-border: rgba(0,0,0,0.3);
+    --btn-border-hover: rgba(0,0,0,0.5);
     --btn-bg-hover: rgba(27,31,35,0.06);
     --focus-ring: rgba(3,102,214,0.18);
     --drop-bg: #fff;
@@ -11,8 +11,8 @@
   }
   @media (prefers-color-scheme: dark){
     :root{
-      --btn-border: rgba(255,255,255,0.18);
-      --btn-border-hover: rgba(255,255,255,0.28);
+      --btn-border: rgba(255,255,255,0.3);
+      --btn-border-hover: rgba(255,255,255,0.5);
       --btn-bg-hover: rgba(255,255,255,0.08);
       --focus-ring: rgba(100,180,255,0.25);
       --drop-bg: #1f232a;
@@ -21,8 +21,8 @@
     }
   }
   body.dark-mode{
-    --btn-border: rgba(255,255,255,0.18);
-    --btn-border-hover: rgba(255,255,255,0.28);
+    --btn-border: rgba(255,255,255,0.3);
+    --btn-border-hover: rgba(255,255,255,0.5);
     --btn-bg-hover: rgba(255,255,255,0.08);
     --focus-ring: rgba(100,180,255,0.25);
     --drop-bg: #1f232a;
@@ -66,6 +66,7 @@
     box-shadow:0 0 0 3px var(--focus-ring);
   }
   .git-btn svg{width:22px;height:22px;}
+  #offcanvas-toggle.git-btn{border-color:var(--btn-border);}
   #menuDrop{
     background:var(--drop-bg);
     border:1px solid var(--drop-border);


### PR DESCRIPTION
## Summary
- increase button border contrast for light and dark modes
- ensure offcanvas toggle uses the border variable

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68afff893228832b867855de1b242385