### PR TITLE
Fix vertical alignment of landing topbar button

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -277,7 +277,8 @@
       padding: 0.4rem 0.75rem;
       font-size: 0.875rem;
       white-space: nowrap;
-      display: inline-block;
+      display: inline-flex;
+      align-items: center;
       background: var(--landing-primary);
       color: var(--landing-text);
     }


### PR DESCRIPTION
## Summary
- center "Jetzt testen" landing topbar button using flex alignment

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b106e42354832b9d6847614ba4f5a7