### PR TITLE
Fix login page colors in light mode

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -127,6 +127,15 @@ body.uk-padding {
   color: #fff;
 }
 
+.login-card a {
+  color: var(--accent-color, #1e87f0);
+}
+
+.login-version {
+  color: var(--color-text);
+  opacity: 0.7;
+}
+
 .sortable-list li,
 .terms li,
 .dropzone,

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -59,7 +59,7 @@
           </form>
       </div>
       {% if version %}
-      <div class="uk-text-center uk-text-meta uk-margin-small-top">Version {{ version }}</div>
+      <div class="uk-text-center uk-text-meta uk-margin-small-top login-version">Version {{ version }}</div>
       {% endif %}
     </div>
   </div>

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,4 +1,4 @@
-<nav class="uk-navbar-container uk-padding-small topbar {{ mode is defined and mode == 'light' ? 'uk-light' : 'uk-dark' }}" role="navigation" aria-label="{{ t('primary_navigation') }}" uk-navbar>
+<nav class="uk-navbar-container uk-padding-small topbar {{ mode is defined and mode == 'dark' ? 'uk-light' : 'uk-dark' }}" role="navigation" aria-label="{{ t('primary_navigation') }}" uk-navbar>
     <div class="uk-navbar-left">
       <div class="uk-navbar-item">
         <button id="offcanvas-toggle"


### PR DESCRIPTION
## Summary
- correct navbar theme logic so light mode uses dark text
- style login page links and version badge for better contrast

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b36f431c98832b950c6cc73c79e556