### PR TITLE
fix: allow landing offcanvas to overlay viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,10 @@
 - Bump version to 0.2.188 [skip ci]
 - Bump version to 0.2.189 [skip ci]
 
+### Fix
+
+- Allow landing offcanvas menu to expand beyond topbar on mobile
+
 ### Docs
 
 - Remove version bump entries from changelog

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -52,24 +52,24 @@
                   aria-label="Menü"></button>
         </div>
       </nav>
-      <div id="qr-offcanvas" uk-offcanvas="overlay: true">
-        <div class="uk-offcanvas-bar">
-          <button class="uk-offcanvas-close" type="button" uk-close aria-label="Menü schließen"></button>
-          <ul class="uk-nav uk-nav-default">
-            {% for link in links %}
-              <li>
-                <a href="{{ link.href }}">
-                  <span class="uk-margin-small-right" uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
-          <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="https://demo.quizrace.app" target="_blank" rel="noopener">
-            <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt Demo starten
-          </a>
-        </div>
-      </div>
     </header>
+    <div id="qr-offcanvas" uk-offcanvas="overlay: true">
+      <div class="uk-offcanvas-bar">
+        <button class="uk-offcanvas-close" type="button" uk-close aria-label="Menü schließen"></button>
+        <ul class="uk-nav uk-nav-default">
+          {% for link in links %}
+            <li>
+              <a href="{{ link.href }}">
+                <span class="uk-margin-small-right" uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+        <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="https://demo.quizrace.app" target="_blank" rel="noopener">
+          <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt Demo starten
+        </a>
+      </div>
+    </div>
 
     <section class="qr-hero uk-section uk-section-large">
       <div class="qr-hero-bg" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- move landing offcanvas element outside topbar so mobile menu overlays full viewport
- document fix in changelog

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b57d680fac832ba9c26d6b5f467fd7