### PR TITLE
feat: add language menu to landing

### DIFF
--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -64,6 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
 document.addEventListener('DOMContentLoaded', () => {
   const themeToggles = document.querySelectorAll('.theme-toggle');
   const accessibilityToggles = document.querySelectorAll('.accessibility-toggle');
+  const langButtons = document.querySelectorAll('.lang-option');
 
   const applyTheme = () => {
     const dark = localStorage.getItem('darkMode') !== 'false';
@@ -85,5 +86,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   accessibilityToggles.forEach(btn => btn.addEventListener('click', () => {
     setTimeout(applyContrast, 0);
+  }));
+
+  langButtons.forEach(btn => btn.addEventListener('click', () => {
+    const lang = btn.dataset.lang;
+    const url = new URL(window.location.href);
+    url.searchParams.set('lang', lang);
+    window.location.href = url.toString();
   }));
 });

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -4,6 +4,7 @@ return [
     'help' => 'Hilfe',
     'design_toggle' => 'Design wechseln',
     'contrast_toggle' => 'Barrierefrei',
+    'language_toggle' => 'Sprache wechseln',
     'configuration' => 'Konfiguration',
     'help_modal_text' => 'Dark-Mode und Barrierefrei-Modus lassen sich hier im Menü umschalten. Der Barrierefrei-Modus vergrößert die Schrift für bessere Lesbarkeit. Passe Farben zentral über CSS-Variablen an (<code>--topbar-text</code>, <code>--topbar-drop-bg</code> …).',
     'quiz_progress' => 'Fortschritt des Quiz',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -4,6 +4,7 @@ return [
     'help' => 'Help',
     'design_toggle' => 'Toggle theme',
     'contrast_toggle' => 'Barrier-free mode',
+    'language_toggle' => 'Change language',
     'configuration' => 'Configuration',
     'help_modal_text' => 'Dark mode and barrier-free mode can be toggled in this menu. The barrier-free mode enlarges fonts for better readability. Adjust colors via CSS variables (<code>--topbar-text</code>, <code>--topbar-drop-bg</code> …).',
     'quiz_progress' => 'Quiz progress',

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -68,6 +68,23 @@
                     <span id="accessibilityIcon" aria-hidden="true"></span>
                   </button>
                 </li>
+                <li>
+                  <div class="uk-inline">
+                    <button id="languageMenuToggle" type="button" class="uk-button uk-button-default git-btn" aria-label="{{ t('language_toggle') }}" aria-expanded="false" role="menuitem">
+                      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm6.93 6h-2.54c-.11-1.47-.43-2.87-.92-4.17 1.84.69 3.29 2.1 4.05 3.84zM12 4c.96 1.18 1.62 2.64 1.88 4H10.12c.26-1.36.92-2.82 1.88-4zM4.26 14c-.17-.64-.26-1.31-.26-2s.09-1.36.26-2h3.09c-.07.66-.11 1.32-.11 2s.04 1.34.11 2H4.26zm.81 2h2.54c.11 1.47.43 2.87.92 4.17-1.84-.69-3.29-2.1-4.05-3.84zm2.54-8H5.07c.76-1.74 2.21-3.15 4.05-3.84-.49 1.3-.81 2.7-.92 4.17zM12 20c-.96-1.18-1.62-2.64-1.88-4h3.76c-.26 1.36-.92 2.82-1.88 4zm2.62-6H9.38c-.08-.66-.12-1.32-.12-2s.04-1.34.12-2h5.24c.08.66.12 1.32.12 2s-.04 1.34-.12 2zm.81 6c.49-1.3.81-2.7.92-4.17h2.54c-.76 1.74-2.21 3.15-4.05 3.84zM16.65 14c.07-.66.11-1.32.11-2s-.04-1.34-.11-2h3.09c.17.64.26 1.31.26 2s-.09 1.36-.26 2h-3.09z" fill="currentColor"/></svg>
+                    </button>
+                    <div id="languageDrop" class="uk-dropdown" hidden uk-dropdown="mode: click; pos: left-top; offset: 0">
+                      <ul class="uk-nav uk-dropdown-nav" role="menu">
+                        <li>
+                          <button class="uk-button uk-button-default git-btn lang-option" data-lang="de" role="menuitem">{{ t('german') }}</button>
+                        </li>
+                        <li>
+                          <button class="uk-button uk-button-default git-btn lang-option" data-lang="en" role="menuitem">{{ t('english') }}</button>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add language selector to landing config menu
- handle language switching via JavaScript
- localize language toggle label

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eeefd318832bb8bae7daecd28d9a