### PR TITLE
style: add danger color tokens

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -4,6 +4,8 @@
     --color-bg: #1e1e1e;
     --color-primary: #0c86d0;
     --color-text: #f5f5f5;
+    --danger-500: #ff6b6b;
+    --danger-600: #ff4c4c;
   }
 html,
 body {
@@ -94,8 +96,12 @@ body .uk-alert-success {
   color: #fff;
 }
 body .uk-alert-danger {
-  background-color: #5a1a1a;
+  background-color: var(--danger-600);
   color: #fff;
+}
+
+body .uk-form-danger {
+  border-color: var(--danger-600) !important;
 }
 body .uk-alert-primary {
   background-color: var(--accent-color, #003366);
@@ -310,6 +316,8 @@ html.dark-mode,
 body.dark-mode {
   background-color: #000 !important;
   color: #f5f5f5;
+  --danger-500: #ff6b6b;
+  --danger-600: #ff4c4c;
 }
 body.dark-mode a {
   color: var(--accent-color, #9dc6ff);
@@ -395,8 +403,12 @@ body.dark-mode .uk-alert-success {
   color: #fff;
 }
 body.dark-mode .uk-alert-danger {
-  background-color: #5a1a1a;
+  background-color: var(--danger-600);
   color: #fff;
+}
+
+body.dark-mode .uk-form-danger {
+  border-color: var(--danger-600) !important;
 }
 body.dark-mode .uk-alert-primary {
   background-color: var(--accent-color, #003366);

--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -69,7 +69,7 @@ body.high-contrast .uk-alert-success {
   color: #ffffff;
 }
 body.high-contrast .uk-alert-danger {
-  background-color: #8b0000;
+  background-color: var(--danger-500);
   color: #ffffff;
 }
 body.high-contrast .uk-alert-primary {
@@ -175,13 +175,18 @@ body.dark-mode.high-contrast .uk-alert-success {
 }
 
 body.dark-mode.high-contrast .uk-alert-danger {
-  background-color: #8b0000;
+  background-color: var(--danger-500);
   color: #ffffff;
 }
 
 body.dark-mode.high-contrast .uk-alert-primary {
   background-color: #00008b;
   color: #ffffff;
+}
+
+body.high-contrast .uk-form-danger,
+body.dark-mode.high-contrast .uk-form-danger {
+  border-color: var(--danger-600) !important;
 }
 
 body.high-contrast .flip-card-front,

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -10,6 +10,8 @@
   --landing-bg: #ffffff;
   --landing-text: #0f172a;
   --landing-primary: #0c86d0;
+  --danger-500: #8b0000;
+  --danger-600: #660000;
 }
 
 /* Dark-Mode auf der Landing (klassisch via .theme-dark am <html>) */
@@ -24,6 +26,8 @@
   --landing-bg: #1e1e1e;
   --landing-text: #f5f5f5;
   --landing-primary: #0c86d0;
+  --danger-500: #ff6b6b;
+  --danger-600: #ff4c4c;
 }
 
 /* Flächen */
@@ -97,12 +101,14 @@
   --landing-bg: #ffffff;
   --landing-text: #0f172a;
   --landing-primary: #0c86d0;
+  --danger-500: #8b0000;
+  --danger-600: #660000;
 }
 .theme-dark .page-landing {
   --bg:#0b1020; --text:#e6eaf3; --muted:#a3adc2; --section-bg:#0e1426;
   --card-bg:#121a31; --card-border:rgba(255,255,255,.06); --shadow:0 6px 24px rgba(0,0,0,.35);
   --hero-grad-start:#0b1020; --hero-grad-end:#10214a; --link:#93c5fd; --link-hover:#bfdbfe;
-  --landing-bg:#1e1e1e; --landing-text:#f5f5f5; --landing-primary:#0c86d0;
+  --landing-bg:#1e1e1e; --landing-text:#f5f5f5; --landing-primary:#0c86d0; --danger-500:#ff6b6b; --danger-600:#ff4c4c;
 }
 
 /* Topbar */

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -13,6 +13,8 @@ html {
   --color-bg: #fff;
   --color-primary: #0c86d0;
   --color-text: #232323;
+  --danger-500: #8b0000;
+  --danger-600: #660000;
 }
 
 body {
@@ -478,8 +480,17 @@ a.uk-accordion-title {
 }
 
 .uk-text-danger.uk-text-italic {
-  color: #e54b4b !important;
+  color: var(--danger-500) !important;
   font-style: italic;
+}
+
+body .uk-alert-danger {
+  background-color: var(--danger-600);
+  color: #fff;
+}
+
+.uk-form-danger {
+  border-color: var(--danger-600) !important;
 }
 
 /* Modern style for onboarding steps */


### PR DESCRIPTION
## Summary
- add danger color tokens for landing and global styles
- use danger tokens for alerts, text, and form validation in light, dark, and high contrast themes

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b438d74aac832b9e9ff64b424f3555