### PR TITLE
Align contact cards with form top

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -484,7 +484,7 @@
     <h3 class="uk-heading-medium uk-text-center" uk-scrollspy="cls: uk-animation-slide-top-small">Kontaktieren Sie uns – persönlich &amp; praxisnah</h3>
     <p class="uk-text-lead uk-text-center" uk-scrollspy="cls: uk-animation-fade; delay: 150">Sie möchten QuizRace testen, ein Angebot anfordern oder haben individuelle Fragen?<br>
     Schreiben Sie uns – wir melden uns garantiert persönlich zurück!</p>
-    <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-middle" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
+    <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
       <div>
         <form id="contact-form" class="uk-form-stacked uk-width-large uk-margin-auto">
           <div class="uk-margin">
@@ -509,6 +509,7 @@
       </div>
       <div>
         <div class="uk-grid uk-child-width-1-1 uk-grid-small">
+          <div><div class="uk-form-label" aria-hidden="true">&nbsp;</div></div>
           <div>
             <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
               <p class="uk-margin-small-bottom uk-text-large">E-Mail</p>


### PR DESCRIPTION
## Summary
- Align the contact information grid with the top of the contact form by switching to `uk-flex-top`.
- Insert a spacer above the email contact card equal to the "Ihr Name" label height so both blocks begin at the same level.

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b60d44bad8832bb3a503166456e6f8