### PR TITLE
docs: document Docker Compose project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Zum Start genügt:
 cp sample.env .env
 docker compose up --build -d
 ```
+Die Datei setzt `COMPOSE_PROJECT_NAME=sommerfest-quiz`, damit Docker Compose vorhandene Container und Volumes bei späteren Deployments wiederverwendet.
 Falls der Reverse Proxy das Docker-Netzwerk noch nicht kennt, lege es vorher an:
 ```bash
 docker network create ${NETWORK:-webproxy}
@@ -441,7 +442,7 @@ Das Projekt *QuizRace* ist eine Web-Applikation zur Erstellung und Verwaltung vo
    composer install
    ```
    Beim ersten Aufruf wird eine `composer.lock` erzeugt und alle benötigten Bibliotheken geladen.
-2. Die Beispieldatei `sample.env` in `.env` kopieren und bei Bedarf anpassen:
+2. Die Beispieldatei `sample.env` in `.env` kopieren und bei Bedarf anpassen. Sie enthält `COMPOSE_PROJECT_NAME=sommerfest-quiz`, wodurch Docker Compose bei späteren Deployments bestehende Container und Volumes wiederverwendet:
    ```bash
    cp sample.env .env
    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ curl -X DELETE http://$DOMAIN/tenants \
 
 Die Mandanten-Logik nutzt folgende Variablen aus `.env` oder `sample.env`:
 
+- `COMPOSE_PROJECT_NAME` hält den Docker-Compose-Projektnamen stabil, damit Container und Volumes bei Updates weiterverwendet werden.
 - `DOMAIN` legt die Basis-Domain für alle Mandanten fest.
 - `MAIN_DOMAIN` definiert die Hauptdomain des Quiz-Containers.
 - `POSTGRES_DSN`, `POSTGRES_USER` und `POSTGRES_PASSWORD` bestimmen den Datenbankzugang.

--- a/sample.env
+++ b/sample.env
@@ -2,6 +2,10 @@
 # Beispiel-Konfiguration
 ####################
 
+# Fester Projektname für Docker Compose.
+# Sollte unverändert bleiben, damit Container und Volumes bei Deployments wiederverwendet werden.
+COMPOSE_PROJECT_NAME=sommerfest-quiz
+
 # Domain-Routing (z. B. für VIRTUAL_HOST)
 DOMAIN=example.com            # Basis-Domain aller Mandanten
 MAIN_DOMAIN=quizrace.app      # Hauptdomain des Quiz-Containers


### PR DESCRIPTION
## Summary
- fix project name in `sample.env` to ensure stable Docker Compose resources
- document `COMPOSE_PROJECT_NAME` in README and docs

## Testing
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b590828510832b99c6f7ef5ced1446