### PR TITLE
Revamp landing hero styling

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -1,36 +1,29 @@
 <!-- HERO / HEADER -->
 <section class="hero-bg-quizrace uk-section uk-padding-remove-top uk-flex uk-flex-middle uk-light" style="min-height:100vh; position:relative;">
   <div class="hero-overlay"></div>
-  <div class="uk-container hero-content">
-    <div class="uk-grid uk-flex-middle uk-child-width-1-1 uk-child-width-1-2@m" uk-grid>
-      <div>
-        <div class="hero-text">
-          <h1 class="hero-headline" uk-scrollspy="cls: uk-animation-slide-right-small">
-            Das Team-Quiz, das Ihr Event <span id="rotating-word" class="marker-text">unvergesslich</span> macht.
-          </h1>
-          <p class="hero-subtext" uk-scrollspy="cls: uk-animation-fade; delay: 150">
-            Trete gegen Freunde und Kollegen an.<br>
-            Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams.<br>
-            In Minuten startklar – live, vor Ort oder hybrid!<br>
-            Ohne App-Download, 100% datensicher, individuell anpassbar.
-          </p>
-        </div>
-        <div class="separator width-100 bottom-border border-2px border-color-gray-light margin-top-bottom-30px uk-width-1-2@s" uk-scrollspy="cls: uk-animation-fade; delay: 250"></div>
-        <div class="hero-buttons uk-margin-top" uk-scrollspy="cls: uk-animation-scale-up; delay: 300">
-          <a class="cta-main uk-button uk-button-primary" href="{{ basePath }}/onboarding">Event starten</a>
-          <a class="btn btn-black uk-button uk-button-secondary" href="https://demo.quizrace.app" target="_blank" rel="noopener">Demo anschauen</a>
-        </div>
-      </div>
-      <div>
-        <div class="hero-video" uk-scrollspy="cls: uk-animation-slide-left-small; delay: 300">
-          <div class="video-placeholder uk-flex uk-flex-middle uk-flex-center uk-border-rounded">
-            <span>Video Placeholder</span>
+    <div class="uk-container hero-content">
+      <div class="uk-grid uk-flex-middle uk-child-width-1-1" uk-grid>
+        <div>
+          <div class="hero-text">
+            <h1 class="hero-headline" uk-scrollspy="cls: uk-animation-slide-right-small">
+              Das Team-Quiz, das Ihr Event <span id="rotating-word" class="marker-text">unvergesslich</span> macht.
+            </h1>
+            <p class="hero-subtext" uk-scrollspy="cls: uk-animation-fade; delay: 150">
+              Trete gegen Freunde und Kollegen an.<br>
+              Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams.<br>
+              In Minuten startklar – live, vor Ort oder hybrid!<br>
+              Ohne App-Download, 100% datensicher, individuell anpassbar.
+            </p>
+          </div>
+          <div class="separator width-100 bottom-border border-2px border-color-gray-light margin-top-bottom-30px uk-width-1-2@s" uk-scrollspy="cls: uk-animation-fade; delay: 250"></div>
+          <div class="hero-buttons uk-margin-top" uk-scrollspy="cls: uk-animation-scale-up; delay: 300">
+            <a class="cta-main uk-button uk-button-primary" href="{{ basePath }}/onboarding">Event starten</a>
+            <a class="btn btn-black uk-button uk-button-secondary" href="https://demo.quizrace.app" target="_blank" rel="noopener">Demo anschauen</a>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
 <!-- Warum QuizRace? -->
 <section class="uk-section section-blue">

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -86,11 +86,11 @@
   --card-border: rgba(15,23,42,.08);
   --shadow: 0 4px 18px rgba(0,0,0,.08);
 
-  --brand-50:#eff6ff; --brand-100:#dbeafe; --brand-200:#bfdbfe;
-  --brand-300:#93c5fd; --brand-400:#60a5fa; --brand-500:#3b82f6;
-  --brand-600:#2563eb; --brand-700:#1d4ed8; --brand-800:#1e40af; --brand-900:#1e3a8a;
-  --hero-grad-start: var(--brand-900);
-  --hero-grad-end: var(--brand-600);
+    --brand-50:#eff6ff; --brand-100:#dbeafe; --brand-200:#bfdbfe;
+    --brand-300:#93c5fd; --brand-400:#60a5fa; --brand-500:#3b82f6;
+    --brand-600:#2563eb; --brand-700:#1d4ed8; --brand-800:#1e40af; --brand-900:#1e3a8a;
+    --hero-grad-start: var(--brand-800);
+    --hero-grad-end: var(--brand-500);
   --link: var(--brand-700);
   --link-hover: var(--brand-600);
   --focus-ring: 0 0 0 3px rgba(59,130,246,.35);
@@ -101,7 +101,7 @@
 .theme-dark .page-landing {
   --bg:#0b1020; --text:#e6eaf3; --muted:#a3adc2; --section-bg:#0e1426;
   --card-bg:#121a31; --card-border:rgba(255,255,255,.06); --shadow:0 6px 24px rgba(0,0,0,.35);
-  --hero-grad-start:#0b1020; --hero-grad-end:#10214a; --link:#93c5fd; --link-hover:#bfdbfe;
+    --hero-grad-start:#1e3a8a; --hero-grad-end:#2563eb; --link:#93c5fd; --link-hover:#bfdbfe;
   --landing-bg:#1e1e1e; --landing-text:#f5f5f5; --landing-primary:#0c86d0;
 }
 
@@ -131,19 +131,33 @@
 
 /* Hero */
 .page-landing .hero-bg-quizrace{
-  background:
-    radial-gradient(1200px 600px at 80% -10%, color-mix(in oklab, var(--hero-grad-end) 22%, transparent), transparent 60%),
-    linear-gradient(135deg, var(--hero-grad-start) 0%, var(--hero-grad-end) 100%);
-  color:#fff;
-}
+    background:
+      radial-gradient(1200px 600px at 80% -10%, color-mix(in oklab, var(--hero-grad-end) 22%, transparent), transparent 60%),
+      linear-gradient(135deg, var(--hero-grad-start) 0%, var(--hero-grad-end) 100%);
+    color:#fff;
+    position:relative;
+    z-index:0;
+  }
 .page-landing .hero-bg-quizrace .hero-overlay{
-  position:absolute; inset:0;
-  background: linear-gradient(to bottom, rgba(0,0,0,.25), rgba(0,0,0,.1) 40%, transparent 70%);
-  pointer-events:none;
-}
-.page-landing .hero-bg-quizrace .hero-content{ position:relative; z-index:1; }
-.page-landing .hero-bg-quizrace .hero-headline,
-.page-landing .hero-bg-quizrace .hero-subtext{ color:#fff; }
+    position:absolute; inset:0;
+    background: linear-gradient(to bottom, rgba(0,0,0,.25), rgba(0,0,0,.1) 40%, transparent 70%);
+    pointer-events:none;
+    z-index:0;
+  }
+  .page-landing .hero-bg-quizrace .hero-content{ position:relative; z-index:1; }
+  .page-landing .hero-bg-quizrace .hero-headline,
+  .page-landing .hero-bg-quizrace .hero-subtext{ color:#fff; }
+  .page-landing .hero-headline{
+    font-size:clamp(3rem,7vw,5rem);
+    font-weight:800;
+    line-height:1.1;
+    margin-bottom:1rem;
+  }
+  .page-landing .hero-subtext{
+    font-size:clamp(1.25rem,3vw,1.75rem);
+    font-weight:500;
+    line-height:1.4;
+  }
 .page-landing .hero-video .video-placeholder{
   width:100%; aspect-ratio:16/9; background:var(--card-bg);
   border:1px solid var(--card-border); box-shadow:var(--shadow); border-radius:12px;


### PR DESCRIPTION
## Summary
- simplify landing hero layout by removing video placeholder
- boost hero callouts with large typography and bold blue gradient background
- ensure hero overlay stays behind option menu

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b439b72420832b99254f9d9922f957