### PR TITLE
Fix admin dashboard gap

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -58,17 +58,6 @@
           </div>
         </div>
       {% endblock %}
-      {% block headerbar %}
-        {% set activeRoute = currentPath|split('/admin/')|last %}
-        {% if activeRoute == '' %}
-          {% set activeRoute = 'dashboard' %}
-        {% endif %}
-      {% if activeRoute == 'dashboard' %}
-        <div class="uk-container uk-container-large">
-          <h2 class="uk-heading-bullet">Willkommen {{ username }}</h2>
-        </div>
-      {% endif %}
-    {% endblock %}
   {% endembed %}
   {% if not stripe_configured %}
     <div class="uk-container uk-container-large">
@@ -99,6 +88,7 @@
       <ul id="adminSwitcher" class="uk-switcher uk-margin">
     <li class="{{ activeRoute == 'dashboard' ? 'uk-active' }}">
       <div class="uk-container uk-container-large dashboard-container">
+        <h2 class="uk-heading-bullet">Willkommen {{ username }}</h2>
         <div id="dashboard" class="uk-margin-large-top">
           <div class="uk-grid-large" uk-grid>
             <!-- Spalte 2–3: Inhalt -->


### PR DESCRIPTION
## Summary
- move dashboard welcome heading into main container to avoid left gap when opening admin start page

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables)*
- `vendor/bin/phpunit tests/Controller/AdminControllerTest.php` *(fails: output truncated due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b37845d894832b951b1ec303798e5b