### PR TITLE
Add docker slim log to admin logs page

### DIFF
--- a/src/Controller/AdminLogsController.php
+++ b/src/Controller/AdminLogsController.php
@@ -18,6 +18,7 @@ class AdminLogsController
     {
         $appLog = LogService::tail('app');
         $stripeLog = LogService::tail('stripe');
+        $slimLog = LogService::tailDocker('slim-1');
         $view = Twig::fromRequest($request);
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
@@ -26,6 +27,7 @@ class AdminLogsController
         return $view->render($response, 'admin/logs.twig', [
             'appLog' => $appLog,
             'stripeLog' => $stripeLog,
+            'slimLog' => $slimLog,
             'role' => $role,
             'currentPath' => $request->getUri()->getPath(),
             'domainType' => $request->getAttribute('domainType'),

--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -8,6 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Level;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+use function App\runSyncProcess;
 
 /**
  * Factory for Monolog loggers that write to the application's log directory.
@@ -47,5 +48,17 @@ class LogService
             return '';
         }
         return implode('', array_slice($content, -$lines));
+    }
+
+    /**
+     * Fetch the most recent Docker log lines for the given container.
+     */
+    public static function tailDocker(string $container, int $lines = 20): string
+    {
+        $result = runSyncProcess('docker', ['logs', '--tail', (string) $lines, $container]);
+        if ($result['stdout'] !== '') {
+            return $result['stdout'];
+        }
+        return $result['stderr'];
     }
 }

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -56,6 +56,12 @@
         {% else %}
           <p class="uk-text-muted">{{ t('text_no_logs') }}</p>
         {% endif %}
+        <h2>docker slim</h2>
+        {% if slimLog %}
+          <pre class="uk-text-small">{{ slimLog|e }}</pre>
+        {% else %}
+          <p class="uk-text-muted">{{ t('text_no_logs') }}</p>
+        {% endif %}
       </div>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- show docker logs of slim container on admin logs page
- support fetching container logs via LogService

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, database and nginx errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d54f1b64832ba8142ec810442e91