### PR TITLE
Sync player state with session storage on catalog init

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -629,14 +629,14 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       sessionStorage.removeItem('quizSolved');
       localStorage.removeItem(playerNameKey);
     }
-    [playerNameKey,'quizCatalog'].forEach(k => {
+    [playerNameKey, 'quizCatalog', 'quizSolved'].forEach(k => {
       const v = localStorage.getItem(k);
       if(v && !sessionStorage.getItem(k)){
         sessionStorage.setItem(k, v);
       }
     });
-    applyConfig();
     updateUserName();
+    applyConfig();
     const catalogs = await loadCatalogList();
     const params = new URLSearchParams(window.location.search);
     const id = params.get('katalog');


### PR DESCRIPTION
## Summary
- Ensure player name, catalog selection, and solved state are copied from localStorage to sessionStorage before configuration is applied
- Invoke `updateUserName` right after synchronization so the team name is shown immediately

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b685951c20832bba26bf778fd8b19f