### PR TITLE
Log onboarding background process output

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,12 @@ Welches Docker-Image dabei verwendet wird, lässt sich über die Variable `APP_I
 Dieses Tag sollte dem lokal gebauten Slim-Image entsprechen (`docker build -t <tag> .`),
 da das Onboarding-Skript diese Variable nutzt.
 
+Schlägt das Onboarding fehl, hilft ein Blick in das Log:
+
+```bash
+tail -n 50 logs/onboarding.log
+```
+
 Das Skript legt dabei eine Compose-Datei an, die analog zum Hauptcontainer
 einen PHP-Webserver auf Port `8080` startet und `VIRTUAL_PORT=8080` setzt.
 Nur so kann der `acme-companion` die HTTP-Challenge beantworten und das


### PR DESCRIPTION
## Summary
- log background process output to `logs/onboarding.log` with timestamps
- document how to inspect onboarding log in README

## Testing
- `composer install`
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e956dbd4832b91fe1dc330f23249