### PR TITLE
Improve topbar button contrast in light mode

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -1,12 +1,12 @@
 :root{
   --btn-bg: transparent;
-  --btn-border: rgba(0,0,0,0.3);
-  --btn-border-hover: rgba(0,0,0,0.5);
+  --btn-border: rgba(0,0,0,0.6);
+  --btn-border-hover: rgba(0,0,0,0.8);
   --btn-bg-hover: rgba(27,31,35,0.06);
-  --focus-ring: rgba(3,102,214,0.18);
+  --focus-ring: rgba(3,102,214,0.25);
   --drop-bg: #fff;
   --drop-border: rgba(27,31,35,0.12);
-  --text: #111;
+  --text: #000;
 }
 @media (prefers-color-scheme: dark){
   :root{
@@ -64,7 +64,7 @@ body.dark-mode.high-contrast{
   outline:none;
   box-shadow:0 0 0 3px var(--focus-ring);
 }
-.git-btn svg{width:22px;height:22px;}
+.git-btn svg{width:24px;height:24px;}
 #offcanvas-toggle.git-btn{border-color:var(--btn-border);}
 #menuDrop{
   background:var(--drop-bg);

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -10,9 +10,9 @@
                 aria-haspopup="true"
                 aria-label="{{ t('menu') }}">
           <svg viewBox="0 0 24 24" aria-hidden="true">
-            <line x1="4" y1="6" x2="20" y2="6" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-            <line x1="4" y1="12" x2="20" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-            <line x1="4" y1="18" x2="20" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            <line x1="4" y1="6" x2="20" y2="6" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+            <line x1="4" y1="12" x2="20" y2="12" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+            <line x1="4" y1="18" x2="20" y2="18" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
           </svg>
         </button>
         {% block left %}{% endblock %}


### PR DESCRIPTION
## Summary
- Increase light mode button border opacity for better visibility
- Darken topbar icons and enlarge hamburger lines for improved contrast

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b07f3289ac832b921c6906927e8e65