### PR TITLE
feat: improve landing backgrounds for dark and light mode

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -105,7 +105,7 @@
 </style>
 
 <!-- Warum QuizRace? -->
-<section class="uk-section uk-section-default">
+<section class="uk-section section-blue">
   <div class="uk-container">
     <div class="uk-grid uk-flex-middle" uk-grid>
       <div class="uk-width-expand@m">
@@ -130,7 +130,7 @@
 </section>
 
 <!-- USPs / Features -->
-<section id="features" class="uk-section uk-section-default" style="background:#f9f9f9">
+<section id="features" class="uk-section section-gray">
   <div class="uk-container">
     <h3 class="uk-text-center uk-heading-medium poppins text-black uk-margin-large-bottom" uk-scrollspy="cls: uk-animation-slide-top-small">Was macht QuizRace einzigartig?</h3>
     <div class="uk-grid uk-child-width-1-4@m uk-child-width-1-2@s uk-flex-center uk-grid-match uk-margin-large-bottom" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-left-small; delay: 150">
@@ -167,7 +167,7 @@
 </section>
 
 <!-- Highlight / Kurs oder Feature -->
-<section class="uk-section uk-section-default">
+<section class="uk-section section-white">
   <div class="uk-container">
       <div class="uk-text-center uk-margin-large-bottom">
         <h2 class="uk-heading-medium text-black" uk-scrollspy="cls: uk-animation-slide-top-small">NEU: Interaktiver Event-Editor</h2>
@@ -192,7 +192,7 @@
 </section>
 
 <!-- Vivid Vision -->
-<section id="vivid-vision" class="uk-section uk-section-muted">
+<section id="vivid-vision" class="uk-section section-blue">
   <div class="uk-container">
     <div class="uk-text-center uk-margin-medium-bottom">
       <h2 class="uk-heading-line"><span>So fühlt sich Ihr Event mit QuizRace an</span></h2>
@@ -247,7 +247,7 @@
 </section>
 
 <!-- Pricing / Abomodelle -->
-<section id="pricing" class="uk-section" style="background:#f9f9f9">
+<section id="pricing" class="uk-section section-gray">
     <div class="uk-container">
       <h2 class="uk-heading-medium uk-text-center text-black" uk-scrollspy="cls: uk-animation-slide-top-small">Abomodelle für jedes Event</h2>
       <p class="uk-text-center uk-text-lead uk-margin-large-bottom" uk-scrollspy="cls: uk-animation-fade; delay: 150">Einfacher Start – faire Preise – alle Abos 7 Tage kostenlos testen!</p>
@@ -315,7 +315,7 @@
 </section>
 
 <!-- Steps / Ablauf -->
-<section class="uk-section uk-section-default">
+<section class="uk-section section-white">
   <div class="uk-container">
       <h3 class="uk-text-center uk-heading-medium poppins text-black" uk-scrollspy="cls: uk-animation-slide-top-small">In 4 Schritten zum Erlebnis-Quiz mit QuizRace</h3>
       <p class="uk-text-lead uk-text-center" uk-scrollspy="cls: uk-animation-fade; delay: 150"><strong>QuizRace bringt Action ins Event: Erstelle Fragenkataloge, drucke QR-Codes aus, klebe sie an spannende Stationen – und lass die Teams live gegeneinander antreten. Jedes Team erlebt das Quiz direkt vor Ort, beantwortet Fragen oder erhält Info-Karten und sammelt am Ende die Lösung fürs große Rätselwort!</strong></p>
@@ -345,7 +345,7 @@
 </section>
 
 <!-- Über uns / Founder -->
-<section class="uk-section about-section uk-light">
+<section class="uk-section about-section section-blue">
   <div class="uk-container">
     <h2 class="uk-text-center uk-heading-medium" uk-scrollspy="cls: uk-animation-slide-top-small">Wer steckt hinter QuizRace?</h2>
     <div class="uk-width-2xlarge uk-margin-auto uk-text-center uk-text-lead" uk-scrollspy="cls: uk-animation-fade; delay: 150">
@@ -360,7 +360,7 @@
 </section>
 
 <!-- Kontakt / Kontaktformular und Cards -->
-<section id="contact-us" class="uk-section uk-section-primary uk-light">
+<section id="contact-us" class="uk-section section-gray">
   <div class="uk-container">
     <h3 class="uk-heading-medium uk-text-center" uk-scrollspy="cls: uk-animation-slide-top-small">Kontaktieren Sie uns – persönlich & praxisnah</h3>
     <p class="uk-text-lead uk-text-center" uk-scrollspy="cls: uk-animation-fade; delay: 150">Sie möchten QuizRace testen, ein Angebot anfordern oder haben individuelle Fragen?<br>

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -25,6 +25,15 @@
 .page-landing .uk-section { background: var(--section-bg); color: var(--text); }
 .page-landing .uk-section.uk-section-default { background: var(--bg); }
 
+/* Farbschemata für Bereiche */
+.page-landing .section-blue { background: #e0f2ff; color: var(--text); }
+.page-landing .section-gray { background: #f1f5f9; color: var(--text); }
+.page-landing .section-white { background: #ffffff; color: var(--text); }
+
+.theme-dark .page-landing .section-blue,
+.theme-dark .page-landing .section-white { background: #000000; color: var(--text); }
+.theme-dark .page-landing .section-gray { background: #121a31; color: var(--text); }
+
 /* Karten/Kacheln auf der Landing (UIKit gezielt überstimmen) */
 .page-landing .uk-card,
 .page-landing .uk-card-default,


### PR DESCRIPTION
## Summary
- alternate landing page backgrounds for light theme
- ensure dark theme uses black and dark gray with white text

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b40d892538832b9565f19828b87ceb