### PR TITLE
Move hamburger menu left on landing

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -244,6 +244,16 @@ body.dark-mode .qr-landing .qr-topbar{
 }
 .qr-landing .top-cta:focus-visible{ box-shadow:0 0 0 3px var(--qr-ring); }
 
+/* Offcanvas */
+#qr-offcanvas .uk-offcanvas-close.git-btn{
+  position:absolute;
+  top:8px;
+  right:8px;
+}
+#qr-offcanvas .offcanvas-cta.git-btn{
+  width:100%;
+}
+
 /* Hero */
 .qr-landing .qr-hero.uk-section{ background:transparent !important; position:relative; overflow:hidden; }
 .qr-landing .qr-hero-bg{

--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -72,7 +72,12 @@ body:not(.dark-mode) .topbar .uk-navbar-nav>li>a{
   box-shadow:0 0 0 3px var(--topbar-focus-ring);
 }
 .git-btn svg{width:24px;height:24px;}
-.uk-navbar-toggle.git-btn{height:40px;padding:0;}
+.uk-navbar-toggle.git-btn{
+  width:40px;
+  height:40px;
+  padding:0;
+  aspect-ratio:1/1;
+}
 .uk-navbar-toggle.git-btn .uk-navbar-toggle-icon{width:24px;height:24px;}
 #offcanvas-toggle.git-btn{border-color:var(--topbar-btn-border);}
 #menuDrop{

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -27,7 +27,16 @@
     <header class="qr-topbar">
       <nav class="uk-navbar-container" uk-navbar>
         <div class="uk-navbar-left">
-          <a class="uk-navbar-item uk-logo" href="landing">QuizRace</a>
+          <div class="uk-navbar-item">
+            <button id="offcanvas-toggle"
+                    class="uk-navbar-toggle uk-hidden@m git-btn"
+                    uk-navbar-toggle-icon
+                    uk-toggle="target: #qr-offcanvas"
+                    aria-controls="qr-offcanvas"
+                    aria-expanded="false"
+                    aria-label="Menü"></button>
+            <a class="uk-logo" href="landing">QuizRace</a>
+          </div>
         </div>
         <div class="uk-navbar-right">
           <ul class="uk-navbar-nav uk-visible@m">
@@ -61,19 +70,12 @@
               </ul>
             </div>
           </div>
-          <button id="offcanvas-toggle"
-                  class="uk-navbar-toggle uk-hidden@m git-btn"
-                  uk-navbar-toggle-icon
-                  uk-toggle="target: #qr-offcanvas"
-                  aria-controls="qr-offcanvas"
-                  aria-expanded="false"
-                  aria-label="Menü"></button>
         </div>
       </nav>
     </header>
-    <div id="qr-offcanvas" uk-offcanvas="overlay: true">
+    <div id="qr-offcanvas" uk-offcanvas="overlay: true; flip: true">
       <div class="uk-offcanvas-bar">
-        <button class="uk-offcanvas-close" type="button" uk-close aria-label="Menü schließen"></button>
+        <button class="uk-offcanvas-close git-btn" type="button" uk-close aria-label="Menü schließen"></button>
         <ul class="uk-nav uk-nav-default">
           {% for link in links %}
             <li>
@@ -83,7 +85,7 @@
             </li>
           {% endfor %}
         </ul>
-        <a class="btn btn-black uk-width-1-1 uk-margin-top" href="https://demo.quizrace.app" target="_blank" rel="noopener">
+        <a class="btn btn-black uk-width-1-1 uk-margin-top git-btn offcanvas-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">
           <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt Demo starten
         </a>
       </div>


### PR DESCRIPTION
## Summary
- Move landing hamburger menu to the left of the title
- Open landing offcanvas from the right and style its buttons
- Make the hamburger toggle square

## Testing
- `vendor/bin/phpunit` *(fails: process did not complete)*
- `python3 tests/test_html_validity.py`
- `node tests/test_competition_mode.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5cd49e980832ba2bac9163166dc5b