### PR TITLE
Fix QR card colors for manual dark theme

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -322,6 +322,9 @@ body[data-theme="dark"] {
   color: #f5f5f5;
   --danger-500: #ff6b6b;
   --danger-600: #ff4c4c;
+  --qr-card: #1e1e1e;
+  --qr-border: rgba(255, 255, 255, 0.1);
+  --qr-card-border: var(--qr-border);
 }
 body[data-theme="dark"] a {
   color: var(--accent-color, #9dc6ff);


### PR DESCRIPTION
## Summary
- ensure QR card variables are set when using `data-theme="dark"`

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aec2e710832b9d90305cedcd7938