### PR TITLE
Use RouteContext for base path

### DIFF
--- a/src/Controller/OnboardingEmailController.php
+++ b/src/Controller/OnboardingEmailController.php
@@ -8,6 +8,7 @@ use App\Service\EmailConfirmationService;
 use App\Service\MailService;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
+use Slim\Routing\RouteContext;
 use Slim\Views\Twig;
 
 /**
@@ -37,7 +38,7 @@ class OnboardingEmailController
         }
 
         $token = $this->service->createToken($email);
-        $base = rtrim($request->getUri()->getBasePath(), '/');
+        $base = rtrim(RouteContext::fromRequest($request)->getBasePath(), '/');
         $uri = $request->getUri()
             ->withPath($base . '/onboarding/email/confirm')
             ->withQuery('token=' . urlencode($token));
@@ -70,7 +71,7 @@ class OnboardingEmailController
             return $response->withStatus(400);
         }
 
-        $base = rtrim($request->getUri()->getBasePath(), '/');
+        $base = rtrim(RouteContext::fromRequest($request)->getBasePath(), '/');
         $uri = $request->getUri()
             ->withPath($base . '/onboarding')
             ->withQuery(http_build_query([


### PR DESCRIPTION
## Summary
- use `RouteContext` to obtain Slim base path instead of calling `getBasePath()` on `UriInterface`

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `composer test` *(fails: missing Stripe env vars and database errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f439a7f8832bb29b040489013b6f