### PR TITLE
style: improve form error contrast

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1049,4 +1049,12 @@ body.admin-page {
   }
 }
 
+/* Increase contrast for form error state */
+.uk-form-danger,
+.uk-form-danger:focus {
+  color: #c72426;
+  border-color: #c72426;
+  background-color: #ffe5e5;
+}
+
 


### PR DESCRIPTION
## Summary
- improve contrast for `.uk-form-danger` with darker red text and light background

## Testing
- `composer test` *(fails: Missing STRIPE_* env variables and nginx reload error)*
- `vendor/bin/phpcs` *(fails: existing indentation and line length issues)*
- `curl -s http://127.0.0.1:8080/login`

------
https://chatgpt.com/codex/tasks/task_e_68b387b3ba24832b88a3cda19ac7514d