### PR TITLE
refactor: derive base url from request

### DIFF
--- a/src/Controller/AdminCatalogController.php
+++ b/src/Controller/AdminCatalogController.php
@@ -10,6 +10,7 @@ use Slim\Views\Twig;
 use App\Service\CatalogService;
 use App\Service\ConfigService;
 use App\Service\EventService;
+use App\Service\UrlService;
 use App\Infrastructure\Database;
 use PDO;
 
@@ -64,21 +65,7 @@ class AdminCatalogController
         if ($catalogsJson !== null) {
             $catalogs = json_decode($catalogsJson, true) ?? [];
         }
-        $uri    = $request->getUri();
-        $domain = getenv('DOMAIN');
-        if ($domain !== false && $domain !== '') {
-            if (preg_match('#^https?://#', $domain) === 1) {
-                $baseUrl = rtrim($domain, '/');
-            } else {
-                $baseUrl = 'https://' . $domain;
-            }
-        } else {
-            $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
-            $port    = $uri->getPort();
-            if ($port !== null && !in_array($port, [80, 443], true)) {
-                $baseUrl .= ':' . $port;
-            }
-        }
+        $baseUrl = UrlService::determineBaseUrl($request);
 
         return $view->render($response, 'kataloge.twig', [
             'kataloge' => $catalogs,

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -20,6 +20,7 @@ use App\Infrastructure\Database;
 use App\Service\StripeService;
 use App\Service\VersionService;
 use App\Application\Seo\PageSeoConfigService;
+use App\Service\UrlService;
 use PDO;
 
 /**
@@ -173,21 +174,8 @@ class AdminController
             }
         }
 
-        $uri    = $request->getUri();
-        $domain = getenv('DOMAIN');
-        if ($domain !== false && $domain !== '') {
-            if (preg_match('#^https?://#', $domain) === 1) {
-                $baseUrl = rtrim($domain, '/');
-            } else {
-                $baseUrl = 'https://' . $domain;
-            }
-        } else {
-            $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
-            $port    = $uri->getPort();
-            if ($port !== null && !in_array($port, [80, 443], true)) {
-                $baseUrl .= ':' . $port;
-            }
-        }
+        $baseUrl = UrlService::determineBaseUrl($request);
+        $uri = $request->getUri();
 
         $mainDomain = getenv('MAIN_DOMAIN')
             ?: getenv('DOMAIN')

--- a/src/Service/UrlService.php
+++ b/src/Service/UrlService.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class UrlService
+{
+    public static function determineBaseUrl(Request $req): string
+    {
+        $uri = $req->getUri();
+        $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
+        $port = $uri->getPort();
+        if ($port !== null && !in_array($port, [80, 443], true)) {
+            $baseUrl .= ':' . $port;
+        }
+
+        $domain = getenv('DOMAIN');
+        if ($domain !== false && $domain !== '') {
+            $envHost = parse_url($domain, PHP_URL_HOST) ?: $domain;
+            if ($envHost !== '' && $envHost !== $uri->getHost()) {
+                if (preg_match('#^https?://#', $domain) === 1) {
+                    $baseUrl = rtrim($domain, '/');
+                } else {
+                    $baseUrl = 'https://' . $domain;
+                }
+            }
+        }
+
+        return $baseUrl;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize base URL calculation in new UrlService
- resolve base URLs via request scheme/host, only using DOMAIN for tenant-specific overrides
- update admin controllers to use UrlService

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d1a08dc0832ba575d42b8e5657ba