### PR TITLE
Use explicit classes for topbar theme variables

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -1,4 +1,4 @@
-:root{
+body:not(.dark-mode){
   --btn-bg: transparent;
   --btn-border: rgba(0,0,0,0.6);
   --btn-border-hover: rgba(0,0,0,0.8);
@@ -7,17 +7,6 @@
   --drop-bg: #fff;
   --drop-border: rgba(27,31,35,0.12);
   --text: #000;
-}
-@media (prefers-color-scheme: dark){
-  :root{
-    --btn-border: rgba(255,255,255,0.3);
-    --btn-border-hover: rgba(255,255,255,0.5);
-    --btn-bg-hover: rgba(255,255,255,0.08);
-    --focus-ring: rgba(100,180,255,0.25);
-    --drop-bg: #1f232a;
-    --drop-border: rgba(255,255,255,0.14);
-    --text: #e6e9ef;
-  }
 }
 body.dark-mode{
   --btn-border: rgba(255,255,255,0.3);


### PR DESCRIPTION
## Summary
- Remove prefers-color-scheme media query from topbar stylesheet
- Define light-mode variables under `body:not(.dark-mode)` so classes control topbar colors

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_team_restrict.js`
- `node tests/test_profile_flow.js`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f31caea8832b8e8c9e5d109ae8c8