### PR TITLE
Hide empty hamburger menu toggle

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -6,11 +6,16 @@ document.addEventListener('DOMContentLoaded', function () {
   const configMenu = document.getElementById('menuDrop');
   const offcanvasToggle = document.getElementById('offcanvas-toggle');
   const offcanvas = document.getElementById('qr-offcanvas');
+  const offcanvasHasItems = offcanvas && offcanvas.querySelector('li');
   const darkStylesheet = document.querySelector('link[href$="dark.css"]');
   const uikitStylesheet = document.querySelector('link[href*="uikit"]');
   const themeIcon = document.getElementById('themeIcon');
   const accessibilityIcon = document.getElementById('accessibilityIcon');
   const helpBtn = document.getElementById('helpBtn');
+
+  if (offcanvasToggle && !offcanvasHasItems) {
+    offcanvasToggle.hidden = true;
+  }
 
   const storedTheme = localStorage.getItem('darkMode');
   let dark = storedTheme !== 'false';
@@ -146,7 +151,7 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  if (offcanvasToggle && offcanvas) {
+  if (offcanvasToggle && offcanvasHasItems) {
     UIkit.util.on(offcanvas, 'show', () => {
       offcanvasToggle.setAttribute('aria-expanded', 'true');
     });

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -14,7 +14,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a class="uk-navbar-toggle" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+      <a class="uk-navbar-toggle git-btn" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
         <span uk-navbar-toggle-icon></span>
       </a>
       <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{% block title %}Admin{% endblock %}</title>
     <link rel="stylesheet" href="{{ basePath }}/css/uikit.min.css">
+    <link rel="stylesheet" href="{{ basePath }}/css/topbar.css">
     <script src="{{ basePath }}/js/uikit.min.js"></script>
     <script src="{{ basePath }}/js/uikit-icons.min.js"></script>
     <style>
@@ -33,7 +34,7 @@
         </div>
         <div class="uk-navbar-right">
             <a href="{{ basePath }}/logout" class="uk-button uk-button-danger uk-margin-small-right">Abmelden</a>
-            <a class="uk-navbar-toggle" href="#" uk-icon="icon: cog"></a>
+            <a class="uk-navbar-toggle git-btn" href="#" uk-icon="icon: cog"></a>
         </div>
     </nav>
 


### PR DESCRIPTION
## Summary
- hide mobile hamburger toggle if off-canvas menu has no items
- make manual admin log menu toggle square
- include topbar styles and square icon in legacy base template

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d9f611c0832bbcacfcbe91564461