### PR TITLE
Add theme-dark toggle for landing tokens

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -23,6 +23,7 @@ document.addEventListener('DOMContentLoaded', function () {
   if (dark) {
     document.body.classList.add('dark-mode');
     document.documentElement.classList.add('dark-mode');
+    document.documentElement.classList.add('theme-dark');
     if (uikitStylesheet) {
       document.body.classList.add('uk-light');
     }
@@ -95,6 +96,7 @@ document.addEventListener('DOMContentLoaded', function () {
         event.preventDefault();
         dark = document.body.classList.toggle('dark-mode');
         document.documentElement.classList.toggle('dark-mode', dark);
+        document.documentElement.classList.toggle('theme-dark', dark);
         if (uikitStylesheet) {
           document.body.classList.toggle('uk-light', dark);
         }


### PR DESCRIPTION
## Summary
- Toggle `theme-dark` class on `<html>` when switching themes to ensure landing page tokens update.

## Testing
- `composer phpunit` *(fails: Missing STRIPE_* environment variables and hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68b436094134832bb597a9464fb4d0fc