### PR TITLE
Ensure latest image pulled before tenant upgrade

### DIFF
--- a/scripts/upgrade_tenant.sh
+++ b/scripts/upgrade_tenant.sh
@@ -35,6 +35,11 @@ if [ ! -f "$COMPOSE_FILE" ]; then
   exit 1
 fi
 
+if ! $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" pull "$SERVICE" >/dev/null 2>&1; then
+  echo "pull failed" >&2
+  exit 1
+fi
+
 if ! $DOCKER_COMPOSE -f "$COMPOSE_FILE" -p "$SLUG" up -d --no-deps --force-recreate "$SERVICE" >/dev/null 2>&1; then
   echo "upgrade failed" >&2
   exit 1


### PR DESCRIPTION
## Summary
- pull tenant service image before compose up to guarantee fresh image
- surface pull failures with clear stderr message for API consumption

## Testing
- `composer install`
- `./scripts/run_tests.sh` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b064fdc564832ba5321f1acf3a04e0