### PR TITLE
fix admin dark mode background

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -41,6 +41,13 @@ body .uk-card h3,
 body .uk-card p {
   color: #f5f5f5;
 }
+body[data-theme="dark"] .wrapper,
+body[data-theme="dark"] .content,
+body[data-theme="dark"] .uk-background-muted,
+body[data-theme="dark"] .uk-background-default {
+  background-color: #000 !important;
+  color: #f5f5f5;
+}
 body .uk-progress {
   background-color: #333;
   color: var(--accent-color, #1e87f0);


### PR DESCRIPTION
## Summary
- ensure admin dark mode backgrounds fill the entire page

## Testing
- `phpunit` *(fails: Errors: 26, Failures: 8)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`


------
https://chatgpt.com/codex/tasks/task_e_68b67bd8bc40832b887a00d20d656373