### PR TITLE
Make landing topbar sticky

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -156,6 +156,9 @@ body[data-theme="dark"] .qr-landing .section-gray { background: #161b22; color: 
   min-height:64px;
   height:64px;
   border-bottom: 1px solid var(--qr-card-border);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 @media (max-width: 959px) {
   .qr-landing .qr-topbar{


### PR DESCRIPTION
## Summary
- Keep landing page topbar visible by making it sticky with a high z-index

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other configuration; PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b55c373380832bb8cebf80cfa7bb70