### PR TITLE
refactor: improve dark mode handling

### DIFF
--- a/public/Impressum.html
+++ b/public/Impressum.html
@@ -6,7 +6,7 @@
   <title>Impressum</title>
   <link rel="stylesheet" href="/css/uikit.min.css">
   <link rel="stylesheet" href="/css/main.css">
-  <link rel="stylesheet" href="/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="/css/dark.css">
 </head>
 <body class="uk-padding uk-background-default">
   <div class="wrapper">

--- a/public/Lizenz.html
+++ b/public/Lizenz.html
@@ -6,7 +6,7 @@
   <title>Lizenz</title>
   <link rel="stylesheet" href="/css/uikit.min.css">
   <link rel="stylesheet" href="/css/main.css">
-  <link rel="stylesheet" href="/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="/css/dark.css">
 </head>
 <body class="uk-padding uk-background-muted">
   <h1>Lizenz</h1>

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -1,84 +1,83 @@
 /* Zusätzliche Styles für Dark Mode */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #1e1e1e;
-    --color-primary: #0c86d0;
-    --color-text: #f5f5f5;
-  }
-html,
-body {
+html.uk-dark {
+  --color-bg: #1e1e1e;
+  --color-primary: #0c86d0;
+  --color-text: #f5f5f5;
+}
+html.uk-dark,
+html.uk-dark body {
   background-color: #000 !important;
   color: #f5f5f5;
 }
-body a {
+html.uk-dark body a {
   color: var(--accent-color, #9dc6ff);
 }
-body h1,
-body h2,
-body h3,
-body h4,
-body h5,
-body h6 {
+html.uk-dark body h1,
+html.uk-dark body h2,
+html.uk-dark body h3,
+html.uk-dark body h4,
+html.uk-dark body h5,
+html.uk-dark body h6 {
   color: #f5f5f5;
 }
-body .uk-card-title {
+html.uk-dark body .uk-card-title {
   color: #f5f5f5;
 }
-body .uk-card-default {
+html.uk-dark body .uk-card-default {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
-body .uk-card-default a {
+html.uk-dark body .uk-card-default a {
   color: var(--accent-color, #9dc6ff);
 }
-body .uk-card h3,
-body .uk-card p {
+html.uk-dark body .uk-card h3,
+html.uk-dark body .uk-card p {
   color: #f5f5f5;
 }
-body .uk-progress {
+html.uk-dark body .uk-progress {
   background-color: #333;
   color: var(--accent-color, #1e87f0);
 }
-body .uk-button-primary {
+html.uk-dark body .uk-button-primary {
   background-color: var(--accent-color, #1e87f0);
   border-color: var(--accent-color, #1e87f0);
 }
-body .uk-button,
-body .uk-button-default {
+html.uk-dark body .uk-button,
+html.uk-dark body .uk-button-default {
   color: #fff;
   background-color: #333;
   border-color: #555;
 }
-body .btn-black {
+html.uk-dark body .btn-black {
   background-color: #333 !important;
   color: #f5f5f5 !important;
   border: 2px solid #666;
 }
-body .btn-black:hover {
+html.uk-dark body .btn-black:hover {
   background-color: #f5f5f5 !important;
   color: #000 !important;
   border-color: #f5f5f5;
 }
-body .btn-transparent {
+html.uk-dark body .btn-transparent {
   background-color: transparent !important;
   color: var(--accent-color, #9dc6ff) !important;
   border: 2px solid var(--accent-color, #9dc6ff);
 }
-body .btn-transparent:hover {
+html.uk-dark body .btn-transparent:hover {
   background-color: var(--accent-color, #9dc6ff) !important;
   color: #000 !important;
 }
-body input,
-body textarea,
-body select {
+html.uk-dark body input,
+html.uk-dark body textarea,
+html.uk-dark body select {
   background-color: #1e1e1e;
   color: #f5f5f5;
   border-color: #555;
 }
-body .sortable-list li,
-body .terms li,
-body .dropzone,
-body .mc-option {
+html.uk-dark body .sortable-list li,
+html.uk-dark body .terms li,
+html.uk-dark body .dropzone,
+html.uk-dark body .mc-option {
   background-color: #1e1e1e;
   border-color: #444;
   color: #f5f5f5;
@@ -86,300 +85,300 @@ body .mc-option {
   padding: 16px;
   white-space: normal;
 }
-body .dropzone.over {
+html.uk-dark body .dropzone.over {
   background-color: #2a2a2a;
 }
-body .uk-alert-success {
+html.uk-dark body .uk-alert-success {
   background-color: #145214;
   color: #fff;
 }
-body .uk-alert-danger {
+html.uk-dark body .uk-alert-danger {
   background-color: #5a1a1a;
   color: #fff;
 }
-body .uk-alert-primary {
+html.uk-dark body .uk-alert-primary {
   background-color: var(--accent-color, #003366);
   color: #fff;
 }
 
-body .mc-option input {
+html.uk-dark body .mc-option input {
   transform: scale(1.3);
   margin-right: 8px;
 }
 
 /* Einheitlicher Kartenrahmen fuer Admin-Tabs im Dunkelmodus */
-body .tab-card {
+html.uk-dark body .tab-card {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
-body .topbar {
+html.uk-dark body .topbar {
   background-color: #1e1e1e;
   border-color: #444;
   padding-top: env(safe-area-inset-top);
 }
 
-body .git-btn,
-body .uk-icon-button:not(.uk-button-primary) {
+html.uk-dark body .git-btn,
+html.uk-dark body .uk-icon-button:not(.uk-button-primary) {
   background-color: rgba(255, 255, 255, 0.1);
   border: 1px solid #444;
 }
-body .event-header-bar {
+html.uk-dark body .event-header-bar {
   background-color: #1e1e1e;
   border-color: #444;
 }
 
-body .modern-info-card {
+html.uk-dark body .modern-info-card {
   border-color: #444;
 }
 
 /* Sticky actions and onboarding components in Dark Mode */
-body .sticky-actions {
+html.uk-dark body .sticky-actions {
   background: rgba(0, 0, 0, 0.95);
 }
 
-body .onboarding-step {
+html.uk-dark body .onboarding-step {
   border-color: #444;
   background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
   box-shadow: 0 6px 30px rgba(0,0,0,0.5);
 }
 
-body .onboarding-timeline .timeline-step {
+html.uk-dark body .onboarding-timeline .timeline-step {
   border-color: #555;
   color: #ddd;
 }
 
-body .onboarding-timeline .timeline-step.inactive {
+html.uk-dark body .onboarding-timeline .timeline-step.inactive {
   color: #444;
   border-color: #555;
   cursor: not-allowed;
 }
 
-body .onboarding-timeline .timeline-step.active,
-body .onboarding-timeline .timeline-step.completed {
+html.uk-dark body .onboarding-timeline .timeline-step.active,
+html.uk-dark body .onboarding-timeline .timeline-step.completed {
   border-color: var(--accent-color, #1e87f0);
   color: var(--accent-color, #1e87f0);
 }
 
-body .uk-icon,
-body .uk-icon-button {
+html.uk-dark body .uk-icon,
+html.uk-dark body .uk-icon-button {
   color: #f5f5f5;
 }
 
-body .site-footer {
+html.uk-dark body .site-footer {
   background-color: #1e1e1e;
   border-color: #444;
   color: #f5f5f5;
   padding-bottom: calc(1rem + env(safe-area-inset-bottom));
 }
 
-body .footer-menu a {
+html.uk-dark body .footer-menu a {
   color: var(--accent-color, #9dc6ff);
 }
 
-body .uk-icon-button {
+html.uk-dark body .uk-icon-button {
   color: #fff;
   background-color: rgba(255, 255, 255, 0.2);
 }
-body .uk-icon-button.uk-button-primary {
+html.uk-dark body .uk-icon-button.uk-button-primary {
   background-color: var(--accent-color, #1e87f0);
   border-color: var(--accent-color, #1e87f0);
 }
 
 /* Active state for navigation items in dark off-canvas menus */
-.uk-offcanvas-bar .uk-nav-default > li.uk-active > a {
+html.uk-dark .uk-offcanvas-bar .uk-nav-default > li.uk-active > a {
   background-color: rgba(255, 255, 255, 0.15);
   color: #fff;
 }
 
 /* Active state for navigation items in dark mode */
-body .uk-navbar-nav > li.uk-active > a,
-body .uk-nav-default > li.uk-active > a {
+html.uk-dark body .uk-navbar-nav > li.uk-active > a,
+html.uk-dark body .uk-nav-default > li.uk-active > a {
   background-color: rgba(255, 255, 255, 0.15);
   color: #fff;
 }
 
 /* Styles for Trumbowyg editor in Dark Mode */
-body .trumbowyg-box,
-body .trumbowyg-editor {
+html.uk-dark body .trumbowyg-box,
+html.uk-dark body .trumbowyg-editor {
   background-color: #1e1e1e !important;
   color: #f5f5f5 !important;
 }
 
-body .trumbowyg-button-pane {
+html.uk-dark body .trumbowyg-button-pane {
   background-color: #2a2a2a;
   border-color: #444;
 }
 
-body .trumbowyg-button-pane button {
+html.uk-dark body .trumbowyg-button-pane button {
   color: #f5f5f5;
 }
 
-body .trumbowyg-button-pane button svg {
+html.uk-dark body .trumbowyg-button-pane button svg {
   fill: #f5f5f5;
 }
 
-body .trumbowyg-button-pane button:hover {
+html.uk-dark body .trumbowyg-button-pane button:hover {
   background-color: #333;
 }
 
 /* Styles fuer QR-Scan-Popup im Dunkelmodus */
-body .uk-modal-dialog {
+html.uk-dark body .uk-modal-dialog {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
 /* Hoverfarbe für Katalogkarten im Dunkelmodus */
-body .uk-card-hover:hover {
+html.uk-dark body .uk-card-hover:hover {
   background-color: #333;
   color: #f5f5f5;
 }
 
 /* Tabellenlesbarkeit im Dunkelmodus verbessern */
-body .uk-table th,
-body .uk-table td {
+html.uk-dark body .uk-table th,
+html.uk-dark body .uk-table td {
   color: #f5f5f5;
   background-color: #1e1e1e;
   border-color: #444;
 }
-body .uk-table thead th {
+html.uk-dark body .uk-table thead th {
   background-color: #333;
 }
-body .uk-table tr {
+html.uk-dark body .uk-table tr {
   border-color: #444;
 }
 
-@media (min-width: 640px) {
-  body .sortable-list li,
-  body .terms li,
-  body .dropzone,
-  body .mc-option {
-    font-size: 1.3rem;
-  }
+  @media (min-width: 640px) {
+html.uk-dark body .sortable-list li,
+html.uk-dark body .terms li,
+html.uk-dark body .dropzone,
+html.uk-dark body .mc-option {
+  font-size: 1.3rem;
+}
 }
 
-@media (min-width: 960px) {
-  body .sortable-list li,
-  body .terms li,
-  body .dropzone,
-  body .mc-option {
-    font-size: 1.5rem;
-  }
-body .mc-option input {
+  @media (min-width: 960px) {
+html.uk-dark body .sortable-list li,
+html.uk-dark body .terms li,
+html.uk-dark body .dropzone,
+html.uk-dark body .mc-option {
+  font-size: 1.5rem;
+}
+html.uk-dark body .mc-option input {
   transform: scale(1.3);
 }
 }
 
-body .flip-card-front,
-body .flip-card-back {
+html.uk-dark body .flip-card-front,
+html.uk-dark body .flip-card-back {
   background-color: #1e1e1e;
   color: #f5f5f5;
   border: 1px solid #444;
 }
 
 /* FAQ page elements in Dark Mode */
-body .uk-heading-divider {
+html.uk-dark body .uk-heading-divider {
   border-bottom-color: #444;
   color: #f5f5f5;
 }
 
-body .uk-heading-bullet {
+html.uk-dark body .uk-heading-bullet {
   color: #f5f5f5;
 }
 
-body .uk-heading-bullet::before {
+html.uk-dark body .uk-heading-bullet::before {
   border-color: #444;
 }
 
-body .uk-accordion-title {
+html.uk-dark body .uk-accordion-title {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
-body .uk-accordion-title::before {
+html.uk-dark body .uk-accordion-title::before {
   filter: invert(1);
 }
 
-body .uk-accordion-content {
+html.uk-dark body .uk-accordion-content {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 }
 
-html.dark-mode,
-body.dark-mode {
+  html.dark-mode,
+html.uk-dark body.dark-mode {
   background-color: #000 !important;
   color: #f5f5f5;
 }
-body.dark-mode a {
+html.uk-dark body.dark-mode a {
   color: var(--accent-color, #9dc6ff);
 }
-body.dark-mode h1,
-body.dark-mode h2,
-body.dark-mode h3,
-body.dark-mode h4,
-body.dark-mode h5,
-body.dark-mode h6 {
+html.uk-dark body.dark-mode h1,
+html.uk-dark body.dark-mode h2,
+html.uk-dark body.dark-mode h3,
+html.uk-dark body.dark-mode h4,
+html.uk-dark body.dark-mode h5,
+html.uk-dark body.dark-mode h6 {
   color: #f5f5f5;
 }
-body.dark-mode .uk-card-title {
+html.uk-dark body.dark-mode .uk-card-title {
   color: #f5f5f5;
 }
-body.dark-mode .uk-card-default {
+html.uk-dark body.dark-mode .uk-card-default {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
-body.dark-mode .uk-card-default a {
+html.uk-dark body.dark-mode .uk-card-default a {
   color: var(--accent-color, #9dc6ff);
 }
-body.dark-mode .uk-card h3,
-body.dark-mode .uk-card p {
+html.uk-dark body.dark-mode .uk-card h3,
+html.uk-dark body.dark-mode .uk-card p {
   color: #f5f5f5;
 }
-body.dark-mode .uk-progress {
+html.uk-dark body.dark-mode .uk-progress {
   background-color: #333;
   color: var(--accent-color, #1e87f0);
 }
-body.dark-mode .uk-button-primary {
+html.uk-dark body.dark-mode .uk-button-primary {
   background-color: var(--accent-color, #1e87f0);
   border-color: var(--accent-color, #1e87f0);
 }
-body.dark-mode .uk-button,
-body.dark-mode .uk-button-default {
+html.uk-dark body.dark-mode .uk-button,
+html.uk-dark body.dark-mode .uk-button-default {
   color: #fff;
   background-color: #333;
   border-color: #555;
 }
-body.dark-mode .btn-black {
+html.uk-dark body.dark-mode .btn-black {
   background-color: #333 !important;
   color: #f5f5f5 !important;
   border: 2px solid #666;
 }
-body.dark-mode .btn-black:hover {
+html.uk-dark body.dark-mode .btn-black:hover {
   background-color: #f5f5f5 !important;
   color: #000 !important;
   border-color: #f5f5f5;
 }
-body.dark-mode .btn-transparent {
+html.uk-dark body.dark-mode .btn-transparent {
   background-color: transparent !important;
   color: var(--accent-color, #9dc6ff) !important;
   border: 2px solid var(--accent-color, #9dc6ff);
 }
-body.dark-mode .btn-transparent:hover {
+html.uk-dark body.dark-mode .btn-transparent:hover {
   background-color: var(--accent-color, #9dc6ff) !important;
   color: #000 !important;
 }
-body.dark-mode input,
-body.dark-mode textarea,
-body.dark-mode select {
+html.uk-dark body.dark-mode input,
+html.uk-dark body.dark-mode textarea,
+html.uk-dark body.dark-mode select {
   background-color: #1e1e1e;
   color: #f5f5f5;
   border-color: #555;
 }
-body.dark-mode .sortable-list li,
-body.dark-mode .terms li,
-body.dark-mode .dropzone,
-body.dark-mode .mc-option {
+html.uk-dark body.dark-mode .sortable-list li,
+html.uk-dark body.dark-mode .terms li,
+html.uk-dark body.dark-mode .dropzone,
+html.uk-dark body.dark-mode .mc-option {
   background-color: #1e1e1e;
   border-color: #444;
   color: #f5f5f5;
@@ -387,274 +386,272 @@ body.dark-mode .mc-option {
   padding: 16px;
   white-space: normal;
 }
-body.dark-mode .dropzone.over {
+html.uk-dark body.dark-mode .dropzone.over {
   background-color: #2a2a2a;
 }
-body.dark-mode .uk-alert-success {
+html.uk-dark body.dark-mode .uk-alert-success {
   background-color: #145214;
   color: #fff;
 }
-body.dark-mode .uk-alert-danger {
+html.uk-dark body.dark-mode .uk-alert-danger {
   background-color: #5a1a1a;
   color: #fff;
 }
-body.dark-mode .uk-alert-primary {
+html.uk-dark body.dark-mode .uk-alert-primary {
   background-color: var(--accent-color, #003366);
   color: #fff;
 }
 
-body.dark-mode .mc-option input {
+html.uk-dark body.dark-mode .mc-option input {
   transform: scale(1.3);
   margin-right: 8px;
 }
 
 /* Einheitlicher Kartenrahmen fuer Admin-Tabs im Dunkelmodus */
-body.dark-mode .tab-card {
+html.uk-dark body.dark-mode .tab-card {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
-body.dark-mode .topbar {
+html.uk-dark body.dark-mode .topbar {
   background-color: #1e1e1e;
   border-color: #444;
   padding-top: env(safe-area-inset-top);
 }
-body.dark-mode .event-header-bar {
+html.uk-dark body.dark-mode .event-header-bar {
   background-color: #1e1e1e;
   border-color: #444;
 }
 
-body.dark-mode .modern-info-card {
+html.uk-dark body.dark-mode .modern-info-card {
   border-color: #444;
 }
 
 /* Sticky actions and onboarding components in Dark Mode */
-body.dark-mode .sticky-actions {
+html.uk-dark body.dark-mode .sticky-actions {
   background: rgba(0, 0, 0, 0.95);
 }
 
-body.dark-mode .onboarding-step {
+html.uk-dark body.dark-mode .onboarding-step {
   border-color: #444;
   background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
   box-shadow: 0 6px 30px rgba(0,0,0,0.5);
 }
 
-body.dark-mode .onboarding-timeline .timeline-step {
+html.uk-dark body.dark-mode .onboarding-timeline .timeline-step {
   border-color: #555;
   color: #ddd;
 }
 
-body.dark-mode .onboarding-timeline .timeline-step.inactive {
+html.uk-dark body.dark-mode .onboarding-timeline .timeline-step.inactive {
   color: #444;
   border-color: #555;
   cursor: not-allowed;
 }
 
-body.dark-mode .onboarding-timeline .timeline-step.active,
-body.dark-mode .onboarding-timeline .timeline-step.completed {
+html.uk-dark body.dark-mode .onboarding-timeline .timeline-step.active,
+html.uk-dark body.dark-mode .onboarding-timeline .timeline-step.completed {
   border-color: var(--accent-color, #1e87f0);
   color: var(--accent-color, #1e87f0);
 }
 
-body .pricing-grid .uk-card-quizrace {
+html.uk-dark body .pricing-grid .uk-card-quizrace {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
-body .pricing-grid .uk-card-quizrace.uk-card-popular {
+html.uk-dark body .pricing-grid .uk-card-quizrace.uk-card-popular {
   background-color: #0c86d0;
   color: #fff;
 }
 
-body .pricing-grid .uk-card-quizrace .uk-text-meta,
-body .pricing-grid .uk-card-quizrace li,
-body .pricing-grid .uk-card-quizrace h3 {
+html.uk-dark body .pricing-grid .uk-card-quizrace .uk-text-meta,
+html.uk-dark body .pricing-grid .uk-card-quizrace li,
+html.uk-dark body .pricing-grid .uk-card-quizrace h3 {
   color: #f5f5f5;
 }
 
-body.dark-mode .pricing-grid .uk-card-quizrace {
+html.uk-dark body.dark-mode .pricing-grid .uk-card-quizrace {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
-body.dark-mode .pricing-grid .uk-card-quizrace.uk-card-popular {
+html.uk-dark body.dark-mode .pricing-grid .uk-card-quizrace.uk-card-popular {
   background-color: #0c86d0;
   color: #fff;
 }
 
-body.dark-mode .pricing-grid .uk-card-quizrace .uk-text-meta,
-body.dark-mode .pricing-grid .uk-card-quizrace li,
-body.dark-mode .pricing-grid .uk-card-quizrace h3 {
+html.uk-dark body.dark-mode .pricing-grid .uk-card-quizrace .uk-text-meta,
+html.uk-dark body.dark-mode .pricing-grid .uk-card-quizrace li,
+html.uk-dark body.dark-mode .pricing-grid .uk-card-quizrace h3 {
   color: #f5f5f5;
 }
 
-body.dark-mode .uk-icon,
-body.dark-mode .uk-icon-button {
+html.uk-dark body.dark-mode .uk-icon,
+html.uk-dark body.dark-mode .uk-icon-button {
   color: #f5f5f5;
 }
 
-body.dark-mode .site-footer {
+html.uk-dark body.dark-mode .site-footer {
   background-color: #1e1e1e;
   border-color: #444;
   padding-bottom: calc(1rem + env(safe-area-inset-bottom));
 }
 
-body.dark-mode .uk-icon-button {
+html.uk-dark body.dark-mode .uk-icon-button {
   color: #fff;
   background-color: rgba(255, 255, 255, 0.2);
 }
-body.dark-mode .uk-icon-button.uk-button-primary {
+html.uk-dark body.dark-mode .uk-icon-button.uk-button-primary {
   background-color: var(--accent-color, #1e87f0);
   border-color: var(--accent-color, #1e87f0);
 }
 
 /* Active state for navigation items in dark off-canvas menus */
-.uk-offcanvas-bar .uk-nav-default > li.uk-active > a {
+html.uk-dark .uk-offcanvas-bar .uk-nav-default > li.uk-active > a {
   background-color: rgba(255, 255, 255, 0.15);
   color: #fff;
 }
 
 /* Active state for navigation items in dark mode */
-body.dark-mode .uk-navbar-nav > li.uk-active > a,
-body.dark-mode .uk-nav-default > li.uk-active > a {
+html.uk-dark body.dark-mode .uk-navbar-nav > li.uk-active > a,
+html.uk-dark body.dark-mode .uk-nav-default > li.uk-active > a {
   background-color: rgba(255, 255, 255, 0.15);
   color: #fff;
 }
 
 /* Styles for Trumbowyg editor in Dark Mode */
-body.dark-mode .trumbowyg-box,
-body.dark-mode .trumbowyg-editor {
+html.uk-dark body.dark-mode .trumbowyg-box,
+html.uk-dark body.dark-mode .trumbowyg-editor {
   background-color: #1e1e1e !important;
   color: #f5f5f5 !important;
 }
 
-body.dark-mode .trumbowyg-button-pane {
+html.uk-dark body.dark-mode .trumbowyg-button-pane {
   background-color: #2a2a2a;
   border-color: #444;
 }
 
-body.dark-mode .trumbowyg-button-pane button {
+html.uk-dark body.dark-mode .trumbowyg-button-pane button {
   color: #f5f5f5;
 }
 
-body.dark-mode .trumbowyg-button-pane button svg {
+html.uk-dark body.dark-mode .trumbowyg-button-pane button svg {
   fill: #f5f5f5;
 }
 
-body.dark-mode .trumbowyg-button-pane button:hover {
+html.uk-dark body.dark-mode .trumbowyg-button-pane button:hover {
   background-color: #333;
 }
 
 /* Styles fuer QR-Scan-Popup im Dunkelmodus */
-body.dark-mode .uk-modal-dialog {
+html.uk-dark body.dark-mode .uk-modal-dialog {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
 /* Hoverfarbe für Katalogkarten im Dunkelmodus */
-body.dark-mode .uk-card-hover:hover {
+html.uk-dark body.dark-mode .uk-card-hover:hover {
   background-color: #333;
   color: #f5f5f5;
 }
 
 /* Tabellenlesbarkeit im Dunkelmodus verbessern */
-body.dark-mode .uk-table th,
-body.dark-mode .uk-table td {
+html.uk-dark body.dark-mode .uk-table th,
+html.uk-dark body.dark-mode .uk-table td {
   color: #f5f5f5;
   background-color: #1e1e1e;
   border-color: #444;
 }
-body.dark-mode .uk-table thead th {
+html.uk-dark body.dark-mode .uk-table thead th {
   background-color: #333;
 }
-body.dark-mode .uk-table tr {
+html.uk-dark body.dark-mode .uk-table tr {
   border-color: #444;
 }
 
-@media (min-width: 640px) {
-  body.dark-mode .sortable-list li,
-  body.dark-mode .terms li,
-  body.dark-mode .dropzone,
-  body.dark-mode .mc-option {
-    font-size: 1.3rem;
-  }
+  @media (min-width: 640px) {
+html.uk-dark body.dark-mode .sortable-list li,
+html.uk-dark body.dark-mode .terms li,
+html.uk-dark body.dark-mode .dropzone,
+html.uk-dark body.dark-mode .mc-option {
+  font-size: 1.3rem;
+}
 }
 
-@media (min-width: 960px) {
-  body.dark-mode .sortable-list li,
-  body.dark-mode .terms li,
-  body.dark-mode .dropzone,
-  body.dark-mode .mc-option {
-    font-size: 1.5rem;
-  }
-body.dark-mode .mc-option input {
+  @media (min-width: 960px) {
+html.uk-dark body.dark-mode .sortable-list li,
+html.uk-dark body.dark-mode .terms li,
+html.uk-dark body.dark-mode .dropzone,
+html.uk-dark body.dark-mode .mc-option {
+  font-size: 1.5rem;
+}
+html.uk-dark body.dark-mode .mc-option input {
   transform: scale(1.3);
 }
 }
 
-body.dark-mode .flip-card-front,
-body.dark-mode .flip-card-back {
+html.uk-dark body.dark-mode .flip-card-front,
+html.uk-dark body.dark-mode .flip-card-back {
   background-color: #1e1e1e;
   color: #f5f5f5;
   border: 1px solid #444;
 }
 
 /* FAQ page elements in Dark Mode */
-body.dark-mode .uk-heading-divider {
+html.uk-dark body.dark-mode .uk-heading-divider {
   border-bottom-color: #444;
   color: #f5f5f5;
 }
 
-body.dark-mode .uk-heading-bullet {
+html.uk-dark body.dark-mode .uk-heading-bullet {
   color: #f5f5f5;
 }
 
-body.dark-mode .uk-heading-bullet::before {
+html.uk-dark body.dark-mode .uk-heading-bullet::before {
   border-color: #444;
 }
 
-body.dark-mode .uk-accordion-title {
+html.uk-dark body.dark-mode .uk-accordion-title {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
-body.dark-mode .uk-accordion-title::before {
+html.uk-dark body.dark-mode .uk-accordion-title::before {
   filter: invert(1);
 }
 
-body.dark-mode .uk-accordion-content {
+html.uk-dark body.dark-mode .uk-accordion-content {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
 /* Landing page adjustments in Dark Mode */
-@media (prefers-color-scheme: dark) {
-  body.landing-page {
-    --landing-bg: #1e1e1e;
-    --landing-text: #f5f5f5;
-    --landing-primary: #0c86d0;
-    background: var(--landing-bg);
-    color: var(--landing-text);
-  }
+html.uk-dark body.landing-page {
+  --landing-bg: #1e1e1e;
+  --landing-text: #f5f5f5;
+  --landing-primary: #0c86d0;
+  background: var(--landing-bg);
+  color: var(--landing-text);
+}
 
-  body.landing-page .uk-card-quizrace {
-    background: var(--landing-bg);
-    color: var(--landing-text);
-  }
+html.uk-dark body.landing-page .uk-card-quizrace {
+  background: var(--landing-bg);
+  color: var(--landing-text);
+}
 
-  body.landing-page .uk-card-quizrace .uk-icon {
-    color: var(--landing-primary);
-  }
+html.uk-dark body.landing-page .uk-card-quizrace .uk-icon {
+  color: var(--landing-primary);
+}
 
-  body.landing-page .topbar .top-cta,
-  body.landing-page .cta-main {
-    background: var(--landing-primary);
-    color: var(--landing-text);
-  }
+html.uk-dark body.landing-page .topbar .top-cta,
+html.uk-dark body.landing-page .cta-main {
+  background: var(--landing-primary);
+  color: var(--landing-text);
+}
 
-  body.landing-page .topbar .top-cta:hover,
-  body.landing-page .cta-main:hover {
-    background: var(--landing-text);
-    color: var(--landing-primary);
-  }
+html.uk-dark body.landing-page .topbar .top-cta:hover,
+html.uk-dark body.landing-page .cta-main:hover {
+  background: var(--landing-text);
+  color: var(--landing-primary);
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,12 +9,16 @@ document.addEventListener('DOMContentLoaded', function () {
   const themeIcon = document.getElementById('themeIcon');
   const accessibilityIcon = document.getElementById('accessibilityIcon');
   const helpBtn = document.getElementById('helpBtn');
+  const darkStylesheet = document.getElementById('darkStylesheet');
 
   const storedTheme = localStorage.getItem('darkMode');
   const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   let dark = storedTheme === 'true' || (storedTheme === null && prefersDark);
 
   function applyTheme () {
+    if (darkStylesheet) {
+      darkStylesheet.disabled = !dark;
+    }
     document.body.classList.toggle('uk-dark', dark);
     document.body.classList.toggle('uk-light', !dark);
     document.documentElement.classList.toggle('uk-dark', dark);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -5,7 +5,7 @@
 {% block head %}
   <meta name="csrf-token" content="{{ csrf_token }}">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/ui/trumbowyg.min.css">
   <script src="https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js"></script>

--- a/templates/admin/landingpage/edit.html.twig
+++ b/templates/admin/landingpage/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -5,7 +5,7 @@
 {% block head %}
   <meta http-equiv="refresh" content="5">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/admin/pages/edit.twig
+++ b/templates/admin/pages/edit.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/ui/trumbowyg.min.css">
   <script src="https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js"></script>

--- a/templates/datenschutz.twig
+++ b/templates/datenschutz.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -5,7 +5,7 @@
 {% block head %}
   <meta name="csrf-token" content="{{ csrf_token }}">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/faq.twig
+++ b/templates/faq.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/impressum.twig
+++ b/templates/impressum.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
 {% endblock %}

--- a/templates/lizenz.twig
+++ b/templates/lizenz.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="{{ basePath }}/css/onboarding.css">
 {% endblock %}

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/profile.twig
+++ b/templates/profile.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/register.twig
+++ b/templates/register.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link id="darkStylesheet" rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add `darkStylesheet` ID to all templates referencing dark.css
- toggle dark.css via `disabled` attribute in `applyTheme`
- scope dark styles to `.uk-dark` without media query

## Testing
- `composer test` *(fails: Tests: 271, Assertions: 582, Errors: 26, Failures: 6)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d33d3b58832b943ef48bbbc1066e