### PR TITLE
fix: align landing button icon color with text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Tag image as sommerfest-quiz
 
+### Fix
+
+- Ensure landing button icons match text color in dark theme
+
 ### Chore
 
 - Add pages table for SEO config

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -265,6 +265,9 @@ body.qr-landing { color: var(--qr-fg); }
 .qr-landing .feature-box svg [fill="none"] {
   fill: none;
 }
+.qr-landing .uk-button .uk-icon {
+  color: currentColor;
+}
 
 /* Navbar NUR auf Landing, damit Kontrast stimmt */
 .qr-landing .uk-navbar,


### PR DESCRIPTION
## Summary
- ensure landing button icons inherit text color so they remain visible on dark theme
- document fix in changelog

## Testing
- `composer test` *(fails: PHPUnit output truncated; see log for details)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f3a5a488832b9d03921c0c81929c