### PR TITLE
Re-enable plan selection button after errors

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -275,7 +275,11 @@ document.addEventListener('DOMContentLoaded', () => {
           url.searchParams.set('step', '5');
           window.history.replaceState({}, '', url);
           showStep(5);
-          finalizeTenant();
+          try {
+            await finalizeTenant();
+          } finally {
+            reset();
+          }
           return;
         }
         try {
@@ -293,16 +297,15 @@ document.addEventListener('DOMContentLoaded', () => {
           if (res.ok && data.url) {
             if (isAllowed(data.url)) {
               window.location.href = escape(data.url);
-            } else {
-              console.error('Blocked redirect to untrusted URL:', data.url);
-              reset();
+              return;
             }
-            return;
+            console.error('Blocked redirect to untrusted URL:', data.url);
+          } else {
+            alert(data.error || 'Fehler beim Start der Zahlung.');
           }
-          alert(data.error || 'Fehler beim Start der Zahlung.');
-          reset();
         } catch (e) {
           alert('Fehler beim Start der Zahlung.');
+        } finally {
           reset();
         }
       });
@@ -431,6 +434,7 @@ document.addEventListener('DOMContentLoaded', () => {
       mark('create', false);
       addLog('Ungültige Daten für die Registrierung.');
       alert('Ungültige Daten für die Registrierung.');
+      tenantFinalizing = false;
       return;
     }
 


### PR DESCRIPTION
## Summary
- ensure onboarding plan buttons re-enable themselves on errors
- reset finalization state when tenant data validation fails

## Testing
- `composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b5863ea604832ba9c20ba683524734