### PR TITLE
feat: limit onboarding task log height

### DIFF
--- a/public/css/onboarding.css
+++ b/public/css/onboarding.css
@@ -87,6 +87,11 @@ details > summary::-webkit-details-marker {
   padding: 0.5rem 1rem;
 }
 
+#task-log {
+  max-height: calc(1.5rem * 5);
+  overflow-y: auto;
+}
+
 @media (prefers-color-scheme: light) {
   .site-footer {
     background-color: var(--primary-color);

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -397,6 +397,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const li = document.createElement('li');
       li.textContent = msg;
       taskLog.appendChild(li);
+      taskLog.scrollTop = taskLog.scrollHeight;
       if (taskLogDetails) {
         taskLogDetails.open = true;
       }


### PR DESCRIPTION
## Summary
- limit task log height to roughly five lines with scroll
- auto-scroll to latest log entry in onboarding wizard

## Testing
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`
- `composer phpunit` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ecc85424832b8fadb66de7d8d20b