### PR TITLE
fix: override UIkit card backgrounds

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -6,6 +6,9 @@
     --color-text: #f5f5f5;
     --danger-500: #ff6b6b;
     --danger-600: #ff4c4c;
+    --qr-card: #1e1e1e;
+    --qr-border: rgba(255, 255, 255, 0.1);
+    --qr-bg-soft: #161b22;
   }
 html,
 body {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -15,6 +15,9 @@ html {
   --color-text: #232323;
   --danger-500: #8b0000;
   --danger-600: #660000;
+  --qr-card: #ffffff;
+  --qr-border: rgba(0, 0, 0, 0.1);
+  --qr-bg-soft: #f3f4f6;
 }
 
 body {
@@ -977,6 +980,23 @@ body.admin-page {
   .dashboard-grid > * {
     padding-left: 8px;
   }
+}
+
+/* Standardsektionen neutralisieren und selbst einfärben */
+.uk-card,
+.uk-panel {
+  background: var(--qr-card);
+  color: inherit;
+  border: 1px solid var(--qr-border);
+  border-radius: 12px;
+}
+
+.section--muted {
+  background: var(--qr-bg-soft);
+}
+
+.section--transparent {
+  background: transparent;
 }
 
 


### PR DESCRIPTION
## Summary
- add theme variables for card, border and soft backgrounds
- neutralize UIkit defaults for cards and panels; add muted and transparent section helpers
- define dark theme equivalents for new variables

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `vendor/bin/phpunit` *(fails: hangs without summary)*

------
https://chatgpt.com/codex/tasks/task_e_68b5975dbf40832b8ddfe3bd7cc6f8fd