### PR TITLE
feat: add icons to landing page navigation

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -174,20 +174,29 @@ body[data-theme="dark"] .qr-landing .qr-topbar{
   font-weight:500;
   opacity:.9;
   text-decoration:none;
-  transition:opacity .2s,text-decoration-color .2s;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:0 10px;
+  line-height:38px;
+  height:40px;
+  border:1px solid transparent;
+  border-radius:6px;
+  transition:opacity .2s,background .12s,border-color .12s;
 }
 .qr-landing .qr-topbar .uk-navbar-nav>li>a:hover,
 .qr-landing .qr-topbar .uk-navbar-nav>li.uk-active>a{
   opacity:1;
-  text-decoration:underline;
-  text-decoration-color:currentColor;
+  background:color-mix(in oklab,var(--qr-text) 8%,transparent);
+  border-color:color-mix(in oklab,var(--qr-text) 40%,transparent);
+  text-decoration:none;
 }
 .qr-landing .qr-topbar .uk-navbar-nav>li>a:focus-visible,
 .qr-landing .qr-topbar #themeToggle:focus-visible,
 .qr-landing .qr-topbar .uk-navbar-toggle:focus-visible{
   outline:none;
   box-shadow:0 0 0 3px var(--qr-ring);
-  border-radius:8px;
+  border-radius:6px;
 }
 .qr-landing .qr-topbar .uk-navbar-toggle{ color:var(--qr-text)!important; }
 .qr-landing .top-cta{
@@ -200,6 +209,9 @@ body[data-theme="dark"] .qr-landing .qr-topbar{
   border:1px solid var(--qr-landing-primary);
   box-shadow:none;
   transition:opacity .2s,transform .2s;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
 }
 .qr-landing .top-cta:hover{
   opacity:.85;
@@ -268,8 +280,12 @@ body[data-theme="dark"] .qr-landing .qr-badge{
   text-decoration-color:currentColor;
 }
 
+
 .qr-landing .uk-button{
   transition:opacity .2s,transform .2s;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
 }
 .qr-landing .uk-button:hover{
   opacity:.85;

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -1,10 +1,10 @@
 {% extends 'layout.twig' %}
 
 {% set links = [
-  { 'href': '#features', 'label': 'Features' },
-  { 'href': '#pricing', 'label': 'Preise' },
-  { 'href': '#contact-us', 'label': 'Kontakt' },
-  { 'href': 'faq', 'label': 'FAQ' }
+  { 'href': '#features', 'label': 'Features', 'icon': 'star' },
+  { 'href': '#pricing', 'label': 'Preise', 'icon': 'credit-card' },
+  { 'href': '#contact-us', 'label': 'Kontakt', 'icon': 'mail' },
+  { 'href': 'faq', 'label': 'FAQ', 'icon': 'question' }
 ] %}
 
 {% block title %}QuizRace – Das interaktive Team-Quiz für Events{% endblock %}
@@ -27,10 +27,16 @@
         <div class="uk-navbar-right uk-visible@m">
           <ul class="uk-navbar-nav">
             {% for link in links %}
-              <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+              <li>
+                <a href="{{ link.href }}">
+                  <span class="uk-margin-small-right" uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+                </a>
+              </li>
             {% endfor %}
           </ul>
-          <a class="uk-navbar-item uk-button uk-button-primary top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt Demo starten</a>
+          <a class="uk-navbar-item uk-button uk-button-primary top-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">
+            <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt Demo starten
+          </a>
         </div>
         <div class="uk-navbar-right uk-hidden@m">
           <button id="themeToggle" class="uk-button uk-button-default" aria-label="Design umschalten">
@@ -50,10 +56,16 @@
           <button class="uk-offcanvas-close" type="button" uk-close aria-label="Menü schließen"></button>
           <ul class="uk-nav uk-nav-default">
             {% for link in links %}
-              <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+              <li>
+                <a href="{{ link.href }}">
+                  <span class="uk-margin-small-right" uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+                </a>
+              </li>
             {% endfor %}
           </ul>
-          <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt Demo starten</a>
+          <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="https://demo.quizrace.app" target="_blank" rel="noopener">
+            <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt Demo starten
+          </a>
         </div>
       </div>
     </header>
@@ -67,8 +79,12 @@
             <h1 class="qr-h1">Das Team-Quiz, das Ihr Event unvergesslich macht.</h1>
             <p class="qr-sub">Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams. In Minuten startklar – live, vor Ort oder hybrid.</p>
             <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
-              <a class="uk-button uk-button-primary cta-main" href="https://demo.quizrace.app" target="_blank" rel="noopener">Jetzt Demo starten</a>
-              <a class="uk-button uk-button-secondary btn btn-black" href="#features">Mehr erfahren</a>
+              <a class="uk-button uk-button-primary cta-main" href="https://demo.quizrace.app" target="_blank" rel="noopener">
+                <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt Demo starten
+              </a>
+              <a class="uk-button uk-button-secondary btn btn-black" href="#features">
+                <span class="uk-margin-small-right" uk-icon="icon: info"></span>Mehr erfahren
+              </a>
             </div>
             <div class="qr-proof uk-margin-top">
               <img src="{{ basePath }}/img/trust-badges.avif" alt="Logos">


### PR DESCRIPTION
## Summary
- add uk-icon support to marketing landing navigation and CTA buttons
- style topbar and buttons for icon+label layout similar to GitHub

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, etc. ; PHPUnit errors)*
- `php -S 127.0.0.1:8000 -t public` *(fails: PDO::__construct(): Argument #1 ($dsn) must be a valid data source name)*

------
https://chatgpt.com/codex/tasks/task_e_68b5607a1328832bb3015c8260c0840a