### PR TITLE
Highlight rotating hero word for marketing landing

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -115,7 +115,7 @@
         <div class="uk-grid uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
           <div>
             <span class="qr-badge">Made in Germany</span>
-            <h1 class="qr-h1">Das Team-Quiz, das Ihr Event unvergesslich macht.</h1>
+            <h1 class="qr-h1">Das Team-Quiz, das Ihr Event <span id="rotating-word">unvergesslich</span> macht.</h1>
             <p class="qr-sub">Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams. In Minuten startklar – live, vor Ort oder hybrid.</p>
             <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
               <a class="btn btn-black cta-main" href="https://demo.quizrace.app" target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary
- Wrap "unvergesslich" in the landing hero heading with a `rotating-word` span so JS can target it

## Testing
- `node - <<'NODE' ... NODE`
- `composer test` *(fails: Missing STRIPE_* env vars, nginx reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f2f93714832b8a455e6ed9ba0e14