### PR TITLE
Update landing hero subtitle and tidy LogService imports

### DIFF
--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -8,6 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Level;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+
 use function App\runSyncProcess;
 
 /**

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -116,7 +116,8 @@
           <div>
             <span class="qr-badge">Made in Germany</span>
             <h1 class="qr-h1">Das Team-Quiz, das Ihr Event <span id="rotating-word">unvergesslich</span> macht.</h1>
-            <p class="qr-sub">Interaktive Quiz-Rallyes für Firmen, Schulen &amp; Teams. In Minuten startklar – live, vor Ort oder hybrid.</p>
+            <p class="qr-sub">Interaktive Quiz-Rallyes für jedes Event – vom Kindergeburtstag bis zur Firmenfeier.
+            In Minuten startklar – live, vor Ort oder hybrid.</p>
             <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
               <a class="btn btn-black cta-main" href="https://demo.quizrace.app" target="_blank" rel="noopener">
                 <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt Demo starten


### PR DESCRIPTION
## Summary
- Rephrase hero subtitle on landing page to emphasize suitability for any event
- Add missing blank line between class and function imports in LogService

## Testing
- `./vendor/bin/phpcs src/`
- `./vendor/bin/phpstan analyse src/`
- `STRIPE_SECRET_KEY=1 STRIPE_PUBLISHABLE_KEY=1 STRIPE_PRICE_STARTER=1 STRIPE_PRICE_STANDARD=1 STRIPE_PRICE_PROFESSIONAL=1 STRIPE_PRICING_TABLE_ID=1 STRIPE_WEBHOOK_SECRET=1 ./vendor/bin/phpunit --stop-on-error` *(fails: Unknown "t" function in base.twig)*

------
https://chatgpt.com/codex/tasks/task_e_68b603164ba0832bbccc9a9be17757a7