### PR TITLE
Ensure hamburger menu button is square on landing page

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -336,6 +336,7 @@ body.dark-mode .qr-landing .qr-topbar{
 .qr-landing .qr-topbar #offcanvas-toggle.git-btn{
   width:56px;
   height:56px;
+  min-height:56px;
   aspect-ratio:1/1;
   border-radius:6px;
 }

--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -75,6 +75,7 @@ body:not(.dark-mode) .topbar .uk-navbar-nav>li>a{
 .uk-navbar-toggle.git-btn{
   width:40px;
   height:40px;
+  min-height:40px;
   padding:0;
   aspect-ratio:1/1;
 }


### PR DESCRIPTION
## Summary
- Override UIkit's default min-height to keep hamburger toggle square
- Match offcanvas toggle height and min-height on landing page

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f2ea258c832ba5f06a0f1dbca185