### PR TITLE
Handle invites when teams are missing

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -217,7 +217,8 @@ return function (\Slim\App $app, TranslationService $translator) {
                 $teamService,
                 $eventService,
                 $catalogService,
-                new QrCodeService()
+                new QrCodeService(),
+                $resultService
             ))
             ->withAttribute('onboardingEmailController', new OnboardingEmailController($emailConfirmService))
             ->withAttribute('catalogDesignController', new CatalogDesignController($catalogService))


### PR DESCRIPTION
## Summary
- derive team names from stored results when no teams are configured and return a 404 if still none found
- inject ResultService into QrController and wire routing
- add unit tests covering result-based invites and missing-team errors

## Testing
- `./vendor/bin/phpunit tests/Controller/QrControllerTest.php`
- `./vendor/bin/phpunit` *(fails: Unknown "t" function in Twig template)*
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b723a27798832ba471b58d78f27fb7