### PR TITLE
feat: redesign landing topbar

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -97,30 +97,34 @@
 
 
 /* Topbar */
-.page-landing .github-header{
-  background: linear-gradient(180deg, #ffffff 0%, #f3f4f6 100%) !important;
+.page-landing .qr-topbar{
+  background: linear-gradient(180deg, rgba(255,255,255,0.8) 0%, rgba(243,244,246,0.8) 100%);
+  backdrop-filter: blur(8px);
   color:var(--text);
   min-height:64px;
   height:64px;
   border-bottom: 1px solid var(--card-border);
 }
 @media (max-width: 959px) {
-  .page-landing .github-header{
+  .page-landing .qr-topbar{
     min-height:56px;
     height:56px;
   }
 }
-.theme-dark .page-landing .github-header{
-  background: linear-gradient(180deg, #0d1117 0%, #161b22 100%) !important;
+.theme-dark .page-landing .qr-topbar{
+  background: linear-gradient(180deg, rgba(13,17,23,0.8) 0%, rgba(22,27,34,0.8) 100%);
 }
-.page-landing .github-header .uk-navbar-nav>li>a{ color:var(--text)!important; font-weight:500; opacity:.9; }
-.page-landing .github-header .uk-navbar-nav>li>a:hover,
-.page-landing .github-header .uk-navbar-nav>li.uk-active>a{ opacity:1; text-decoration:none; }
-.page-landing .github-header .uk-navbar-nav>li>a:focus-visible{ outline:none; box-shadow:var(--focus-ring); border-radius:8px; }
-.page-landing .github-header .uk-navbar-toggle{ color:var(--text)!important; }
-.page-landing .github-header .git-btn{
-  border-radius:0;
+.page-landing .qr-topbar .uk-navbar-nav>li>a{ color:var(--text)!important; font-weight:500; opacity:.9; }
+.page-landing .qr-topbar .uk-navbar-nav>li>a:hover,
+.page-landing .qr-topbar .uk-navbar-nav>li.uk-active>a{ opacity:1; text-decoration:none; }
+.page-landing .qr-topbar .uk-navbar-nav>li>a:focus-visible,
+.page-landing .qr-topbar .theme-toggle:focus-visible,
+.page-landing .qr-topbar .uk-navbar-toggle:focus-visible{
+  outline:none;
+  box-shadow:var(--focus-ring);
+  border-radius:8px;
 }
+.page-landing .qr-topbar .uk-navbar-toggle{ color:var(--text)!important; }
 .page-landing .top-cta{
   border-radius:10px;
   padding:0 16px;

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -4,8 +4,7 @@
   { 'href': '#features', 'label': 'Features' },
   { 'href': '#pricing', 'label': 'Preise' },
   { 'href': '#contact-us', 'label': 'Kontakt' },
-  { 'href': basePath ~ '/faq', 'label': 'FAQ' },
-  { 'href': basePath ~ '/login', 'label': 'Login' }
+  { 'href': basePath ~ '/faq', 'label': 'FAQ' }
 ] %}
 
 {% block title %}QuizRace – Das interaktive Team-Quiz für Events{% endblock %}
@@ -22,32 +21,44 @@
 
 {% block body %}
   <div class="landing-content">
-    {% embed 'topbar.twig' with { nav_class: 'github-header' } %}
-      {% block left %}
-        <a class="uk-logo" href="{{ basePath }}/landing">QuizRace</a>
-        {% endblock %}
-      {% block center %}
-        <ul class="uk-navbar-nav uk-visible@m">
-          {% for link in links %}
-            <li><a href="{{ link.href }}">{{ link.label }}</a></li>
-          {% endfor %}
-        </ul>
-      {% endblock %}
-      {% block right %}
-        <a class="uk-navbar-item uk-button uk-button-primary top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt testen</a>
-      {% endblock %}
-    {% endembed %}
-
-    <div id="qr-offcanvas" uk-offcanvas="overlay: true">
-      <div class="uk-offcanvas-bar">
-        <button class="uk-offcanvas-close" type="button" uk-close aria-label="Menu"></button>
-        <ul class="uk-nav uk-nav-default">
-          {% for link in links %}
-            <li><a href="{{ link.href }}">{{ link.label }}</a></li>
-          {% endfor %}
-        </ul>
+    <header class="qr-topbar">
+      <nav class="uk-navbar-container" uk-navbar>
+        <div class="uk-navbar-left">
+          <a class="uk-navbar-item uk-logo" href="{{ basePath }}/landing">QuizRace</a>
+        </div>
+        <div class="uk-navbar-right uk-visible@m">
+          <ul class="uk-navbar-nav">
+            {% for link in links %}
+              <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+            {% endfor %}
+          </ul>
+          <a class="uk-navbar-item uk-button uk-button-primary top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Live-Demo</a>
+        </div>
+        <div class="uk-navbar-right uk-hidden@m">
+          <button id="themeToggle" class="uk-button uk-button-default theme-toggle" aria-label="Design umschalten">
+            <span id="themeIcon" aria-hidden="true"></span>
+          </button>
+          <button id="offcanvas-toggle"
+                  class="uk-navbar-toggle"
+                  uk-navbar-toggle-icon
+                  uk-toggle="target: #qr-offcanvas"
+                  aria-controls="qr-offcanvas"
+                  aria-expanded="false"
+                  aria-label="Menü"></button>
+        </div>
+      </nav>
+      <div id="qr-offcanvas" uk-offcanvas="overlay: true">
+        <div class="uk-offcanvas-bar">
+          <button class="uk-offcanvas-close" type="button" uk-close aria-label="Menü schließen"></button>
+          <ul class="uk-nav uk-nav-default">
+            {% for link in links %}
+              <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+            {% endfor %}
+          </ul>
+          <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="https://demo.quizrace.app" target="_blank" rel="noopener">Live-Demo</a>
+        </div>
       </div>
-    </div>
+    </header>
 
     {{ content|raw }}
   </div>


### PR DESCRIPTION
## Summary
- replace topbar embed on landing with custom header and offcanvas
- add mobile dark-mode toggle and Live-Demo button
- style new topbar with gradient, blur and focus rings

## Testing
- `composer test` *(fails: process did not complete due to missing configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b540aa92dc832bbc8f08bdf2d7f09c