### PR TITLE
style: improve landing topbar contrast

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -175,6 +175,7 @@
       flex-wrap: nowrap;
       display: flex;
       align-items: center;
+      background: #0c86d0;
     }
     .topbar .uk-navbar-left {
       padding-left: 0.5rem;
@@ -193,6 +194,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      color: #fff;
     }
     .topbar .uk-navbar-toggle {
       width: 44px;
@@ -206,6 +208,7 @@
       padding: 0;
       font-family: 'Poppins', sans-serif;
       font-weight: 700;
+      color: #fff;
     }
     @media (max-width: 640px) {
       .topbar .uk-logo {
@@ -219,8 +222,6 @@
     }
     .top-cta,
     .cta-main {
-      background: #007bff;
-      color: #fff;
       border-radius: 8px;
       font-family: 'Poppins',sans-serif;
       font-weight: 500;
@@ -232,6 +233,15 @@
       font-size: 0.875rem;
       white-space: nowrap;
       display: inline-block;
+      background: #fff;
+      color: #0c86d0;
+    }
+    .top-cta:hover {
+      background: #e5e5e5;
+    }
+    .cta-main {
+      background: #007bff;
+      color: #fff;
     }
     .cta-main {
       display: block;


### PR DESCRIPTION
## Summary
- Emphasize landing topbar with blue background and white navigation text
- Re-style call-to-action in topbar to appear as white button with blue text

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY; Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b07de924c0832b87bf2910a166af07