### PR TITLE
Fix apostrophe encoding in marketing link

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -1,7 +1,7 @@
 {% extends 'layout.twig' %}
 
 {% set links = [
-  { 'href': '#how-it-works', 'label': 'So funktioniert\u2019s', 'icon': 'settings' },
+    { 'href': '#how-it-works', 'label': 'So funktioniert’s', 'icon': 'settings' },
   { 'href': '#scenarios', 'label': 'Szenarien', 'icon': 'thumbnails' },
   { 'href': '#pricing', 'label': 'Preise', 'icon': 'credit-card' },
   { 'href': '#faq', 'label': 'FAQ', 'icon': 'question' },


### PR DESCRIPTION
## Summary
- use proper apostrophe in marketing landing page navigation label

## Testing
- `vendor/bin/phpunit` *(fails: hangs without completing)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5f10824d8832b9ffe4b88611d84c2