### PR TITLE
Run onboarding synchronously and expose onboarding logs

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -475,16 +475,15 @@ document.addEventListener('DOMContentLoaded', async () => {
       } catch (_) {
         data = undefined;
       }
-      if (res.status === 202 && (!body || !data)) {
-        addLog('Server akzeptierte die Anfrage, lieferte jedoch keine Rückmeldung.');
-        return false;
-      }
-      if (!res.ok || !data || data.status !== 'queued') {
+      if (!res.ok) {
         const msg = data && data.error ? data.error : body || 'onboard';
         addLog('Fehler beim Onboarding: ' + msg);
         throw new Error(msg);
       }
-      addLog('Onboarding gestartet …');
+      if (data && data.log) {
+        addLog(data.log);
+      }
+      addLog('Onboarding abgeschlossen …');
       return true;
     };
 

--- a/scripts/create_tenant.sh
+++ b/scripts/create_tenant.sh
@@ -102,7 +102,7 @@ fi
 HTTP_STATUS=$(curl -s -o /tmp/onboard.out -w "%{http_code}" -b "$COOKIE_FILE" -X POST \
   "$API_BASE/api/tenants/${SUBDOMAIN}/onboard")
 CURL_EXIT=$?
-if [ "$CURL_EXIT" -ne 0 ] || [ "$HTTP_STATUS" -ge 400 ]; then
+if [ "$CURL_EXIT" -ne 0 ] || [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
   echo "Tenant onboarding failed (status $HTTP_STATUS): $(cat /tmp/onboard.out 2>/dev/null)" >&2
   rm -f /tmp/onboard.out "$COOKIE_FILE"
   exit 1


### PR DESCRIPTION
## Summary
- Run tenant onboarding script synchronously and check for docker-compose file
- Return onboarding log and stderr on failure
- Ensure callers treat non-2xx onboarding responses as errors

## Testing
- `composer test` *(fails: Tests: 277, Assertions: 603, Errors: 26, Failures: 8)*

------
https://chatgpt.com/codex/tasks/task_e_68b6802ec5a4832b99fc5a51dbecb776