### PR TITLE
feat: customize landing page palette

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -106,3 +106,4 @@ curl -X POST http://$DOMAIN/users.json \
 * [Datenschutz](datenschutz.md)
 * [Impressum](impressum.md)
 * [Lizenz](lizenz.md)
+* [Landing-Seiten-Stile](landing-style-overrides.md)

--- a/docs/landing-style-overrides.md
+++ b/docs/landing-style-overrides.md
@@ -1,0 +1,20 @@
+---
+layout: default
+title: Landing-Seite: Styles
+---
+
+## CSS-Variablen der Landing-Seite
+
+Die Marketing-Seite nutzt eigene CSS-Variablen, um Farben für Text und Dropdown-Menüs festzulegen. Die Werte werden direkt im Template `templates/marketing/landing.twig` innerhalb eines `:root`-Blocks gesetzt:
+
+```twig
+<style>
+  :root {
+    --text: #fff;
+    --drop-bg: #0c86d0;
+    --drop-border: rgba(255, 255, 255, 0.32);
+  }
+</style>
+```
+
+Diese Variablen steuern die Palette der Topbar sowie der Konfigurations-Dropdowns. Anpassungen an der Landing-Seite erfolgen über diese Variablen, damit alle Komponenten konsistent bleiben.

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -6,6 +6,17 @@
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
   <style>
+    /* Landing page palette */
+    :root {
+      --text: #fff;
+      --drop-bg: #0c86d0;
+      --drop-border: rgba(255, 255, 255, 0.32);
+    }
+    html body.landing-page {
+      --text: #fff;
+      --drop-bg: #0c86d0;
+      --drop-border: rgba(255, 255, 255, 0.32);
+    }
     body, .uk-card-default {
       font-family: 'Poppins', Arial, sans-serif;
       color: #232323;


### PR DESCRIPTION
## Summary
- Override landing-page palette via `:root` CSS variables for text and dropdown colors
- Document landing-page style overrides

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f5beaa84832b80d1ea6b036aab5e