### PR TITLE
fix: ensure landing navbar uses UIKit-specific background

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -169,13 +169,13 @@
     .uk-link-reset:hover { text-decoration:underline; color:#fff; }
 
     /* Header adjustments */
-    .topbar {
+    .uk-navbar-container.topbar {
       height: 64px;
       padding: 0 1rem;
       flex-wrap: nowrap;
       display: flex;
       align-items: center;
-      background: #0c86d0;
+      background: #0c86d0 !important;
     }
     .topbar .uk-navbar-left {
       padding-left: 0.5rem;


### PR DESCRIPTION
## Summary
- improve landing page topbar style by matching UIKit specificity and forcing blue background

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f3b9457c832baaa72c56542d5d85