### PR TITLE
refactor: use foreground variables for consistent contrast

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -10,10 +10,10 @@
 html,
 body {
   background-color: #000 !important;
-  color: #f5f5f5;
+  color: var(--qr-fg);
 }
 body a {
-  color: var(--accent-color, #9dc6ff);
+  color: #60a5fa;
 }
 body h1,
 body h2,
@@ -21,21 +21,21 @@ body h3,
 body h4,
 body h5,
 body h6 {
-  color: #f5f5f5;
+  color: var(--qr-fg);
 }
 body .uk-card-title {
-  color: #f5f5f5;
+  color: var(--qr-fg);
 }
 body .uk-card-default {
   background-color: #1e1e1e;
-  color: #f5f5f5;
+  color: var(--qr-fg);
 }
 body .uk-card-default a {
-  color: var(--accent-color, #9dc6ff);
+  color: #60a5fa;
 }
 body .uk-card h3,
 body .uk-card p {
-  color: #f5f5f5;
+  color: var(--qr-fg);
 }
 body .uk-progress {
   background-color: #333;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -13,6 +13,7 @@ html {
   --color-bg: #fff;
   --color-primary: #0c86d0;
   --color-text: #232323;
+  --qr-fg: var(--color-text);
   --danger-500: #8b0000;
   --danger-600: #660000;
 }
@@ -21,6 +22,7 @@ body {
   min-height: 100vh;
   overflow-x: hidden;
   background-color: var(--primary-color, #ffffff);
+  color: var(--qr-fg);
 }
 
 .uk-button-primary {
@@ -978,5 +980,12 @@ body.admin-page {
     padding-left: 8px;
   }
 }
+
+/* Kontrast-Guard */
+h1,h2,h3,h4,h5,h6 { color: var(--qr-fg); }
+.uk-text-muted { color: color-mix(in oklab, var(--qr-fg) 70%, transparent); }
+/* Links/CTAs klarer */
+a, .uk-link, .cta-link { color: #60a5fa; }
+a:hover{ text-decoration: underline; }
 
 


### PR DESCRIPTION
## Summary
- define `--qr-fg` and apply as global text color
- add contrast guard rules for headings, muted text and links
- align dark theme styles with new foreground color

## Testing
- `composer test` *(fails: suite did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b59769b380832b8d7b7f599843195e