### PR TITLE
Add interactive editor preview section to landing page

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -93,6 +93,263 @@
     </div>
   </section>
 
+<!-- =========================
+     GitHub-style Screenshot Preview for quizrace.app
+     ========================= -->
+<section class="qr-screenshot-section uk-section uk-padding-remove-top">
+  <div class="qr-screenshot-bg" aria-hidden="true"></div>
+
+  <div class="uk-container uk-container-expand">
+    <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
+      <!-- Left: Messaging (optional) -->
+      <div class="uk-order-last@m">
+        <h2 class="uk-heading-medium uk-margin-small">So sieht QuizRace in Aktion aus</h2>
+        <p class="uk-text-lead uk-margin-small">
+          Intuitiver Editor, klare Auswertung, alles im Browser. <br>
+          DSGVO-konform, Single-Tenant & blitzschnell startklar.
+        </p>
+        <div class="uk-margin">
+          <a class="uk-button uk-button-primary uk-button-large" href="{{ basePath }}/onboarding">Event starten</a>
+          <a class="uk-button uk-button-default uk-button-large" href="https://demo.quizrace.app" target="_blank" rel="noopener">Demo ansehen</a>
+        </div>
+      </div>
+
+      <!-- Right: Screenshot Preview -->
+      <div>
+        <!-- STACK VARIANTE: zwei Ebenen, obere klickbar/animiert -->
+        <div class="qr-shot-stack">
+          <!-- Back layer (blurred/offset) -->
+          <div class="qr-browser-mockup is-back" aria-hidden="true">
+            <div class="qr-browser-chrome">
+              <div class="qr-traffic">
+                <span></span><span></span><span></span>
+              </div>
+              <div class="qr-tab">
+                <span class="qr-favicon" aria-hidden="true">🏁</span>
+                <span class="qr-tab-title">QuizRace</span>
+              </div>
+              <div class="qr-url">https://quizrace.app</div>
+            </div>
+            <div class="qr-browser-content">
+              <img
+                src="{{ basePath }}/img/preview-editor-blurred.jpg"
+                alt=""
+                loading="lazy" decoding="async">
+            </div>
+          </div>
+
+          <!-- Front layer (interactive) -->
+          <figure class="qr-browser-mockup tilt-target">
+            <div class="qr-browser-chrome" role="group" aria-label="Browserfenster Vorschau">
+              <div class="qr-traffic" aria-hidden="true">
+                <span></span><span></span><span></span>
+              </div>
+              <div class="qr-tab" aria-hidden="true">
+                <span class="qr-favicon">🏁</span>
+                <span class="qr-tab-title">QuizRace – Event-Editor</span>
+              </div>
+              <div class="qr-url" aria-hidden="true">https://quizrace.app/editor</div>
+            </div>
+            <div class="qr-browser-content">
+              <!-- Variante A: statischer Screenshot -->
+              <img
+                src="{{ basePath }}/img/preview-editor.jpg"
+                alt="QuizRace Editor – Fragenkatalog mit Live-Vorschau"
+                loading="lazy" decoding="async">
+              <!-- Variante B: Video – ersetze <img> durch <video> -->
+              <!--
+              <video controls playsinline preload="metadata" poster="{{ basePath }}/img/preview-editor-poster.jpg">
+                <source src="{{ basePath }}/media/preview-editor.webm" type="video/webm">
+                <source src="{{ basePath }}/media/preview-editor.mp4" type="video/mp4">
+              </video>
+              -->
+            </div>
+            <figcaption class="qr-caption uk-text-meta">
+              Live-Vorschau, Drag&Drop, Team-Management – alles ohne App.
+            </figcaption>
+          </figure>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+/* =========================
+   Design Tokens (GitHub-ish + QuizRace Blue)
+   ========================= */
+:root{
+  --qr-canvas: #ffffff;
+  --qr-subtle: #f6f8fa;
+  --qr-border: #d0d7de;
+  --qr-text: #24292f;
+  --qr-muted: #57606a;
+  --qr-blue: #2f81f7;          /* GitHub blue */
+  --qr-cyan: #0ea5e9;          /* Akzent 2 */
+  --qr-shadow-soft: 0 8px 24px rgba(140,149,159,.25);
+  --qr-shadow-strong: 0 24px 60px rgba(31,35,40,.35);
+  --qr-radius: 14px;
+}
+@media (prefers-color-scheme: dark){
+  :root{
+    --qr-canvas: #0d1117;
+    --qr-subtle: #161b22;
+    --qr-border: #30363d;
+    --qr-text: #e6edf3;
+    --qr-muted: #7d8590;
+    --qr-shadow-soft: 0 10px 28px rgba(0,0,0,.45);
+    --qr-shadow-strong: 0 36px 84px rgba(0,0,0,.6);
+  }
+}
+
+/* =========================
+   Section Background (blauer Verlauf + feines Grid)
+   ========================= */
+.qr-screenshot-section{ position: relative; overflow: clip; }
+.qr-screenshot-bg{
+  position:absolute; inset:0; z-index:0;
+  background:
+    linear-gradient(180deg, rgba(8,12,20,.70) 0%, rgba(8,12,20,.52) 40%, rgba(8,12,20,.80) 100%),
+    radial-gradient(1200px 520px at 15% 12%, rgba(47,129,247,.35), rgba(47,129,247,0) 60%),
+    radial-gradient(1000px 520px at 90% 18%, rgba(14,165,233,.25), rgba(14,165,233,0) 62%);
+  pointer-events:none;
+}
+/* ultra-subtle grid */
+.qr-screenshot-bg::after{
+  content:""; position:absolute; inset:0; opacity:.06; pointer-events:none;
+  background-image:
+    linear-gradient(to right, #fff 1px, transparent 1px),
+    linear-gradient(to bottom, #fff 1px, transparent 1px);
+  background-size: 44px 44px, 44px 44px;
+  mix-blend-mode: overlay;
+}
+@media (prefers-color-scheme: dark){
+  .qr-screenshot-bg::after{ opacity:.08; background-image:
+    linear-gradient(to right, #000 1px, transparent 1px),
+    linear-gradient(to bottom, #000 1px, transparent 1px);
+  }
+}
+
+/* =========================
+   Browser Mockup
+   ========================= */
+.qr-browser-mockup{
+  position: relative; z-index:1;
+  background: var(--qr-canvas);
+  border: 1px solid var(--qr-border);
+  border-radius: 18px;
+  box-shadow: var(--qr-shadow-strong);
+  overflow: hidden;
+  transform-style: preserve-3d;
+}
+.qr-browser-chrome{
+  display:grid; grid-template-columns: auto 1fr auto;
+  align-items:center; gap:10px;
+  padding:10px 12px;
+  background: linear-gradient(180deg, var(--qr-subtle), color-mix(in oklab, var(--qr-subtle) 86%, transparent));
+  border-bottom: 1px solid var(--qr-border);
+}
+.qr-traffic{
+  display:inline-flex; gap:6px;
+}
+.qr-traffic span{
+  width:12px; height:12px; border-radius:50%;
+  background: #ff5f56; box-shadow: inset 0 0 0 1px rgba(0,0,0,.08);
+}
+.qr-traffic span:nth-child(2){ background:#ffbd2e; }
+.qr-traffic span:nth-child(3){ background:#27c93f; }
+
+.qr-tab{
+  display:inline-flex; align-items:center; gap:8px;
+  padding:6px 10px; border-radius: 8px;
+  background: color-mix(in oklab, var(--qr-subtle) 70%, transparent);
+  border: 1px solid var(--qr-border);
+  box-shadow: 0 1px 0 rgba(0,0,0,.04) inset;
+  max-width: 60%;
+}
+.qr-favicon{ filter: saturate(1.2); }
+.qr-tab-title{
+  font-weight:600; font-size: .9rem; color: var(--qr-text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.qr-url{
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: .8rem; color: var(--qr-muted);
+  padding:6px 10px; border-radius: 8px;
+  border: 1px solid var(--qr-border);
+  background: color-mix(in oklab, var(--qr-subtle) 70%, transparent);
+}
+
+.qr-browser-content{
+  aspect-ratio: 16/9;
+  background: var(--qr-subtle);
+  overflow:hidden;
+}
+.qr-browser-content img,
+.qr-browser-content video{
+  display:block; width:100%; height:100%; object-fit: cover;
+}
+
+/* Caption */
+.qr-caption{ padding:8px 12px 12px; color: var(--qr-muted); text-align:center; }
+
+/* =========================
+   Stack Layout
+   ========================= */
+.qr-shot-stack{
+  position: relative; padding: 30px 10px 10px; /* breathing */
+}
+.qr-browser-mockup.is-back{
+  position: absolute; inset: 0 24px 24px 0; transform: translate3d(-12px, 14px, 0) scale(.985);
+  filter: blur(.6px) saturate(.9);
+  z-index:0; pointer-events:none;
+  opacity:.85;
+}
+
+/* =========================
+   Tilt Interaction (with a11y fallback)
+   ========================= */
+@media (hover:hover) and (pointer:fine){
+  .tilt-target{
+    transition: transform .2s ease, box-shadow .2s ease;
+    will-change: transform;
+  }
+  .tilt-target:hover{ box-shadow: 0 32px 88px rgba(31,35,40,.45); }
+}
+@media (prefers-reduced-motion: reduce){
+  .tilt-target{ transition: none !important; transform: none !important; }
+}
+
+/* Helpers for spacing on small screens */
+@media (max-width: 959.98px){
+  .qr-browser-content{ aspect-ratio: 4/3; }
+  .qr-browser-mockup.is-back{ display:none; }
+}
+</style>
+
+<script>
+/* Tiny tilt without libs; disables for reduced motion */
+(function(){
+  const prefersReduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (prefersReduced) return;
+  const el = document.querySelector('.tilt-target');
+  if (!el) return;
+
+  const damp = 16; // größer = weniger Neigung
+  function onMove(e){
+    const r = el.getBoundingClientRect();
+    const cx = r.left + r.width/2;
+    const cy = r.top + r.height/2 + window.scrollY;
+    const x = (e.pageX - cx) / r.width;
+    const y = (e.pageY - cy) / r.height;
+    el.style.transform = `perspective(1200px) rotateY(${x*damp*-1}deg) rotateX(${y*damp}deg) translateZ(0)`;
+  }
+  function reset(){ el.style.transform = ""; }
+  el.addEventListener('mousemove', onMove);
+  el.addEventListener('mouseleave', reset);
+})();
+</script>
+
   <!-- ===== Warum ===== -->
   <section id="warum" class="uk-section uk-section-default">
     <div class="uk-container container-xl">


### PR DESCRIPTION
## Summary
- showcase QuizRace editor with GitHub-style screenshot block and tilt animation on landing page using provided markup verbatim

## Testing
- `composer install`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd93ebd4832bbb303b0293999476