### PR TITLE
style: ensure black contact text in light theme

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -317,19 +317,19 @@
       <div>
         <div class="uk-grid uk-child-width-1-1 uk-grid-small">
           <div>
-            <div class="uk-card uk-card-primary uk-card-body uk-light uk-text-left padding-30px">
+            <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
               <p class="uk-margin-small-bottom uk-text-large">E-Mail</p>
               <a href="mailto:office@quizrace.app" class="uk-text-lead uk-link-reset">office@quizrace.app</a>
             </div>
           </div>
           <div>
-            <div class="uk-card uk-card-primary uk-card-body uk-light uk-text-left padding-30px">
+            <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
               <p class="uk-margin-small-bottom uk-text-large">Telefon</p>
               <a href="tel:+4933203609080" class="uk-text-lead uk-link-reset">+49 33203 609080</a>
             </div>
           </div>
           <div>
-            <div class="uk-card uk-card-primary uk-card-body uk-light uk-text-left padding-30px">
+            <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
               <p class="uk-margin-small-bottom uk-text-large">Adresse</p>
               <span class="uk-text-lead">Weidenbusch 8, 14532 Kleinmachnow</span>
             </div>

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -512,6 +512,13 @@ body[data-theme="dark"] .qr-landing .btn.btn-black.uk-button-secondary{
   box-shadow:0 10px 24px rgba(37,99,235,.20);
 }
 
+/* Contact details card */
+body.qr-landing:not([data-theme="dark"]) .contact-card,
+body.qr-landing:not([data-theme="dark"]) .contact-card a,
+body.qr-landing:not([data-theme="dark"]) .contact-card span{
+  color:#000;
+}
+
 /* Form & A11y */
 .qr-landing #contact-form .uk-input,
 .qr-landing #contact-form .uk-textarea{


### PR DESCRIPTION
## Summary
- Render contact details cards with default card styling
- Ensure contact text appears black on the landing page in light theme

## Testing
- `composer test` *(fails: Missing STRIPE_* environment vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f282b4ac832baf2cc69f9989d491