### PR TITLE
Extract NullRedirectManager stub

### DIFF
--- a/tests/Service/NullRedirectManager.php
+++ b/tests/Service/NullRedirectManager.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Application\Routing\RedirectManager;
+
+class NullRedirectManager extends RedirectManager
+{
+    public function __construct()
+    {
+    }
+
+    public function register(string $from, string $to, int $status = 301): void
+    {
+    }
+}

--- a/tests/Service/PageSeoConfigServiceTest.php
+++ b/tests/Service/PageSeoConfigServiceTest.php
@@ -6,17 +6,10 @@ namespace Tests\Service;
 
 use App\Application\Seo\PageSeoConfigService;
 use App\Application\Seo\SeoValidator;
-use App\Application\Routing\RedirectManager;
 use App\Domain\PageSeoConfig;
 use App\Infrastructure\Cache\PageSeoCache;
 use PDO;
 use PHPUnit\Framework\TestCase;
-
-class NullRedirectManager extends RedirectManager
-{
-    public function __construct() {}
-    public function register(string $from, string $to, int $status = 301): void {}
-}
 
 class PageSeoConfigServiceTest extends TestCase
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,4 +3,5 @@
 require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/TestCase.php';
 require __DIR__ . '/Service/ArrayLogger.php';
+require __DIR__ . '/Service/NullRedirectManager.php';
 require __DIR__ . '/Uri.php';


### PR DESCRIPTION
## Summary
- move `NullRedirectManager` into its own test stub class
- load the new stub in the test bootstrap
- use the stub in `PageSeoConfigServiceTest`

## Testing
- `vendor/bin/phpcs tests/bootstrap.php tests/Service/PageSeoConfigServiceTest.php tests/Service/NullRedirectManager.php`
- `vendor/bin/phpunit tests/Service/PageSeoConfigServiceTest.php`
- `composer test` *(fails: Tests: 277, Assertions: 603, Errors: 26, Failures: 8)*


------
https://chatgpt.com/codex/tasks/task_e_68b6d2985b6c832ba2635da09e8e6428