### PR TITLE
fix: remove opacity from accessibility toggle icon

### DIFF
--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -48,7 +48,7 @@
               <li>
                 <button id="accessibilityToggle" class="uk-button uk-button-default git-btn accessibility-toggle" aria-label="{{ t('contrast_toggle') }}" role="menuitem">
                   <span id="accessibilityIcon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor" opacity="0.4"/></svg>
+                    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor" /></svg>
                   </span>
                 </button>
               </li>


### PR DESCRIPTION
## Summary
- ensure accessibility toggle icon uses full currentColor

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b0df8c6980832b907c98aace9ab5f5