### PR TITLE
fix: make landing topbar github buttons rectangular

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -118,6 +118,9 @@
 .page-landing .github-header .uk-navbar-nav>li.uk-active>a{ opacity:1; text-decoration:none; }
 .page-landing .github-header .uk-navbar-nav>li>a:focus-visible{ outline:none; box-shadow:var(--focus-ring); border-radius:8px; }
 .page-landing .github-header .uk-navbar-toggle{ color:var(--text)!important; }
+.page-landing .github-header .git-btn{
+  border-radius:0;
+}
 .page-landing .top-cta{
   border-radius:10px;
   padding:0 16px;


### PR DESCRIPTION
## Summary
- remove border radius from landing topbar GitHub-style buttons so they render rectangular

## Testing
- `vendor/bin/phpcs src/` *(fails: Header blocks must be separated by a single blank line in src/Service/LogService.php)*
- `vendor/bin/phpstan analyse src/`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY and other environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b7652494832b90bc690d8e03425c