### PR TITLE
refactor: replace UIkit card modifiers with qr-card

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -99,7 +99,7 @@
     <div class="uk-grid-large uk-child-width-1-3@m" uk-grid>
       <!-- Veranstalter:innen -->
       <div>
-        <div class="uk-card uk-card-default uk-card-body uk-height-1-1">
+        <div class="uk-card qr-card uk-card-body uk-height-1-1">
           <h3 class="uk-margin-remove-bottom">Für Veranstalter:innen</h3>
           <p class="uk-text-meta uk-margin-small">Ergebnis vor Aufwand</p>
           <ul class="uk-list uk-list-bullet">
@@ -112,7 +112,7 @@
 
       <!-- Teilnehmende -->
       <div>
-        <div class="uk-card uk-card-default uk-card-body uk-height-1-1">
+        <div class="uk-card qr-card uk-card-body uk-height-1-1">
           <h3 class="uk-margin-remove-bottom">Für Teilnehmende</h3>
           <p class="uk-text-meta uk-margin-small">Einfach rein, sofort Spaß</p>
           <ul class="uk-list uk-list-bullet">
@@ -125,7 +125,7 @@
 
       <!-- IT & Datenschutz -->
       <div>
-        <div class="uk-card uk-card-default uk-card-body uk-height-1-1">
+        <div class="uk-card qr-card uk-card-body uk-height-1-1">
           <h3 class="uk-margin-remove-bottom">Für IT &amp; Datenschutz</h3>
           <p class="uk-text-meta uk-margin-small">Sicher &amp; revisionsfest</p>
           <ul class="uk-list uk-list-bullet">

--- a/content/lizenz.html
+++ b/content/lizenz.html
@@ -1,7 +1,7 @@
   <div class="uk-container uk-container-small legal-container">
     <h1 class="uk-heading-divider uk-hidden">Lizenz</h1>
     <p>Diese Anwendung steht unter einer proprietären Lizenz. Den vollständigen Text finden Sie untenstehend sowie in der Datei <code>LICENSE</code>. Die kommerzielle Nutzung ist erlaubt, der Quellcode bleibt jedoch Eigentum von René Buske und darf nicht ohne vorherige schriftliche Genehmigung kopiert, verbreitet, verändert oder öffentlich zugänglich gemacht werden.</p>
-    <div class="uk-card uk-card-default uk-card-body uk-margin">
+    <div class="uk-card qr-card uk-card-body uk-margin">
       <h3 class="uk-heading-bullet">Disclaimer / Hinweis</h3>
         <p>Die Sommerfeier 2025 Quiz-App ist das Ergebnis einer spannenden Zusammenarbeit zwischen menschlicher Erfahrung und k&uuml;nstlicher Intelligenz. W&auml;hrend Ideen, Organisation und jede Menge Praxiswissen von Menschen stammen, wurden alle Codezeilen experimentell komplett von OpenAI Codex geschrieben. F&uuml;r die kreativen Konzepte und Inhalte kam ChatGPT 4.1 zum Einsatz, bei der Fehlersuche half Github Copilot und das Logo wurde von der KI Sora entworfen.</p>
         <p>Diese App wurde im Rahmen einer Machbarkeitsstudie entwickelt, um das Potenzial moderner Codeassistenten in der Praxis zu erproben.</p>

--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -20,7 +20,7 @@ body {
 }
 
 /* Card appearance */
-.uk-card-default {
+.qr-card {
   border-radius: 10px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -29,11 +29,11 @@ body h6 {
 body .uk-card-title {
   color: #f5f5f5;
 }
-body .uk-card-default {
+body .qr-card {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
-body .uk-card-default a {
+body .qr-card a {
   color: var(--accent-color, #9dc6ff);
 }
 body .uk-card h3,
@@ -335,11 +335,11 @@ body[data-theme="dark"] h6 {
 body[data-theme="dark"] .uk-card-title {
   color: #f5f5f5;
 }
-body[data-theme="dark"] .uk-card-default {
+body[data-theme="dark"] .qr-card {
   background-color: #1e1e1e;
   color: #f5f5f5;
 }
-body[data-theme="dark"] .uk-card-default a {
+body[data-theme="dark"] .qr-card a {
   color: var(--accent-color, #9dc6ff);
 }
 body[data-theme="dark"] .uk-card h3,

--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -8,7 +8,7 @@ body.high-contrast a {
   color: #0000ee;
   text-decoration: underline;
 }
-body.high-contrast .uk-card-default {
+body.high-contrast .qr-card {
   background-color: #ffffff;
   color: #000000;
   border-color: #000000;
@@ -88,7 +88,7 @@ body[data-theme="dark"].high-contrast a {
   text-decoration: underline;
 }
 
-body[data-theme="dark"].high-contrast .uk-card-default {
+body[data-theme="dark"].high-contrast .qr-card {
   background-color: #000000;
   color: #ffffff;
   border-color: #ffffff;

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -57,7 +57,7 @@ body.qr-landing { background: var(--qr-bg); color: var(--qr-fg); }
 
 /* Karten/Kacheln auf der Landing (UIKit gezielt überstimmen) */
 .qr-landing .uk-card,
-.qr-landing .uk-card-default,
+.qr-landing .qr-card,
 .qr-landing .feature-box {
   background: var(--qr-card-bg) !important;
   color: var(--qr-text) !important;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -983,7 +983,9 @@ body.admin-page {
 }
 
 /* Standardsektionen neutralisieren und selbst einfärben */
+
 .uk-card,
+.qr-card,
 .uk-panel {
   background: var(--qr-card);
   color: inherit;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -992,7 +992,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Erstellt ein Bearbeitungsformular für eine Frage
   function createCard(q, index = -1) {
     const card = document.createElement('div');
-    card.className = 'uk-card uk-card-default uk-card-body uk-margin question-card';
+    card.className = 'uk-card qr-card uk-card-body uk-margin question-card';
     if (index >= 0) {
       card.dataset.index = String(index);
     }
@@ -1265,7 +1265,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Vorschau-Bereich anlegen
     const preview = document.createElement('div');
-    preview.className = 'uk-card uk-card-muted uk-card-body question-preview';
+    preview.className = 'uk-card qr-card uk-card-body question-preview';
 
     const formCol = document.createElement('div');
     formCol.appendChild(typeSelect);
@@ -2556,7 +2556,7 @@ document.addEventListener('DOMContentLoaded', function () {
           // mobile card
           if (tenantCards) {
             const card = document.createElement('div');
-            card.className = 'uk-card uk-card-default uk-card-small uk-margin-small';
+            card.className = 'uk-card qr-card uk-card-small uk-margin-small';
             card.innerHTML = `
               <div class="uk-card-header uk-flex uk-flex-between uk-flex-middle">
                 <div>
@@ -2836,7 +2836,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const wrapper = document.createElement('div');
         wrapper.className = 'uk-width-1-1 uk-width-1-2@s';
         const card = document.createElement('div');
-        card.className = 'export-card uk-card uk-card-default uk-card-body';
+        card.className = 'export-card uk-card qr-card uk-card-body';
         let href = withBase('/?katalog=' + encodeURIComponent(c.slug));
         if (ev.uid) {
           href = withBase('/?event=' + encodeURIComponent(ev.uid) + '&katalog=' + encodeURIComponent(c.slug));
@@ -2884,7 +2884,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const wrapper = document.createElement('div');
         wrapper.className = 'uk-width-1-1 uk-width-1-2@s';
         const card = document.createElement('div');
-        card.className = 'export-card uk-card uk-card-default uk-card-body uk-position-relative';
+        card.className = 'export-card uk-card qr-card uk-card-body uk-position-relative';
         const btn = document.createElement('button');
         btn.className = 'qr-print-btn uk-icon-button uk-position-top-right';
         btn.setAttribute('data-team', t);

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -73,7 +73,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     if(!block){
       block = document.createElement('div');
       block.dataset.role = 'catalog-comment-block';
-      block.className = 'modern-info-card uk-card uk-card-default uk-card-body uk-box-shadow-medium uk-margin';
+      block.className = 'modern-info-card uk-card qr-card uk-card-body uk-box-shadow-medium uk-margin';
       block.style.whiteSpace = 'pre-wrap';
       headerEl.appendChild(block);
     }
@@ -310,7 +310,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     catalogs.forEach(cat => {
       const cardWrap = document.createElement('div');
       const card = document.createElement('div');
-      card.className = 'uk-card uk-card-default uk-card-body uk-card-hover';
+      card.className = 'uk-card qr-card uk-card-body uk-card-hover';
       card.style.cursor = 'pointer';
       card.addEventListener('click', () => {
         const localSolved = new Set(JSON.parse(sessionStorage.getItem('quizSolved') || '[]'));

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1410,7 +1410,7 @@ async function runQuiz(questions, skipIntro){
     modal.setAttribute('aria-modal', 'true');
     modal.innerHTML =
       '<div class="uk-modal-dialog uk-modal-body">' +
-        '<div class="uk-card uk-card-default uk-card-body uk-padding-small uk-width-1-1">' +
+        '<div class="uk-card qr-card uk-card-body uk-padding-small uk-width-1-1">' +
           '<p class="uk-text-small">Hinweis zum Hochladen von Gruppenfotos:<br>' +
             'Ich bestätige, dass alle auf dem Foto abgebildeten Personen vor der Aufnahme darüber informiert wurden, dass das Gruppenfoto zu Dokumentationszwecken erstellt und ggf. veröffentlicht wird. Alle Anwesenden hatten Gelegenheit, der Aufnahme zu widersprechen, indem sie den Aufnahmebereich verlassen oder dies ausdrücklich mitteilen konnten.' +
           '</p>' +

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -306,7 +306,7 @@ document.addEventListener('DOMContentLoaded', () => {
     cards.forEach(card => {
       const col = document.createElement('div');
       const c = document.createElement('div');
-      c.className = 'uk-card uk-card-default uk-card-body';
+      c.className = 'uk-card qr-card uk-card-body';
       const h = document.createElement('h4');
       h.className = 'uk-card-title';
       h.append(document.createTextNode(card.title));

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -119,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function renderQuestionPreview(q, catMap){
     const card = document.createElement('div');
-    card.className = 'uk-card uk-card-muted uk-card-body question-preview';
+    card.className = 'uk-card qr-card uk-card-body question-preview';
     const title = document.createElement('h5');
     const info = catMap[q.catalog];
     const cat = q.catalogName || (info ? info.name : q.catalog);
@@ -382,7 +382,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const dialog = document.createElement('div');
     dialog.className = 'uk-modal-dialog uk-modal-body';
     const card = document.createElement('div');
-    card.className = 'uk-card uk-card-default uk-card-body uk-padding-small uk-width-1-1';
+    card.className = 'uk-card qr-card uk-card-body uk-padding-small uk-width-1-1';
 
     const p = document.createElement('p');
     p.className = 'uk-text-small';

--- a/public/js/trumbowyg-pages.js
+++ b/public/js/trumbowyg-pages.js
@@ -35,7 +35,7 @@ $.extend(true, $.trumbowyg, {
         trumbowyg.addBtnDef('uikit-card', {
           fn: function () {
             trumbowyg.execCmd('insertHTML',
-              `<div class="uk-card uk-card-default uk-card-body">
+              `<div class="uk-card qr-card uk-card-body">
                 <h3 class="uk-card-title">Karte</h3>
                 <p>Inhalt hier</p>
               </div>`);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -78,7 +78,7 @@
   {% endif %}
   <div class="uk-grid-collapse" uk-grid>
     <aside class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
-      <div class="uk-card uk-card-default uk-card-body qr-sidebar-card">
+      <div class="uk-card qr-card uk-card-body qr-sidebar-card">
         {% include 'admin/_nav.twig' %}
       </div>
     </aside>
@@ -94,7 +94,7 @@
           <div class="uk-grid-large" uk-grid>
             <!-- Spalte 2–3: Inhalt -->
             <div class="uk-width-1-1 uk-width-2-3@m">
-              <div class="uk-card uk-card-default uk-card-body uk-margin-small">
+              <div class="uk-card qr-card uk-card-body uk-margin-small">
                 <div class="uk-flex uk-flex-between uk-flex-middle">
                   <h3 class="uk-card-title uk-margin-remove">Für heute geplant</h3>
                   <div>
@@ -119,14 +119,14 @@
 
               <div class="uk-child-width-1-2@m uk-grid-small uk-margin-small dashboard-grid" uk-grid>
                 <div>
-                  <div class="uk-card uk-card-default uk-card-body">
+                  <div class="uk-card qr-card uk-card-body">
                     <h4 class="uk-margin-remove-bottom">Teams anlegen & organisieren</h4>
                     <p class="uk-text-meta uk-margin-small-top">Erstelle Teams, generiere QR-Codes und teile Einladungen.</p>
                     <a href="{{ basePath }}/admin/teams" class="uk-link-reset uk-text-bold">Teams verwalten →</a>
                   </div>
                 </div>
                 <div>
-                  <div class="uk-card uk-card-default uk-card-body">
+                  <div class="uk-card qr-card uk-card-body">
                     <h4 class="uk-margin-remove-bottom">Auswertung & Ergebnisse</h4>
                     <p class="uk-text-meta uk-margin-small-top">Live-Ergebnisse prüfen und PDF-Berichte exportieren.</p>
                     <a href="{{ basePath }}/admin/results" class="uk-link-reset uk-text-bold">Zur Auswertung →</a>
@@ -134,7 +134,7 @@
                 </div>
               </div>
 
-              <div class="uk-card uk-card-default uk-card-body uk-margin-small">
+              <div class="uk-card qr-card uk-card-body uk-margin-small">
                 <h3 class="uk-card-title uk-margin-remove">{{ t('heading_subscription_usage') }}</h3>
                 <div data-subscription
                      data-label-plan="{{ t('label_plan') }}"
@@ -157,7 +157,7 @@
 
             <!-- Spalte 1: Kalender -->
             <div class="uk-width-1-1 uk-width-1-3@m">
-              <div class="uk-card uk-card-default uk-card-small uk-card-body uk-margin-small">
+              <div class="uk-card qr-card uk-card-small uk-card-body uk-margin-small">
                 <div class="uk-flex uk-flex-between uk-flex-middle uk-margin-small-bottom">
                   <h3 class="uk-card-title uk-margin-remove">August 2025</h3>
                   <div>
@@ -516,7 +516,7 @@
         <div class="card-grid" uk-grid id="summaryCatalogs">
           {% for c in catalogs %}
           <div class="uk-width-1-1 uk-width-1-2@s">
-            <div class="export-card uk-card uk-card-default uk-card-body">
+            <div class="export-card uk-card qr-card uk-card-body">
               {% if event.uid %}
                 {% set link = baseUrl ? baseUrl ~ '/?event=' ~ event.uid ~ '&katalog=' ~ c.slug : '?event=' ~ event.uid ~ '&katalog=' ~ c.slug %}
               {% else %}
@@ -530,7 +530,7 @@
           </div>
           {% else %}
           <div class="uk-width-1-1">
-            <div class="export-card uk-card uk-card-default uk-card-body">{{ t('text_no_catalogs') }}</div>
+            <div class="export-card uk-card qr-card uk-card-body">{{ t('text_no_catalogs') }}</div>
           </div>
           {% endfor %}
         </div>
@@ -539,7 +539,7 @@
         <div class="card-grid" uk-grid id="summaryTeams">
           {% for t in teams %}
           <div class="uk-width-1-1 uk-width-1-2@s">
-            <div class="export-card uk-card uk-card-default uk-card-body uk-position-relative">
+            <div class="export-card uk-card qr-card uk-card-body uk-position-relative">
               <button class="qr-print-btn uk-icon-button uk-position-top-right" data-team="{{ t }}" uk-icon="icon: print" aria-label="QR-Code drucken"></button>
               <h4 class="uk-card-title">{{ t }}</h4>
               <img class="qr-img" src="{{ basePath }}/qr/team?t={{ t|url_encode }}" alt="Team QR" width="96" height="96">
@@ -548,7 +548,7 @@
           </div>
           {% else %}
           <div class="uk-width-1-1">
-            <div class="export-card uk-card uk-card-default uk-card-body">{{ t('text_no_data') }}</div>
+            <div class="export-card uk-card qr-card uk-card-body">{{ t('text_no_data') }}</div>
           </div>
           {% endfor %}
         </div>
@@ -1051,7 +1051,7 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_subscription') }}</h2>
         {% set hasCustomer = tenant and tenant.stripe_customer_id %}
-        <div class="uk-card uk-card-default uk-card-body uk-margin-small" id="subscription-card">
+        <div class="uk-card qr-card uk-card-body uk-margin-small" id="subscription-card">
           <div id="subscription-details"
             data-label-plan="{{ t('label_plan') }}"
             data-label-price="{{ t('label_price') }}"
@@ -1074,7 +1074,7 @@
           {% endif %}
         </div>
         {% if stripe_configured and hasCustomer %}
-        <div class="uk-card uk-card-default uk-card-body uk-margin-small">
+        <div class="uk-card qr-card uk-card-body uk-margin-small">
           <h3 class="uk-card-title uk-margin-remove">{{ t('heading_invoices') }}</h3>
           <div id="invoice-list"
                data-label-invoice="{{ t('billing_invoice') }}"

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -38,7 +38,7 @@
   {% endembed %}
   <div class="uk-grid-collapse" uk-grid>
     <aside class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
-      <div class="uk-card uk-card-default uk-card-body qr-sidebar-card">
+      <div class="uk-card qr-card uk-card-body qr-sidebar-card">
         {% include 'admin/_nav.twig' %}
       </div>
     </aside>

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -21,7 +21,7 @@
     <div class="uk-grid-match uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m" uk-grid aria-label="Veranstaltungsliste">
       {% for ev in events %}
       <div>
-        <div class="uk-card uk-card-default uk-card-hover">
+        <div class="uk-card qr-card uk-card-hover">
           <div class="uk-card-body">
             <a href="{{ basePath }}/?event={{ ev.uid }}" class="uk-link-toggle">
               <h3 class="uk-card-title">{{ ev.name }}</h3>

--- a/templates/help.twig
+++ b/templates/help.twig
@@ -18,7 +18,7 @@
   {% endembed %}
   <div class="uk-container uk-container-small">
     {% if config.inviteText %}
-    <div class="modern-info-card uk-card uk-card-default uk-card-body uk-box-shadow-medium uk-margin">
+    <div class="modern-info-card uk-card qr-card uk-card-body uk-box-shadow-medium uk-margin">
       <article class="uk-article uk-margin-remove">{{ config.inviteText|uikitify|raw }}</article>
     </div>
     {% endif %}

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -23,7 +23,7 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
-    <div class="uk-card uk-card-default uk-card-body uk-box-shadow-large uk-margin" uk-scrollspy="cls: uk-animation-fade">
+    <div class="uk-card qr-card uk-card-body uk-box-shadow-large uk-margin" uk-scrollspy="cls: uk-animation-fade">
       <div id="quiz-header" class="uk-text-center uk-margin" uk-scrollspy="cls: uk-animation-scale-up; delay: 100">
         <img id="quiz-logo" class="logo-placeholder"
              src="{% if config.logoPath %}{{ basePath ~ config.logoPath }}{% else %}{{ basePath }}/logo-160.svg{% endif %}"

--- a/templates/kataloge.twig
+++ b/templates/kataloge.twig
@@ -14,7 +14,7 @@
         <div class="uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid aria-labelledby="catalogs-heading">
             {% for katalog in kataloge %}
             <div>
-                <div class="uk-card uk-card-default uk-card-hover uk-card-body custom-card uk-margin-small-bottom">
+                <div class="uk-card qr-card uk-card-hover uk-card-body custom-card uk-margin-small-bottom">
                     <div class="uk-grid-small uk-flex-middle" uk-grid>
                         <div class="uk-width-expand">
                             <div class="uk-text-bold">{{ katalog.name }}</div>

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -14,7 +14,7 @@
   {% embed 'topbar.twig' %}{% endembed %}
 <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
   <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
-    <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+    <div class="uk-width-1-1 uk-margin-auto uk-card qr-card uk-card-body uk-box-shadow-large">
           <h3 class="uk-card-title uk-text-center">Login</h3>
           {% if reset_success %}
           <div class="uk-alert-success" uk-alert>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -93,7 +93,7 @@
             </div>
           </div>
           <div>
-            <div class="qr-mockup uk-card uk-card-default">
+            <div class="qr-mockup uk-card qr-card">
               <picture>
                 <source srcset="{{ basePath }}/img/quizrace-shot.avif" type="image/avif">
                 <img src="{{ basePath }}/img/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="QuizRace Screenshot">

--- a/templates/onboarding.twig
+++ b/templates/onboarding.twig
@@ -54,7 +54,7 @@
     <div class="uk-text-center uk-margin">
       <button class="uk-button uk-button-default" id="restartOnboarding">Neu starten</button>
     </div>
-    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1">
+    <div class="uk-card qr-card uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step1">
       <h3 class="uk-card-title">1. E-Mail eingeben und bestätigen</h3>
       <div class="uk-margin">
         <input id="email" class="uk-input" type="email" placeholder="E-Mail-Adresse" required>
@@ -64,7 +64,7 @@
       <div id="emailStatus" class="uk-margin-small-top uk-text-success" hidden></div>
     </div>
 
-    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step2" hidden>
+    <div class="uk-card qr-card uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step2" hidden>
       <h3 class="uk-card-title">2. Subdomain wählen</h3>
       <div id="verifiedHint" class="uk-alert-success" uk-alert hidden>
         <p>Deine E-Mail-Adresse wurde erfolgreich bestätigt.</p>
@@ -79,7 +79,7 @@
       <button class="uk-button uk-button-primary" id="saveSubdomain">Subdomain speichern</button>
     </div>
 
-    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-margin-auto" id="step3" hidden>
+    <div class="uk-card qr-card uk-card-body onboarding-step uk-width-1-1 uk-margin-auto" id="step3" hidden>
       <h3 class="uk-card-title">3. Rechnungsdaten</h3>
       <div class="uk-margin"><input id="imprintName" class="uk-input" type="text" placeholder="Name/Firma" required></div>
       <div class="uk-margin"><input id="imprintStreet" class="uk-input" type="text" placeholder="Straße und Hausnummer" required></div>
@@ -90,7 +90,7 @@
       <button class="uk-button uk-button-primary" id="saveImprint">Weiter</button>
     </div>
 
-    <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-margin-auto" id="step4" hidden>
+    <div class="uk-card qr-card uk-card-body onboarding-step uk-width-1-1 uk-margin-auto" id="step4" hidden>
       <h3 class="uk-card-title">4. Tarif wählen</h3>
       {% if stripe_configured and stripe_pricing_table_id %}
       <p>Wähle einen Tarif und schließe die Zahlung über Stripe ab. Du kannst jeden kostenpflichtigen Tarif 7 Tage lang kostenlos testen.</p>
@@ -109,7 +109,7 @@
       {% endif %}
     </div>
 
-      <div class="uk-card uk-card-default uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step5" hidden>
+      <div class="uk-card qr-card uk-card-body onboarding-step uk-width-1-1 uk-width-1-2@m uk-margin-auto" id="step5" hidden>
         <h3 class="uk-card-title">5. App erstellen</h3>
         <p>Deine App wird erstellt. Bitte warten …</p>
         <ul id="task-status" class="uk-list uk-text-left uk-margin"></ul>

--- a/templates/password_confirm.twig
+++ b/templates/password_confirm.twig
@@ -14,7 +14,7 @@
   {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
     <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
-      <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+      <div class="uk-width-1-1 uk-margin-auto uk-card qr-card uk-card-body uk-box-shadow-large">
         <h3 class="uk-card-title uk-text-center">Neues Passwort</h3>
           {% if success %}
           <div class="uk-alert-success" uk-alert>

--- a/templates/password_request.twig
+++ b/templates/password_request.twig
@@ -14,7 +14,7 @@
   {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
     <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
-      <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+      <div class="uk-width-1-1 uk-margin-auto uk-card qr-card uk-card-body uk-box-shadow-large">
         <h3 class="uk-card-title uk-text-center">Passwort zurücksetzen</h3>
         {% if success %}
         <div class="uk-alert-success" uk-alert>

--- a/templates/profile.twig
+++ b/templates/profile.twig
@@ -14,7 +14,7 @@
   {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
     <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
-      <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+      <div class="uk-width-1-1 uk-margin-auto uk-card qr-card uk-card-body uk-box-shadow-large">
         <h3 class="uk-card-title uk-text-center">{{ t('title_profile') }}</h3>
         <form id="profile-form" class="uk-form-stacked">
           <div class="uk-margin">

--- a/templates/register.twig
+++ b/templates/register.twig
@@ -14,7 +14,7 @@
   {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-flex uk-flex-center uk-margin-large-top">
     <div class="uk-width-1-1@s uk-width-1-2@m uk-width-1-3@l">
-      <div class="uk-width-1-1 uk-margin-auto uk-card uk-card-default uk-card-body uk-box-shadow-large">
+      <div class="uk-width-1-1 uk-margin-auto uk-card qr-card uk-card-body uk-box-shadow-large">
         <h3 class="uk-card-title uk-text-center">Registrieren</h3>
         {% if not allowed %}
         <div class="uk-alert-danger" uk-alert>


### PR DESCRIPTION
## Summary
- drop `uk-card-default` and `uk-card-muted` in favour of a project-specific `qr-card`
- style new `qr-card` class across themes and remove UIkit default backgrounds

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, etc.; 25 errors, 8 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a1411654832bba14e8a76dace73e