### PR TITLE
fix: improve topbar contrast in light theme

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -35,6 +35,25 @@ body[data-theme="dark"].high-contrast{
   --topbar-btn-bg-hover: rgba(255,255,255,0.16);
   --topbar-focus-ring: rgba(140,200,255,0.8);
 }
+
+/* Buttons in der Topbar */
+.topbar .uk-button,
+.topbar .uk-navbar-nav>li>a{
+  color: var(--qr-fg);
+  border-color: var(--btn-border, rgba(0,0,0,0.12));
+}
+body:not(.dark-mode) .topbar .uk-button,
+body:not(.dark-mode) .topbar .uk-navbar-nav>li>a{
+  color: #0f172a;
+  border-color: rgba(0,0,0,0.12);
+}
+
+/* Dropdown/Offcanvas */
+.uk-dropdown, .uk-drop, .uk-offcanvas-bar{
+  background: var(--drop-bg, var(--qr-card));
+  color: var(--qr-fg);
+  border: 1px solid var(--drop-border, var(--qr-border));
+}
 .git-btn{
   width:40px;height:40px;padding:0;
   border-radius:6px;


### PR DESCRIPTION
## Summary
- ensure topbar buttons and links use theme foreground colors with light-mode overrides
- apply dropdown and offcanvas background/border tokens for light theme

## Testing
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `vendor/bin/phpunit tests/HealthzEndpointTest.php`
- `composer test` *(fails: Script vendor/bin/phpunit handling the phpunit event returned with error code 143)*

------
https://chatgpt.com/codex/tasks/task_e_68b5974f62fc832b84fcdbf754891032