### PR TITLE
Load .env variables in onboarding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,9 @@ scripts/delete_tenant.sh foo
 ```
 
 Beide Skripte lesen die Variable `DOMAIN` aus `.env` und nutzen sie
-für die vhost-Konfiguration.
+für die vhost-Konfiguration. Befindet sich im Projektverzeichnis eine `.env`,
+lädt `scripts/onboard_tenant.sh` sie automatisch und übernimmt die dort
+definierten Variablen.
 
 Das Proxy-Setup legt zudem standardmäßig ein Docker-Netzwerk namens
 `webproxy` an. Nach dem Aufruf von `scripts/create_tenant.sh` oder einem

--- a/scripts/onboard_tenant.sh
+++ b/scripts/onboard_tenant.sh
@@ -11,6 +11,14 @@ error_exit() {
   exit 1
 }
 
+SCRIPT_DIR="$(dirname "$0")"
+if [ -f "$SCRIPT_DIR/../.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$SCRIPT_DIR/../.env"
+  set +a
+fi
+
 if [ "$#" -lt 1 ]; then
   error_exit "Usage: $0 <tenant-slug>"
 fi

--- a/tests/OnboardingScriptTest.php
+++ b/tests/OnboardingScriptTest.php
@@ -45,4 +45,44 @@ class OnboardingScriptTest extends TestCase
         unlink($compose);
         rmdir(dirname($compose));
     }
+
+    public function testOnboardTenantUsesEnvFile(): void
+    {
+        $slug = 't' . bin2hex(random_bytes(3));
+        $root = dirname(__DIR__);
+        $tenantDir = $root . '/tenants';
+        if (!is_dir($tenantDir)) {
+            mkdir($tenantDir);
+        }
+
+        $stubDir = sys_get_temp_dir() . '/docker_stub_' . uniqid();
+        mkdir($stubDir);
+        file_put_contents($stubDir . '/docker', "#!/bin/sh\nexit 0\n");
+        chmod($stubDir . '/docker', 0755);
+        file_put_contents($stubDir . '/curl', "#!/bin/sh\nexit 0\n");
+        chmod($stubDir . '/curl', 0755);
+
+        $envPath = $stubDir . ':' . getenv('PATH');
+        file_put_contents($root . '/.env', "DOMAIN=example.test\nAPP_IMAGE=image\n");
+        $cmd = sprintf(
+            'PATH=%s %s/scripts/onboard_tenant.sh %s 2>&1',
+            escapeshellarg($envPath),
+            escapeshellarg($root),
+            escapeshellarg($slug)
+        );
+        exec($cmd, $output, $ret);
+        unlink($root . '/.env');
+
+        $this->assertSame(0, $ret, implode("\n", $output));
+        $compose = $root . '/tenants/' . $slug . '/docker-compose.yml';
+        $this->assertFileExists($compose);
+
+        $json = json_decode(end($output), true);
+        $this->assertIsArray($json);
+        $this->assertSame('success', $json['status'] ?? '');
+        $this->assertSame($slug, $json['slug'] ?? '');
+
+        unlink($compose);
+        rmdir(dirname($compose));
+    }
 }


### PR DESCRIPTION
## Summary
- source project `.env` in `scripts/onboard_tenant.sh`
- document automatic `.env` usage in onboarding documentation
- cover `.env` sourcing with new onboarding script test

## Testing
- `vendor/bin/phpunit tests/OnboardingScriptTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b5e944e7cc832bb93322b9a70a3167