### PR TITLE
Remove legacy topbar controls partial

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1147,7 +1147,6 @@
       <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
       <h3 class="uk-margin-small">QuizRace</h3>
       {% include 'admin/_nav.twig' %}
-      {% include '_topbar_controls.twig' %}
     </div>
   </div>
 {% endblock %}

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -27,7 +27,6 @@
           <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
           <h3 class="uk-margin-small">QuizRace</h3>
           {% include 'admin/_nav.twig' %}
-          {% include '_topbar_controls.twig' %}
         </div>
       </div>
     {% endblock %}


### PR DESCRIPTION
## Summary
- drop unused `_topbar_controls.twig` include from admin templates
- rely on topbar dropdown for theme and accessibility toggles

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b07a627e80832b8b6aaa9322c07824