### PR TITLE
Add example section after dark hero template

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -29,3 +29,5 @@ Weitere Funktionen wie der QR-Code-Login mit Namensspeicherung oder der Wettkamp
 ## Statische Seiten bearbeiten
 
 Im Tab **Seiten** können Administratoren die HTML-Dateien `landing`, `impressum`, `datenschutz` und `faq` anpassen. Über das Untermenü wird die gewünschte Seite ausgewählt und im **Trumbowyg**-Editor bearbeitet. Zusätzlich stehen eigene UIkit-Blöcke zur Verfügung, etwa ein Hero-Abschnitt oder eine Card. Mit **Speichern** werden die Änderungen im Ordner `content/` abgelegt. Die Schaltfläche *Vorschau* zeigt den aktuellen Stand direkt im Modal an. Alternativ kann der Editor weiterhin über `/admin/pages/{slug}` aufgerufen werden.
+
+Wird die dunkle Hero-Vorlage (`uk-section-primary uk-light`) genutzt, sollte anschließend ein Abschnitt mit einer Hintergrundklasse wie `section--alt` eingefügt werden, damit der Seitenhintergrund wieder aufgehellt wird.

--- a/public/js/trumbowyg-pages.js
+++ b/public/js/trumbowyg-pages.js
@@ -27,7 +27,14 @@ $.extend(true, $.trumbowyg, {
                   <h1 class="uk-heading-large">Hero-Titel</h1>
                   <p class="uk-text-lead">Introtext</p>
                 </div>
-              </div>`);
+              </div>
+              <!-- Beispiel: Abschnitt mit alternierender Hintergrundfarbe -->
+              <section class="uk-section section--alt">
+                <div class="uk-container">
+                  <h2>Abschnittstitel</h2>
+                  <p>Inhalt hier</p>
+                </div>
+              </section>`);
           },
           title: 'UIkit Hero'
         });


### PR DESCRIPTION
## Summary
- extend `uikit-hero` template in page editor with sample follow-up section
- document that dark hero blocks should be followed by an alternative background section

## Testing
- `composer test` *(fails: process hangs after PHPUnit output)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a143fa8c832b91727a5c36205cea