### PR TITLE
Improve tenant health check with HTTP fallback and TLS logging

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -448,10 +448,13 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const waitForTenant = async slug => {
-      const url = `https://${slug}.${window.mainDomain}/healthz`;
-      for (let i = 0; i < 30; i++) {
+      const httpUrl = `http://${slug}.${window.mainDomain}/healthz`;
+      const httpsUrl = `https://${slug}.${window.mainDomain}/healthz`;
+      const attempts = window.waitForTenantRetries || 90;
+      const delay = window.waitForTenantDelay || 2000;
+      for (let i = 0; i < attempts; i++) {
         try {
-          const res = await fetch(url, {
+          const res = await fetch(httpUrl, {
             headers: { Accept: 'application/json' },
             credentials: 'omit'
           });
@@ -459,14 +462,34 @@ document.addEventListener('DOMContentLoaded', () => {
             const ct = res.headers.get('Content-Type') || '';
             if (ct.includes('application/json')) {
               const data = await res.json();
-              if (data.status === 'ok') return;
+              if (data.status === 'ok') {
+                try {
+                  const secure = await fetch(httpsUrl, {
+                    headers: { Accept: 'application/json' },
+                    credentials: 'omit'
+                  });
+                  if (secure.ok && !secure.redirected) {
+                    const ct2 = secure.headers.get('Content-Type') || '';
+                    if (ct2.includes('application/json')) {
+                      const data2 = await secure.json();
+                      if (data2.status === 'ok') return;
+                    }
+                  }
+                } catch (e) {
+                  if (e instanceof Error && /certificate|tls|ssl/i.test(e.message)) {
+                    addLog('Zertifikat noch nicht verfügbar');
+                  }
+                }
+              }
             }
           }
-        } catch (_) {
-          /* ignore fetch errors */
+        } catch (e) {
+          if (e instanceof Error && /certificate|tls|ssl/i.test(e.message)) {
+            addLog('Zertifikat noch nicht verfügbar');
+          }
         }
         addLog('Warten auf Tenant …');
-        await wait(2000);
+        await wait(delay);
       }
       throw new Error('timeout');
     };


### PR DESCRIPTION
## Summary
- try tenant health check via HTTP first and fallback to HTTPS when ready
- log TLS certificate availability errors instead of ignoring them
- allow configurable retry attempts and delay to accommodate certificate issuance

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b57f7284a8832b825f404a18b3835f