### PR TITLE
Remove 7-day free trial from subscription feature lists

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -407,7 +407,6 @@
           <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">9&nbsp;€/Monat</div>
           <div class="uk-text-meta uk-margin-small-bottom">Für kleine Events &amp; Einsteiger</div>
           <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom">
-            <li><b>7 Tage kostenlos testen</b></li>
             <li><b>1 Event gleichzeitig</b></li>
             <li>5 Teams &amp; 5 Kataloge à 5 Fragen</li>
             <li>Unbegrenzte Teilnehmende pro Team¹</li>
@@ -426,7 +425,6 @@
           <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">39&nbsp;€/Monat</div>
           <div class="uk-text-meta uk-margin-small-bottom">Beliebt bei Schulen &amp; Teams</div>
           <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom">
-            <li><b>7 Tage kostenlos testen</b></li>
             <li><b>Alle Starter-Funktionen</b></li>
             <li>Bis zu 3 Events gleichzeitig</li>
             <li>10 Teams &amp; 10 Kataloge à 10 Fragen</li>
@@ -444,7 +442,6 @@
           <div class="uk-text-xxlarge uk-margin-small-bottom" style="font-weight:700;">79&nbsp;€/Monat</div>
           <div class="uk-text-meta uk-margin-small-bottom">Für Agenturen &amp; Unternehmen</div>
           <ul class="uk-list uk-list-large uk-text-left uk-margin-small-bottom">
-            <li><b>7 Tage kostenlos testen</b></li>
             <li><b>Alle Standard-Funktionen</b></li>
             <li>20 Events gleichzeitig (mehr auf Anfrage)</li>
             <li>100 Teams &amp; 50 Kataloge à 50 Fragen</li>

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1104,17 +1104,14 @@
                   <th scope="col">
                     {{ t('plan_starter') }}<br>
                     <div class="uk-text-large">9&nbsp;€/Monat</div>
-                    <div class="uk-text-meta">7 Tage kostenlos testen</div>
                   </th>
                   <th scope="col">
                     {{ t('plan_standard') }}<br>
                     <div class="uk-text-large">39&nbsp;€/Monat</div>
-                    <div class="uk-text-meta">7 Tage kostenlos testen</div>
                   </th>
                   <th scope="col">
                     {{ t('plan_professional') }}<br>
                     <div class="uk-text-large">79&nbsp;€/Monat</div>
-                    <div class="uk-text-meta">7 Tage kostenlos testen</div>
                   </th>
                 </tr>
               </thead>


### PR DESCRIPTION
## Summary
- remove "7 Tage kostenlos testen" bullet from all subscription plans on landing page
- drop 7-day free trial note from admin plan comparison table

## Testing
- `composer test` *(fails: process produced no summary; initial phpunit output `E..........`)*

------
https://chatgpt.com/codex/tasks/task_e_68b61290c430832b89eecaf95f2c8e1f