### PR TITLE
refactor: unify landing page theme variables

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -627,34 +627,4 @@ body.dark-mode .uk-accordion-content {
   color: #f5f5f5;
 }
 
-/* Landing page adjustments in Dark Mode */
-@media (prefers-color-scheme: dark) {
-  body.landing-page {
-    --landing-bg: #1e1e1e;
-    --landing-text: #f5f5f5;
-    --landing-primary: #0c86d0;
-    background: var(--landing-bg);
-    color: var(--landing-text);
-  }
-
-  body.landing-page .uk-card-quizrace {
-    background: var(--landing-bg);
-    color: var(--landing-text);
-  }
-
-  body.landing-page .uk-card-quizrace .uk-icon {
-    color: var(--landing-primary);
-  }
-
-  body.landing-page .topbar .top-cta,
-  body.landing-page .cta-main {
-    background: var(--landing-primary);
-    color: var(--landing-text);
-  }
-
-  body.landing-page .topbar .top-cta:hover,
-  body.landing-page .cta-main:hover {
-    background: var(--landing-text);
-    color: var(--landing-primary);
-  }
 }

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -24,9 +24,9 @@
     @media (prefers-color-scheme: dark) {
       :root,
       body.landing-page {
-        --landing-bg: #000;
+        --landing-bg: #1e1e1e;
         --landing-text: #f5f5f5;
-        --landing-primary: #005a8e;
+        --landing-primary: #0c86d0;
         --text: #fff;
         --drop-bg: var(--landing-primary);
         --drop-border: rgba(255, 255, 255, 0.32);


### PR DESCRIPTION
## Summary
- remove redundant landing-specific dark-mode styles
- standardize landing page color variables for dark mode

## Testing
- `python3 tests/test_html_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b1083b8ce8832b8494317f127024d2