### PR TITLE
Remove address card from contact section

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -319,12 +319,6 @@
               <a href="tel:+4933203609080" class="uk-text-lead uk-link-reset">+49 33203 609080</a>
             </div>
           </div>
-          <div>
-            <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
-              <p class="uk-margin-small-bottom uk-text-large">Adresse</p>
-              <span class="uk-text-lead">Weidenbusch 8, 14532 Kleinmachnow</span>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -156,8 +156,6 @@
       <strong>Kontakt</strong>
       <p>
         René Buske<br>
-        Weidenbusch&nbsp;8<br>
-        14532&nbsp;Kleinmachnow<br>
         <a href="mailto:office@quizrace.app">office@quizrace.app</a><br>
         <a href="tel:+4933203609080">+49&nbsp;33203&nbsp;609080</a>
       </p>


### PR DESCRIPTION
## Summary
- remove physical address card from landing page contact section
- drop address lines from footer contact info

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY; Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68b601ca826c832bbf4cd9a631cfc394