### PR TITLE
feat: add prefers-color-scheme fallback

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -51,6 +51,16 @@ body:not(.dark-mode){
   --qr-landing-text:var(--qr-fg);
 }
 
+/* System-Fallback: nutzt bevorzugtes Farbschema, falls JS-Toggle ausfällt */
+@media (prefers-color-scheme: dark) {
+  body:not(.dark-mode) {
+    --qr-bg:#0d1117;
+    --qr-fg:#e6e9ef;
+    --qr-bg-soft:#11151b;
+    --qr-card:#161b22;
+  }
+}
+
 body { background: var(--qr-bg); color: var(--qr-fg); }
 .uk-section { background: transparent; }
 .section--alt { background: var(--qr-bg-soft); color: var(--qr-fg); }


### PR DESCRIPTION
## Summary
- support system color preference on landing page when JS toggle fails

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b59d010b3c832b92fc4788feef8024