### PR TITLE
Improve button contrast in dark mode

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -44,6 +44,25 @@ body .uk-button-default {
   background-color: #333;
   border-color: #555;
 }
+body .btn-black {
+  background-color: #333 !important;
+  color: #f5f5f5 !important;
+  border: 2px solid #666;
+}
+body .btn-black:hover {
+  background-color: #f5f5f5 !important;
+  color: #000 !important;
+  border-color: #f5f5f5;
+}
+body .btn-transparent {
+  background-color: transparent !important;
+  color: #9dc6ff !important;
+  border: 2px solid #9dc6ff;
+}
+body .btn-transparent:hover {
+  background-color: #9dc6ff !important;
+  color: #000 !important;
+}
 body input,
 body textarea,
 body select {
@@ -325,6 +344,25 @@ body.dark-mode .uk-button-default {
   color: #fff;
   background-color: #333;
   border-color: #555;
+}
+body.dark-mode .btn-black {
+  background-color: #333 !important;
+  color: #f5f5f5 !important;
+  border: 2px solid #666;
+}
+body.dark-mode .btn-black:hover {
+  background-color: #f5f5f5 !important;
+  color: #000 !important;
+  border-color: #f5f5f5;
+}
+body.dark-mode .btn-transparent {
+  background-color: transparent !important;
+  color: #9dc6ff !important;
+  border: 2px solid #9dc6ff;
+}
+body.dark-mode .btn-transparent:hover {
+  background-color: #9dc6ff !important;
+  color: #000 !important;
 }
 body.dark-mode input,
 body.dark-mode textarea,


### PR DESCRIPTION
## Summary
- ensure btn-black and btn-transparent are legible in dark themes
- add high-contrast hover states for dark mode buttons

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f225b310832b9b6baa7b85c073ad