### PR TITLE
fix: remove redundant nullsafe operator

### DIFF
--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -157,7 +157,7 @@ class StripeService
                 $plan = (string) $session->metadata['plan'];
             } else {
                 $item = $session->line_items->data[0] ?? null;
-                $priceId = $item?->price?->id ?? '';
+                $priceId = $item?->price->id ?? '';
                 if ($priceId !== '') {
                     $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
                     $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';


### PR DESCRIPTION
## Summary
- avoid redundant nullsafe access in StripeService to satisfy phpstan

## Testing
- `vendor/bin/phpcs src/Service/StripeService.php`
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `vendor/bin/phpunit --no-progress --colors=never` *(fails: missing STRIPE environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a5755c00832b9fe08c4ade9efffc