### PR TITLE
Handle tenant onboarding errors synchronously

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -434,16 +434,12 @@ document.addEventListener('DOMContentLoaded', () => {
       } catch (_) {
         data = undefined;
       }
-      if (res.status === 202 && (!body || !data)) {
-        addLog('Server akzeptierte die Anfrage, lieferte jedoch keine Rückmeldung.');
-        return false;
-      }
-      if (!res.ok || !data || data.status !== 'queued') {
+      if (!res.ok || !data || data.status !== 'success') {
         const msg = data && data.error ? data.error : body || 'onboard';
         addLog('Fehler beim Onboarding: ' + msg);
         throw new Error(msg);
       }
-      addLog('Onboarding gestartet …');
+      addLog('Onboarding abgeschlossen …');
       return true;
     };
 
@@ -586,9 +582,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       return;
     } catch (e) {
-      if (taskEls.wait && !taskEls.wait.spinner.hidden && !taskEls.wait.li.querySelector('span:not([uk-spinner])')) {
-        mark('wait', false);
-      }
+      ['import', 'proxy', 'ssl', 'wait'].forEach(id => {
+        const entry = taskEls[id];
+        if (entry && !entry.spinner.hidden && !entry.li.querySelector('span:not([uk-spinner])')) {
+          mark(id, false);
+        }
+      });
       const msg = e.message === 'timeout'
         ? 'Mandant wurde erstellt, ist jedoch noch nicht verfügbar. Bitte später erneut versuchen.'
         : 'Fehler: ' + e.message;

--- a/src/routes.php
+++ b/src/routes.php
@@ -81,7 +81,6 @@ use App\Controller\BackupController;
 use App\Domain\Roles;
 use App\Domain\Plan;
 
-use function App\runBackgroundProcess;
 use function App\runSyncProcess;
 
 require_once __DIR__ . '/Controller/HomeController.php';
@@ -1151,12 +1150,26 @@ return function (\Slim\App $app, TranslationService $translator) {
             return $response->withHeader('Content-Type', 'application/json')->withStatus(500);
         }
 
-        runBackgroundProcess($script, [$slug]);
+        $result = runSyncProcess($script, [$slug]);
 
-        $payload = ['status' => 'queued', 'tenant' => $slug];
+        if (!$result['success']) {
+            $message = trim($result['stderr'] !== '' ? $result['stderr'] : $result['stdout']);
+            $response->getBody()->write(json_encode(['error' => $message]));
+
+            return $response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(500);
+        }
+
+        $lines = array_filter(array_map('trim', explode("\n", $result['stdout'])));
+        $payload = json_decode(end($lines) ?: '', true);
+        if (!is_array($payload)) {
+            $payload = ['status' => 'success', 'tenant' => $slug];
+        }
+
         $response->getBody()->write(json_encode($payload));
 
-        return $response->withHeader('Content-Type', 'application/json')->withStatus(202);
+        return $response->withHeader('Content-Type', 'application/json');
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::SERVICE_ACCOUNT))->add(new CsrfMiddleware());
 
     $app->delete('/api/tenants/{slug}', function (Request $request, Response $response, array $args) {


### PR DESCRIPTION
## Summary
- run tenant onboarding script synchronously and return error details
- show onboarding completion or failure in UI

## Testing
- `composer test` *(fails: Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d1014008832b8a2c2150f28f3fc7