### PR TITLE
Fix onboarding light theme classes

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,13 +19,13 @@ document.addEventListener('DOMContentLoaded', function () {
     if (darkStylesheet) {
       darkStylesheet.disabled = !dark;
     }
-    document.body.classList.toggle('uk-dark', !dark);
-    document.body.classList.toggle('uk-light', dark);
-    document.documentElement.classList.toggle('uk-dark', !dark);
-    document.documentElement.classList.toggle('uk-light', dark);
+    document.body.classList.toggle('uk-dark', dark);
+    document.body.classList.toggle('uk-light', !dark);
+    document.documentElement.classList.toggle('uk-dark', dark);
+    document.documentElement.classList.toggle('uk-light', !dark);
     document.querySelectorAll('.topbar').forEach(el => {
-      el.classList.toggle('uk-dark', !dark);
-      el.classList.toggle('uk-light', dark);
+      el.classList.toggle('uk-dark', dark);
+      el.classList.toggle('uk-light', !dark);
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure light mode uses correct UIkit classes in onboarding

## Testing
- `./vendor/bin/phpunit tests/ProcessHelpersTest.php`
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_profile_flow.js`
- `node tests/test_team_restrict.js`


------
https://chatgpt.com/codex/tasks/task_e_68b32daead18832baa4987e06abe4554