### PR TITLE
Style dark-mode dropdown menu in Subdomains view

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -638,3 +638,26 @@ body[data-theme="dark"] .uk-accordion-content {
   color: #f5f5f5;
 }
 
+/* Dark mode dropdown menu styling */
+body.dark-mode .dropdown-menu,
+body.dark-mode .v-menu__content,
+body.dark-mode .uk-dropdown {
+  background-color: #1e1e1e !important;
+  color: #e6e9ef !important;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+body.dark-mode .dropdown-menu a,
+body.dark-mode .v-list-item,
+body.dark-mode .uk-dropdown a,
+body.dark-mode .uk-dropdown button {
+  color: #e6e9ef !important;
+}
+
+body.dark-mode .dropdown-menu a:hover,
+body.dark-mode .v-list-item:hover,
+body.dark-mode .uk-dropdown a:hover,
+body.dark-mode .uk-dropdown button:hover {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+


### PR DESCRIPTION
## Summary
- style dropdown menus for dark mode, matching overall design

## Testing
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b56f7bdf14832b99b0cf3ba5bec151