### PR TITLE
Allow templates to define custom help buttons

### DIFF
--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -22,6 +22,7 @@
   </div>
       <div class="uk-navbar-right">
         {% block right %}{% endblock %}
+        {% block help_button %}{% endblock %}
         {% block switches %}
         <div class="uk-navbar-item config-menu uk-inline">
           <button id="configMenuToggle" type="button"


### PR DESCRIPTION
## Summary
- add a new `help_button` block to `topbar.twig` so templates can inject their own help button

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b073d59d00832b8384ec41a0faf848