### PR TITLE
Arrange profile name buttons full width

### DIFF
--- a/templates/profile.twig
+++ b/templates/profile.twig
@@ -23,9 +23,13 @@
               <input class="uk-input" type="text" id="playerName" name="playerName" placeholder="{{ t('label_player_name') }}">
             </div>
           </div>
-          <div class="uk-margin">
-            <button id="save-name" class="uk-button uk-button-primary uk-margin-right">{{ t('action_save_player') }}</button>
-            <button id="delete-name" class="uk-button" type="button">{{ t('action_delete_player') }}</button>
+          <div class="uk-grid-small uk-margin" uk-grid>
+            <div class="uk-width-1-2">
+              <button id="save-name" class="uk-button uk-button-primary uk-width-1-1">{{ t('action_save_player') }}</button>
+            </div>
+            <div class="uk-width-1-2">
+              <button id="delete-name" class="uk-button uk-width-1-1" type="button">{{ t('action_delete_player') }}</button>
+            </div>
           </div>
           <p class="uk-text-meta">{{ t('text_player_name_hint') }}</p>
         </form>


### PR DESCRIPTION
## Summary
- Arrange profile dialog buttons side-by-side at equal width

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables and PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6deae1b90832b823127359252daa1