### PR TITLE
ci: rebase changelog update before push

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -45,4 +45,5 @@ jobs:
             echo "Changelog unchanged" && exit 0
           fi
           git commit -m "docs: update changelog [skip ci]"
+          git pull --rebase origin main
           git push https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git HEAD:main


### PR DESCRIPTION
## Summary
- rebase changelog updates on latest main before pushing

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b6079da8c8832ba27ae0392c8b05f7