### PR TITLE
Route starter plan through Stripe checkout

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -268,16 +268,6 @@ document.addEventListener('DOMContentLoaded', () => {
           return;
         }
         localStorage.setItem('onboard_plan', plan);
-        if (plan === 'starter') {
-          const s5 = document.querySelector('.timeline-step[data-step="5"]');
-          if (s5) s5.classList.remove('inactive');
-          const url = new URL(window.location);
-          url.searchParams.set('step', '5');
-          window.history.replaceState({}, '', url);
-          showStep(5);
-          finalizeTenant();
-          return;
-        }
         try {
           const res = await fetch(withBase('/onboarding/checkout'), {
             method: 'POST',

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -93,12 +93,6 @@
       <h3 class="uk-card-title">4. Tarif wählen</h3>
       {% if stripe_configured %}
       <p>Wähle einen Tarif und schließe die Zahlung über Stripe ab. Du kannst jeden kostenpflichtigen Tarif 7 Tage lang kostenlos testen.</p>
-      {% else %}
-      <p class="uk-text-danger">Zahlungsdienstleister nicht konfiguriert. Nur der Starter-Tarif ist verfügbar.</p>
-      {% if stripe_missing %}
-      <p class="uk-text-meta">Fehlende Variablen: {{ stripe_missing|join(', ') }}</p>
-      {% endif %}
-      {% endif %}
       <div class="pricing-grid uk-child-width-1-1 uk-child-width-1-3@m" uk-grid>
         <div>
           <div class="uk-card uk-card-price uk-card-quizrace uk-text-center">
@@ -118,7 +112,6 @@
             <button class="btn btn-transparent uk-width-1-1 uk-button-large uk-margin-small-top plan-select" data-plan="starter">Tarif wählen</button>
           </div>
         </div>
-        {% if stripe_configured %}
         <div>
           <div class="uk-card uk-card-popular uk-card-quizrace uk-text-center">
             <span class="uk-label uk-label-large">Meist gewählt</span>
@@ -152,12 +145,17 @@
             <button class="btn btn-transparent uk-width-1-1 uk-button-large plan-select" data-plan="professional">Tarif wählen</button>
           </div>
         </div>
-        {% endif %}
       </div>
       <p class="uk-text-meta uk-text-center uk-margin-large-top">Alle Preise zzgl. MwSt. – individuelle Lösungen auf Anfrage.</p>
       <p class="uk-text-meta uk-margin-top">1 (Die Teamgröße ist nicht technisch limitiert und kann bedarfsgerecht festgelegt werden.)</p>
       <p class="uk-text-meta uk-margin-top">2 (Im Starter-Paket mit Wasserzeichen oder ohne individuelles Layout/Logo)</p>
       <p class="uk-text-meta uk-margin-top">3 (z.&nbsp;B. Datenschutz, AGB, Einladung, FAQ, Spielanleitung – alles eigenständig editierbar)</p>
+      {% else %}
+      <p class="uk-text-danger">Zahlungsdienstleister nicht konfiguriert.</p>
+      {% if stripe_missing %}
+      <p class="uk-text-meta">Fehlende Variablen: {{ stripe_missing|join(', ') }}</p>
+      {% endif %}
+      {% endif %}
     </div>
 
       <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step5" hidden>


### PR DESCRIPTION
## Summary
- Redirect all onboarding plan selections, including starter, through Stripe checkout
- Hide starter plan when Stripe is not configured

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b58646bbbc832bb35b5b78048b7165