### PR TITLE
Add automatic team creation on first result submission

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -98,8 +98,8 @@ class ResultController
         $data = json_decode((string) $request->getBody(), true);
         $result = ['success' => false];
         if (is_array($data)) {
+            $name = (string)($data['name'] ?? '');
             if (isset($data['puzzleTime'])) {
-                $name = (string)($data['name'] ?? '');
                 $catalog = (string)($data['catalog'] ?? '');
                 $time = (int)$data['puzzleTime'];
                 $answer = (string)($data['puzzleAnswer'] ?? '');
@@ -130,6 +130,9 @@ class ResultController
             } else {
                 $this->service->add($data);
                 $result['success'] = true;
+            }
+            if ($name !== '' && $result['success']) {
+                $this->teams->addIfMissing($name);
             }
         }
         $response->getBody()->write(json_encode($result));


### PR DESCRIPTION
## Summary
- automatically create team entries when new result is submitted
- expose addIfMissing helper in TeamService

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY...)*

------
https://chatgpt.com/codex/tasks/task_e_68b6eb259874832ba2cc49d3c706db95