### PR TITLE
style: emulate GitHub header on landing

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -96,25 +96,33 @@
 
 
 /* Topbar */
-.page-landing .uk-navbar-container{
-  background: color-mix(in oklab, var(--bg) 85%, transparent) !important;
-  backdrop-filter: blur(10px);
+.page-landing .github-header{
+  background: linear-gradient(180deg, #0d1117 0%, #161b22 100%) !important;
+  color:#f0f6fc;
+  min-height:64px;
+  height:64px;
   border-bottom: 1px solid var(--card-border);
 }
-.page-landing .uk-navbar-nav>li>a{ color:var(--text)!important; font-weight:500; opacity:.9; }
-.page-landing .uk-navbar-nav>li>a:hover,
-.page-landing .uk-navbar-nav>li.uk-active>a{ opacity:1; text-decoration:none; }
-.page-landing .uk-navbar-nav>li>a:focus-visible{ outline:none; box-shadow:var(--focus-ring); border-radius:8px; }
-.page-landing .uk-navbar-toggle{ color:var(--text)!important; }
+.page-landing .github-header .uk-navbar-nav>li>a{ color:#f0f6fc!important; font-weight:500; opacity:.9; }
+.page-landing .github-header .uk-navbar-nav>li>a:hover,
+.page-landing .github-header .uk-navbar-nav>li.uk-active>a{ opacity:1; text-decoration:none; }
+.page-landing .github-header .uk-navbar-nav>li>a:focus-visible{ outline:none; box-shadow:var(--focus-ring); border-radius:8px; }
+.page-landing .github-header .uk-navbar-toggle{ color:#f0f6fc!important; }
 .page-landing .top-cta{
-  border-radius:10px; padding:0 16px; line-height:38px; height:40px;
-  background:var(--landing-primary)!important; color:var(--landing-text)!important;
-  border:1px solid color-mix(in oklab,var(--landing-primary) 60%,transparent);
-  box-shadow:0 6px 18px rgba(12,134,208,.18);
+  border-radius:10px;
+  padding:0 16px;
+  line-height:38px;
+  height:40px;
+  background:#0d1117!important;
+  color:#f0f6fc!important;
+  border:1px solid #1f6feb;
+  box-shadow:none;
+  transition:background .2s,color .2s;
 }
 .page-landing .top-cta:hover{
-  background:var(--landing-text)!important;
-  color:var(--landing-primary)!important;
+  background:#f0f6fc!important;
+  color:#0d1117!important;
+  border-color:#1f6feb;
   transform:translateY(-1px);
 }
 .page-landing .top-cta:focus-visible{ box-shadow:var(--focus-ring); }

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -12,7 +12,7 @@
 
 {% block body %}
   <div class="landing-content">
-    {% embed 'topbar.twig' %}
+    {% embed 'topbar.twig' with { nav_class: 'github-header' } %}
       {% block left %}
         <a class="uk-logo" href="{{ basePath }}/landing">QuizRace</a>
         {% endblock %}

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -1,4 +1,4 @@
-<nav class="uk-navbar-container uk-padding-small topbar" role="navigation" aria-label="{{ t('primary_navigation') }}" uk-navbar>
+<nav class="uk-navbar-container uk-padding-small topbar{% if nav_class is defined %} {{ nav_class }}{% endif %}" role="navigation" aria-label="{{ t('primary_navigation') }}" uk-navbar>
     <div class="uk-navbar-left">
       <div class="uk-navbar-item">
         <button id="offcanvas-toggle"


### PR DESCRIPTION
## Summary
- restyle landing navbar with dark GitHub-like colors
- tweak CTA button for GitHub-inspired contrast and hover effect
- allow passing extra classes to shared topbar

## Testing
- `composer test` *(fails: 271 tests, 26 errors, 6 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b43f8c4e08832babf906764e102d40