### PR TITLE
Center start button text on landing page

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -502,7 +502,9 @@ body.dark-mode .qr-landing .qr-badge{
   transform:translateY(-1px);
 }
 .cta-ghost{
-  display:inline-block;
+  display:flex;
+  align-items:center;
+  justify-content:center;
   border:2px solid var(--qr-blue,#2F81F7);
   color:var(--qr-blue,#2F81F7)!important;
   background:transparent;
@@ -523,7 +525,6 @@ body.dark-mode .qr-landing .qr-badge{
 }
 @media (max-width: 640px) {
   .cta-ghost{
-    display:block;
     width:100%;
   }
 }


### PR DESCRIPTION
## Summary
- Center the "Jetzt starten" CTA text horizontally and vertically using flexbox
- Keep button full width on small screens without overriding flex layout

## Testing
- `vendor/bin/phpunit` *(fails: process hangs after reporting an error)*

------
https://chatgpt.com/codex/tasks/task_e_68b6136932fc832bb30ffb7a6da313fc