### PR TITLE
Remove environment logging from Stripe checkout

### DIFF
--- a/src/Controller/StripeCheckoutController.php
+++ b/src/Controller/StripeCheckoutController.php
@@ -22,9 +22,6 @@ class StripeCheckoutController
             return $response->withStatus(400);
         }
 
-        // Debug environment for Stripe setup
-        error_log('ENV ' . json_encode($_ENV));
-
         $plan = Plan::tryFrom((string) ($data['plan'] ?? ''));
         $email = (string) ($data['email'] ?? '');
         $subdomain = (string) ($data['subdomain'] ?? '');


### PR DESCRIPTION
## Summary
- remove debug logging of `$_ENV` in Stripe checkout controller to avoid leaking environment data

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b58cbeb790832b9ef14f10a9b280ec