### PR TITLE
Scope footer layout to landing page only

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -46,7 +46,9 @@
 
     <footer class="uk-section uk-section-xsmall uk-footer">
         <div class="uk-container uk-text-center">
-            <span>DATENSCHUTZ</span> | <span>IMPRESSUM</span> | <span>LIZENZ</span>
+            <a href="{{ basePath }}/impressum">{{ t('imprint') }}</a> |
+            <a href="{{ basePath }}/datenschutz">{{ t('privacy') }}</a> |
+            <a href="{{ basePath }}/lizenz">{{ t('license') }}</a>
         </div>
     </footer>
 </body>

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -56,30 +56,13 @@
       {% block body %}{% endblock %}
     </main>
     <footer class="site-footer">
-      <div class="footer-columns">
-        <div class="footer-section footer-about">
-          <strong>QuizRace</strong>
-          <p>Interaktive QR-Code-Rallyes für Events &ndash; schnell startklar und datensicher.</p>
+      {% block footer %}
+        <div class="uk-text-center">
+          <a href="{{ basePath }}/impressum">{{ t('imprint') }}</a> |
+          <a href="{{ basePath }}/datenschutz">{{ t('privacy') }}</a> |
+          <a href="{{ basePath }}/lizenz">{{ t('license') }}</a>
         </div>
-        <div class="footer-section footer-contact">
-          <strong>Kontakt</strong>
-          <p>
-            René Buske<br>
-            Weidenbusch&nbsp;8<br>
-            14532&nbsp;Kleinmachnow<br>
-            <a href="mailto:office@quizrace.app">office@quizrace.app</a><br>
-            <a href="tel:+4933203609080">+49&nbsp;33203&nbsp;609080</a>
-          </p>
-        </div>
-        <div class="footer-section footer-legal">
-          <strong>Rechtliches</strong>
-          <ul>
-            <li><a href="{{ basePath }}/impressum">{{ t('imprint') }}</a></li>
-            <li><a href="{{ basePath }}/datenschutz">{{ t('privacy') }}</a></li>
-            <li><a href="{{ basePath }}/lizenz">{{ t('license') }}</a></li>
-          </ul>
-        </div>
-      </div>
+      {% endblock %}
     </footer>
   </div>
   <script src="{{ basePath }}/js/uikit.min.js" defer></script>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -146,6 +146,33 @@
   </div>
 {% endblock %}
 
+{% block footer %}
+  <div class="footer-columns">
+    <div class="footer-section footer-about">
+      <strong>QuizRace</strong>
+      <p>Interaktive QR-Code-Rallyes für Events &ndash; schnell startklar und datensicher.</p>
+    </div>
+    <div class="footer-section footer-contact">
+      <strong>Kontakt</strong>
+      <p>
+        René Buske<br>
+        Weidenbusch&nbsp;8<br>
+        14532&nbsp;Kleinmachnow<br>
+        <a href="mailto:office@quizrace.app">office@quizrace.app</a><br>
+        <a href="tel:+4933203609080">+49&nbsp;33203&nbsp;609080</a>
+      </p>
+    </div>
+    <div class="footer-section footer-legal">
+      <strong>Rechtliches</strong>
+      <ul>
+        <li><a href="{{ basePath }}/impressum">{{ t('imprint') }}</a></li>
+        <li><a href="{{ basePath }}/datenschutz">{{ t('privacy') }}</a></li>
+        <li><a href="{{ basePath }}/lizenz">{{ t('license') }}</a></li>
+      </ul>
+    </div>
+  </div>
+{% endblock %}
+
 {% block scripts %}
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/landing.js" defer></script>


### PR DESCRIPTION
## Summary
- Show simple `Impressum | Datenschutz | Lizenz` footer on all standard pages
- Keep multi-column footer exclusively on landing page
- Link to legal pages in admin layout footer

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f6ec46ec832ba0dd65261979fa43