### PR TITLE
Handle empty team list when generating PDFs

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -208,9 +208,29 @@ class ResultController
      */
     public function pdf(Request $request, Response $response): Response
     {
-        $teams = $this->teams->getAll();
         $results = $this->service->getAll();
         $questionResults = $this->service->getQuestionResults();
+        $teams = $this->teams->getAll();
+
+        if ($teams === []) {
+            $names = array_merge(
+                array_column($results, 'name'),
+                array_column($questionResults, 'name')
+            );
+            $names = array_filter(
+                $names,
+                static fn ($n) => is_string($n) && $n !== ''
+            );
+            $teams = array_values(array_unique($names));
+        }
+
+        if ($teams === []) {
+            $response->getBody()->write('Keine Ergebnisse vorhanden.');
+            return $response
+                ->withStatus(404)
+                ->withHeader('Content-Type', 'text/plain; charset=UTF-8');
+        }
+
         $catalogMax = [];
         $scores = [];
         $photos = [];

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -213,6 +213,7 @@ class ResultControllerTest extends TestCase
             ');'
         );
         $pdo->exec("INSERT INTO teams(sort_order,name,uid,event_uid) VALUES(1,'Team1','1','1')");
+        $pdo->exec("INSERT INTO teams(sort_order,name,uid,event_uid) VALUES(2,'Team2','2','2')");
 
         $cfg = new \App\Service\ConfigService($pdo);
         $teams = new \App\Service\TeamService($pdo, $cfg);


### PR DESCRIPTION
## Summary
- derive team names from results if team service returns none and return 404 when no data available
- ensure PDF result test has a team for the second event

## Testing
- `vendor/bin/phpunit --filter testPdfReflectsActiveEvent tests/Controller/ResultControllerTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET, Database error, Error creating tenant, runSyncProcess failed, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68b7238476f8832bb30b7f767e62713c