### PR TITLE
Toggle topbar classes on theme switch

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,6 +19,10 @@ document.addEventListener('DOMContentLoaded', function () {
     document.body.classList.toggle('uk-light', !dark);
     document.documentElement.classList.toggle('uk-dark', dark);
     document.documentElement.classList.toggle('uk-light', !dark);
+    document.querySelectorAll('.topbar').forEach(el => {
+      el.classList.toggle('uk-dark', dark);
+      el.classList.toggle('uk-light', !dark);
+    });
   }
 
   applyTheme();


### PR DESCRIPTION
## Summary
- ensure topbar uses dark/light classes when theme toggles

## Testing
- `node - <<'NODE' ... NODE`
- `composer test` *(fails: hangs after phpunit output)*

------
https://chatgpt.com/codex/tasks/task_e_68b2308d7f2c832b82339ae388d34385