### PR TITLE
Add color styles for high-contrast Git button

### DIFF
--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -115,10 +115,18 @@ body.high-contrast .git-btn {
   background-color: #ffffff;
 }
 
+body.high-contrast .git-btn {
+  color: #000000;
+}
+
 body.dark-mode.high-contrast .uk-icon-button,
 body.dark-mode.high-contrast .git-btn {
   border: 2px solid #ffffff;
   background-color: #000000;
+}
+
+body.dark-mode.high-contrast .git-btn {
+  color: #ffffff;
 }
 body.dark-mode.high-contrast .onboarding-timeline .timeline-step.inactive {
   border-color: #999999;


### PR DESCRIPTION
## Summary
- ensure Git button has distinct colors in high-contrast and dark high-contrast themes

## Testing
- `npm run build` *(fails: Could not read package.json)*
- `scripts/run_tests.sh` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dc0b0ab4832bacc0004ab6d2b39b