### PR TITLE
Darken focused input fields in light mode

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -27,6 +27,14 @@ body.uk-background-default {
   color: var(--color-text);
 }
 
+/* Darken focused form controls for better visibility */
+.uk-input:focus,
+.uk-select:focus,
+.uk-textarea:focus {
+  background-color: #333;
+  color: #fff;
+}
+
 .uk-button-primary {
   background-color: var(--accent-color, #1e87f0);
   border-color: var(--accent-color, #1e87f0);
@@ -617,6 +625,13 @@ body.admin-page textarea {
   background: #fff;
   color: #222;
   border-color: #bbb;
+}
+
+body.admin-page input:focus,
+body.admin-page select:focus,
+body.admin-page textarea:focus {
+  background: #333;
+  color: #fff;
 }
 
 body.admin-page input::placeholder,


### PR DESCRIPTION
## Summary
- Darken focused inputs for better visibility in light mode
- Apply the same dark focus style to admin form elements

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables; Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68b3944aa9a0832b93c64080eea8957b