### PR TITLE
Fix topbar player name visibility in light mode

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -36,6 +36,10 @@ body[data-theme="dark"].high-contrast{
   --topbar-focus-ring: rgba(140,200,255,0.8);
 }
 
+#topbar-title {
+  color: var(--topbar-text);
+}
+
 /* Buttons in der Topbar */
 .topbar .uk-button,
 .topbar .uk-navbar-nav>li>a{


### PR DESCRIPTION
## Summary
- ensure topbar player label uses `--topbar-text` so it's visible in light mode

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d188a9f4832baa5b297c9e80a473