### PR TITLE
refactor: use accent color variable in dark mode

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -6,7 +6,7 @@ body {
   color: #f5f5f5;
 }
 body a {
-  color: #9dc6ff;
+  color: var(--accent-color, #9dc6ff);
 }
 body h1,
 body h2,
@@ -24,7 +24,7 @@ body .uk-card-default {
   color: #f5f5f5;
 }
 body .uk-card-default a {
-  color: #9dc6ff;
+  color: var(--accent-color, #9dc6ff);
 }
 body .uk-card h3,
 body .uk-card p {
@@ -32,11 +32,11 @@ body .uk-card p {
 }
 body .uk-progress {
   background-color: #333;
-  color: #1e87f0;
+  color: var(--accent-color, #1e87f0);
 }
 body .uk-button-primary {
-  background-color: #1e87f0;
-  border-color: #1e87f0;
+  background-color: var(--accent-color, #1e87f0);
+  border-color: var(--accent-color, #1e87f0);
 }
 body .uk-button,
 body .uk-button-default {
@@ -56,11 +56,11 @@ body .btn-black:hover {
 }
 body .btn-transparent {
   background-color: transparent !important;
-  color: #9dc6ff !important;
-  border: 2px solid #9dc6ff;
+  color: var(--accent-color, #9dc6ff) !important;
+  border: 2px solid var(--accent-color, #9dc6ff);
 }
 body .btn-transparent:hover {
-  background-color: #9dc6ff !important;
+  background-color: var(--accent-color, #9dc6ff) !important;
   color: #000 !important;
 }
 body input,
@@ -93,7 +93,7 @@ body .uk-alert-danger {
   color: #fff;
 }
 body .uk-alert-primary {
-  background-color: #003366;
+  background-color: var(--accent-color, #003366);
   color: #fff;
 }
 
@@ -152,8 +152,8 @@ body .onboarding-timeline .timeline-step.inactive {
 
 body .onboarding-timeline .timeline-step.active,
 body .onboarding-timeline .timeline-step.completed {
-  border-color: #1e87f0;
-  color: #1e87f0;
+  border-color: var(--accent-color, #1e87f0);
+  color: var(--accent-color, #1e87f0);
 }
 
 body .uk-icon,
@@ -169,7 +169,7 @@ body .site-footer {
 }
 
 body .footer-menu a {
-  color: #9dc6ff;
+  color: var(--accent-color, #9dc6ff);
 }
 
 body .uk-icon-button {
@@ -177,8 +177,8 @@ body .uk-icon-button {
   background-color: rgba(255, 255, 255, 0.2);
 }
 body .uk-icon-button.uk-button-primary {
-  background-color: #1e87f0;
-  border-color: #1e87f0;
+  background-color: var(--accent-color, #1e87f0);
+  border-color: var(--accent-color, #1e87f0);
 }
 
 /* Active state for navigation items in dark off-canvas menus */
@@ -307,7 +307,7 @@ body.dark-mode {
   color: #f5f5f5;
 }
 body.dark-mode a {
-  color: #9dc6ff;
+  color: var(--accent-color, #9dc6ff);
 }
 body.dark-mode h1,
 body.dark-mode h2,
@@ -325,7 +325,7 @@ body.dark-mode .uk-card-default {
   color: #f5f5f5;
 }
 body.dark-mode .uk-card-default a {
-  color: #9dc6ff;
+  color: var(--accent-color, #9dc6ff);
 }
 body.dark-mode .uk-card h3,
 body.dark-mode .uk-card p {
@@ -333,11 +333,11 @@ body.dark-mode .uk-card p {
 }
 body.dark-mode .uk-progress {
   background-color: #333;
-  color: #1e87f0;
+  color: var(--accent-color, #1e87f0);
 }
 body.dark-mode .uk-button-primary {
-  background-color: #1e87f0;
-  border-color: #1e87f0;
+  background-color: var(--accent-color, #1e87f0);
+  border-color: var(--accent-color, #1e87f0);
 }
 body.dark-mode .uk-button,
 body.dark-mode .uk-button-default {
@@ -357,11 +357,11 @@ body.dark-mode .btn-black:hover {
 }
 body.dark-mode .btn-transparent {
   background-color: transparent !important;
-  color: #9dc6ff !important;
-  border: 2px solid #9dc6ff;
+  color: var(--accent-color, #9dc6ff) !important;
+  border: 2px solid var(--accent-color, #9dc6ff);
 }
 body.dark-mode .btn-transparent:hover {
-  background-color: #9dc6ff !important;
+  background-color: var(--accent-color, #9dc6ff) !important;
   color: #000 !important;
 }
 body.dark-mode input,
@@ -394,7 +394,7 @@ body.dark-mode .uk-alert-danger {
   color: #fff;
 }
 body.dark-mode .uk-alert-primary {
-  background-color: #003366;
+  background-color: var(--accent-color, #003366);
   color: #fff;
 }
 
@@ -447,8 +447,8 @@ body.dark-mode .onboarding-timeline .timeline-step.inactive {
 
 body.dark-mode .onboarding-timeline .timeline-step.active,
 body.dark-mode .onboarding-timeline .timeline-step.completed {
-  border-color: #1e87f0;
-  color: #1e87f0;
+  border-color: var(--accent-color, #1e87f0);
+  color: var(--accent-color, #1e87f0);
 }
 
 body .pricing-grid .uk-card-quizrace {
@@ -499,8 +499,8 @@ body.dark-mode .uk-icon-button {
   background-color: rgba(255, 255, 255, 0.2);
 }
 body.dark-mode .uk-icon-button.uk-button-primary {
-  background-color: #1e87f0;
-  border-color: #1e87f0;
+  background-color: var(--accent-color, #1e87f0);
+  border-color: var(--accent-color, #1e87f0);
 }
 
 /* Active state for navigation items in dark off-canvas menus */


### PR DESCRIPTION
## Summary
- replace hardcoded accent colors in dark.css with CSS variable

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f3131a90832bb79c6be2615990fa