### PR TITLE
Remove global styles from landing page head

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -3,9 +3,6 @@
 {% block title %}QuizRace – Das interaktive Team-Quiz für Events{% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="preload" href="{{ basePath }}/css/landing.css" as="style">
   <link rel="stylesheet" href="{{ basePath }}/css/landing.css">


### PR DESCRIPTION
## Summary
- prune global stylesheet links from marketing landing head block
- rely on landing-specific CSS and Google Fonts

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY...)*

------
https://chatgpt.com/codex/tasks/task_e_68b413c38d0c832b8b36223215b26c98