### PR TITLE
Center top CTA text

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -249,7 +249,9 @@
       padding: 0.4rem 0.75rem;
       font-size: 0.875rem;
       white-space: nowrap;
-      display: inline-block;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       background: #fff;
       color: #0c86d0;
     }


### PR DESCRIPTION
## Summary
- center "Jetzt testen" text horizontally and vertically in the top bar CTA button using flexbox

## Testing
- `vendor/bin/phpunit` *(fails: database is locked, unique constraint violations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fb5c7580832b949c0e5b8006b6c9