### PR TITLE
feat: apply dark blue theme to landing page

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -1,47 +1,47 @@
 /* Design-Tokens NUR für die Landing */
 .page-landing {
-  --bg: #ffffff;
-  --text: #0f172a;
-  --muted: #475569;
-  --section-bg: #f7f8fa;
-  --card-bg: #ffffff;
-  --card-border: rgba(15,23,42,.08);
-  --shadow: 0 4px 18px rgba(0,0,0,.08);
-  --landing-bg: #ffffff;
-  --landing-text: #0f172a;
-  --landing-primary: #0c86d0;
-  --danger-500: #8b0000;
-  --danger-600: #660000;
+  --bg: #0d1117;
+  --text: #f0f6fc;
+  --muted: #a3adc2;
+  --section-bg: #161b22;
+  --card-bg: #161b22;
+  --card-border: rgba(240,246,252,.1);
+  --shadow: 0 6px 24px rgba(0,0,0,.35);
+  --landing-bg: #0d1117;
+  --landing-text: #f0f6fc;
+  --landing-primary: #1f6feb;
+  --danger-500: #ff6b6b;
+  --danger-600: #ff4c4c;
 
   --brand-50:#eff6ff; --brand-100:#dbeafe; --brand-200:#bfdbfe;
   --brand-300:#93c5fd; --brand-400:#60a5fa; --brand-500:#3b82f6;
   --brand-600:#2563eb; --brand-700:#1d4ed8; --brand-800:#1e40af; --brand-900:#1e3a8a;
   --hero-grad-start:#0d1117;
   --hero-grad-end:#6e40c9;
-  --link: var(--brand-700);
-  --link-hover: var(--brand-600);
-  --focus-ring: 0 0 0 3px rgba(59,130,246,.35);
+  --link: #58a6ff;
+  --link-hover: #1f6feb;
+  --focus-ring: 0 0 0 3px rgba(31,111,235,.35);
 }
 
 /* Dark-Mode auf der Landing (klassisch via .theme-dark am <html>) */
 .theme-dark .page-landing {
-  --bg: #0b1020;
-  --text: #e6eaf3;
+  --bg: #0d1117;
+  --text: #f0f6fc;
   --muted: #a3adc2;
-  --section-bg: #0e1426;
-  --card-bg: #121a31;
-  --card-border: rgba(255,255,255,.06);
+  --section-bg: #161b22;
+  --card-bg: #161b22;
+  --card-border: rgba(240,246,252,.1);
   --shadow: 0 6px 24px rgba(0,0,0,.35);
-  --landing-bg: #1e1e1e;
-  --landing-text: #f5f5f5;
-  --landing-primary: #0c86d0;
+  --landing-bg: #0d1117;
+  --landing-text: #f0f6fc;
+  --landing-primary: #1f6feb;
   --danger-500: #ff6b6b;
   --danger-600: #ff4c4c;
 
   --hero-grad-start:#0d1117;
   --hero-grad-end:#6e40c9;
-  --link:#93c5fd;
-  --link-hover:#bfdbfe;
+  --link:#58a6ff;
+  --link-hover:#1f6feb;
 }
 
 /* Flächen */
@@ -50,13 +50,13 @@
 .page-landing .uk-section.uk-section-default { background: var(--bg); }
 
 /* Farbschemata für Bereiche */
-.page-landing .section-blue { background: #e0f2ff; color: var(--text); }
-.page-landing .section-gray { background: #f1f5f9; color: var(--text); }
-.page-landing .section-white { background: #ffffff; color: var(--text); }
+.page-landing .section-blue { background: #0d1117; color: var(--text); }
+.page-landing .section-gray { background: #161b22; color: var(--text); }
+.page-landing .section-white { background: #0d1117; color: var(--text); }
 
 .theme-dark .page-landing .section-blue,
-.theme-dark .page-landing .section-white { background: #000000; color: var(--text); }
-.theme-dark .page-landing .section-gray { background: #121a31; color: var(--text); }
+.theme-dark .page-landing .section-white { background: #0d1117; color: var(--text); }
+.theme-dark .page-landing .section-gray { background: #161b22; color: var(--text); }
 
 /* Karten/Kacheln auf der Landing (UIKit gezielt überstimmen) */
 .page-landing .uk-card,
@@ -170,7 +170,7 @@
 .page-landing .cta-main.uk-button-primary{
   background:var(--landing-primary)!important; color:var(--landing-text)!important;
   border:1px solid color-mix(in oklab,var(--landing-primary) 60%,transparent);
-  box-shadow:0 10px 24px rgba(12,134,208,.22);
+  box-shadow:0 10px 24px rgba(31,111,235,.22);
   border-radius:12px; padding:0 22px; line-height:46px; height:48px;
 }
 .page-landing .cta-main.uk-button-primary:hover{
@@ -181,7 +181,7 @@
 .page-landing .btn.btn-black.uk-button-secondary{
   background:#111827!important; color:#fff!important; border:0; border-radius:12px; line-height:46px; height:48px;
 }
-.theme-dark .page-landing .btn.btn-black.uk-button-secondary{ background:#0b1020!important; }
+.theme-dark .page-landing .btn.btn-black.uk-button-secondary{ background:#0d1117!important; }
 
 .page-landing .uk-section{ padding-top:72px; padding-bottom:72px; }
 @media (min-width:1200px){ .page-landing .uk-section{ padding-top:88px; padding-bottom:88px; } }


### PR DESCRIPTION
## Summary
- switch landing palette to dark blue with updated background, section and card variables
- align link and CTA accents with new primary color
- mirror dark blue values for explicit `.theme-dark` overrides

## Testing
- `vendor/bin/phpunit` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68b45dffa484832b9f7f947a2f842eee