### PR TITLE
feat: allow custom image tag for tenant upgrade

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -167,7 +167,18 @@ document.addEventListener('DOMContentLoaded', function () {
       const originalHtml = el.innerHTML;
       const text = (el.textContent || '').trim();
       el.innerHTML = text ? `<span class="uk-margin-small-right" uk-spinner></span>${text}` : '<span uk-spinner></span>';
-      apiFetch('/api/tenants/' + encodeURIComponent(sub) + '/upgrade', { method: 'POST' })
+      const tag = window.prompt(window.transDockerTagPrompt || 'Neues Docker-Tag:');
+      if (tag === null) {
+        el.innerHTML = originalHtml;
+        el.classList.remove('uk-disabled');
+        return;
+      }
+      const opts = { method: 'POST' };
+      if ((tag || '').trim() !== '') {
+        opts.headers = { 'Content-Type': 'application/json' };
+        opts.body = JSON.stringify({ image: tag.trim() });
+      }
+      apiFetch('/api/tenants/' + encodeURIComponent(sub) + '/upgrade', opts)
         .then(r => r.json().then(data => ({ ok: r.ok, data })))
         .then(({ ok, data }) => {
           if (!ok) throw new Error(data.error || 'Fehler');

--- a/src/routes.php
+++ b/src/routes.php
@@ -1287,7 +1287,15 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        $result = runSyncProcess($script, [$slug]);
+        $body = (array) $request->getParsedBody();
+        $image = isset($body['image']) ? (string) $body['image'] : '';
+        $cmd = [$slug];
+        if ($image !== '') {
+            $cmd[] = '--image';
+            $cmd[] = $image;
+        }
+
+        $result = runSyncProcess($script, $cmd);
         if (!$result['success']) {
             $message = trim($result['stderr'] !== '' ? $result['stderr'] : $result['stdout']);
             $response->getBody()->write(json_encode([


### PR DESCRIPTION
## Summary
- allow specifying custom Docker image tag in upgrade_tenant.sh
- forward optional image tag through API and admin UI

## Testing
- `sh -n scripts/upgrade_tenant.sh`
- `scripts/run_tests.sh` *(fails: Missing STRIPE_* env vars but tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68b066dc9578832b9c8a8d818e74f115