### PR TITLE
Ensure uk-light only when dark stylesheet is present

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', function () {
     darkStylesheet.toggleAttribute('disabled', !dark);
   }
 
-  if (dark) {
+  if (darkStylesheet && dark) {
     document.body.classList.add('dark-mode', 'uk-light');
     document.documentElement.classList.add('dark-mode');
   }
@@ -91,8 +91,8 @@ document.addEventListener('DOMContentLoaded', function () {
         event.preventDefault();
         dark = document.body.classList.toggle('dark-mode');
         document.documentElement.classList.toggle('dark-mode', dark);
-        document.body.classList.toggle('uk-light', dark);
         if (darkStylesheet) {
+          document.body.classList.toggle('uk-light', dark);
           darkStylesheet.toggleAttribute('disabled', !dark);
         }
         localStorage.setItem('darkMode', dark ? 'true' : 'false');


### PR DESCRIPTION
## Summary
- Guard dark-mode initialization with a check for the dark stylesheet before applying `uk-light` and `dark-mode` classes.
- Toggle `uk-light` during theme switch only when a dark stylesheet is available.

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f73d7cfc832b9b30106f8254c04d