### PR TITLE
Scope landing styles to landing page

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -32,7 +32,7 @@
   --qr-muted:#e6eaf3;
   --qr-shadow:0 6px 24px rgba(0,0,0,.35);
 }
-body:not(.dark-mode){
+body.qr-landing:not(.dark-mode){
   --qr-bg:#ffffff;
   --qr-fg:#101418;
   --qr-bg-soft:#f6f8fa;
@@ -51,9 +51,9 @@ body:not(.dark-mode){
   --qr-landing-text:var(--qr-fg);
 }
 
-body { background: var(--qr-bg); color: var(--qr-fg); }
-.uk-section { background: transparent; }
-.section--alt { background: var(--qr-bg-soft); color: var(--qr-fg); }
+body.qr-landing { background: var(--qr-bg); color: var(--qr-fg); }
+.qr-landing .uk-section { background: transparent; }
+.qr-landing .section--alt { background: var(--qr-bg-soft); color: var(--qr-fg); }
 
 /* Karten/Kacheln auf der Landing (UIKit gezielt überstimmen) */
 .qr-landing .uk-card,
@@ -187,7 +187,7 @@ body.dark-mode .qr-landing .qr-topbar{
   z-index:0;
   pointer-events:none;
 }
-.hero-bg-quizrace {
+.qr-landing .hero-bg-quizrace {
   background:
     radial-gradient(600px 400px at 0% 0%, color-mix(in oklab, var(--qr-hero-grad-end) 35%, transparent), transparent),
     radial-gradient(500px 350px at 100% 0%, color-mix(in oklab, #60a5fa 40%, transparent), transparent),
@@ -358,5 +358,5 @@ body.dark-mode .qr-landing .btn.btn-black.uk-button-secondary{ background:#0d111
 @keyframes drawUnderline { from { width: 0; } to { width: 100%; } }
 
 /* Proof badges */
-.qr-proof { display:flex; align-items:center; gap:16px; }
-.qr-proof img { height:28px; }
+.qr-landing .qr-proof { display:flex; align-items:center; gap:16px; }
+.qr-landing .qr-proof img { height:28px; }


### PR DESCRIPTION
## Summary
- scope landing page tokens and section styles to `body.qr-landing`
- limit hero background and proof badge rules to the landing body

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b59ceddb28832bbde65a83927a7dd8