### PR TITLE
feat: add collapsible log to onboarding

### DIFF
--- a/public/css/onboarding.css
+++ b/public/css/onboarding.css
@@ -72,6 +72,15 @@
   margin-top: auto;
 }
 
+details > summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
+}
+
 @media (prefers-color-scheme: light) {
   .site-footer {
     background-color: var(--primary-color);

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -353,6 +353,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     const taskStatus = document.getElementById('task-status');
     const taskLog = document.getElementById('task-log');
+    const taskLogDetails = taskLog ? taskLog.closest('details') : null;
 
     const tasks = [
       { id: 'create', label: 'Mandant anlegen' },
@@ -369,6 +370,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const li = document.createElement('li');
       li.textContent = msg;
       taskLog.appendChild(li);
+      if (taskLogDetails) {
+        taskLogDetails.open = true;
+      }
     };
 
     const start = id => {

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -164,7 +164,10 @@
         <h3 class="uk-card-title">5. App erstellen</h3>
         <p>Deine App wird erstellt. Bitte warten …</p>
         <ul id="task-status" class="uk-list uk-text-left uk-margin"></ul>
-        <ul id="task-log" class="uk-list uk-text-left uk-text-meta uk-margin"></ul>
+        <details class="uk-margin">
+          <summary>Log anzeigen</summary>
+          <ul id="task-log" class="uk-list uk-text-left uk-text-meta uk-margin-small-top"></ul>
+        </details>
       </div>
     </div>
   {% endblock %}


### PR DESCRIPTION
## Summary
- add collapsible details section for onboarding task log
- open log details automatically when new entries are appended
- style details summary cursor for better UX

## Testing
- `composer test` *(fails: Tests: 274, Assertions: 587, Errors: 25, Failures: 8)*

------
https://chatgpt.com/codex/tasks/task_e_68b57f6c5f98832bb4ae8c88c19e27a6