### PR TITLE
refactor: use data-theme for theme switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Dieses Projekt zeigt, wie Mensch und KI zusammen ganz neue digitale Möglichkeit
 - **src/** – PHP-Code mit Routen, Controllern und Services
 - **docs/** – Zusätzliche Dokumentation, z.B. [Richtlinien zur Worttrennung](docs/frontend-word-break.md)
 
+## Theme-Steuerung
+
+Das Erscheinungsbild wechselt zwischen Hell- und Dunkelmodus über das
+`data-theme`-Attribut am `<body>`- und `<html>`-Element. Styles greifen
+mit Selektoren wie `[data-theme="dark"]` auf den aktuellen Modus zu;
+die frühere Klasse `.dark-mode` kommt nicht mehr zum Einsatz.
+
 ## Schnellstart
 
 Stelle sicher, dass PHP 8.2 oder höher installiert ist:

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -312,82 +312,82 @@ body .uk-accordion-content {
 }
 }
 
-html.dark-mode,
-body.dark-mode {
+html[data-theme='dark'],
+body[data-theme='dark'] {
   background-color: #000 !important;
   color: #f5f5f5;
   --danger-500: #ff6b6b;
   --danger-600: #ff4c4c;
 }
-body.dark-mode a {
+body[data-theme='dark'] a {
   color: var(--accent-color, #9dc6ff);
 }
-body.dark-mode h1,
-body.dark-mode h2,
-body.dark-mode h3,
-body.dark-mode h4,
-body.dark-mode h5,
-body.dark-mode h6 {
+body[data-theme='dark'] h1,
+body[data-theme='dark'] h2,
+body[data-theme='dark'] h3,
+body[data-theme='dark'] h4,
+body[data-theme='dark'] h5,
+body[data-theme='dark'] h6 {
   color: #f5f5f5;
 }
-body.dark-mode .uk-card-title {
+body[data-theme='dark'] .uk-card-title {
   color: #f5f5f5;
 }
-body.dark-mode .uk-card-default {
+body[data-theme='dark'] .uk-card-default {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
-body.dark-mode .uk-card-default a {
+body[data-theme='dark'] .uk-card-default a {
   color: var(--accent-color, #9dc6ff);
 }
-body.dark-mode .uk-card h3,
-body.dark-mode .uk-card p {
+body[data-theme='dark'] .uk-card h3,
+body[data-theme='dark'] .uk-card p {
   color: #f5f5f5;
 }
-body.dark-mode .uk-progress {
+body[data-theme='dark'] .uk-progress {
   background-color: #333;
   color: var(--accent-color, #1e87f0);
 }
-body.dark-mode .uk-button-primary {
+body[data-theme='dark'] .uk-button-primary {
   background-color: var(--accent-color, #1e87f0);
   border-color: var(--accent-color, #1e87f0);
 }
-body.dark-mode .uk-button,
-body.dark-mode .uk-button-default {
+body[data-theme='dark'] .uk-button,
+body[data-theme='dark'] .uk-button-default {
   color: #fff;
   background-color: #333;
   border-color: #555;
 }
-body.dark-mode .btn-black {
+body[data-theme='dark'] .btn-black {
   background-color: #333 !important;
   color: #f5f5f5 !important;
   border: 2px solid #666;
 }
-body.dark-mode .btn-black:hover {
+body[data-theme='dark'] .btn-black:hover {
   background-color: #f5f5f5 !important;
   color: #000 !important;
   border-color: #f5f5f5;
 }
-body.dark-mode .btn-transparent {
+body[data-theme='dark'] .btn-transparent {
   background-color: transparent !important;
   color: var(--accent-color, #9dc6ff) !important;
   border: 2px solid var(--accent-color, #9dc6ff);
 }
-body.dark-mode .btn-transparent:hover {
+body[data-theme='dark'] .btn-transparent:hover {
   background-color: var(--accent-color, #9dc6ff) !important;
   color: #000 !important;
 }
-body.dark-mode input,
-body.dark-mode textarea,
-body.dark-mode select {
+body[data-theme='dark'] input,
+body[data-theme='dark'] textarea,
+body[data-theme='dark'] select {
   background-color: #1e1e1e;
   color: #f5f5f5;
   border-color: #555;
 }
-body.dark-mode .sortable-list li,
-body.dark-mode .terms li,
-body.dark-mode .dropzone,
-body.dark-mode .mc-option {
+body[data-theme='dark'] .sortable-list li,
+body[data-theme='dark'] .terms li,
+body[data-theme='dark'] .dropzone,
+body[data-theme='dark'] .mc-option {
   background-color: #1e1e1e;
   border-color: #444;
   color: #f5f5f5;
@@ -395,75 +395,75 @@ body.dark-mode .mc-option {
   padding: 16px;
   white-space: normal;
 }
-body.dark-mode .dropzone.over {
+body[data-theme='dark'] .dropzone.over {
   background-color: #2a2a2a;
 }
-body.dark-mode .uk-alert-success {
+body[data-theme='dark'] .uk-alert-success {
   background-color: #145214;
   color: #fff;
 }
-body.dark-mode .uk-alert-danger {
+body[data-theme='dark'] .uk-alert-danger {
   background-color: var(--danger-600);
   color: #fff;
 }
 
-body.dark-mode .uk-form-danger {
+body[data-theme='dark'] .uk-form-danger {
   border-color: var(--danger-600) !important;
 }
-body.dark-mode .uk-alert-primary {
+body[data-theme='dark'] .uk-alert-primary {
   background-color: var(--accent-color, #003366);
   color: #fff;
 }
 
-body.dark-mode .mc-option input {
+body[data-theme='dark'] .mc-option input {
   transform: scale(1.3);
   margin-right: 8px;
 }
 
 /* Einheitlicher Kartenrahmen fuer Admin-Tabs im Dunkelmodus */
-body.dark-mode .tab-card {
+body[data-theme='dark'] .tab-card {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
-body.dark-mode .topbar {
+body[data-theme='dark'] .topbar {
   background-color: #1e1e1e;
   border-color: #444;
   padding-top: env(safe-area-inset-top);
 }
-body.dark-mode .event-header-bar {
+body[data-theme='dark'] .event-header-bar {
   background-color: #1e1e1e;
   border-color: #444;
 }
 
-body.dark-mode .modern-info-card {
+body[data-theme='dark'] .modern-info-card {
   border-color: #444;
 }
 
 /* Sticky actions and onboarding components in Dark Mode */
-body.dark-mode .sticky-actions {
+body[data-theme='dark'] .sticky-actions {
   background: rgba(0, 0, 0, 0.95);
 }
 
-body.dark-mode .onboarding-step {
+body[data-theme='dark'] .onboarding-step {
   border-color: #444;
   background: linear-gradient(135deg, #1e1e1e 0%, #2a2a2a 100%);
   box-shadow: 0 6px 30px rgba(0,0,0,0.5);
 }
 
-body.dark-mode .onboarding-timeline .timeline-step {
+body[data-theme='dark'] .onboarding-timeline .timeline-step {
   border-color: #555;
   color: #ddd;
 }
 
-body.dark-mode .onboarding-timeline .timeline-step.inactive {
+body[data-theme='dark'] .onboarding-timeline .timeline-step.inactive {
   color: #444;
   border-color: #555;
   cursor: not-allowed;
 }
 
-body.dark-mode .onboarding-timeline .timeline-step.active,
-body.dark-mode .onboarding-timeline .timeline-step.completed {
+body[data-theme='dark'] .onboarding-timeline .timeline-step.active,
+body[data-theme='dark'] .onboarding-timeline .timeline-step.completed {
   border-color: var(--accent-color, #1e87f0);
   color: var(--accent-color, #1e87f0);
 }
@@ -484,38 +484,38 @@ body .pricing-grid .uk-card-quizrace h3 {
   color: #f5f5f5;
 }
 
-body.dark-mode .pricing-grid .uk-card-quizrace {
+body[data-theme='dark'] .pricing-grid .uk-card-quizrace {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
-body.dark-mode .pricing-grid .uk-card-quizrace.uk-card-popular {
+body[data-theme='dark'] .pricing-grid .uk-card-quizrace.uk-card-popular {
   background-color: #0c86d0;
   color: #fff;
 }
 
-body.dark-mode .pricing-grid .uk-card-quizrace .uk-text-meta,
-body.dark-mode .pricing-grid .uk-card-quizrace li,
-body.dark-mode .pricing-grid .uk-card-quizrace h3 {
+body[data-theme='dark'] .pricing-grid .uk-card-quizrace .uk-text-meta,
+body[data-theme='dark'] .pricing-grid .uk-card-quizrace li,
+body[data-theme='dark'] .pricing-grid .uk-card-quizrace h3 {
   color: #f5f5f5;
 }
 
-body.dark-mode .uk-icon,
-body.dark-mode .uk-icon-button {
+body[data-theme='dark'] .uk-icon,
+body[data-theme='dark'] .uk-icon-button {
   color: #f5f5f5;
 }
 
-body.dark-mode .site-footer {
+body[data-theme='dark'] .site-footer {
   background-color: #1e1e1e;
   border-color: #444;
   padding-bottom: calc(1rem + env(safe-area-inset-bottom));
 }
 
-body.dark-mode .uk-icon-button {
+body[data-theme='dark'] .uk-icon-button {
   color: #fff;
   background-color: rgba(255, 255, 255, 0.2);
 }
-body.dark-mode .uk-icon-button.uk-button-primary {
+body[data-theme='dark'] .uk-icon-button.uk-button-primary {
   background-color: var(--accent-color, #1e87f0);
   border-color: var(--accent-color, #1e87f0);
 }
@@ -527,114 +527,114 @@ body.dark-mode .uk-icon-button.uk-button-primary {
 }
 
 /* Active state for navigation items in dark mode */
-body.dark-mode .uk-navbar-nav > li.uk-active > a,
-body.dark-mode .uk-nav-default > li.uk-active > a {
+body[data-theme='dark'] .uk-navbar-nav > li.uk-active > a,
+body[data-theme='dark'] .uk-nav-default > li.uk-active > a {
   background-color: rgba(255, 255, 255, 0.15);
   color: #fff;
 }
 
 /* Styles for Trumbowyg editor in Dark Mode */
-body.dark-mode .trumbowyg-box,
-body.dark-mode .trumbowyg-editor {
+body[data-theme='dark'] .trumbowyg-box,
+body[data-theme='dark'] .trumbowyg-editor {
   background-color: #1e1e1e !important;
   color: #f5f5f5 !important;
 }
 
-body.dark-mode .trumbowyg-button-pane {
+body[data-theme='dark'] .trumbowyg-button-pane {
   background-color: #2a2a2a;
   border-color: #444;
 }
 
-body.dark-mode .trumbowyg-button-pane button {
+body[data-theme='dark'] .trumbowyg-button-pane button {
   color: #f5f5f5;
 }
 
-body.dark-mode .trumbowyg-button-pane button svg {
+body[data-theme='dark'] .trumbowyg-button-pane button svg {
   fill: #f5f5f5;
 }
 
-body.dark-mode .trumbowyg-button-pane button:hover {
+body[data-theme='dark'] .trumbowyg-button-pane button:hover {
   background-color: #333;
 }
 
 /* Styles fuer QR-Scan-Popup im Dunkelmodus */
-body.dark-mode .uk-modal-dialog {
+body[data-theme='dark'] .uk-modal-dialog {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
 /* Hoverfarbe für Katalogkarten im Dunkelmodus */
-body.dark-mode .uk-card-hover:hover {
+body[data-theme='dark'] .uk-card-hover:hover {
   background-color: #333;
   color: #f5f5f5;
 }
 
 /* Tabellenlesbarkeit im Dunkelmodus verbessern */
-body.dark-mode .uk-table th,
-body.dark-mode .uk-table td {
+body[data-theme='dark'] .uk-table th,
+body[data-theme='dark'] .uk-table td {
   color: #f5f5f5;
   background-color: #1e1e1e;
   border-color: #444;
 }
-body.dark-mode .uk-table thead th {
+body[data-theme='dark'] .uk-table thead th {
   background-color: #333;
 }
-body.dark-mode .uk-table tr {
+body[data-theme='dark'] .uk-table tr {
   border-color: #444;
 }
 
 @media (min-width: 640px) {
-  body.dark-mode .sortable-list li,
-  body.dark-mode .terms li,
-  body.dark-mode .dropzone,
-  body.dark-mode .mc-option {
+  body[data-theme='dark'] .sortable-list li,
+  body[data-theme='dark'] .terms li,
+  body[data-theme='dark'] .dropzone,
+  body[data-theme='dark'] .mc-option {
     font-size: 1.3rem;
   }
 }
 
 @media (min-width: 960px) {
-  body.dark-mode .sortable-list li,
-  body.dark-mode .terms li,
-  body.dark-mode .dropzone,
-  body.dark-mode .mc-option {
+  body[data-theme='dark'] .sortable-list li,
+  body[data-theme='dark'] .terms li,
+  body[data-theme='dark'] .dropzone,
+  body[data-theme='dark'] .mc-option {
     font-size: 1.5rem;
   }
-body.dark-mode .mc-option input {
+body[data-theme='dark'] .mc-option input {
   transform: scale(1.3);
 }
 }
 
-body.dark-mode .flip-card-front,
-body.dark-mode .flip-card-back {
+body[data-theme='dark'] .flip-card-front,
+body[data-theme='dark'] .flip-card-back {
   background-color: #1e1e1e;
   color: #f5f5f5;
   border: 1px solid #444;
 }
 
 /* FAQ page elements in Dark Mode */
-body.dark-mode .uk-heading-divider {
+body[data-theme='dark'] .uk-heading-divider {
   border-bottom-color: #444;
   color: #f5f5f5;
 }
 
-body.dark-mode .uk-heading-bullet {
+body[data-theme='dark'] .uk-heading-bullet {
   color: #f5f5f5;
 }
 
-body.dark-mode .uk-heading-bullet::before {
+body[data-theme='dark'] .uk-heading-bullet::before {
   border-color: #444;
 }
 
-body.dark-mode .uk-accordion-title {
+body[data-theme='dark'] .uk-accordion-title {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
 
-body.dark-mode .uk-accordion-title::before {
+body[data-theme='dark'] .uk-accordion-title::before {
   filter: invert(1);
 }
 
-body.dark-mode .uk-accordion-content {
+body[data-theme='dark'] .uk-accordion-content {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }

--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -78,34 +78,34 @@ body.high-contrast .uk-alert-primary {
 }
 
 /* High contrast styles when dark mode is also enabled */
-body.dark-mode.high-contrast {
+body.high-contrast[data-theme='dark'] {
   background-color: #000000 !important;
   color: #ffffff !important;
 }
 
-body.dark-mode.high-contrast a {
+body.high-contrast[data-theme='dark'] a {
   color: #ffff00;
   text-decoration: underline;
 }
 
-body.dark-mode.high-contrast .uk-card-default {
+body.high-contrast[data-theme='dark'] .uk-card-default {
   background-color: #000000;
   color: #ffffff;
   border-color: #ffffff;
 }
-body.dark-mode.high-contrast .modern-info-card {
+body.high-contrast[data-theme='dark'] .modern-info-card {
   border-color: #ffffff;
 }
-body.dark-mode.high-contrast .onboarding-step {
+body.high-contrast[data-theme='dark'] .onboarding-step {
   border-color: #ffffff;
   box-shadow: none;
 }
-body.dark-mode.high-contrast .onboarding-timeline .timeline-step {
+body.high-contrast[data-theme='dark'] .onboarding-timeline .timeline-step {
   border-color: #ffffff;
   color: #ffffff;
 }
-body.dark-mode.high-contrast .onboarding-timeline .timeline-step.active,
-body.dark-mode.high-contrast .onboarding-timeline .timeline-step.completed {
+body.high-contrast[data-theme='dark'] .onboarding-timeline .timeline-step.active,
+body.high-contrast[data-theme='dark'] .onboarding-timeline .timeline-step.completed {
   border-color: #ffffff;
   color: #ffffff;
 }
@@ -119,73 +119,73 @@ body.high-contrast .git-btn {
   color: #000000;
 }
 
-body.dark-mode.high-contrast .uk-icon-button,
-body.dark-mode.high-contrast .git-btn {
+body.high-contrast[data-theme='dark'] .uk-icon-button,
+body.high-contrast[data-theme='dark'] .git-btn {
   border: 2px solid #ffffff;
   background-color: #000000;
 }
 
-body.dark-mode.high-contrast .git-btn {
+body.high-contrast[data-theme='dark'] .git-btn {
   color: #ffffff;
 }
-body.dark-mode.high-contrast .onboarding-timeline .timeline-step.inactive {
+body.high-contrast[data-theme='dark'] .onboarding-timeline .timeline-step.inactive {
   border-color: #999999;
   color: #999999;
   cursor: not-allowed;
 }
 
-body.dark-mode.high-contrast .uk-button-primary {
+body.high-contrast[data-theme='dark'] .uk-button-primary {
   background-color: #ffff00;
   border-color: #ffff00;
   color: #000000;
 }
 
-body.dark-mode.high-contrast .uk-button,
-body.dark-mode.high-contrast .uk-button-default {
+body.high-contrast[data-theme='dark'] .uk-button,
+body.high-contrast[data-theme='dark'] .uk-button-default {
   background-color: #000000;
   color: #ffffff;
   border-color: #ffffff;
 }
 
-body.dark-mode.high-contrast input,
-body.dark-mode.high-contrast textarea,
-body.dark-mode.high-contrast select {
+body.high-contrast[data-theme='dark'] input,
+body.high-contrast[data-theme='dark'] textarea,
+body.high-contrast[data-theme='dark'] select {
   background-color: #000000;
   color: #ffffff;
   border-color: #ffffff;
 }
 
-body.dark-mode.high-contrast .sortable-list li,
-body.dark-mode.high-contrast .terms li,
-body.dark-mode.high-contrast .dropzone,
-body.dark-mode.high-contrast .mc-option {
+body.high-contrast[data-theme='dark'] .sortable-list li,
+body.high-contrast[data-theme='dark'] .terms li,
+body.high-contrast[data-theme='dark'] .dropzone,
+body.high-contrast[data-theme='dark'] .mc-option {
   background: #000000;
   border: 2px solid #ffffff;
   color: #ffffff;
 }
 
-body.dark-mode.high-contrast .dropzone.over {
+body.high-contrast[data-theme='dark'] .dropzone.over {
   background: #333333;
   border-color: #ffffff;
 }
 
-body.dark-mode.high-contrast .uk-alert-success {
+body.high-contrast[data-theme='dark'] .uk-alert-success {
   background-color: #008000;
   color: #ffffff;
 }
 
-body.dark-mode.high-contrast .uk-alert-danger {
+body.high-contrast[data-theme='dark'] .uk-alert-danger {
   background-color: var(--danger-500);
   color: #ffffff;
 }
 
-body.dark-mode.high-contrast .uk-alert-primary {
+body.high-contrast[data-theme='dark'] .uk-alert-primary {
   background-color: #00008b;
   color: #ffffff;
 }
 
 body.high-contrast .uk-form-danger,
-body.dark-mode.high-contrast .uk-form-danger {
+body.high-contrast[data-theme='dark'] .uk-form-danger {
   border-color: var(--danger-600) !important;
 }
 
@@ -196,8 +196,8 @@ body.high-contrast .flip-card-back {
   border: 2px solid #000000;
 }
 
-body.dark-mode.high-contrast .flip-card-front,
-body.dark-mode.high-contrast .flip-card-back {
+body.high-contrast[data-theme='dark'] .flip-card-front,
+body.high-contrast[data-theme='dark'] .flip-card-back {
   background-color: #000000;
   color: #ffffff;
   border: 2px solid #ffffff;

--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -1,4 +1,4 @@
-body:not(.dark-mode){
+body:not([data-theme='dark']){
   --btn-bg: transparent;
   --btn-border: rgba(0,0,0,0.6);
   --btn-border-hover: rgba(0,0,0,0.8);
@@ -8,7 +8,7 @@ body:not(.dark-mode){
   --drop-border: rgba(27,31,35,0.12);
   --text: #000;
 }
-body.dark-mode{
+body[data-theme='dark']{
   --btn-border: rgba(255,255,255,0.3);
   --btn-border-hover: rgba(255,255,255,0.5);
   --btn-bg-hover: rgba(255,255,255,0.08);
@@ -26,7 +26,7 @@ body.high-contrast{
   --btn-bg-hover: #e6e6e6;
   --focus-ring: rgba(0,120,255,0.6);
 }
-body.dark-mode.high-contrast{
+body.high-contrast[data-theme='dark']{
   --text: #ffffff;
   --drop-bg: #000000;
   --drop-border: #ffffff;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -20,13 +20,11 @@ document.addEventListener('DOMContentLoaded', function () {
     darkStylesheet.toggleAttribute('disabled', !dark);
   }
 
-  if (dark) {
-    document.body.classList.add('dark-mode');
-    document.documentElement.classList.add('dark-mode');
-    document.documentElement.classList.add('theme-dark');
-    if (uikitStylesheet) {
-      document.body.classList.add('uk-light');
-    }
+  document.body.dataset.theme = dark ? 'dark' : 'light';
+  document.documentElement.dataset.theme = dark ? 'dark' : 'light';
+  document.documentElement.classList.toggle('theme-dark', dark);
+  if (uikitStylesheet) {
+    document.body.classList.toggle('uk-light', dark);
   }
 
   const sunSVG = `
@@ -94,8 +92,10 @@ document.addEventListener('DOMContentLoaded', function () {
       });
       toggle.addEventListener('click', function (event) {
         event.preventDefault();
-        dark = document.body.classList.toggle('dark-mode');
-        document.documentElement.classList.toggle('dark-mode', dark);
+        dark = document.body.dataset.theme === 'dark';
+        dark = !dark;
+        document.body.dataset.theme = dark ? 'dark' : 'light';
+        document.documentElement.dataset.theme = dark ? 'dark' : 'light';
         document.documentElement.classList.toggle('theme-dark', dark);
         if (uikitStylesheet) {
           document.body.classList.toggle('uk-light', dark);


### PR DESCRIPTION
## Summary
- replace `.dark-mode` selectors with `[data-theme="dark"]` across CSS
- toggle theme via `data-theme` attributes in app.js
- document data-theme usage in README

## Testing
- `composer test` *(fails: Missing STRIPE env vars; multiple PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5670077d0832badf8d8e7646c55b0