### PR TITLE
Fix light mode visibility on admin login

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,13 +19,13 @@ document.addEventListener('DOMContentLoaded', function () {
     if (darkStylesheet) {
       darkStylesheet.disabled = !dark;
     }
-    document.body.classList.toggle('uk-dark', dark);
-    document.body.classList.toggle('uk-light', !dark);
-    document.documentElement.classList.toggle('uk-dark', dark);
-    document.documentElement.classList.toggle('uk-light', !dark);
+    document.body.classList.toggle('uk-dark', !dark);
+    document.body.classList.toggle('uk-light', dark);
+    document.documentElement.classList.toggle('uk-dark', !dark);
+    document.documentElement.classList.toggle('uk-light', dark);
     document.querySelectorAll('.topbar').forEach(el => {
-      el.classList.toggle('uk-dark', dark);
-      el.classList.toggle('uk-light', !dark);
+      el.classList.toggle('uk-dark', !dark);
+      el.classList.toggle('uk-light', dark);
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure theme toggler assigns uk-dark in light mode and uk-light in dark mode so text and icons stay visible on login screen

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b327677868832b978f1e20a4bb4442