### PR TITLE
Fix landing page media query

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -109,6 +109,7 @@
     min-height:56px;
     height:56px;
   }
+}
 .theme-dark .page-landing .github-header{
   background: linear-gradient(180deg, #0d1117 0%, #161b22 100%) !important;
 }


### PR DESCRIPTION
## Summary
- close missing media query in landing page CSS so dark theme styles apply globally

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py` *(no output)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `vendor/bin/phpunit` *(fails: process hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aecc6dd8832bb0a8c63096c9d593