### PR TITLE
feat: improve dark theme colors

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -1,4 +1,41 @@
 /* Dark theme variables handled via UIkit classes. */
 :root {
   --uk-inverse: #f5f5f5;
+  --color-bg: #111;
+  --color-text: #f5f5f5;
+}
+
+body.uk-dark {
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+body.uk-dark .uk-card-default {
+  background-color: #1a1a1a;
+  color: var(--color-text);
+}
+
+body.uk-dark .sortable-list li,
+body.uk-dark .terms li,
+body.uk-dark .dropzone,
+body.uk-dark .mc-option {
+  background: #1a1a1a;
+  border-color: #333;
+  color: var(--color-text);
+}
+
+body.uk-dark .dropzone.over {
+  background: #2a2a2a;
+}
+
+body.uk-dark .page-editor {
+  background: #1a1a1a;
+  border-color: #333;
+  color: var(--color-text);
+}
+
+body.uk-dark .qr-label {
+  background: #1a1a1a;
+  border-color: #444;
+  color: var(--color-text);
 }


### PR DESCRIPTION
## Summary
- add base color variables for dark theme
- style dark mode body and components for better contrast

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b230a0bc0c832b884a291ca2ee36e0