### PR TITLE
fix: improve landing page contrast

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -36,19 +36,19 @@ body.dark-mode.high-contrast{
   --focus-ring: rgba(140,200,255,0.8);
 }
 .topbar, .topbar .uk-navbar-nav > li > a, .topbar .uk-navbar-item{
-  color:var(--text);
+  color:var(--topbar-text, var(--text));
 }
 .topbar .uk-navbar-nav > li > a:hover,
 .topbar .uk-navbar-nav > li > a:focus,
 .topbar .uk-navbar-item:hover,
 .topbar .uk-navbar-item:focus{
-  color:var(--text);
+  color:var(--topbar-text, var(--text));
 }
 .git-btn{
   width:40px;height:40px;padding:0;
   border-radius:6px;
   border:1px solid var(--btn-border);
-  color:var(--text);
+  color:var(--topbar-text, var(--text));
   display:inline-flex;align-items:center;justify-content:center;
   box-sizing:border-box;cursor:pointer;
   transition:background .12s,border-color .12s,box-shadow .12s;
@@ -68,7 +68,7 @@ body.dark-mode.high-contrast{
   border:1px solid var(--drop-border);
   border-radius:8px;
   padding:8px;
-  color:var(--text);
+  color:var(--topbar-text, var(--text));
   min-width:auto !important;
   width:fit-content !important;
   transform-origin: top right;

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -18,6 +18,7 @@
       --text: #fff;
       --drop-bg: var(--landing-primary);
       --drop-border: rgba(255, 255, 255, 0.32);
+      --topbar-text: var(--landing-text);
     }
     @media (prefers-color-scheme: dark) {
       :root,
@@ -27,6 +28,7 @@
         --text: #fff;
         --drop-bg: var(--landing-primary);
         --drop-border: rgba(255, 255, 255, 0.32);
+        --topbar-text: var(--landing-text);
       }
     }
     body.dark-mode.landing-page {
@@ -35,6 +37,7 @@
       --text: #fff;
       --drop-bg: var(--landing-primary);
       --drop-border: rgba(255, 255, 255, 0.32);
+      --topbar-text: var(--landing-text);
     }
     body, .uk-card-default {
       font-family: 'Poppins', Arial, sans-serif;
@@ -59,7 +62,7 @@
     }
     .uk-section.about-section {
       background: #000;
-      color: var(--landing-text);
+      color: var(--text);
     }
     .uk-section.about-section a {
       color: var(--landing-primary);
@@ -210,10 +213,7 @@
       display: flex;
       align-items: center;
       background: var(--landing-bg);
-      color: var(--landing-text);
-    }
-    .topbar a {
-      color: var(--landing-text);
+      color: var(--topbar-text);
     }
     .topbar .uk-navbar-left {
       padding-left: 0.5rem;
@@ -232,7 +232,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      color: var(--landing-text);
+      color: var(--topbar-text);
     }
     .topbar .uk-navbar-item:hover,
     .topbar .uk-navbar-item:focus,
@@ -254,14 +254,14 @@
       padding: 0;
       font-family: 'Poppins', sans-serif;
       font-weight: 700;
-      color: var(--landing-text);
+      color: var(--topbar-text);
     }
     .topbar .uk-logo:hover,
     .topbar .uk-logo:focus {
       color: var(--landing-primary);
     }
     .topbar .git-btn {
-      color: var(--landing-text);
+      color: var(--topbar-text);
     }
     .topbar .git-btn:hover,
     .topbar .git-btn:focus {
@@ -292,10 +292,10 @@
       display: inline-flex;
       align-items: center;
       background: var(--landing-primary);
-      color: var(--landing-text);
+      color: var(--landing-bg);
     }
     .topbar .top-cta:hover {
-      background: var(--landing-text);
+      background: var(--landing-bg);
       color: var(--landing-primary);
     }
     .cta-main {


### PR DESCRIPTION
## Summary
- add `--topbar-text` variable for landing page
- ensure landing topbar and CTA contrast
- use generic text color in about section

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b162ab5e58832ba5ed1d456ea7f361