### PR TITLE
Persist onboarding data on server

### DIFF
--- a/src/Controller/OnboardingEmailController.php
+++ b/src/Controller/OnboardingEmailController.php
@@ -37,6 +37,11 @@ class OnboardingEmailController
             return $response->withStatus(400);
         }
 
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION['onboarding']['email'] = $email;
+
         $token = $this->service->createToken($email);
         $base = rtrim(RouteContext::fromRequest($request)->getBasePath(), '/');
         $uri = $request->getUri()
@@ -70,6 +75,12 @@ class OnboardingEmailController
         if ($email === null) {
             return $response->withStatus(400);
         }
+
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION['onboarding']['email'] = $email;
+        $_SESSION['onboarding']['verified'] = true;
 
         $base = rtrim(RouteContext::fromRequest($request)->getBasePath(), '/');
         $uri = $request->getUri()

--- a/src/Controller/OnboardingSessionController.php
+++ b/src/Controller/OnboardingSessionController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+/**
+ * Store onboarding wizard data in the server session.
+ */
+class OnboardingSessionController
+{
+    /**
+     * Return current onboarding data as JSON.
+     */
+    public function get(Request $request, Response $response): Response
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $data = $_SESSION['onboarding'] ?? [];
+        $payload = json_encode($data, JSON_THROW_ON_ERROR);
+        $response->getBody()->write($payload);
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    /**
+     * Merge provided data into the onboarding session.
+     */
+    public function store(Request $request, Response $response): Response
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $current = $_SESSION['onboarding'] ?? [];
+        $_SESSION['onboarding'] = array_merge($current, $data);
+        return $response->withStatus(204);
+    }
+
+    /**
+     * Clear onboarding data from the session.
+     */
+    public function clear(Request $request, Response $response): Response
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        unset($_SESSION['onboarding']);
+        return $response->withStatus(204);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -68,6 +68,7 @@ use App\Controller\Marketing\ContactController;
 use App\Controller\RegisterController;
 use App\Controller\OnboardingController;
 use App\Controller\OnboardingEmailController;
+use App\Controller\OnboardingSessionController;
 use App\Controller\StripeCheckoutController;
 use App\Controller\StripeSessionController;
 use App\Controller\StripeWebhookController;
@@ -120,6 +121,7 @@ require_once __DIR__ . '/Controller/Marketing/ContactController.php';
 require_once __DIR__ . '/Controller/RegisterController.php';
 require_once __DIR__ . '/Controller/OnboardingController.php';
 require_once __DIR__ . '/Controller/OnboardingEmailController.php';
+require_once __DIR__ . '/Controller/OnboardingSessionController.php';
 require_once __DIR__ . '/Controller/StripeCheckoutController.php';
 require_once __DIR__ . '/Controller/StripeSessionController.php';
 require_once __DIR__ . '/Controller/StripeWebhookController.php';
@@ -349,6 +351,18 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/onboarding/email/status', function (Request $request, Response $response) {
         return $request->getAttribute('onboardingEmailController')->status($request, $response);
     });
+    $app->get('/onboarding/session', function (Request $request, Response $response) {
+        $controller = new OnboardingSessionController();
+        return $controller->get($request, $response);
+    });
+    $app->post('/onboarding/session', function (Request $request, Response $response) {
+        $controller = new OnboardingSessionController();
+        return $controller->store($request, $response);
+    })->add(new CsrfMiddleware());
+    $app->delete('/onboarding/session', function (Request $request, Response $response) {
+        $controller = new OnboardingSessionController();
+        return $controller->clear($request, $response);
+    })->add(new CsrfMiddleware());
     $app->get('/onboarding/tenants/{subdomain}', function (Request $request, Response $response, array $args) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(404);


### PR DESCRIPTION
## Summary
- store onboarding wizard fields in server session via new controller
- persist email verification data on backend
- replace client-side localStorage with fetch-based session persistence

## Testing
- `vendor/bin/phpunit` *(fails: process did not complete in container)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5b8b5d750832b88ec7bda1154c386