### PR TITLE
Invert UIkit theme classes for light mode visibility

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -26,13 +26,13 @@ document.addEventListener('DOMContentLoaded', function () {
     if (darkStylesheet) {
       darkStylesheet.disabled = !dark;
     }
-    document.body.classList.toggle('uk-dark', dark);
-    document.body.classList.toggle('uk-light', !dark);
-    document.documentElement.classList.toggle('uk-dark', dark);
-    document.documentElement.classList.toggle('uk-light', !dark);
+    document.body.classList.toggle('uk-dark', !dark);
+    document.body.classList.toggle('uk-light', dark);
+    document.documentElement.classList.toggle('uk-dark', !dark);
+    document.documentElement.classList.toggle('uk-light', dark);
     document.querySelectorAll('.topbar').forEach(el => {
-      el.classList.toggle('uk-dark', dark);
-      el.classList.toggle('uk-light', !dark);
+      el.classList.toggle('uk-dark', !dark);
+      el.classList.toggle('uk-light', dark);
     });
   }
 


### PR DESCRIPTION
## Summary
- invert theme toggles in `applyTheme()` so light mode uses `uk-dark` and dark mode uses `uk-light`
- ensure topbar follows inverted class logic

## Testing
- `vendor/bin/phpunit` *(fails: process hung, required environment)*
- `npm run lint` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b387a7fe38832b865d2c3b3b05ef1b