### PR TITLE
Use landing text color in landing page topbar

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -220,7 +220,15 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      color: var(--landing-bg);
+      color: var(--landing-text);
+    }
+    .topbar .uk-navbar-item:hover,
+    .topbar .uk-navbar-item:focus,
+    .topbar .uk-navbar-nav > li > a:hover,
+    .topbar .uk-navbar-nav > li > a:focus,
+    .topbar .uk-navbar-toggle:hover,
+    .topbar .uk-navbar-toggle:focus {
+      color: var(--landing-primary);
     }
     .topbar .uk-navbar-toggle {
       width: 44px;
@@ -234,10 +242,18 @@
       padding: 0;
       font-family: 'Poppins', sans-serif;
       font-weight: 700;
-      color: var(--landing-bg);
+      color: var(--landing-text);
+    }
+    .topbar .uk-logo:hover,
+    .topbar .uk-logo:focus {
+      color: var(--landing-primary);
     }
     .topbar .git-btn {
-      color: var(--landing-bg);
+      color: var(--landing-text);
+    }
+    .topbar .git-btn:hover,
+    .topbar .git-btn:focus {
+      color: var(--landing-primary);
     }
     @media (max-width: 640px) {
       .topbar .uk-logo {


### PR DESCRIPTION
## Summary
- use `--landing-text` for topbar navigation text
- add hover/focus color transitions for topbar items

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b103b94ed4832b959eb999ac3ab95f