### PR TITLE
Fix dark mode icons in admin login dialog

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -172,7 +172,8 @@ body .onboarding-timeline .timeline-step.completed {
 }
 
 body .uk-icon,
-body .uk-icon-button {
+body .uk-icon-button,
+body .uk-form-icon {
   color: #f5f5f5;
 }
 
@@ -508,7 +509,8 @@ body[data-theme="dark"] .pricing-grid .uk-card-quizrace h3 {
 }
 
 body[data-theme="dark"] .uk-icon,
-body[data-theme="dark"] .uk-icon-button {
+body[data-theme="dark"] .uk-icon-button,
+body[data-theme="dark"] .uk-form-icon {
   color: #f5f5f5;
 }
 


### PR DESCRIPTION
## Summary
- Ensure form icons render correctly in dark mode by styling `.uk-form-icon`

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ab27a604832b866363de2e405922