### PR TITLE
feat: dark pricing cards

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -413,6 +413,22 @@ body.dark-mode .onboarding-timeline .timeline-step.completed {
   color: #1e87f0;
 }
 
+body .pricing-grid .uk-card-quizrace {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+}
+
+body .pricing-grid .uk-card-quizrace.uk-card-popular {
+  background-color: #0c86d0;
+  color: #fff;
+}
+
+body .pricing-grid .uk-card-quizrace .uk-text-meta,
+body .pricing-grid .uk-card-quizrace li,
+body .pricing-grid .uk-card-quizrace h3 {
+  color: #f5f5f5;
+}
+
 body.dark-mode .pricing-grid .uk-card-quizrace {
   background-color: #1e1e1e;
   color: #f5f5f5;


### PR DESCRIPTION
## Summary
- extend prefers-color-scheme dark styles for pricing cards

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f1f70908832bafd869be1ff1476e