### PR TITLE
Add onboarding checkout cancellation handling

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -355,8 +355,16 @@ document.addEventListener('DOMContentLoaded', async () => {
       } catch (e) {
         const msg = e.message === 'no plan'
           ? 'Es wurde kein Tarif übermittelt.'
-          : 'Zahlung nicht bestätigt – bitte erneut versuchen';
+          : 'Zahlung nicht bestätigt – bitte kontaktiere uns.';
         alert(msg);
+        await fetch(withBase('/onboarding/checkout/' + encodeURIComponent(sessionId) + '/cancel'), {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'X-CSRF-Token': window.csrfToken || '',
+            'X-Requested-With': 'fetch'
+          }
+        });
         const url = new URL(window.location);
         url.searchParams.delete('session_id');
         url.searchParams.set('step', '4');

--- a/src/routes.php
+++ b/src/routes.php
@@ -376,6 +376,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RateLimitMiddleware(10, 60));
     $app->post('/onboarding/checkout', StripeCheckoutController::class);
     $app->get('/onboarding/checkout/{id}', StripeSessionController::class);
+    $app->post('/onboarding/checkout/{id}/cancel', [SubscriptionController::class, 'cancelOnboardingCheckout']);
     $app->post('/stripe/webhook', StripeWebhookController::class);
     $app->get('/login', [LoginController::class, 'show']);
     $app->post('/login', [LoginController::class, 'login']);


### PR DESCRIPTION
## Summary
- cancel failed Stripe subscriptions during onboarding
- add server endpoint and route to cancel or expire checkout sessions
- inform users and reset wizard when cancellation occurs

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ecb775e8832b891fe5d60107e6b8