### PR TITLE
feat: improve landing page theme variables

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -10,27 +10,31 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
   <style>
     /* Landing page palette */
-    @media (prefers-color-scheme: light) {
-      :root,
-      body.landing-page {
-        --landing-bg: #fff;
-        --landing-text: #232323;
-        --landing-primary: #0c86d0;
-        --text: #fff;
-        --drop-bg: var(--landing-primary);
-        --drop-border: rgba(255, 255, 255, 0.32);
-      }
+    :root,
+    body.landing-page {
+      --landing-bg: #fff;
+      --landing-text: #232323;
+      --landing-primary: #0c86d0;
+      --text: #fff;
+      --drop-bg: var(--landing-primary);
+      --drop-border: rgba(255, 255, 255, 0.32);
     }
     @media (prefers-color-scheme: dark) {
       :root,
       body.landing-page {
         --landing-bg: #1e1e1e;
         --landing-text: #f5f5f5;
-        --landing-primary: #0c86d0;
         --text: #fff;
         --drop-bg: var(--landing-primary);
         --drop-border: rgba(255, 255, 255, 0.32);
       }
+    }
+    body.dark-mode.landing-page {
+      --landing-bg: #1e1e1e;
+      --landing-text: #f5f5f5;
+      --text: #fff;
+      --drop-bg: var(--landing-primary);
+      --drop-border: rgba(255, 255, 255, 0.32);
     }
     body, .uk-card-default {
       font-family: 'Poppins', Arial, sans-serif;
@@ -205,7 +209,11 @@
       flex-wrap: nowrap;
       display: flex;
       align-items: center;
-      background-color: var(--landing-primary);
+      background: var(--landing-bg);
+      color: var(--landing-text);
+    }
+    .topbar a {
+      color: var(--landing-text);
     }
     .topbar .uk-navbar-left {
       padding-left: 0.5rem;


### PR DESCRIPTION
## Summary
- move light theme variables outside media queries for default mode
- add dark mode overrides and topbar color support

## Testing
- `composer test` *(fails: vendor/bin/phpunit: not found)*
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY and related variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b1573d0060832bb10151a36f3a4d03