### PR TITLE
Unify demo CTA and add trust badges

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -340,3 +340,7 @@ body[data-theme="dark"] .qr-landing .btn.btn-black.uk-button-secondary{ backgrou
 }
 .qr-landing .underline-animate::after { animation: drawUnderline 0.6s ease-out forwards; animation-delay: 0.3s; }
 @keyframes drawUnderline { from { width: 0; } to { width: 100%; } }
+
+/* Proof badges */
+.qr-proof { display:flex; align-items:center; gap:16px; }
+.qr-proof img { height:28px; }

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -30,7 +30,7 @@
               <li><a href="{{ link.href }}">{{ link.label }}</a></li>
             {% endfor %}
           </ul>
-          <a class="uk-navbar-item uk-button uk-button-primary top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Live-Demo</a>
+          <a class="uk-navbar-item uk-button uk-button-primary top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt Demo starten</a>
         </div>
         <div class="uk-navbar-right uk-hidden@m">
           <button id="themeToggle" class="uk-button uk-button-default" aria-label="Design umschalten">
@@ -53,7 +53,7 @@
               <li><a href="{{ link.href }}">{{ link.label }}</a></li>
             {% endfor %}
           </ul>
-          <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="https://demo.quizrace.app" target="_blank" rel="noopener">Live-Demo</a>
+          <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt Demo starten</a>
         </div>
       </div>
     </header>
@@ -67,10 +67,13 @@
             <h1 class="qr-h1">Das Team-Quiz, das Ihr Event unvergesslich macht.</h1>
             <p class="qr-sub">Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams. In Minuten startklar – live, vor Ort oder hybrid.</p>
             <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
-              <a class="uk-button uk-button-primary cta-main" href="{{ basePath }}/onboarding">Event starten</a>
+              <a class="uk-button uk-button-primary cta-main" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt Demo starten</a>
               <a class="uk-button uk-button-secondary btn btn-black" href="#features">Mehr erfahren</a>
             </div>
-            <p class="uk-text-small uk-margin-top">Über 1.000 Teams vertrauen QuizRace.</p>
+            <div class="qr-proof uk-margin-top">
+              <img src="{{ basePath }}/img/trust-badges.avif" alt="Logos">
+              <span>Bereits bei Firmen-Events &amp; Schulfesten im Einsatz</span>
+            </div>
           </div>
           <div>
             <div class="qr-mockup uk-card uk-card-default">


### PR DESCRIPTION
## Summary
- Standardize primary CTA wording to "Jetzt Demo starten" in topbar, mobile menu, and hero
- Add trust-badge proof line highlighting existing event use cases
- Style new `.qr-proof` section with flex layout and fixed image height

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b54a7d65d8832bb05eb4600676dd6f