### PR TITLE
style: add git style to menu toggle

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -53,6 +53,8 @@ body.dark-mode.high-contrast{
   box-shadow:0 0 0 3px var(--focus-ring);
 }
 .git-btn svg{width:24px;height:24px;}
+.uk-navbar-toggle.git-btn{height:40px;padding:0;}
+.uk-navbar-toggle.git-btn .uk-navbar-toggle-icon{width:24px;height:24px;}
 #offcanvas-toggle.git-btn{border-color:var(--btn-border);}
 #menuDrop{
   background:var(--drop-bg);

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -3,7 +3,7 @@
       <div class="uk-navbar-item">
         <button id="offcanvas-toggle"
                 type="button"
-                class="uk-navbar-toggle uk-hidden@m"
+                class="uk-navbar-toggle uk-hidden@m git-btn"
                 uk-navbar-toggle-icon
                 uk-toggle="target: #qr-offcanvas"
                 aria-controls="qr-offcanvas"


### PR DESCRIPTION
## Summary
- style offcanvas menu toggle with git-style button
- ensure navbar toggle icon displays with git button styling

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b4616e43d4832ba48eb4e60be66058