### PR TITLE
Add logging for Stripe checkout and session integration tests

### DIFF
--- a/src/Controller/StripeCheckoutController.php
+++ b/src/Controller/StripeCheckoutController.php
@@ -22,6 +22,9 @@ class StripeCheckoutController
             return $response->withStatus(400);
         }
 
+        // Debug environment for Stripe setup
+        error_log('ENV ' . json_encode($_ENV));
+
         $plan = Plan::tryFrom((string) ($data['plan'] ?? ''));
         $email = (string) ($data['email'] ?? '');
         $subdomain = (string) ($data['subdomain'] ?? '');
@@ -49,6 +52,7 @@ class StripeCheckoutController
         ];
         $priceId = $priceMap[$plan->value];
         if ($priceId === '') {
+            error_log('Missing priceId for plan ' . $plan->value);
             return $this->jsonError($response, 422, 'invalid plan');
         }
 
@@ -72,7 +76,9 @@ class StripeCheckoutController
                 $subdomain,
                 7
             );
+            error_log('createCheckoutSession returned ' . $url);
         } catch (Throwable $e) {
+            error_log('Stripe API error for plan ' . $plan->value . ': ' . $e->getMessage());
             $this->reportError($e);
             return $this->jsonError($response, 500, 'internal error');
         }

--- a/src/Controller/StripeSessionController.php
+++ b/src/Controller/StripeSessionController.php
@@ -18,7 +18,10 @@ class StripeSessionController
     public function __invoke(Request $request, Response $response, array $args): Response
     {
         $sessionId = (string) ($args['id'] ?? '');
-        $service = new StripeService();
+        $service = $request->getAttribute('stripeService');
+        if (!$service instanceof StripeService) {
+            $service = new StripeService();
+        }
         $info = $sessionId !== ''
             ? $service->getCheckoutSessionInfo($sessionId)
             : ['paid' => false, 'customer_id' => null, 'client_reference_id' => null];

--- a/tests/Controller/StripeCheckoutControllerTest.php
+++ b/tests/Controller/StripeCheckoutControllerTest.php
@@ -86,4 +86,53 @@ class StripeCheckoutControllerTest extends TestCase
         $this->assertSame(7, $service->args['create'][7] ?? null);
         $this->assertStringContainsString('&step=4', $service->args['create'][1] ?? '');
     }
+
+    public function testPostReturnsCheckoutUrl(): void
+    {
+        putenv('STRIPE_SECRET_KEY=key');
+        putenv('STRIPE_PUBLISHABLE_KEY=pub');
+        putenv('STRIPE_WEBHOOK_SECRET=wh');
+        putenv('STRIPE_PRICE_STARTER=starter');
+        putenv('STRIPE_PRICE_STANDARD=price_standard');
+        putenv('STRIPE_PRICE_PROFESSIONAL=pro');
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+        $service = new class extends StripeService {
+            public function __construct()
+            {
+            }
+            public function createCheckoutSession(
+                string $priceId,
+                string $successUrl,
+                string $cancelUrl,
+                string $plan,
+                ?string $customerEmail = null,
+                ?string $customerId = null,
+                ?string $clientReferenceId = null,
+                ?int $trialPeriodDays = null,
+                bool $embedded = false
+            ): string {
+                return 'https://example.com/checkout';
+            }
+        };
+        $request = $this->createRequest('POST', '/onboarding/checkout', [
+            'Content-Type' => 'application/json',
+            'X-CSRF-Token' => 'tok',
+        ]);
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, json_encode([
+            'plan' => 'standard',
+            'email' => 'u@example.com',
+            'subdomain' => 'tenant1'
+        ]));
+        rewind($stream);
+        $request = $request->withBody((new \Slim\Psr7\Factory\StreamFactory())->createStreamFromResource($stream));
+        $request = $request->withAttribute('stripeService', $service);
+        $response = $app->handle($request);
+        $this->assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        $data = json_decode($body, true);
+        $this->assertSame('https://example.com/checkout', $data['url'] ?? null);
+    }
 }

--- a/tests/Controller/StripeSessionControllerTest.php
+++ b/tests/Controller/StripeSessionControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Service\StripeService;
+use Tests\TestCase;
+
+final class StripeSessionControllerTest extends TestCase
+{
+    public function testUsesSessionIdFromRoute(): void
+    {
+        $app = $this->getAppInstance();
+        $service = new class extends StripeService {
+            public array $args = [];
+
+            public function __construct()
+            {
+            }
+
+            public function getCheckoutSessionInfo(string $sessionId): array
+            {
+                $this->args[] = $sessionId;
+                return ['paid' => true, 'customer_id' => null, 'client_reference_id' => null];
+            }
+        };
+        $request = $this->createRequest('GET', '/onboarding/checkout/sess_123');
+        $request = $request->withAttribute('stripeService', $service);
+        $response = $app->handle($request);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['sess_123'], $service->args);
+        $data = json_decode((string) $response->getBody(), true);
+        $this->assertTrue($data['paid']);
+    }
+}


### PR DESCRIPTION
## Summary
- log environment details and Stripe errors in checkout controller
- allow injecting Stripe service into session controller
- add tests covering checkout URL response and session lookup

## Testing
- `php scripts/check_stripe_config.php`
- `curl -s -D - -H 'Content-Type: application/json' -d '{"plan":"standard","email":"u@example.com","subdomain":"tenant1"}' http://127.0.0.1:8000/onboarding/checkout`
- `vendor/bin/phpcs src/Controller/StripeCheckoutController.php src/Controller/StripeSessionController.php tests/Controller/StripeCheckoutControllerTest.php tests/Controller/StripeSessionControllerTest.php`
- `vendor/bin/phpunit tests/Controller/StripeCheckoutControllerTest.php tests/Controller/StripeSessionControllerTest.php > /tmp/phpunit.log 2>&1 && grep -E "Tests:|Failures|Errors|Warnings|Risky" /tmp/phpunit.log | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b54ce3c694832b896444855ce40726