### PR TITLE
refactor: add log details container

### DIFF
--- a/public/css/onboarding.css
+++ b/public/css/onboarding.css
@@ -81,6 +81,12 @@ details > summary::-webkit-details-marker {
   display: none;
 }
 
+#task-log-details {
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+}
+
 @media (prefers-color-scheme: light) {
   .site-footer {
     background-color: var(--primary-color);

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -361,7 +361,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     const taskStatus = document.getElementById('task-status');
     const taskLog = document.getElementById('task-log');
-    const taskLogDetails = taskLog ? taskLog.closest('details') : null;
+    const taskLogDetails = document.getElementById('task-log-details');
 
     const tasks = [
       { id: 'create', label: 'Mandant anlegen' },

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -162,7 +162,7 @@
         <h3 class="uk-card-title">5. App erstellen</h3>
         <p>Deine App wird erstellt. Bitte warten …</p>
         <ul id="task-status" class="uk-list uk-text-left uk-margin"></ul>
-        <details class="uk-margin">
+        <details id="task-log-details" class="uk-margin">
           <summary>Log anzeigen</summary>
           <ul id="task-log" class="uk-list uk-text-left uk-text-meta uk-margin-small-top"></ul>
         </details>


### PR DESCRIPTION
## Summary
- give onboarding task log a dedicated details container with unique ID
- update onboarding script to open the log container when adding entries
- style the log container to match the onboarding UI

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b58a764f0c832b9e7a8aaeea835292