### PR TITLE
refactor: centralize landing navigation links

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -1,5 +1,13 @@
 {% extends 'layout.twig' %}
 
+{% set links = [
+  { 'href': '#features', 'label': 'Features' },
+  { 'href': '#pricing', 'label': 'Preise' },
+  { 'href': '#contact-us', 'label': 'Kontakt' },
+  { 'href': basePath ~ '/faq', 'label': 'FAQ' },
+  { 'href': basePath ~ '/login', 'label': 'Login' }
+] %}
+
 {% block title %}QuizRace – Das interaktive Team-Quiz für Events{% endblock %}
 
 {% block head %}
@@ -20,11 +28,9 @@
         {% endblock %}
       {% block center %}
         <ul class="uk-navbar-nav uk-visible@m">
-          <li><a href="#features">Features</a></li>
-          <li><a href="#pricing">Preise</a></li>
-          <li><a href="#contact-us">Kontakt</a></li>
-          <li><a href="{{ basePath }}/faq">FAQ</a></li>
-          <li><a href="{{ basePath }}/login">Login</a></li>
+          {% for link in links %}
+            <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+          {% endfor %}
         </ul>
       {% endblock %}
       {% block right %}
@@ -36,11 +42,9 @@
       <div class="uk-offcanvas-bar">
         <button class="uk-offcanvas-close" type="button" uk-close aria-label="Menu"></button>
         <ul class="uk-nav uk-nav-default">
-          <li><a href="#features">Features</a></li>
-          <li><a href="#pricing">Preise</a></li>
-          <li><a href="#contact-us">Kontakt</a></li>
-          <li><a href="{{ basePath }}/faq">FAQ</a></li>
-          <li><a href="{{ basePath }}/login">Login</a></li>
+          {% for link in links %}
+            <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+          {% endfor %}
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- define navigation links in a single array
- render desktop and offcanvas menus from shared loop

## Testing
- `composer test` *(fails: Database error: fail; failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aed6af74832ba5a9a68a0f3215ad