### PR TITLE
Use Poppins font globally on landing page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -18,6 +18,7 @@ html {
 body {
   min-height: 100vh;
   overflow-x: hidden;
+  font-family: 'Poppins', sans-serif;
 }
 
 .uk-button-primary {


### PR DESCRIPTION
## Summary
- Apply the `Poppins` typeface to the site by setting it on the `body` element.

## Testing
- `composer test` *(fails: missing Stripe configuration and database setup, multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b230a44ad0832bacac362bacd8a943