### PR TITLE
Use UIkit classes for theme colors

### DIFF
--- a/public/Impressum.html
+++ b/public/Impressum.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/dark.css">
 </head>
-<body class="uk-padding uk-background-muted">
+<body class="uk-padding uk-background-default">
   <div class="wrapper">
     <main class="content">
       <h1>Impressum</h1>
@@ -36,7 +36,7 @@
       <p>Der Quellcode dieser Anwendung ist unter der MIT-Lizenz auf GitHub verfügbar:<br>
       <a href="https://github.com/bastelix/sommerfest-quiz">https://github.com/bastelix/sommerfest-quiz</a></p>
     </main>
-    <footer class="site-footer">
+    <footer class="site-footer uk-section uk-section-default uk-text-center">
       <nav class="footer-menu">
         <ul>
           <li><a href="Datenschutz.html">Datenschutz</a></li>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -18,25 +18,12 @@ html {
 body {
   min-height: 100vh;
   overflow-x: hidden;
-  background-color: var(--primary-color, #ffffff);
 }
 
 .uk-button-primary {
   background-color: var(--accent-color, #1e87f0);
   border-color: var(--accent-color, #1e87f0);
 }
-
-.about-section {
-  background-color: #000;
-  color: #fff;
-}
-
-.about-section .uk-text-lead,
-.uk-light .uk-text-lead {
-  color: #fff;
-}
-
-
 body.uk-padding {
   padding-top: 0;
   padding-left: 8px;
@@ -59,10 +46,7 @@ body.uk-padding {
 
 
 .site-footer {
-  background-color: var(--landing-bg, #f5f5f5);
-  color: var(--landing-text, #222);
   padding: 1rem;
-  text-align: center;
 }
 
 .footer-menu ul {
@@ -75,17 +59,7 @@ body.uk-padding {
 }
 
 .footer-menu a {
-  color: var(--landing-text, #222);
   text-decoration: none;
-}
-
-body.dark-mode .site-footer {
-  background-color: var(--landing-bg-dark, #1e1e1e);
-  color: var(--landing-text-dark, #f5f5f5);
-}
-
-body.dark-mode .footer-menu a {
-  color: var(--landing-text-dark, #f5f5f5);
 }
 
 .sortable-list li,

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -50,12 +50,12 @@
   </style>
   {% endif %}
 </head>
-<body class="{% block body_class %}{% endblock %}">
+<body class="uk-background-default {% block body_class %}{% endblock %}">
   <div class="wrapper">
     <main class="content">
       {% block body %}{% endblock %}
     </main>
-    <footer class="site-footer">
+    <footer class="site-footer uk-section uk-section-default uk-text-center">
       <nav class="footer-menu">
         <ul>
           <li><a href="{{ basePath }}/impressum">{{ t('imprint') }}</a></li>


### PR DESCRIPTION
## Summary
- remove hard-coded footer and body colors in `main.css`
- use UIkit section and background classes in layout and static pages
- rely on UIkit light/dark classes for theme switching

## Testing
- `composer test` *(fails: Missing STRIPE env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b22911cad0832ba034269714be2880