### PR TITLE
feat: add mobile-friendly Usecases CTA button

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -344,7 +344,9 @@
     </script>
 
     <div class="uk-text-center uk-margin-large">
-      <a class="uk-button uk-button-primary uk-button-large" href="{{ basePath }}/onboarding">Use-Case auswählen &amp; starten</a>
+      <a class="cta-ghost uk-button uk-button-large" href="{{ basePath }}/onboarding">
+        Idee gefunden – los geht’s
+      </a>
     </div>
   </div>
 </section>

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -501,6 +501,32 @@ body.dark-mode .qr-landing .qr-badge{
   opacity:.85;
   transform:translateY(-1px);
 }
+.cta-ghost{
+  display:inline-block;
+  border:2px solid var(--qr-blue,#2F81F7);
+  color:var(--qr-blue,#2F81F7)!important;
+  background:transparent;
+  border-radius:12px;
+  font-weight:600;
+  font-size:1.05rem;
+  text-transform:none; /* kein ALL CAPS */
+  letter-spacing:0.2px;
+  padding:0.8em 1.6em;
+  transition:all .25s ease-in-out;
+}
+.cta-ghost:hover,
+.cta-ghost:focus{
+  background:var(--qr-blue,#2F81F7);
+  color:#fff!important;
+  box-shadow:0 6px 18px rgba(47,129,247,.35);
+  text-decoration:none;
+}
+@media (max-width: 640px) {
+  .cta-ghost{
+    display:block;
+    width:100%;
+  }
+}
 body.qr-landing:not(.dark-mode) .btn.btn-black.uk-button-secondary{
   background-color:#e5e7eb;
   color:var(--qr-landing-text);


### PR DESCRIPTION
## Summary
- replace Usecases button with "Idee gefunden – los geht’s" CTA
- style new `.cta-ghost` button and make it full width on small screens

## Testing
- `vendor/bin/phpunit` *(fails: Missing STRIPE_* environment variables)*
- `python3 tests/test_html_validity.py`
- `pytest tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`


------
https://chatgpt.com/codex/tasks/task_e_68b60bdc808c832b8adcd4d3560938f5