### PR TITLE
Handle failed Stripe checkout redirects

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -282,10 +282,23 @@ document.addEventListener('DOMContentLoaded', () => {
           const data = await res.json();
           if (res.ok && data.url) {
             if (isAllowed(data.url)) {
-              window.location.href = escape(data.url);
+              try {
+                const verify = await fetch(data.url, { method: 'HEAD', redirect: 'manual' });
+                if (verify.ok || verify.type === 'opaque') {
+                  window.location.href = escape(data.url);
+                  return;
+                }
+              } catch (_) {
+                // network error, handled below
+              }
+              const retry = confirm('Die Zahlungsseite konnte nicht geladen werden. Erneut versuchen?');
+              if (retry) {
+                setTimeout(() => btn.click(), 0);
+              }
               return;
             }
             console.error('Blocked redirect to untrusted URL:', data.url);
+            alert('Unzulässige Weiterleitung. Zahlung wurde nicht gestartet.');
           } else {
             alert(data.error || 'Fehler beim Start der Zahlung.');
           }


### PR DESCRIPTION
## Summary
- verify Stripe checkout URLs before redirecting during onboarding
- show retry prompt if Stripe session URL is unreachable

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b58cc31594832b9c5537d0d4d2ef80