### PR TITLE
Add mesh-gradient hero to landing page

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -1,26 +1,3 @@
-<!-- HERO / HEADER -->
-<section class="hero-bg-quizrace uk-section uk-padding-remove-top uk-flex uk-flex-middle uk-light" style="min-height:100vh; position:relative;">
-  <div class="hero-overlay"></div>
-  <div class="uk-container hero-content">
-    <div class="hero-text">
-      <h1 class="hero-headline" uk-scrollspy="cls: uk-animation-slide-right-small">
-        Das Team-Quiz, das Ihr Event <span id="rotating-word" class="marker-text">unvergesslich</span> macht.
-      </h1>
-      <p class="hero-subtext" uk-scrollspy="cls: uk-animation-fade; delay: 150">
-        Trete gegen Freunde und Kollegen an.<br>
-        Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams.<br>
-        In Minuten startklar – live, vor Ort oder hybrid!<br>
-        Ohne App-Download, 100% datensicher, individuell anpassbar.
-      </p>
-    </div>
-    <div class="separator width-100 bottom-border border-2px border-color-gray-light margin-top-bottom-30px uk-width-1-2@s" uk-scrollspy="cls: uk-animation-fade; delay: 250"></div>
-    <div class="hero-buttons uk-margin-top" uk-scrollspy="cls: uk-animation-scale-up; delay: 300">
-      <a class="cta-main uk-button uk-button-primary" href="{{ basePath }}/onboarding">Event starten</a>
-      <a class="btn btn-black uk-button uk-button-secondary" href="#features">Mehr erfahren</a>
-    </div>
-  </div>
-</section>
-
 <!-- Warum QuizRace? -->
 <section class="uk-section section-blue">
   <div class="uk-container">

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -141,39 +141,52 @@
 .page-landing .top-cta:focus-visible{ box-shadow:var(--focus-ring); }
 
 /* Hero */
-.page-landing .hero-bg-quizrace{
+.page-landing .qr-hero{ position:relative; overflow:hidden; }
+.page-landing .qr-hero-bg{
+  position:absolute;
+  inset:0;
+  z-index:-1;
   background:
-    radial-gradient(1200px 600px at 80% -10%, color-mix(in oklab, var(--hero-grad-end) 35%, transparent), transparent 60%),
+    radial-gradient(1000px at 15% 20%, color-mix(in oklab, var(--brand-400) 40%, transparent), transparent 70%),
+    radial-gradient(1200px at 85% -10%, color-mix(in oklab, var(--hero-grad-end) 35%, transparent), transparent 70%),
     linear-gradient(135deg, var(--hero-grad-start) 0%, var(--hero-grad-end) 100%);
-  color:var(--landing-text);
 }
-.page-landing .hero-bg-quizrace .hero-overlay{
-  position:absolute; inset:0; z-index:0;
-  background: linear-gradient(to bottom, rgba(0,0,0,.25), rgba(0,0,0,.1) 40%, transparent 70%);
-  pointer-events:none;
+.page-landing .qr-badge{
+  display:inline-block;
+  padding:4px 12px;
+  background: color-mix(in oklab, var(--brand-100) 60%, transparent);
+  color:var(--brand-800);
+  font-size:.75rem;
+  font-weight:600;
+  border-radius:9999px;
+  margin-bottom:16px;
 }
-.page-landing .hero-bg-quizrace .hero-content{ position:relative; z-index:1; }
-.page-landing .hero-bg-quizrace .hero-text{
-  max-width:800px;
-  margin-inline:auto;
-  text-align:center;
+.theme-dark .page-landing .qr-badge{
+  background: color-mix(in oklab, var(--brand-800) 40%, transparent);
+  color:var(--brand-100);
 }
-.page-landing .hero-bg-quizrace .hero-headline,
-.page-landing .hero-bg-quizrace .hero-subtext{ color:var(--landing-text); }
-.page-landing .hero-bg-quizrace .hero-headline{
-  font-size:clamp(3rem,5vw,4.5rem);
+.page-landing .qr-h1{
+  font-weight:700;
+  font-size:clamp(2.5rem,5vw,3.5rem);
   line-height:1.2;
+  margin:0 0 16px;
+  max-width:46ch;
 }
-.page-landing .hero-bg-quizrace .hero-subtext{
-  font-size:clamp(1.25rem,2.5vw,1.75rem);
+.page-landing .qr-sub{
+  font-size:1.25rem;
   line-height:1.6;
+  margin-bottom:32px;
+  max-width:46ch;
+  color:var(--muted);
 }
-.page-landing .hero-buttons{
-  display:flex;
-  flex-wrap:wrap;
-  gap:16px;
-  justify-content:center;
+.page-landing .qr-mockup{
+  background:var(--card-bg);
+  border:1px solid var(--card-border);
+  box-shadow:var(--shadow);
+  border-radius:12px;
+  overflow:hidden;
 }
+.page-landing .qr-mockup img{ display:block; width:100%; height:auto; }
 .page-landing .marker-text::after{ /* vorhandene Unterstreichung beibehalten */ }
 
 /* Buttons, Links, Sections, Cards */

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -49,6 +49,32 @@
       </div>
     </div>
 
+    <section class="qr-hero uk-section uk-section-large">
+      <div class="qr-hero-bg" aria-hidden="true"></div>
+      <div class="uk-container">
+        <div class="uk-grid uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
+          <div>
+            <span class="qr-badge">Made in Germany</span>
+            <h1 class="qr-h1">Das Team-Quiz, das Ihr Event unvergesslich macht.</h1>
+            <p class="qr-sub">Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams. In Minuten startklar – live, vor Ort oder hybrid.</p>
+            <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
+              <a class="uk-button uk-button-primary cta-main" href="{{ basePath }}/onboarding">Event starten</a>
+              <a class="uk-button uk-button-secondary btn btn-black" href="#features">Mehr erfahren</a>
+            </div>
+            <p class="uk-text-small uk-margin-top">Über 1.000 Teams vertrauen QuizRace.</p>
+          </div>
+          <div>
+            <div class="qr-mockup uk-card uk-card-default">
+              <picture>
+                <source srcset="{{ basePath }}/img/quizrace-shot.avif" type="image/avif">
+                <img src="{{ basePath }}/img/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="QuizRace Screenshot">
+              </picture>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     {{ content|raw }}
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add hero section with badge, CTA buttons, social proof, and screenshot mockup
- Style new hero with mesh-gradient background and component classes
- Clean old hero markup from landing content

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5410b9868832b89085d3d79060899