### PR TITLE
Wrap admin tables and add sticky header

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -142,8 +142,18 @@ body.uk-padding {
 }
 
 /* Stripe-ähnliche Lesbarkeit für Tenant-Tabelle */
+.qr-table-wrap {
+  max-height: 60vh;
+}
 .qr-table thead th {
   font-weight: 600;
+  position: sticky;
+  top: 0;
+  background: var(--qr-card);
+  z-index: 1;
+}
+.qr-table td {
+  padding: 0.6rem;
 }
 .qr-mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -981,7 +981,7 @@
         </div>
 
         <!-- DESKTOP TABLE -->
-        <div class="uk-visible@s uk-overflow-auto">
+        <div class="uk-visible@s uk-overflow-auto qr-table-wrap">
           <table class="uk-table uk-table-divider uk-table-middle uk-table-striped qr-table">
               <thead>
                 <tr>
@@ -1107,8 +1107,8 @@
             <div class="uk-text-meta">Wird für Stripe-Kund*in verwendet.</div>
           </div>
           {% endif %}
-        <div class="uk-overflow-auto uk-margin-top">
-          <table class="uk-table uk-table-divider uk-table-small uk-text-center">
+        <div class="uk-overflow-auto qr-table-wrap uk-margin-top">
+          <table class="uk-table uk-table-divider uk-table-small uk-text-center qr-table">
               <thead>
                 <tr>
                   <th scope="col"></th>


### PR DESCRIPTION
## Summary
- Wrap admin tables with `qr-table-wrap` containers and apply `qr-table` class
- Add styles for `qr-table` and `qr-table-wrap` including sticky headers and reduced cell padding

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b73a76b96c832b8a642d61544c2bc8