### PR TITLE
Style email links as blue buttons

### DIFF
--- a/templates/emails/double_optin.twig
+++ b/templates/emails/double_optin.twig
@@ -3,6 +3,12 @@
 {% block content %}
 <p>Hallo,</p>
 <p>bitte bestätige deine E-Mail-Adresse durch Klick auf den folgenden Link:</p>
-<p><a href="{{ link }}">{{ link }}</a></p>
+<p>
+  <a
+    href="{{ link }}"
+    style="display:inline-block;background-color:#1a73e8;color:#ffffff;padding:10px 20px;border-radius:4px;text-decoration:none;"
+  >E-Mail-Adresse bestätigen</a>
+</p>
+<p><a href="{{ link }}" style="color:#1a73e8;">{{ link }}</a></p>
 <p>Wenn du diese Anfrage nicht gestellt hast, kannst du diese E-Mail ignorieren.</p>
 {% endblock %}

--- a/templates/emails/password_reset.twig
+++ b/templates/emails/password_reset.twig
@@ -3,6 +3,12 @@
 {% block content %}
 <p>Hallo,</p>
 <p>zum Zurücksetzen deines Passworts klicke auf den folgenden Link:</p>
-<p><a href="{{ link }}">{{ link }}</a></p>
+<p>
+  <a
+    href="{{ link }}"
+    style="display:inline-block;background-color:#1a73e8;color:#ffffff;padding:10px 20px;border-radius:4px;text-decoration:none;"
+  >Passwort zurücksetzen</a>
+</p>
+<p><a href="{{ link }}" style="color:#1a73e8;">{{ link }}</a></p>
 <p>Wenn du diese Anfrage nicht gestellt hast, kannst du diese E-Mail ignorieren.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Render onboarding confirmation email with a blue button and fallback link
- Use the same blue button style in password reset emails

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `vendor/bin/phpunit` *(fails: process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b58b85d15c832b9df00021ae650b30