### PR TITLE
Refine landing scenario block

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -86,29 +86,36 @@ body.qr-landing { color: var(--qr-fg); }
   border-radius:999px;
 }
 
-/* Pill-Cloud */
-.pill-list{
+/* Szenarien als Outline-Pills */
+.scenario-cloud{
+  --pill-bg: transparent;
+  --pill-border: var(--qr-border);
+  --pill-fg: color-mix(in oklab, var(--qr-fg) 85%, transparent);
   display:flex;
   flex-wrap:wrap;
-  gap:10px 12px;
+  gap:8px 10px;
   justify-content:center;
-  list-style:none;
-  margin:24px 0 0;
+  max-width:1100px;
+  margin:18px auto 0;
   padding:0;
+  list-style:none;
 }
-.pill{
-  background:color-mix(in oklab, var(--qr-brand-400) 20%, var(--qr-card));
-  border:1px solid var(--qr-border);
-  border-radius:999px;
-  padding:8px 14px;
-  line-height:1;
-  box-shadow:0 1px 0 rgba(0,0,0,.08) inset;
-  transition:transform .08s ease, background .2s ease;
+.scenario-cloud a{
+  display:inline-block;
+  padding:6px 12px;
+  line-height:1.15;
+  font-size:14px;
   white-space:nowrap;
+  border:1px solid var(--pill-border);
+  border-radius:999px;
+  background:var(--pill-bg);
+  color:var(--pill-fg);
+  text-decoration:none;
+  transition:transform .08s ease, background .2s ease, border-color .2s ease;
 }
-.pill:hover{
+.scenario-cloud a:hover{
   transform:translateY(-1px);
-  background:color-mix(in oklab, var(--qr-brand-400) 28%, var(--qr-card));
+  border-color:color-mix(in oklab, #60a5fa 40%, var(--pill-border));
 }
 
 /* Karten/Kacheln auf der Landing (UIKit gezielt überstimmen) */

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -109,39 +109,38 @@
     </section>
     <div class="section-divider"></div>
 
-    <section class="uk-section section--alt uk-padding-remove-top">
-      <div class="uk-container uk-padding">
-        <div class="uk-text-center uk-margin-small-bottom">
-          <span class="eyebrow">Einsatzszenarien</span>
-          <h2 class="uk-margin-small-top">Wo QuizRace glänzt</h2>
-          <p class="uk-text-lead uk-margin-small-top">
-            Von der spontanen Team-Challenge bis zur großen Stadtrallye – in Minuten startklar.
-          </p>
-        </div>
+    <section class="uk-section section--alt">
+      <div class="uk-container uk-text-center">
+        <span class="eyebrow" aria-hidden="true">Einsatzszenarien</span>
+        <h2 class="uk-margin-small">Wo QuizRace glänzt</h2>
+        <p class="uk-text-lead uk-margin-small">
+          Von der spontanen Team-Challenge bis zur großen Stadtrallye – in Minuten startklar.
+        </p>
 
-        <div class="pill-cloud" uk-grid uk-scrollspy="target: .pill; cls: uk-animation-fade; delay: 60">
-          <div class="uk-width-1-1">
-            <ul class="pill-list">
-              <li class="pill">Schnitzeljagd</li>
-              <li class="pill">Teamtag</li>
-              <li class="pill">Schulfeier</li>
-              <li class="pill">Stadtrallye</li>
-              <li class="pill">Messe-Leadspiel</li>
-              <li class="pill">Onboarding</li>
-              <li class="pill">Kick-off</li>
-              <li class="pill">Sommerfest</li>
-              <li class="pill">Weihnachtsfeier</li>
-              <li class="pill">Workshop-Icebreaker</li>
-              <li class="pill">Tag der offenen Tür</li>
-              <li class="pill">Vereinsfest</li>
-            </ul>
-          </div>
-        </div>
+        <ul class="scenario-cloud" aria-label="Einsatzszenarien">
+          <li><a href="/szenarien/schnitzeljagd">Schnitzeljagd</a></li>
+          <li><a href="/szenarien/teamtag">Teamtag</a></li>
+          <li><a href="/szenarien/stadtrallye">Stadtrallye</a></li>
+          <li><a href="/szenarien/schulfeier">Schulfeier</a></li>
+          <li><a href="/szenarien/sommerfest">Sommerfest</a></li>
+          <li><a href="/szenarien/messe-leadspiel">Messe-Leadspiel</a></li>
+          <li><a href="/szenarien/kickoff">Kick-off</a></li>
+          <li><a href="/szenarien/onboarding">Onboarding</a></li>
+          <li><a href="/szenarien/workshop-icebreaker">Workshop-Icebreaker</a></li>
+          <li><a href="/szenarien/tag-der-offenen-tuer">Tag der offenen Tür</a></li>
+          <li><a href="/szenarien/vereinsfest">Vereinsfest</a></li>
+          <li><a href="/szenarien/weihnachtsfeier">Weihnachtsfeier</a></li>
+          <li><a href="/szenarien/firmenjubilaeum">Firmenjubiläum</a></li>
+          <li><a href="/szenarien/networking-event">Networking-Event</a></li>
+          <li><a href="/szenarien/spendenlauf">Spendenlauf</a></li>
+          <li><a href="/szenarien/klassentreffen">Klassentreffen</a></li>
+          <li><a href="/szenarien/sportfest">Sportfest</a></li>
+          <li><a href="/szenarien/offsite">Offsite-Meeting</a></li>
+          <li><a href="/szenarien/orientierungstag">Orientierungstag</a></li>
+          <li><a href="/szenarien/kunden-event">Kunden-Event</a></li>
+        </ul>
 
-        <div class="uk-text-center uk-margin-top">
-          <a class="uk-button uk-button-primary" href="#pricing">Jetzt Szenario auswählen</a>
-          <a class="uk-button uk-button-default uk-margin-small-left" href="#features">Alle Features</a>
-        </div>
+        <a class="uk-button uk-button-primary uk-margin-top" href="#pricing">Jetzt Szenario auswählen</a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Convert "Einsatzszenarien" section to link-based outline pills and expand scenario list
- Replace pill styles with lightweight `scenario-cloud` outline links

## Testing
- ⚠️ `composer test` *(missing Stripe environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b884d0c8832bba6b97a034a420e5