### PR TITLE
Align landing page CTA colors with dark theme

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -262,15 +262,20 @@
       font-size: 0.875rem;
       white-space: nowrap;
       display: inline-block;
-      background: var(--landing-bg);
-      color: var(--landing-primary);
+      background: var(--landing-primary);
+      color: var(--landing-text);
     }
     .topbar .top-cta:hover {
-      background: #e5e5e5;
+      background: var(--landing-text);
+      color: var(--landing-primary);
     }
     .cta-main {
-      background: #007bff;
-      color: var(--landing-bg);
+      background: var(--landing-primary);
+      color: var(--landing-text);
+    }
+    .cta-main:hover {
+      background: var(--landing-text);
+      color: var(--landing-primary);
     }
     .cta-main {
       display: block;


### PR DESCRIPTION
## Summary
- match landing page CTA buttons to dark theme palette

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b103baa7e8832b9df3d97d526d4be7