### PR TITLE
Make topbar sticky and simplify layout

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -173,7 +173,7 @@ body.uk-padding {
 }
 
 .topbar {
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
   right: 0;
@@ -273,11 +273,6 @@ body.uk-padding {
   width: 100%;
   justify-content: center;
 }
-
-.nav-placeholder {
-  height: 56px;
-}
-
 
 .event-header-bar {
   background: #fff;
@@ -391,7 +386,6 @@ a.uk-accordion-title {
 @media print {
   .topbar,
   .sticky-tabs,
-  .nav-placeholder,
   #adminTabs,
   .site-footer,
   .footer-menu,
@@ -636,10 +630,6 @@ body.admin-page {
   margin-top: 0;
 }
 
-.admin-page .nav-placeholder {
-  height: 112px;
-}
-
 @media (min-width: 640px) {
   #adminTabs {
     display: flex;
@@ -661,9 +651,6 @@ body.admin-page {
   .admin-page #eventSelectWrap {
     flex: 0;
     min-width: 220px;
-  }
-  .admin-page .nav-placeholder {
-    height: 56px;
   }
 }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -140,25 +140,4 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  const topbar = document.querySelector('.topbar');
-  const navPlaceholder = document.querySelector('.nav-placeholder');
-
-  function updateNavPlaceholder() {
-    let height = topbar.offsetHeight;
-    const headerBar = document.querySelector('.event-header-bar');
-    if (headerBar) {
-      height += headerBar.offsetHeight;
-    }
-    navPlaceholder.style.height = height + 'px';
-  }
-
-  if (topbar && navPlaceholder) {
-    updateNavPlaceholder();
-  }
-
-  window.addEventListener('resize', () => {
-    if (topbar && navPlaceholder) {
-      updateNavPlaceholder();
-    }
-  });
 });

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -52,19 +52,15 @@
     {% block help_button %}
       <a id="helpBtn" href="#" class="uk-button uk-button-link" uk-icon="icon: question; ratio: 0.95" title="{{ t('help') }}" aria-label="{{ t('help') }}"></a>
     {% endblock %}
-    {% block nav_placeholder %}
+    {% block headerbar %}
       {% set activeRoute = currentPath|split('/admin/')|last %}
       {% if activeRoute == '' %}
         {% set activeRoute = 'dashboard' %}
       {% endif %}
       {% if activeRoute == 'dashboard' %}
-        <div class="nav-placeholder">
-          <div class="uk-container uk-container-large">
-            <h2 class="uk-heading-bullet">Willkommen {{ username }}</h2>
-          </div>
+        <div class="uk-container uk-container-large">
+          <h2 class="uk-heading-bullet">Willkommen {{ username }}</h2>
         </div>
-      {% else %}
-        <div class="nav-placeholder"></div>
       {% endif %}
     {% endblock %}
   {% endembed %}

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -31,11 +31,9 @@
         </div>
       </div>
     {% endblock %}
-    {% block nav_placeholder %}
-      <div class="nav-placeholder">
-        <div class="uk-container uk-container-large">
-          <h2 class="uk-heading-bullet">{{ t('heading_logs') }}</h2>
-        </div>
+    {% block headerbar %}
+      <div class="uk-container uk-container-large">
+        <h2 class="uk-heading-bullet">{{ t('heading_logs') }}</h2>
       </div>
     {% endblock %}
   {% endembed %}

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -69,6 +69,3 @@
   </div>
 </div>
 {% block headerbar %}{% endblock %}
-{% block nav_placeholder %}
-<div class="nav-placeholder"></div>
-{% endblock %}


### PR DESCRIPTION
## Summary
- make topbar sticky instead of fixed
- drop nav-placeholder elements and related JS logic
- tidy admin header blocks now that placeholders are gone

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `vendor/bin/phpunit` *(fails: missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b0628cd050832bb0c2c76c59ccc647