### PR TITLE
Use disabled attribute for dark mode stylesheet

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', function () {
   let dark = storedTheme === 'true' || (storedTheme === null && prefersDark);
 
   if (darkStylesheet) {
-    darkStylesheet.disabled = !dark;
+    darkStylesheet.toggleAttribute('disabled', !dark);
   }
 
   if (dark) {
@@ -93,7 +93,7 @@ document.addEventListener('DOMContentLoaded', function () {
         document.documentElement.classList.toggle('dark-mode', dark);
         document.body.classList.toggle('uk-light', dark);
         if (darkStylesheet) {
-          darkStylesheet.disabled = !dark;
+          darkStylesheet.toggleAttribute('disabled', !dark);
         }
         localStorage.setItem('darkMode', dark ? 'true' : 'false');
         if (themeIcon) {

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css" disabled>
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
 {% endblock %}


### PR DESCRIPTION
## Summary
- disable dark.css by default in index template so it's enabled via JS only
- toggle dark mode by adding or removing the `disabled` attribute instead of the property

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars, PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f32945ac832bac278432067edfc4