### PR TITLE
Allow Stripe checkout domain

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const withBase = p => basePath + p;
   const timelineSteps = document.querySelectorAll('.timeline-step');
   const restartBtn = document.getElementById('restartOnboarding');
+  const hostWhitelist = ['stripe.com'];
   let tenantFinalizing = false;
 
   function isValidEmail(email) {
@@ -45,7 +46,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (window.location.hostname) domains.push(window.location.hostname.toLowerCase());
       if (window.mainDomain) domains.push(window.mainDomain.toLowerCase());
       const host = parsed.hostname.toLowerCase();
-      const domainOk = parsed.protocol === 'https:' && domains.some(d => host === d || host.endsWith('.' + d));
+      const domainMatch = domains.some(d => host === d || host.endsWith('.' + d));
+      const whitelistMatch = hostWhitelist.some(d => host === d || host.endsWith('.' + d));
+      const domainOk = parsed.protocol === 'https:' && (domainMatch || whitelistMatch);
       const pathOk = !allowedPaths.length || allowedPaths.some(p => parsed.pathname.startsWith(p));
       return domainOk && pathOk;
     } catch (e) {


### PR DESCRIPTION
## Summary
- whitelist `stripe.com` for onboarding redirects
- broaden URL validation to trust whitelisted payment providers

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b57f806d40832b92bcf7278823f155