### PR TITLE
Emphasize active slider card on landing page

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -322,9 +322,14 @@
       document.addEventListener('DOMContentLoaded', () => {
         const slider = UIkit.slider('#scenario-slider');
         const pills = Array.from(document.querySelectorAll('#scenario-nav > li'));
+        const slides = Array.from(document.querySelectorAll('.usecase-slider > li'));
 
         function setActive(index) {
           pills.forEach((li, i) => li.classList.toggle('uk-active', i === index));
+        }
+
+        function setCurrent(index) {
+          slides.forEach((li, i) => li.classList.toggle('uk-current', i === index));
         }
 
         pills.forEach((li, i) => {
@@ -332,14 +337,17 @@
             e.preventDefault();
             slider.show(i);
             setActive(i);
+            setCurrent(i);
           });
         });
 
         UIkit.util.on('#scenario-slider', 'itemshown', () => {
           setActive(slider.index);
+          setCurrent(slider.index);
         });
 
         setActive(0);
+        setCurrent(0);
       });
     </script>
 

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -243,17 +243,17 @@ body.qr-landing .site-footer {
   height:100%;
 }
 
-.usecase-slider li.uk-active{
+.usecase-slider li.uk-current{
   z-index:1;
 }
 
-.usecase-slider li.uk-active .uk-card-quizrace{
-  transform:scale(1.05);
+.usecase-slider li.uk-current .uk-card-quizrace{
+  transform:scale(1.08);
   box-shadow:0 12px 28px rgba(0,0,0,.08);
 }
 
-.usecase-slider li.uk-active .uk-card-quizrace:hover{
-  transform:scale(1.05) translateY(-2px);
+.usecase-slider li.uk-current .uk-card-quizrace:hover{
+  transform:scale(1.08) translateY(-2px);
 }
 
 /* Karten/Kacheln auf der Landing (UIKit gezielt überstimmen) */


### PR DESCRIPTION
## Summary
- Make center card in landing slider stand out with scaling and shadow
- Add JavaScript to track and highlight current slide

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b60c5acc44832b97f06d5d2b9535e1