### PR TITLE
Remove email confirmation token after verification

### DIFF
--- a/src/Service/EmailConfirmationService.php
+++ b/src/Service/EmailConfirmationService.php
@@ -77,6 +77,8 @@ class EmailConfirmationService
         $stmt = $this->pdo->prepare('UPDATE email_confirmations SET confirmed = 1 WHERE email = ?');
         $stmt->execute([$email]);
 
+        $this->deleteToken($email);
+
         $this->logger->info('Email confirmed', ['email' => $email]);
 
         return $email;

--- a/tests/Controller/OnboardingEmailControllerTest.php
+++ b/tests/Controller/OnboardingEmailControllerTest.php
@@ -332,10 +332,10 @@ class OnboardingEmailControllerTest extends TestCase
             '/onboarding?email=user%40example.com&verified=1',
             $response->getHeaderLine('Location')
         );
-        $confirmed = (string) $pdo
-            ->query('SELECT confirmed FROM email_confirmations WHERE token = ' . $pdo->quote($token))
+        $count = (int) $pdo
+            ->query('SELECT COUNT(*) FROM email_confirmations WHERE token = ' . $pdo->quote($token))
             ->fetchColumn();
-        $this->assertSame('1', $confirmed);
+        $this->assertSame(0, $count);
 
         $bad = $this->createRequest('GET', '/onboarding/email/confirm?token=invalid');
         $badResp = $app->handle($bad);
@@ -343,7 +343,7 @@ class OnboardingEmailControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testStatusEndpointForConfirmedAndUnconfirmedEmails(): void
+    public function testStatusEndpointReturns404AfterTokenRemoval(): void
     {
         $app = $this->getAppInstance();
         $pdo = $this->setupEmailConfirmations();
@@ -376,7 +376,7 @@ class OnboardingEmailControllerTest extends TestCase
         $app->handle($this->createRequest('GET', '/onboarding/email/confirm?token=' . $token));
 
         $status2 = $app->handle($this->createRequest('GET', '/onboarding/email/status?email=user@example.com'));
-        $this->assertSame(204, $status2->getStatusCode());
+        $this->assertSame(404, $status2->getStatusCode());
 
         $status3 = $app->handle($this->createRequest('GET', '/onboarding/email/status?email=other@example.com'));
         $this->assertSame(404, $status3->getStatusCode());


### PR DESCRIPTION
## Summary
- delete email confirmation token once address is verified
- update onboarding email controller tests for removed tokens

## Testing
- `vendor/bin/phpcs src/Service/EmailConfirmationService.php tests/Controller/OnboardingEmailControllerTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other Stripe env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f515219c832b9f8813b4f926a31d