### PR TITLE
Fix dark mode footer on onboarding

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -118,7 +118,7 @@ body.dark-mode {
   color: var(--qr-text);
 }
 
-html[data-theme],
+body[data-theme],
 body.qr-landing {
   background: var(--qr-hero-gradient);
   background-color: var(--qr-hero-grad-start);

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ locale() }}" data-theme="{% block body_theme %}light{% endblock %}">
+<html lang="{{ locale() }}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
@@ -50,7 +50,7 @@
   </style>
   {% endif %}
 </head>
-<body class="{% block body_class %}{% endblock %}">
+<body data-theme="{% block body_theme %}light{% endblock %}" class="{% block body_class %}{% endblock %}">
   <div class="wrapper">
     <main class="content">
       {% block body %}{% endblock %}


### PR DESCRIPTION
## Summary
- move `data-theme` attribute to `<body>` so dark mode styles cover entire page
- adjust landing CSS to respect `data-theme` on `<body>`

## Testing
- `python3 -m pytest tests/test_json_validity.py`
- `node tests/test_onboarding_plan.js`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e788bae8832bafcec6e0819838c7