### PR TITLE
feat: preserve catalog questions on slug change

### DIFF
--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -220,6 +220,35 @@ class CatalogServiceTest extends TestCase
         $this->assertCount(2, $remaining);
     }
 
+    public function testSlugChangeDoesNotDeleteQuestions(): void
+    {
+        $pdo = $this->createPdo();
+        $cfg = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfg);
+        $service->write('catalogs.json', [[
+            'uid' => 'uid8',
+            'sort_order' => 1,
+            'slug' => 'old',
+            'file' => 'old.json',
+            'name' => 'Old',
+            'comment' => '',
+        ]]);
+        $questions = [['type' => 'text', 'prompt' => 'Q1']];
+        $service->write('old.json', $questions);
+
+        $service->write('catalogs.json', [[
+            'uid' => 'uid8',
+            'sort_order' => 1,
+            'slug' => 'new',
+            'file' => 'old.json',
+            'name' => 'New',
+            'comment' => '',
+        ]]);
+
+        $stmt = $pdo->query("SELECT COUNT(*) FROM questions WHERE catalog_uid='uid8'");
+        $this->assertSame(1, (int) $stmt->fetchColumn());
+    }
+
     public function testReorderCatalogs(): void
     {
         $pdo = $this->createPdo();


### PR DESCRIPTION
## Summary
- avoid wiping catalog table when saving `catalogs.json` by using upserts
- drop catalogs not in payload while keeping existing questions
- add regression test ensuring slug changes keep questions

## Testing
- `vendor/bin/phpunit tests/Service/CatalogServiceTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b730a1f858832bb84217ef749b9399