### PR TITLE
Fix dark mode catalog card hover text color

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -248,9 +248,14 @@ body .uk-modal-dialog {
 }
 
 /* Hoverfarbe für Katalogkarten im Dunkelmodus */
-body .uk-card-hover:hover {
-  background-color: var(--qr-card);
-  color: #f5f5f5;
+body .qr-card.uk-card-hover:hover {
+  background-color: #fff;
+  color: #000;
+}
+
+body .qr-card.uk-card-hover:hover h3,
+body .qr-card.uk-card-hover:hover p {
+  color: #000;
 }
 
 /* Tabellenlesbarkeit im Dunkelmodus verbessern */
@@ -587,9 +592,14 @@ body[data-theme="dark"] .uk-modal-dialog {
 }
 
 /* Hoverfarbe für Katalogkarten im Dunkelmodus */
-body[data-theme="dark"] .uk-card-hover:hover {
-  background-color: var(--qr-card);
-  color: #f5f5f5;
+body[data-theme="dark"] .qr-card.uk-card-hover:hover {
+  background-color: #fff;
+  color: #000;
+}
+
+body[data-theme="dark"] .qr-card.uk-card-hover:hover h3,
+body[data-theme="dark"] .qr-card.uk-card-hover:hover p {
+  color: #000;
 }
 
 /* Tabellenlesbarkeit im Dunkelmodus verbessern */


### PR DESCRIPTION
## Summary
- Ensure catalog cards show black text on hover in dark mode for better contrast

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY...)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e855cb98832bbfb7c236f399bb2d