### PR TITLE
Define dark mode CSS variables

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -320,8 +320,15 @@ body .uk-accordion-content {
 body[data-theme="dark"] {
   background-color: #000 !important;
   color: #f5f5f5;
+  --color-bg: #1e1e1e;
+  --color-primary: #0c86d0;
+  --color-text: #f5f5f5;
   --danger-500: #ff6b6b;
   --danger-600: #ff4c4c;
+  --qr-card: #1e1e1e;
+  --qr-border: rgba(255, 255, 255, 0.1);
+  --qr-card-border: var(--qr-border);
+  --qr-bg-soft: #161b22;
 }
 body[data-theme="dark"] a {
   color: var(--accent-color, #9dc6ff);


### PR DESCRIPTION
## Summary
- Ensure `body[data-theme="dark"]` defines all theme variables for consistent styling

## Testing
- ⚠️ `vendor/bin/phpunit` *(hung due to missing Stripe environment variables)*
- ✅ `python3 tests/test_html_validity.py`
- ✅ `python3 tests/test_json_validity.py`
- ✅ `node tests/test_competition_mode.js`
- ✅ `node tests/test_results_rankings.js`
- ✅ `node tests/test_random_name_prompt.js`
- ✅ `node tests/test_onboarding_plan.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5aeb7fdc8832bac6e228d77615382