### PR TITLE
feat: toggle dark mode class

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   document.body.dataset.theme = dark ? 'dark' : 'light';
+  document.body.classList.toggle('dark-mode', dark);
   if (uikitStylesheet) {
     document.body.classList.toggle('uk-light', dark);
   }
@@ -92,6 +93,7 @@ document.addEventListener('DOMContentLoaded', function () {
         event.preventDefault();
         dark = document.body.dataset.theme !== 'dark';
         document.body.dataset.theme = dark ? 'dark' : 'light';
+        document.body.classList.toggle('dark-mode', dark);
         if (uikitStylesheet) {
           document.body.classList.toggle('uk-light', dark);
         }

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -88,6 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     theme = theme === 'dark' ? 'light' : 'dark';
     localStorage.setItem('qr-theme', theme);
+    document.body.classList.toggle('dark-mode', theme === 'dark');
     apply();
   });
 });


### PR DESCRIPTION
## Summary
- keep body `dark-mode` class in sync with theme toggle in app.js
- apply and update `dark-mode` class on landing theme switch

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b59c6dced4832bb040adf36289f0e7