### PR TITLE
Improve light mode contrast

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -10,15 +10,21 @@ html {
 :root {
   --primary-color: #0c86d0;
   --accent-color: #39f;
-  --color-bg: #fff;
+  --color-bg: #f5f5f5;
   --color-primary: #0c86d0;
-  --color-text: #232323;
+  --color-text: #222;
 }
 
 body {
   min-height: 100vh;
   overflow-x: hidden;
-  background-color: var(--primary-color, #ffffff);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+body.uk-background-default {
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 .uk-button-primary {
@@ -76,6 +82,29 @@ body.uk-padding {
 .footer-menu a {
   color: #222;
   text-decoration: none;
+}
+
+/* Login page enhancements */
+.login-card {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.login-card .uk-input {
+  background: #fff;
+  border-color: #bbb;
+}
+
+.login-card .uk-input:focus {
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px rgba(12, 134, 208, 0.2);
+}
+
+.login-card .uk-button-primary {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  color: #fff;
 }
 
 .sortable-list li,

--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -35,6 +35,12 @@ body.dark-mode.high-contrast{
   --btn-bg-hover: rgba(255,255,255,0.16);
   --focus-ring: rgba(140,200,255,0.8);
 }
+
+.topbar{
+  background-color: #fff;
+  border-bottom: 1px solid #e5e5e5;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
 .git-btn{
   width:40px;height:40px;padding:0;
   border-radius:6px;

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -14,7 +14,7 @@
   {% embed 'topbar.twig' %}{% endembed %}
 <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
   <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
-    <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+    <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large login-card">
           <h3 class="uk-card-title uk-text-center">Login</h3>
           {% if reset_success %}
           <div class="uk-alert-success" uk-alert>


### PR DESCRIPTION
## Summary
- use light gray page background and darker text for better contrast
- style login card inputs and buttons for clarity
- add visible header background and shadow

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d87f80a8832b850f08a9259cb4c6