### PR TITLE
feat: initialize theme before css load

### DIFF
--- a/public/Impressum.html
+++ b/public/Impressum.html
@@ -4,6 +4,25 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Impressum</title>
+  <script>
+  (function () {
+    const storedTheme = localStorage.getItem('darkMode');
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const dark = storedTheme === 'true' || (storedTheme === null && prefersDark);
+    const root = document.documentElement;
+    root.classList.add(dark ? 'uk-dark' : 'uk-light');
+    root.classList.remove(dark ? 'uk-light' : 'uk-dark');
+    window.__initialDark = dark;
+    const mo = new MutationObserver(() => {
+      const ds = document.getElementById('darkStylesheet');
+      if (ds) {
+        ds.disabled = !dark;
+        mo.disconnect();
+      }
+    });
+    mo.observe(document.head, { childList: true });
+  })();
+  </script>
   <link rel="stylesheet" href="/css/uikit.min.css">
   <link rel="stylesheet" href="/css/main.css">
   <link id="darkStylesheet" rel="stylesheet" href="/css/dark.css">

--- a/public/Lizenz.html
+++ b/public/Lizenz.html
@@ -4,6 +4,25 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Lizenz</title>
+  <script>
+  (function () {
+    const storedTheme = localStorage.getItem('darkMode');
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const dark = storedTheme === 'true' || (storedTheme === null && prefersDark);
+    const root = document.documentElement;
+    root.classList.add(dark ? 'uk-dark' : 'uk-light');
+    root.classList.remove(dark ? 'uk-light' : 'uk-dark');
+    window.__initialDark = dark;
+    const mo = new MutationObserver(() => {
+      const ds = document.getElementById('darkStylesheet');
+      if (ds) {
+        ds.disabled = !dark;
+        mo.disconnect();
+      }
+    });
+    mo.observe(document.head, { childList: true });
+  })();
+  </script>
   <link rel="stylesheet" href="/css/uikit.min.css">
   <link rel="stylesheet" href="/css/main.css">
   <link id="darkStylesheet" rel="stylesheet" href="/css/dark.css">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -13,7 +13,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
   const storedTheme = localStorage.getItem('darkMode');
   const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-  let dark = storedTheme === 'true' || (storedTheme === null && prefersDark);
+  let dark;
+  if (document.documentElement.classList.contains('uk-dark')) {
+    dark = true;
+  } else if (document.documentElement.classList.contains('uk-light')) {
+    dark = false;
+  } else {
+    dark = storedTheme === 'true' || (storedTheme === null && prefersDark);
+  }
 
   function applyTheme () {
     if (darkStylesheet) {

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -38,6 +38,25 @@
   }
   </script>
   <link rel="icon" href="{{ basePath }}/favicon.svg" type="image/svg+xml">
+  <script>
+  (function () {
+    const storedTheme = localStorage.getItem('darkMode');
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const dark = storedTheme === 'true' || (storedTheme === null && prefersDark);
+    const root = document.documentElement;
+    root.classList.add(dark ? 'uk-dark' : 'uk-light');
+    root.classList.remove(dark ? 'uk-light' : 'uk-dark');
+    window.__initialDark = dark;
+    const mo = new MutationObserver(() => {
+      const ds = document.getElementById('darkStylesheet');
+      if (ds) {
+        ds.disabled = !dark;
+        mo.disconnect();
+      }
+    });
+    mo.observe(document.head, { childList: true });
+  })();
+  </script>
   <link rel="stylesheet" href="{{ basePath }}/css/uikit.min.css">
   {% block head %}{% endblock %}
   <link rel="stylesheet" href="{{ basePath }}/css/topbar.css">


### PR DESCRIPTION
## Summary
- add early inline script to set dark mode class before CSS loads
- ensure app.js honors initial dark mode class
- replicate early dark mode handling for static pages

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b385ab2218832b9a65b2d6a99898ef