### PR TITLE
Ensure topbar menu opens downward

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -62,6 +62,7 @@ body.dark-mode.high-contrast{
   color:var(--text);
   min-width:auto !important;
   width:fit-content !important;
+  transform-origin: top right;
 }
 .uk-dropdown-nav{
   display:flex;

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -36,7 +36,7 @@
               <path d="M19.14 12.94a7.5 7.5 0 0 0 .05-.94 7.5 7.5 0 0 0-.05-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.33a.5.5 0 0 0-.6-.22l-2.39.96a7.6 7.6 0 0 0-1.63-.94l-.36-2.54a.5.5 0 0 0-.5-.43h-3.84a.5.5 0 0 0-.5.43l-.36 2.54c-.57.24-1.12.55-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.7 7.84a.5.5 0 0 0 .12.64l2.03 1.58c-.03.31-.05.63-.05.94s.02.63.05.94L2.82 13.5a.5.5 0 0 0-.12.64l1.92 3.33a.5.5 0 0 0 .6.22l2.39-.96c.51.39 1.06.7 1.63.94l.36 2.54a.5.5 0 0 0 .5.43h3.84a.5.5 0 0 0 .5-.43l.36-2.54c.57-.24 1.12-.55 1.63-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.33a.5.5 0 0 0-.12-.64l-2.03-1.58ZM12 15.5A3.5 3.5 0 1 1 12 8.5a3.5 3.5 0 0 1 0 7Z" fill="currentColor"/>
             </svg>
           </button>
-          <div id="menuDrop" class="uk-dropdown" hidden uk-dropdown="mode: click; pos: bottom-right; animation: uk-animation-slide-top-small">
+          <div id="menuDrop" class="uk-dropdown" hidden uk-dropdown="mode: click; pos: bottom-right; flip: false; animation: uk-animation-slide-top-small">
             <ul class="uk-nav uk-dropdown-nav" role="menu">
               <li>
                 <button id="themeToggle" class="uk-button uk-button-default git-btn theme-toggle" aria-label="{{ t('design_toggle') }}" role="menuitem">


### PR DESCRIPTION
## Summary
- disable UIkit dropdown flip for the topbar settings menu
- adjust dropdown styling to keep animation anchored at the top right

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b10208f6f0832ba1126896ff4dd344