### PR TITLE
Refactor landing page styling into landing.css

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -627,34 +627,3 @@ body.dark-mode .uk-accordion-content {
   color: #f5f5f5;
 }
 
-/* Landing page adjustments in Dark Mode */
-@media (prefers-color-scheme: dark) {
-  body.landing-page {
-    --landing-bg: #1e1e1e;
-    --landing-text: #f5f5f5;
-    --landing-primary: #0c86d0;
-    background: var(--landing-bg);
-    color: var(--landing-text);
-  }
-
-  body.landing-page .uk-card-quizrace {
-    background: var(--landing-bg);
-    color: var(--landing-text);
-  }
-
-  body.landing-page .uk-card-quizrace .uk-icon {
-    color: var(--landing-primary);
-  }
-
-  body.landing-page .topbar .top-cta,
-  body.landing-page .cta-main {
-    background: var(--landing-primary);
-    color: var(--landing-text);
-  }
-
-  body.landing-page .topbar .top-cta:hover,
-  body.landing-page .cta-main:hover {
-    background: var(--landing-text);
-    color: var(--landing-primary);
-  }
-}

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -7,6 +7,9 @@
   --card-bg: #ffffff;
   --card-border: rgba(15,23,42,.08);
   --shadow: 0 4px 18px rgba(0,0,0,.08);
+  --landing-bg: #ffffff;
+  --landing-text: #0f172a;
+  --landing-primary: #0c86d0;
 }
 
 /* Dark-Mode auf der Landing (klassisch via .theme-dark am <html>) */
@@ -18,6 +21,9 @@
   --card-bg: #121a31;
   --card-border: rgba(255,255,255,.06);
   --shadow: 0 6px 24px rgba(0,0,0,.35);
+  --landing-bg: #1e1e1e;
+  --landing-text: #f5f5f5;
+  --landing-primary: #0c86d0;
 }
 
 /* Flächen */
@@ -88,11 +94,15 @@
   --link: var(--brand-700);
   --link-hover: var(--brand-600);
   --focus-ring: 0 0 0 3px rgba(59,130,246,.35);
+  --landing-bg: #ffffff;
+  --landing-text: #0f172a;
+  --landing-primary: #0c86d0;
 }
 .theme-dark .page-landing {
   --bg:#0b1020; --text:#e6eaf3; --muted:#a3adc2; --section-bg:#0e1426;
   --card-bg:#121a31; --card-border:rgba(255,255,255,.06); --shadow:0 6px 24px rgba(0,0,0,.35);
   --hero-grad-start:#0b1020; --hero-grad-end:#10214a; --link:#93c5fd; --link-hover:#bfdbfe;
+  --landing-bg:#1e1e1e; --landing-text:#f5f5f5; --landing-primary:#0c86d0;
 }
 
 /* Topbar */
@@ -108,11 +118,15 @@
 .page-landing .uk-navbar-toggle{ color:var(--text)!important; }
 .page-landing .top-cta{
   border-radius:10px; padding:0 16px; line-height:38px; height:40px;
-  background:var(--brand-600)!important; color:#fff!important;
-  border:1px solid color-mix(in oklab,var(--brand-700) 60%,transparent);
-  box-shadow:0 6px 18px rgba(37,99,235,.18);
+  background:var(--landing-primary)!important; color:var(--landing-text)!important;
+  border:1px solid color-mix(in oklab,var(--landing-primary) 60%,transparent);
+  box-shadow:0 6px 18px rgba(12,134,208,.18);
 }
-.page-landing .top-cta:hover{ background:var(--brand-700)!important; transform:translateY(-1px); }
+.page-landing .top-cta:hover{
+  background:var(--landing-text)!important;
+  color:var(--landing-primary)!important;
+  transform:translateY(-1px);
+}
 .page-landing .top-cta:focus-visible{ box-shadow:var(--focus-ring); }
 
 /* Hero */
@@ -141,12 +155,16 @@
 .page-landing a:hover{ color:var(--link-hover); }
 
 .page-landing .cta-main.uk-button-primary{
-  background:var(--brand-600)!important; color:#fff!important;
-  border:1px solid color-mix(in oklab,var(--brand-700) 60%,transparent);
-  box-shadow:0 10px 24px rgba(37,99,235,.22);
+  background:var(--landing-primary)!important; color:var(--landing-text)!important;
+  border:1px solid color-mix(in oklab,var(--landing-primary) 60%,transparent);
+  box-shadow:0 10px 24px rgba(12,134,208,.22);
   border-radius:12px; padding:0 22px; line-height:46px; height:48px;
 }
-.page-landing .cta-main.uk-button-primary:hover{ background:var(--brand-700)!important; transform:translateY(-1px); }
+.page-landing .cta-main.uk-button-primary:hover{
+  background:var(--landing-text)!important;
+  color:var(--landing-primary)!important;
+  transform:translateY(-1px);
+}
 .page-landing .btn.btn-black.uk-button-secondary{
   background:#111827!important; color:#fff!important; border:0; border-radius:12px; line-height:46px; height:48px;
 }
@@ -158,10 +176,11 @@
 .page-landing .uk-section:nth-of-type(even){ background:var(--section-bg); }
 
 .page-landing .uk-card-quizrace{
-  background:var(--card-bg); color:var(--text); border:1px solid var(--card-border);
+  background:var(--landing-bg); color:var(--landing-text); border:1px solid var(--card-border);
   box-shadow:var(--shadow); border-radius:14px; padding:24px;
   transition:transform .15s ease, box-shadow .15s ease;
 }
+.page-landing .uk-card-quizrace .uk-icon{ color:var(--landing-primary); }
 .page-landing .uk-card-quizrace:hover{ transform:translateY(-2px); box-shadow:0 12px 28px rgba(0,0,0,.08); }
 
 /* Pricing & Steps */


### PR DESCRIPTION
## Summary
- remove landing-specific styles from dark.css
- define landing page variables for light and dark themes directly in landing.css
- style landing page cards and CTAs using the new variables

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars and database setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b43719c618832b9f9605c6f6137884