### PR TITLE
Ensure deploy workflow sets compose project name and verifies slim service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,4 +22,6 @@ jobs:
             export $(grep -v '^#' .env | xargs)
             BASE_IMAGE="${APP_IMAGE%:*}"
             docker build -t "$APP_IMAGE" -t "${BASE_IMAGE}:latest" .
-            docker compose up -d --build
+            export COMPOSE_PROJECT_NAME=sommerfest-quiz
+            docker compose -p sommerfest-quiz up -d --build --remove-orphans --wait
+            docker compose -p sommerfest-quiz ps slim


### PR DESCRIPTION
## Summary
- set `COMPOSE_PROJECT_NAME` before running compose
- use `docker compose -p sommerfest-quiz up -d --build --remove-orphans --wait`
- verify `slim` service status with `docker compose ps`

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: process hung with missing STRIPE_* env warnings)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py` *(no output)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`


------
https://chatgpt.com/codex/tasks/task_e_68b58c7241a8832b9f1349b1fab92328