### PR TITLE
Fix git button contrast handling

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -95,8 +95,8 @@ body .topbar {
   padding-top: env(safe-area-inset-top);
 }
 
-body .git-btn,
-body .uk-icon-button:not(.uk-button-primary) {
+body.dark-mode .git-btn,
+body.dark-mode .uk-icon-button:not(.uk-button-primary) {
   background-color: rgba(255, 255, 255, 0.1);
   border: 1px solid #444;
 }

--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -113,12 +113,14 @@ body.high-contrast .uk-icon-button,
 body.high-contrast .git-btn {
   border: 2px solid #000000;
   background-color: #ffffff;
+  color: #000000;
 }
 
 body.dark-mode.high-contrast .uk-icon-button,
 body.dark-mode.high-contrast .git-btn {
   border: 2px solid #ffffff;
   background-color: #000000;
+  color: #ffffff;
 }
 body.dark-mode.high-contrast .onboarding-timeline .timeline-step.inactive {
   border-color: #999999;


### PR DESCRIPTION
## Summary
- scope git button styles to dark mode so light theme uses correct colors
- ensure high contrast mode buttons display icons with explicit text colors

## Testing
- `vendor/bin/phpunit`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py` *(no output)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0d48c4414832ba7764695cc29d2a5