### PR TITLE
feat(dark-mode): refine login input styling

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -74,6 +74,14 @@ html.uk-dark body select {
   color: #f5f5f5;
   border-color: #555;
 }
+html.uk-dark body .login-card .uk-input {
+  background-color: #1e1e1e;
+  color: #f5f5f5;
+  border-color: #555;
+}
+html.uk-dark body .login-card .uk-input::placeholder {
+  color: #bbb;
+}
 html.uk-dark body .sortable-list li,
 html.uk-dark body .terms li,
 html.uk-dark body .dropzone,


### PR DESCRIPTION
## Summary
- ensure login card inputs respect dark mode colors
- dim login input placeholders for dark mode

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b385a847b0832bb10f3e52dc5de6cb