### PR TITLE
Add navigation roles for accessibility

### DIFF
--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,4 +1,4 @@
-<nav class="uk-navbar-container uk-padding-small topbar" uk-navbar>
+<nav class="uk-navbar-container uk-padding-small topbar" role="navigation" aria-label="{{ t('primary_navigation') }}" uk-navbar>
     <div class="uk-navbar-left">
       <div class="uk-navbar-item">
         <button id="offcanvas-toggle"
@@ -37,23 +37,23 @@
             </svg>
           </button>
           <div id="menuDrop" class="uk-dropdown" hidden uk-dropdown="mode: click; pos: bottom-right; animation: uk-animation-slide-top-small">
-            <ul class="uk-nav uk-dropdown-nav">
+            <ul class="uk-nav uk-dropdown-nav" role="menu">
               <li>
-                <button id="themeToggle" class="uk-button uk-button-default git-btn theme-toggle" aria-label="{{ t('design_toggle') }}">
+                <button id="themeToggle" class="uk-button uk-button-default git-btn theme-toggle" aria-label="{{ t('design_toggle') }}" role="menuitem">
                   <span id="themeIcon" aria-hidden="true">
                     <svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="currentColor"></path></svg>
                   </span>
                 </button>
               </li>
               <li>
-                <button id="accessibilityToggle" class="uk-button uk-button-default git-btn accessibility-toggle" aria-label="{{ t('contrast_toggle') }}">
+                <button id="accessibilityToggle" class="uk-button uk-button-default git-btn accessibility-toggle" aria-label="{{ t('contrast_toggle') }}" role="menuitem">
                   <span id="accessibilityIcon" aria-hidden="true">
                     <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor" opacity="0.4"/></svg>
                   </span>
                 </button>
               </li>
               <li>
-                <button id="helpBtn" class="uk-button uk-button-default git-btn" aria-label="{{ t('help') }}">
+                <button id="helpBtn" class="uk-button uk-button-default git-btn" aria-label="{{ t('help') }}" role="menuitem">
                   <span aria-hidden="true">
                     <svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2Zm0 16a1.25 1.25 0 1 1 0 2.5A1.25 1.25 0 0 1 12 18Zm1.1-3.9v.65h-2.1V14c0-1.35.9-2.01 1.84-2.56.84-.5 1.66-.99 1.66-1.94 0-.86-.7-1.5-1.75-1.5-1.06 0-1.77.63-1.9 1.6H8.7C8.86 7.63 10.13 6 12.75 6c2.32 0 3.9 1.33 3.9 3.23 0 1.87-1.46 2.7-2.37 3.22-.87.5-1.18.76-1.18 1.65Z" fill="currentColor"/></svg>
                   </span>


### PR DESCRIPTION
## Summary
- add navigation role and primary aria-label to top bar
- mark configuration dropdown as menu with menu items

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and related env variables)*
- `npx --yes pa11y templates/topbar.twig` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b07d5d5e0c832b8e58714af82f6ec9