### PR TITLE
Add QR mockup styling without binary assets

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -242,8 +242,8 @@ body[data-theme="dark"] .qr-landing .qr-badge{
 .qr-landing .qr-mockup{
   background:var(--qr-card-bg);
   border:1px solid var(--qr-card-border);
-  box-shadow:var(--qr-shadow);
-  border-radius:12px;
+  box-shadow:0 20px 60px rgba(2,6,23,.45);
+  border-radius:18px;
   overflow:hidden;
 }
 .qr-landing .qr-mockup img{ display:block; width:100%; height:auto; }


### PR DESCRIPTION
## Summary
- refine QR mockup styling with 18 px radius and deeper shadow
- remove placeholder screenshot binaries from `public/img`

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b54c885f24832b9dfc80c4493ae0b0