### PR TITLE
Refine landing header spacing and mobile menu styles

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -331,6 +331,18 @@ body.dark-mode .qr-landing .qr-topbar{
   border-radius:6px;
 }
 .qr-landing .qr-topbar .uk-navbar-toggle{ color:var(--qr-text)!important; }
+.qr-landing .qr-topbar #offcanvas-toggle.git-btn{
+  width:56px;
+  height:56px;
+  aspect-ratio:1/1;
+  border-radius:6px;
+}
+.qr-landing .qr-topbar .uk-logo{
+  margin-left:8px;
+  font-family:'Poppins',sans-serif;
+  font-weight:700;
+  text-transform:uppercase;
+}
 .qr-landing .top-cta{
   transition:opacity .2s,transform .2s;
   display:inline-flex;
@@ -351,6 +363,7 @@ body.dark-mode .qr-landing .qr-topbar{
 }
 #qr-offcanvas .offcanvas-cta.git-btn{
   width:100%;
+  height:48px;
 }
 
 /* Hero */

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -86,7 +86,7 @@
             </li>
           {% endfor %}
         </ul>
-        <a class="btn btn-black uk-width-1-1 uk-margin-top git-btn offcanvas-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">
+        <a class="uk-button uk-button-default git-btn uk-width-1-1 uk-margin-top offcanvas-cta" href="https://demo.quizrace.app" target="_blank" rel="noopener">
           <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt Demo starten
         </a>
       </div>


### PR DESCRIPTION
## Summary
- space landing logo from the left and apply Poppins uppercase styling
- square offcanvas toggle on mobile
- use unfilled git-btn style for Demo button in mobile offcanvas
- ensure mobile hamburger toggle keeps git-btn border while remaining square

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and related environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ede3a5dc832ba934ca948a751e73