### PR TITLE
style: add dark mode styles for landing page

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -626,3 +626,35 @@ body.dark-mode .uk-accordion-content {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
+
+/* Landing page adjustments in Dark Mode */
+@media (prefers-color-scheme: dark) {
+  body.landing-page {
+    --landing-bg: #1e1e1e;
+    --landing-text: #f5f5f5;
+    --landing-primary: #0c86d0;
+    background: var(--landing-bg);
+    color: var(--landing-text);
+  }
+
+  body.landing-page .uk-card-quizrace {
+    background: var(--landing-bg);
+    color: var(--landing-text);
+  }
+
+  body.landing-page .uk-card-quizrace .uk-icon {
+    color: var(--landing-primary);
+  }
+
+  body.landing-page .topbar .top-cta,
+  body.landing-page .cta-main {
+    background: var(--landing-primary);
+    color: var(--landing-text);
+  }
+
+  body.landing-page .topbar .top-cta:hover,
+  body.landing-page .cta-main:hover {
+    background: var(--landing-text);
+    color: var(--landing-primary);
+  }
+}


### PR DESCRIPTION
## Summary
- add landing page palette variables for dark mode
- apply dark variables to quizrace card and call-to-action elements

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fc3f75f0832bb2510d2ff2fc44b9