### PR TITLE
Enable admin topbar wrapping on narrow screens

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -603,7 +603,7 @@ body.admin-page {
 
 .admin-page .topbar {
   height: auto;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 
 .admin-page .topbar .theme-switch,


### PR DESCRIPTION
## Summary
- Allow admin topbar to wrap so event selector drops below navigation on narrow screens

## Testing
- `composer test` *(fails: process hung after executing phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68afff97e034832b83892dfc4b6e22eb