### PR TITLE
Enable dark mode stylesheet on landing page

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css" disabled>
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Load dark mode stylesheet on marketing landing page to activate theme toggle

## Testing
- `vendor/bin/phpcs src/` *(fails: Header blocks must be separated by a single blank line)*
- `vendor/bin/phpstan analyse src/`
- `./vendor/bin/phpunit` *(fails: multiple errors and missing configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68b2307d603c832b906dc010df054d1d