### PR TITLE
Ensure topbar icons remain visible on landing page

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -210,6 +210,9 @@
       font-weight: 700;
       color: #fff;
     }
+    .topbar .git-btn {
+      color: #fff;
+    }
     @media (max-width: 640px) {
       .topbar .uk-logo {
         font-size: 1rem;


### PR DESCRIPTION
## Summary
- Explicitly set white color for `.topbar .git-btn` on the marketing landing page so icon buttons stay visible against the topbar background in all themes

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `vendor/bin/phpunit` *(fails: hangs, likely missing environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f5bbca6c832bba64c661527d2d0e