### PR TITLE
Fix onboarding footer background color

### DIFF
--- a/public/css/onboarding.css
+++ b/public/css/onboarding.css
@@ -71,3 +71,14 @@
 .pricing-grid .uk-card-quizrace .btn {
   margin-top: auto;
 }
+
+@media (prefers-color-scheme: light) {
+  .site-footer {
+    background-color: var(--primary-color);
+    color: #fff;
+  }
+
+  .site-footer a {
+    color: #fff;
+  }
+}


### PR DESCRIPTION
## Summary
- keep onboarding footer background consistent with body by using primary color

## Testing
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_* env vars and hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f61a4194832baf187c9ee39c10e8