### PR TITLE
feat: set default light theme

### DIFF
--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -50,7 +50,7 @@
   </style>
   {% endif %}
 </head>
-<body class="{% block body_class %}{% endblock %}">
+<body class="{% block body_class %}{% endblock %}" data-theme="{% block body_theme %}light{% endblock %}">
   <div class="wrapper">
     <main class="content">
       {% block body %}{% endblock %}


### PR DESCRIPTION
## Summary
- default to light theme via `data-theme` on body
- allow overriding start theme with new `body_theme` block

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `composer test` *(fails: process hung and killed after phpunit)*


------
https://chatgpt.com/codex/tasks/task_e_68b557505204832ba83c6174579fdf4f