### PR TITLE
feat: ensure btn icons match text color

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -271,6 +271,10 @@ body.qr-landing .site-footer {
   color: currentColor;
 }
 
+.qr-landing .btn .uk-icon {
+  color: currentColor;
+}
+
 /* Navbar NUR auf Landing, damit Kontrast stimmt */
 .qr-landing .uk-navbar,
 .qr-landing .uk-navbar-container {


### PR DESCRIPTION
## Summary
- ensure icons inside `.btn` elements inherit text color like `.uk-button`

## Testing
- `composer test` *(fails: Missing STRIPE_* env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fdbdfed0832b815fc58f0b29683a