### PR TITLE
Restore landing topbar options

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -4,6 +4,9 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css" disabled>
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
   <style>
     body, .uk-card-default {
@@ -317,7 +320,6 @@
       {% block right %}
         <a class="uk-navbar-item top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt testen</a>
       {% endblock %}
-      {% block switches %}{% endblock %}
     {% endembed %}
 
     {{ content|raw }}


### PR DESCRIPTION
## Summary
- Include dark, high-contrast and help styles on landing page
- Enable default topbar controls on landing page

## Testing
- `STRIPE_SECRET_KEY=foo STRIPE_PUBLISHABLE_KEY=foo STRIPE_PRICE_STARTER=1 STRIPE_PRICE_STANDARD=1 STRIPE_PRICE_PROFESSIONAL=1 STRIPE_WEBHOOK_SECRET=foo composer test` *(fails: D..........E....W.EE......FN....)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f55bb9d4832ba92b4980f6696275