### PR TITLE
Add scenario pill section after hero

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -65,6 +65,50 @@ body.qr-landing { color: var(--qr-fg); }
 .qr-landing .uk-section { background: transparent; }
 .qr-landing .section--alt { background: var(--qr-bg-soft); color: var(--qr-fg); }
 
+/* Divider zwischen Sektionen */
+.section-divider{
+  height:1px;
+  background:linear-gradient(90deg, transparent, var(--qr-border), transparent);
+  opacity:.5;
+}
+
+/* Eyebrow/Überzeile */
+.eyebrow{
+  display:inline-block;
+  font-size:12px;
+  letter-spacing:.12em;
+  text-transform:uppercase;
+  opacity:.7;
+  border:1px solid var(--qr-border);
+  padding:4px 8px;
+  border-radius:999px;
+}
+
+/* Pill-Cloud */
+.pill-list{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px 12px;
+  justify-content:center;
+  list-style:none;
+  margin:24px 0 0;
+  padding:0;
+}
+.pill{
+  background:color-mix(in oklab, var(--qr-brand-400) 20%, var(--qr-card));
+  border:1px solid var(--qr-border);
+  border-radius:999px;
+  padding:8px 14px;
+  line-height:1;
+  box-shadow:0 1px 0 rgba(0,0,0,.08) inset;
+  transition:transform .08s ease, background .2s ease;
+  white-space:nowrap;
+}
+.pill:hover{
+  transform:translateY(-1px);
+  background:color-mix(in oklab, var(--qr-brand-400) 28%, var(--qr-card));
+}
+
 /* Karten/Kacheln auf der Landing (UIKit gezielt überstimmen) */
 .qr-landing .uk-card,
 .qr-landing .qr-card,

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -105,6 +105,43 @@
         </div>
       </div>
     </section>
+    <div class="section-divider"></div>
+
+    <section class="uk-section section--alt uk-padding-remove-top">
+      <div class="uk-container uk-padding">
+        <div class="uk-text-center uk-margin-small-bottom">
+          <span class="eyebrow">Einsatzszenarien</span>
+          <h2 class="uk-margin-small-top">Wo QuizRace glänzt</h2>
+          <p class="uk-text-lead uk-margin-small-top">
+            Von der spontanen Team-Challenge bis zur großen Stadtrallye – in Minuten startklar.
+          </p>
+        </div>
+
+        <div class="pill-cloud" uk-grid uk-scrollspy="target: .pill; cls: uk-animation-fade; delay: 60">
+          <div class="uk-width-1-1">
+            <ul class="pill-list">
+              <li class="pill">Schnitzeljagd</li>
+              <li class="pill">Teamtag</li>
+              <li class="pill">Schulfeier</li>
+              <li class="pill">Stadtrallye</li>
+              <li class="pill">Messe-Leadspiel</li>
+              <li class="pill">Onboarding</li>
+              <li class="pill">Kick-off</li>
+              <li class="pill">Sommerfest</li>
+              <li class="pill">Weihnachtsfeier</li>
+              <li class="pill">Workshop-Icebreaker</li>
+              <li class="pill">Tag der offenen Tür</li>
+              <li class="pill">Vereinsfest</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="uk-text-center uk-margin-top">
+          <a class="uk-button uk-button-primary" href="#pricing">Jetzt Szenario auswählen</a>
+          <a class="uk-button uk-button-default uk-margin-small-left" href="#features">Alle Features</a>
+        </div>
+      </div>
+    </section>
 
     {{ content|raw }}
   </div>


### PR DESCRIPTION
## Summary
- add scenario pill section after hero with CTA links
- style new section with divider, eyebrow, and pill cloud

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY...)*
- `vendor/bin/phpunit`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5b3b2b408832babb5f9d1c0ca96a6