### PR TITLE
Align admin options menu to right on mobile

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -99,3 +99,10 @@ body:not(.dark-mode) .topbar .uk-navbar-nav>li>a{
 .uk-dropdown-nav, .uk-dropdown-nav *{
   color:var(--topbar-text);
 }
+
+@media (max-width: 640px) {
+  .topbar .uk-navbar-right {
+    justify-content: flex-end;
+    padding-right: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Ensure the admin topbar options menu aligns flush right on small screens

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f6c9bf10832baab1b37704647bb4