### PR TITLE
fix: reveal hero gradient

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -220,16 +220,18 @@ html[data-theme="dark"] .qr-landing .qr-topbar{
 .qr-landing .top-cta:focus-visible{ box-shadow:0 0 0 3px var(--qr-ring); }
 
 /* Hero */
-.qr-landing .qr-hero{ position:relative; overflow:hidden; }
+.qr-landing .qr-hero.uk-section{ background:transparent !important; position:relative; overflow:hidden; }
 .qr-landing .qr-hero-bg{
   position:absolute;
   inset:0;
-  z-index:-1;
+  z-index:0;
+  pointer-events:none;
   background:
     radial-gradient(1000px at 15% 20%, color-mix(in oklab, var(--qr-brand-400) 40%, transparent), transparent 70%),
     radial-gradient(1200px at 85% -10%, color-mix(in oklab, var(--qr-hero-grad-end) 35%, transparent), transparent 70%),
     linear-gradient(135deg, var(--qr-hero-grad-start) 0%, var(--qr-hero-grad-end) 100%);
 }
+.qr-landing .qr-hero>*{ position:relative; z-index:1; }
 .qr-landing .qr-badge{
   display:inline-block;
   padding:4px 12px;


### PR DESCRIPTION
## Summary
- keep landing hero sections transparent so background gradient shows
- bring hero gradient layer above section background
- ensure hero content stays above gradient layer

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b570a8ff30832bb058043e6af14d6e