### PR TITLE
Improve landing page dark mode styling

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -103,8 +103,8 @@
       width: 100%;
       aspect-ratio: 16/9;
       background: rgba(255, 255, 255, 0.15);
-      border: 2px dashed var(--landing-bg);
-      color: var(--landing-bg);
+      border: 2px dashed var(--landing-text);
+      color: var(--landing-text);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -159,7 +159,11 @@
       background: var(--landing-text);
       color: var(--landing-bg);
     }
-    .uk-card-price .uk-text-meta, .uk-text-meta {
+    .uk-card-price .uk-text-meta {
+      color: var(--landing-text);
+      opacity: 0.7;
+    }
+    .uk-text-meta {
       color: #7b7b7b;
       font-size: 0.95rem;
     }
@@ -192,7 +196,7 @@
     .bg-blue { background: var(--landing-primary); color: var(--landing-bg); }
     .padding-30px { padding: 30px; }
     .uk-link-reset { color:inherit; text-decoration:none; }
-    .uk-link-reset:hover { text-decoration:underline; color:var(--landing-bg); }
+    .uk-link-reset:hover { text-decoration:underline; color:var(--landing-primary); }
 
     /* Header adjustments */
     .uk-navbar-container.topbar {


### PR DESCRIPTION
## Summary
- ensure video placeholder uses contrasting text and borders
- refine pricing card meta text color for better contrast
- fix link hover color to remain visible in dark mode

## Testing
- `composer test` *(fails: Tests: 271, Assertions: 582, Errors: 26, Failures: 6, Warnings: 5, PHPUnit Deprecations: 3, Notices: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b10626e280832b8c771e63fbbc5264