### PR TITLE
Disable dark stylesheet by default on landing page

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css" disabled>
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Disable dark.css by default on marketing landing page to avoid flash during light mode

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY et al)*

------
https://chatgpt.com/codex/tasks/task_e_68b1083eedf8832b95e139e09c2aa353