### PR TITLE
feat: default landing page to dark mode

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -13,8 +13,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const helpBtn = document.getElementById('helpBtn');
 
   const storedTheme = localStorage.getItem('darkMode');
-  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-  let dark = storedTheme === 'true' || (storedTheme === null && prefersDark);
+  let dark = storedTheme !== 'false';
 
   if (darkStylesheet) {
     darkStylesheet.toggleAttribute('disabled', !dark);

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -70,8 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const moonSVG = `<svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="currentColor"></path></svg>`;
 
   const stored = localStorage.getItem('qr-theme');
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  let theme = stored || (prefersDark ? 'dark' : 'light');
+  let theme = stored || 'dark';
 
   const apply = () => {
     document.documentElement.dataset.theme = theme;

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -16,7 +16,9 @@
   <link rel="stylesheet" href="{{ basePath }}/css/topbar.landing.css">
 {% endblock %}
 
-{% block body_class %}qr-landing{% endblock %}
+{% block body_theme %}dark{% endblock %}
+
+{% block body_class %}qr-landing dark-mode{% endblock %}
 
 {% block body %}
   <div class="landing-content">


### PR DESCRIPTION
## Summary
- set marketing landing page to render in dark mode by default
- default theme scripts to dark when no preference stored

## Testing
- `composer test` *(fails: Missing STRIPE env vars; Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aeadaff4832b91293b3e2207a800