### PR TITLE
Reenable plan button on errors

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -239,16 +239,29 @@ document.addEventListener('DOMContentLoaded', () => {
     planButtons.forEach(btn => {
       btn.addEventListener('click', async () => {
         btn.disabled = true;
+        const spinner = document.createElement('span');
+        spinner.setAttribute('uk-spinner', 'ratio: 0.5');
+        spinner.classList.add('uk-margin-small-left');
+        btn.appendChild(spinner);
+        const reset = () => {
+          btn.disabled = false;
+          spinner.remove();
+        };
         const plan = btn.dataset.plan;
         const email = localStorage.getItem('onboard_email') || emailInput.value.trim();
         const subdomain = localStorage.getItem('onboard_subdomain') || '';
-        if (!plan) return;
+        if (!plan) {
+          reset();
+          return;
+        }
         if (!isValidEmail(email)) {
           alert('Ungültige E-Mail-Adresse.');
+          reset();
           return;
         }
         if (!isValidSubdomain(subdomain)) {
           alert('Ungültige Subdomain.');
+          reset();
           return;
         }
         localStorage.setItem('onboard_plan', plan);
@@ -279,12 +292,15 @@ document.addEventListener('DOMContentLoaded', () => {
               window.location.href = escape(data.url);
             } else {
               console.error('Blocked redirect to untrusted URL:', data.url);
+              reset();
             }
             return;
           }
           alert(data.error || 'Fehler beim Start der Zahlung.');
+          reset();
         } catch (e) {
           alert('Fehler beim Start der Zahlung.');
+          reset();
         }
       });
     });


### PR DESCRIPTION
## Summary
- Re-enable plan selection buttons after validation or checkout errors
- Show a spinner while processing and remove it when restoring the button state

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, 25 errors, 8 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b57f950898832ba375f074a2e4fa2c