### PR TITLE
Fix top CTA button color

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -245,7 +245,7 @@
       text-align: center;
       letter-spacing: .04em;
     }
-    .top-cta {
+    .topbar .top-cta {
       padding: 0.4rem 0.75rem;
       font-size: 0.875rem;
       white-space: nowrap;
@@ -253,7 +253,7 @@
       background: #fff;
       color: #0c86d0;
     }
-    .top-cta:hover {
+    .topbar .top-cta:hover {
       background: #e5e5e5;
     }
     .cta-main {


### PR DESCRIPTION
## Summary
- ensure "Jetzt testen" button text is visible on landing page by increasing CSS specificity

## Testing
- `vendor/bin/phpunit`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0f94df2e0832b88ed007caf495140