### PR TITLE
Fix about-section colors on landing page

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -59,10 +59,10 @@
     }
     .uk-section.about-section {
       background: #000;
-      color: var(--landing-bg);
+      color: var(--landing-text);
     }
     .uk-section.about-section a {
-      color: var(--landing-bg);
+      color: var(--landing-primary);
     }
     .hero-bg-quizrace {
       background-image: url('{{ basePath }}/img/quizrace-bg.jpg');


### PR DESCRIPTION
## Summary
- ensure marketing about-section uses landing text color
- make links in about-section use the primary palette for contrast

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b101ef8c94832bb709800e835ca645