### PR TITLE
Restore about-section styles in main.css

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -18,12 +18,25 @@ html {
 body {
   min-height: 100vh;
   overflow-x: hidden;
+  background-color: var(--primary-color, #ffffff);
 }
 
 .uk-button-primary {
   background-color: var(--accent-color, #1e87f0);
   border-color: var(--accent-color, #1e87f0);
 }
+
+.about-section {
+  background-color: #000;
+  color: #fff;
+}
+
+.about-section .uk-text-lead,
+.uk-light .uk-text-lead {
+  color: #fff;
+}
+
+
 body.uk-padding {
   padding-top: 0;
   padding-left: 8px;
@@ -44,9 +57,11 @@ body.uk-padding {
   flex: 1;
 }
 
-
 .site-footer {
+  background-color: #f5f5f5;
+  color: #222;
   padding: 1rem;
+  text-align: center;
 }
 
 .footer-menu ul {
@@ -59,6 +74,7 @@ body.uk-padding {
 }
 
 .footer-menu a {
+  color: #222;
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- Restore `public/css/main.css` to previous version, reintroducing `.about-section` and related footer styles

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ce8d9c24832b87760793b0e123a0