### PR TITLE
feat(admin): edit teams via modal

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -840,6 +840,16 @@ body.admin-page {
   padding: 8px 4px;
 }
 
+#teamsList td.team-name {
+  cursor: pointer;
+}
+
+#teamsList td.team-name .uk-text-truncate {
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: middle;
+}
+
 #teamsTable {
   width: 100%;
   max-width: 100%;
@@ -870,9 +880,6 @@ body.admin-page {
   right: 4px;
   display: block;
 }
-#teamsList input[type="text"] {
-  width: 100%;
-}
 
 @media (min-width: 640px) {
   #teamsTable thead {
@@ -899,9 +906,7 @@ body.admin-page {
     right: auto;
     display: table-cell;
   }
-  #teamsList input[type="text"] {
-    width: auto;
-  }
+  /* no text inputs in team list */
 }
 
 /* Page editor styles */

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -44,6 +44,7 @@ return [
     'heading_catalogs' => 'Kataloge',
     'heading_questions' => 'Fragen bearbeiten',
     'heading_teams' => 'Teams/Personen',
+    'heading_team_edit' => 'Team bearbeiten',
     'heading_results' => 'Ergebnisse',
     'heading_statistics' => 'Statistik',
     'heading_pages' => 'Seiten',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -44,6 +44,7 @@ return [
     'heading_catalogs' => 'Catalogs',
     'heading_questions' => 'Edit questions',
     'heading_teams' => 'Teams/People',
+    'heading_team_edit' => 'Edit team',
     'heading_results' => 'Results',
     'heading_statistics' => 'Statistics',
     'heading_pages' => 'Pages',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -496,6 +496,17 @@
         <div class="uk-margin uk-flex uk-flex-right">
           <button id="teamsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: {{ t('tip_team_save') }}; pos: left"></button>
         </div>
+        <div id="teamEditModal" uk-modal>
+          <div class="uk-modal-dialog uk-modal-body">
+            <h3 class="uk-modal-title">{{ t('heading_team_edit') }}</h3>
+            <input id="teamEditInput" class="uk-input" type="text">
+            <p id="teamEditError" class="uk-text-danger uk-margin-small-top" hidden></p>
+            <div class="uk-margin-top uk-text-right">
+              <button id="teamEditCancel" class="uk-button uk-button-default" type="button">{{ t('action_cancel') }}</button>
+              <button id="teamEditSave" class="uk-button uk-button-primary" type="button">{{ t('action_save') }}</button>
+            </div>
+          </div>
+        </div>
       </div>
     </li>
     <li class="{{ activeRoute == 'summary' ? 'uk-active' }}">


### PR DESCRIPTION
## Summary
- add translations and styles to support modal team editing
- use UIkit modal for team name changes and persist via AJAX

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b73039983c832bb44eb46fb7b0fd53