### PR TITLE
Load topbar styles before landing styles

### DIFF
--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -39,8 +39,8 @@
   </script>
   <link rel="icon" href="{{ basePath }}/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="{{ basePath }}/css/uikit.min.css">
-  {% block head %}{% endblock %}
   <link rel="stylesheet" href="{{ basePath }}/css/topbar.css">
+  {% block head %}{% endblock %}
   {% if config is defined and config.colors is defined %}
   <style>
     :root {


### PR DESCRIPTION
## Summary
- Load `topbar.css` before `landing.css` so landing overrides are applied last

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b565e2a7f0832b9d5cdc0b08a20478