### PR TITLE
Handle onboarding fetch failures

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -347,8 +347,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         } catch (e) {
           const msg = e.message === 'no plan'
             ? 'Es wurde kein Tarif übermittelt.'
-            : 'Fehler bei der Zahlungsprüfung.';
+            : 'Zahlung nicht bestätigt – bitte erneut versuchen';
           alert(msg);
+          const url = new URL(window.location);
+          url.searchParams.delete('session_id');
+          url.searchParams.set('step', '4');
+          window.history.replaceState({}, '', url);
+          showStep(4);
           tenantFinalizing = false;
           return;
         }
@@ -626,6 +631,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         : 'Fehler: ' + e.message;
       addLog(msg);
       alert(msg);
+      const url = new URL(window.location);
+      url.searchParams.delete('session_id');
+      url.searchParams.set('step', '4');
+      window.history.replaceState({}, '', url);
+      showStep(4);
       tenantFinalizing = false;
     }
   }


### PR DESCRIPTION
## Summary
- catch failed payment status fetches during onboarding and send user back to step 4
- redirect to step 4 with an alert on general finalizeTenant errors

## Testing
- `node tests/test_onboarding_plan.js`
- `composer test` *(fails: missing Stripe env vars and PHP unit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c3b06840832b8d9f616cd1cc4397