### PR TITLE
Move theme attribute to root and update landing resources

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -46,7 +46,7 @@
     --qr-ring: rgba(31,111,235,.35);
   }
 }
-body[data-theme="dark"] {
+:root[data-theme="dark"] {
   --qr-bg: #0d1117;
   --qr-text: #fff;
   --qr-muted: #e6eaf3;
@@ -63,7 +63,7 @@ body[data-theme="dark"] {
   --qr-link:#58a6ff;
   --qr-ring: rgba(31,111,235,.35);
 }
-body[data-theme="light"] {
+:root[data-theme="light"] {
   --qr-bg: #ffffff;
   --qr-text: #111827;
   --qr-muted: #374151;
@@ -91,9 +91,9 @@ body[data-theme="light"] {
 .qr-landing .section-gray { background: #f3f4f6; color: var(--qr-text); }
 .qr-landing .section-white { background: #ffffff; color: var(--qr-text); }
 
-body[data-theme="dark"] .qr-landing .section-blue,
-body[data-theme="dark"] .qr-landing .section-white { background: #0d1117; color: var(--qr-text); }
-body[data-theme="dark"] .qr-landing .section-gray { background: #161b22; color: var(--qr-text); }
+html[data-theme="dark"] .qr-landing .section-blue,
+html[data-theme="dark"] .qr-landing .section-white { background: #0d1117; color: var(--qr-text); }
+html[data-theme="dark"] .qr-landing .section-gray { background: #161b22; color: var(--qr-text); }
 
 /* Karten/Kacheln auf der Landing (UIKit gezielt überstimmen) */
 .qr-landing .uk-card,
@@ -166,7 +166,7 @@ body[data-theme="dark"] .qr-landing .section-gray { background: #161b22; color: 
     height:56px;
   }
 }
-body[data-theme="dark"] .qr-landing .qr-topbar{
+html[data-theme="dark"] .qr-landing .qr-topbar{
   background: linear-gradient(180deg, rgba(13,17,23,0.8) 0%, rgba(22,27,34,0.8) 100%);
 }
 .qr-landing .qr-topbar .uk-navbar-nav>li>a{
@@ -240,7 +240,7 @@ body[data-theme="dark"] .qr-landing .qr-topbar{
   border-radius:9999px;
   margin-bottom:16px;
 }
-body[data-theme="dark"] .qr-landing .qr-badge{
+html[data-theme="dark"] .qr-landing .qr-badge{
   background: color-mix(in oklab, var(--qr-brand-800) 40%, transparent);
   color:var(--qr-brand-100);
 }
@@ -316,7 +316,7 @@ body[data-theme="dark"] .qr-landing .qr-badge{
   transition:opacity .2s;
 }
 .qr-landing .btn.btn-black.uk-button-secondary:hover{ opacity:.85; }
-body[data-theme="dark"] .qr-landing .btn.btn-black.uk-button-secondary{ background:#0d1117!important; }
+html[data-theme="dark"] .qr-landing .btn.btn-black.uk-button-secondary{ background:#0d1117!important; }
 
 .qr-landing .uk-section{ padding-top:72px; padding-bottom:72px; }
 @media (min-width:1200px){ .qr-landing .uk-section{ padding-top:88px; padding-bottom:88px; } }

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let theme = stored || (prefersDark ? 'dark' : 'light');
 
   const apply = () => {
-    document.body.dataset.theme = theme;
+    document.documentElement.dataset.theme = theme;
     if (icon) {
       icon.innerHTML = theme === 'dark' ? sunSVG : moonSVG;
     }

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ locale() }}">
+<html lang="{{ locale() }}" data-theme="{% block body_theme %}light{% endblock %}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
@@ -50,7 +50,7 @@
   </style>
   {% endif %}
 </head>
-<body class="{% block body_class %}{% endblock %}" data-theme="{% block body_theme %}light{% endblock %}">
+<body class="{% block body_class %}{% endblock %}">
   <div class="wrapper">
     <main class="content">
       {% block body %}{% endblock %}


### PR DESCRIPTION
## Summary
- Move `data-theme` attribute from `body` to `html` so root variables respond to theme changes
- Toggle theme via `document.documentElement.dataset.theme` in landing script
- Target root for theme styles in landing CSS

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b56579978c832bb3cfa8c336c73b41