### PR TITLE
Handle JSON encoding errors

### DIFF
--- a/src/Application/Actions/Action.php
+++ b/src/Application/Actions/Action.php
@@ -8,6 +8,7 @@ use App\Domain\DomainException\DomainRecordNotFoundException;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
+use JsonException;
 use Slim\Exception\HttpBadRequestException;
 use Slim\Exception\HttpNotFoundException;
 
@@ -82,11 +83,20 @@ abstract class Action
 
     protected function respond(ActionPayload $payload): Response
     {
-        $json = json_encode($payload, JSON_PRETTY_PRINT);
-        $this->response->getBody()->write($json);
+        try {
+            $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+            $this->response->getBody()->write($json);
+        } catch (JsonException $e) {
+            $this->logger->error('JSON encode error: ' . $e->getMessage());
+            $this->response->getBody()->write('{"error":"Encoding error"}');
+
+            return $this->response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(500);
+        }
 
         return $this->response
-                    ->withHeader('Content-Type', 'application/json')
-                    ->withStatus($payload->getStatusCode());
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus($payload->getStatusCode());
     }
 }


### PR DESCRIPTION
## Summary
- Guard JSON responses by throwing on encode errors and returning 500s
- Validate configuration JSON and propagate decoding failures
- Safely persist redirect mappings with JSON_THROW_ON_ERROR

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Database error: fail, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f4ac2d64832baea345beb3985e4a