### PR TITLE
Replace AVIF source with SSL SVG icon

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -96,10 +96,12 @@
           </div>
           <div>
             <div class="qr-mockup uk-card qr-card">
-              <picture>
-                <source srcset="{{ basePath }}/img/quizrace-shot.avif" type="image/avif">
-                <img src="{{ basePath }}/img/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="QuizRace Screenshot">
-              </picture>
+              <svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <title>SSL secure</title>
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+                <circle cx="12" cy="16" r="2"></circle>
+              </svg>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace quiz screenshot AVIF source with inline SSL padlock SVG on landing page

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and related Stripe environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b48b78e0832b9775dfd8a6aa3b0c