### PR TITLE
Remove Docker tag requirement for tenant upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,10 @@
 - Bump version to 0.2.122 [skip ci]
 - Bump version to 0.2.123 [skip ci]
 
+### Feat
+
+- Tenant upgrade endpoint no longer requires Docker tag
+
 ### Docs
 
 - Remove version bump entries from changelog

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -167,18 +167,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const originalHtml = el.innerHTML;
       const text = (el.textContent || '').trim();
       el.innerHTML = text ? `<span class="uk-margin-small-right" uk-spinner></span>${text}` : '<span uk-spinner></span>';
-      const tag = window.prompt(window.transDockerTagPrompt || 'Neues Docker-Tag:');
-      if (tag === null) {
-        el.innerHTML = originalHtml;
-        el.classList.remove('uk-disabled');
-        return;
-      }
-      const opts = { method: 'POST' };
-      if ((tag || '').trim() !== '') {
-        opts.headers = { 'Content-Type': 'application/json' };
-        opts.body = JSON.stringify({ image: tag.trim() });
-      }
-      apiFetch('/api/tenants/' + encodeURIComponent(sub) + '/upgrade', opts)
+      apiFetch('/api/tenants/' + encodeURIComponent(sub) + '/upgrade', { method: 'POST' })
         .then(r => r.json().then(data => ({ ok: r.ok, data })))
         .then(({ ok, data }) => {
           if (!ok) throw new Error(data.error || 'Fehler');

--- a/src/routes.php
+++ b/src/routes.php
@@ -1302,16 +1302,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
 
-        $body = (array) $request->getParsedBody();
-        $image = isset($body['image']) ? (string) $body['image'] : '';
-        if ($image === '') {
-            $response->getBody()->write(json_encode(['error' => 'Image tag required']));
-
-            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
-        }
-
-        $cmd = [$slug, '--image', $image];
-        $result = runSyncProcess($script, $cmd);
+        $result = runSyncProcess($script, [$slug]);
         if (!$result['success']) {
             $message = trim($result['stderr'] !== '' ? $result['stderr'] : $result['stdout']);
             $response->getBody()->write(json_encode([
@@ -1383,19 +1374,6 @@ return function (\Slim\App $app, TranslationService $translator) {
                 ->withStatus(500);
         }
         $currentImage = trim($inspect['stdout']);
-
-        if ($currentImage !== $image) {
-            $response->getBody()->write(json_encode([
-                'error' => 'Image tag mismatch',
-                'expected' => $image,
-                'actual' => $currentImage,
-                'slug' => $slug,
-            ]));
-
-            return $response
-                ->withHeader('Content-Type', 'application/json')
-                ->withStatus(500);
-        }
 
         $response->getBody()->write(json_encode([
             'status' => 'success',

--- a/tests/Controller/UpgradeTenantRouteTest.php
+++ b/tests/Controller/UpgradeTenantRouteTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Domain\Roles;
+use Tests\TestCase;
+
+class UpgradeTenantRouteTest extends TestCase
+{
+    public function testUpgradeWorksWithoutTag(): void
+    {
+        $script = __DIR__ . '/../../scripts/upgrade_tenant.sh';
+        $backup = $script . '.bak';
+        rename($script, $backup);
+        file_put_contents($script, "#!/bin/sh\nexit 0\n");
+        chmod($script, 0755);
+
+        $dir = sys_get_temp_dir() . '/docker-' . uniqid();
+        mkdir($dir);
+        $docker = $dir . '/docker';
+        file_put_contents(
+            $docker,
+            "#!/bin/sh\n" .
+            "if [ \"$1\" = \"compose\" ] && [ \"$2\" = \"version\" ]; then\n" .
+            "  exit 0\n" .
+            "elif [ \"$1\" = \"compose\" ]; then\n" .
+            "  echo abc123\n" .
+            "  exit 0\n" .
+            "elif [ \"$1\" = \"inspect\" ]; then\n" .
+            "  echo test-image:latest\n" .
+            "  exit 0\n" .
+            "fi\n" .
+            "exit 0\n"
+        );
+        chmod($docker, 0755);
+        $oldPath = getenv('PATH');
+        putenv('PATH=' . $dir . ':' . $oldPath);
+
+        putenv('MAIN_DOMAIN=example.com');
+        $_ENV['MAIN_DOMAIN'] = 'example.com';
+
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        $_SESSION['user'] = ['role' => Roles::ADMIN];
+
+        $app = $this->getAppInstance();
+        $req = $this->createRequest('POST', '/api/tenants/foo/upgrade', [
+            'HTTP_HOST'   => 'example.com',
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+        $req = $req->withUri($req->getUri()->withHost('example.com'));
+        $res = $app->handle($req);
+
+        $this->assertSame(200, $res->getStatusCode());
+        $data = json_decode((string) $res->getBody(), true);
+        $this->assertSame('success', $data['status'] ?? null);
+        $this->assertSame('foo', $data['slug'] ?? null);
+
+        @session_destroy();
+        putenv('MAIN_DOMAIN');
+        unset($_ENV['MAIN_DOMAIN']);
+        putenv('PATH=' . $oldPath);
+        unlink($docker);
+        rmdir($dir);
+        unlink($script);
+        rename($backup, $script);
+    }
+}


### PR DESCRIPTION
## Summary
- drop image tag handling in tenant upgrade API and route
- simplify admin upgrade action to call API without tag
- document tag-free upgrade and add regression test

## Testing
- `vendor/bin/phpunit --filter UpgradeTenantRouteTest`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d0bdca20832b872fc41f2dbabaa4