### PR TITLE
fix: preserve player name across catalogs

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -627,7 +627,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       // Ohne Namensübernahme gespeicherte Daten löschen
       sessionStorage.removeItem(playerNameKey);
       sessionStorage.removeItem('quizSolved');
-      localStorage.removeItem(playerNameKey);
+      // localStorage.removeItem(playerNameKey);
     }
     [playerNameKey, 'quizCatalog', 'quizSolved'].forEach(k => {
       const v = localStorage.getItem(k);

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1307,7 +1307,6 @@ async function runQuiz(questions, skipIntro){
         restart.addEventListener('click', () => {
           sessionStorage.removeItem(playerNameKey);
           sessionStorage.removeItem('quizSolved');
-          localStorage.removeItem(playerNameKey);
           const topbar = document.getElementById('topbar-title');
           if(topbar){
             topbar.textContent = topbar.dataset.defaultTitle || '';


### PR DESCRIPTION
## Summary
- retain player name in catalog view by not clearing localStorage
- keep stored name when restarting quiz

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars and hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e9b691bc832bbd94e043d5e78ec3