### PR TITLE
Refactor topbar theming to use data-theme and namespaced variables

### DIFF
--- a/docs/landing-style-overrides.md
+++ b/docs/landing-style-overrides.md
@@ -10,9 +10,9 @@ Die Marketing-Seite nutzt eigene CSS-Variablen, um Farben für Text und Dropdown
 ```twig
 <style>
   :root {
-    --text: #fff;
-    --drop-bg: #0c86d0;
-    --drop-border: rgba(255, 255, 255, 0.32);
+    --topbar-text: #fff;
+    --topbar-drop-bg: #0c86d0;
+    --topbar-drop-border: rgba(255, 255, 255, 0.32);
   }
 </style>
 ```

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -214,7 +214,7 @@ body.uk-padding {
 
 .uk-icon-button {
   border-radius: 6px;
-  border: 1px solid var(--btn-border, #ddd);
+  border: 1px solid var(--topbar-btn-border, #ddd);
 }
 
 .topbar .uk-navbar-item,
@@ -637,7 +637,7 @@ body.admin-page {
   font-size: clamp(20px, 1.5vw + 16px, 24px);
   z-index: 1100;
   border-radius: 6px;
-  border: 1px solid var(--btn-border, #ddd);
+  border: 1px solid var(--topbar-btn-border, #ddd);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 }
 .fab-save {
@@ -677,7 +677,7 @@ body.admin-page {
   background-color: white;
   transition: 0.4s;
   border-radius: 6px;
-  border: 1px solid var(--btn-border, #ddd);
+  border: 1px solid var(--topbar-btn-border, #ddd);
 }
 .switch input:checked + .slider {
   background-color: var(--accent-color);

--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -1,67 +1,67 @@
-body:not(.dark-mode){
-  --btn-bg: transparent;
-  --btn-border: rgba(0,0,0,0.6);
-  --btn-border-hover: rgba(0,0,0,0.8);
-  --btn-bg-hover: rgba(27,31,35,0.06);
-  --focus-ring: rgba(3,102,214,0.25);
-  --drop-bg: #fff;
-  --drop-border: rgba(27,31,35,0.12);
-  --text: #000;
+body:not([data-theme="dark"]){
+  --topbar-btn-bg: transparent;
+  --topbar-btn-border: rgba(0,0,0,0.6);
+  --topbar-btn-border-hover: rgba(0,0,0,0.8);
+  --topbar-btn-bg-hover: rgba(27,31,35,0.06);
+  --topbar-focus-ring: rgba(3,102,214,0.25);
+  --topbar-drop-bg: #fff;
+  --topbar-drop-border: rgba(27,31,35,0.12);
+  --topbar-text: #000;
 }
-body.dark-mode{
-  --btn-border: rgba(255,255,255,0.3);
-  --btn-border-hover: rgba(255,255,255,0.5);
-  --btn-bg-hover: rgba(255,255,255,0.08);
-  --focus-ring: rgba(100,180,255,0.25);
-  --drop-bg: #1f232a;
-  --drop-border: rgba(255,255,255,0.14);
-  --text: #e6e9ef;
+body[data-theme="dark"]{
+  --topbar-btn-border: rgba(255,255,255,0.3);
+  --topbar-btn-border-hover: rgba(255,255,255,0.5);
+  --topbar-btn-bg-hover: rgba(255,255,255,0.08);
+  --topbar-focus-ring: rgba(100,180,255,0.25);
+  --topbar-drop-bg: #1f232a;
+  --topbar-drop-border: rgba(255,255,255,0.14);
+  --topbar-text: #e6e9ef;
 }
 body.high-contrast{
-  --text: #0a0a0a;
-  --drop-bg: #ffffff;
-  --drop-border: #000000;
-  --btn-border: #000000;
-  --btn-border-hover: #000000;
-  --btn-bg-hover: #e6e6e6;
-  --focus-ring: rgba(0,120,255,0.6);
+  --topbar-text: #0a0a0a;
+  --topbar-drop-bg: #ffffff;
+  --topbar-drop-border: #000000;
+  --topbar-btn-border: #000000;
+  --topbar-btn-border-hover: #000000;
+  --topbar-btn-bg-hover: #e6e6e6;
+  --topbar-focus-ring: rgba(0,120,255,0.6);
 }
-body.dark-mode.high-contrast{
-  --text: #ffffff;
-  --drop-bg: #000000;
-  --drop-border: #ffffff;
-  --btn-border: #ffffff;
-  --btn-border-hover: #ffffff;
-  --btn-bg-hover: rgba(255,255,255,0.16);
-  --focus-ring: rgba(140,200,255,0.8);
+body[data-theme="dark"].high-contrast{
+  --topbar-text: #ffffff;
+  --topbar-drop-bg: #000000;
+  --topbar-drop-border: #ffffff;
+  --topbar-btn-border: #ffffff;
+  --topbar-btn-border-hover: #ffffff;
+  --topbar-btn-bg-hover: rgba(255,255,255,0.16);
+  --topbar-focus-ring: rgba(140,200,255,0.8);
 }
 .git-btn{
   width:40px;height:40px;padding:0;
   border-radius:6px;
-  border:1px solid var(--btn-border);
-  color:var(--text);
+  border:1px solid var(--topbar-btn-border);
+  color:var(--topbar-text);
   display:inline-flex;align-items:center;justify-content:center;
   box-sizing:border-box;cursor:pointer;
   transition:background .12s,border-color .12s,box-shadow .12s;
 }
 .git-btn:hover{
-  background:var(--btn-bg-hover);
-  border-color:var(--btn-border-hover);
+  background:var(--topbar-btn-bg-hover);
+  border-color:var(--topbar-btn-border-hover);
 }
 .git-btn:focus{
   outline:none;
-  box-shadow:0 0 0 3px var(--focus-ring);
+  box-shadow:0 0 0 3px var(--topbar-focus-ring);
 }
 .git-btn svg{width:24px;height:24px;}
 .uk-navbar-toggle.git-btn{height:40px;padding:0;}
 .uk-navbar-toggle.git-btn .uk-navbar-toggle-icon{width:24px;height:24px;}
-#offcanvas-toggle.git-btn{border-color:var(--btn-border);}
+#offcanvas-toggle.git-btn{border-color:var(--topbar-btn-border);}
 #menuDrop{
-  background:var(--drop-bg);
-  border:1px solid var(--drop-border);
+  background:var(--topbar-drop-bg);
+  border:1px solid var(--topbar-drop-border);
   border-radius:8px;
   padding:8px;
-  color:var(--text);
+  color:var(--topbar-text);
   min-width:auto !important;
   width:fit-content !important;
   transform-origin: top right;
@@ -72,5 +72,5 @@ body.dark-mode.high-contrast{
   gap:8px;
 }
 .uk-dropdown-nav, .uk-dropdown-nav *{
-  color:var(--text);
+  color:var(--topbar-text);
 }

--- a/public/css/topbar.landing.css
+++ b/public/css/topbar.landing.css
@@ -1,0 +1,37 @@
+body.qr-landing:not([data-theme="dark"]){
+  --topbar-btn-bg: transparent;
+  --topbar-btn-border: var(--qr-card-border);
+  --topbar-btn-border-hover: color-mix(in oklab,var(--qr-text) 40%, transparent);
+  --topbar-btn-bg-hover: color-mix(in oklab,var(--qr-text) 8%, transparent);
+  --topbar-focus-ring: var(--qr-ring);
+  --topbar-drop-bg: var(--qr-card-bg);
+  --topbar-drop-border: var(--qr-card-border);
+  --topbar-text: var(--qr-text);
+}
+body.qr-landing[data-theme="dark"]{
+  --topbar-btn-border: var(--qr-card-border);
+  --topbar-btn-border-hover: color-mix(in oklab,var(--qr-text) 60%, transparent);
+  --topbar-btn-bg-hover: color-mix(in oklab,var(--qr-text) 16%, transparent);
+  --topbar-focus-ring: var(--qr-ring);
+  --topbar-drop-bg: var(--qr-card-bg);
+  --topbar-drop-border: var(--qr-card-border);
+  --topbar-text: var(--qr-text);
+}
+body.qr-landing.high-contrast{
+  --topbar-text: #0a0a0a;
+  --topbar-drop-bg: #ffffff;
+  --topbar-drop-border: #000000;
+  --topbar-btn-border: #000000;
+  --topbar-btn-border-hover: #000000;
+  --topbar-btn-bg-hover: #e6e6e6;
+  --topbar-focus-ring: rgba(0,120,255,0.6);
+}
+body.qr-landing[data-theme="dark"].high-contrast{
+  --topbar-text: #ffffff;
+  --topbar-drop-bg: #000000;
+  --topbar-drop-border: #ffffff;
+  --topbar-btn-border: #ffffff;
+  --topbar-btn-border-hover: #ffffff;
+  --topbar-btn-bg-hover: rgba(255,255,255,0.16);
+  --topbar-focus-ring: rgba(140,200,255,0.8);
+}

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -5,7 +5,7 @@ return [
     'design_toggle' => 'Design wechseln',
     'contrast_toggle' => 'Barrierefrei',
     'configuration' => 'Konfiguration',
-    'help_modal_text' => 'Dark-Mode und Barrierefrei-Modus lassen sich hier im Menü umschalten. Der Barrierefrei-Modus vergrößert die Schrift für bessere Lesbarkeit. Passe Farben zentral über CSS-Variablen an (<code>--text</code>, <code>--drop-bg</code> …).',
+    'help_modal_text' => 'Dark-Mode und Barrierefrei-Modus lassen sich hier im Menü umschalten. Der Barrierefrei-Modus vergrößert die Schrift für bessere Lesbarkeit. Passe Farben zentral über CSS-Variablen an (<code>--topbar-text</code>, <code>--topbar-drop-bg</code> …).',
     'quiz_progress' => 'Fortschritt des Quiz',
     'manual_open' => 'Handbuch öffnen',
     'privacy' => 'Datenschutz',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -5,7 +5,7 @@ return [
     'design_toggle' => 'Toggle theme',
     'contrast_toggle' => 'Barrier-free mode',
     'configuration' => 'Configuration',
-    'help_modal_text' => 'Dark mode and barrier-free mode can be toggled in this menu. The barrier-free mode enlarges fonts for better readability. Adjust colors via CSS variables (<code>--text</code>, <code>--drop-bg</code> …).',
+    'help_modal_text' => 'Dark mode and barrier-free mode can be toggled in this menu. The barrier-free mode enlarges fonts for better readability. Adjust colors via CSS variables (<code>--topbar-text</code>, <code>--topbar-drop-bg</code> …).',
     'quiz_progress' => 'Quiz progress',
     'manual_open' => 'Open manual',
     'privacy' => 'Privacy',

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -13,6 +13,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="preload" href="{{ basePath }}/css/landing.css" as="style">
   <link rel="stylesheet" href="{{ basePath }}/css/landing.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/topbar.landing.css">
 {% endblock %}
 
 {% block body_class %}qr-landing{% endblock %}


### PR DESCRIPTION
## Summary
- switch topbar theme selectors to `data-theme` and namespace variables to `--topbar-*`
- add landing-specific topbar stylesheet and include it on landing page
- update docs and translations for renamed variables

## Testing
- `node - <<'NODE'` (verify topbar variable values for light/dark themes)
- `composer test` *(fails: missing STRIPE keys and 25 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b566d842e8832ba45154024f89869c