### PR TITLE
Add button handle for sortable team rows

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -168,6 +168,19 @@ body.uk-padding {
   height: 44px;
 }
 
+.qr-handle {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.qr-handle:focus {
+  outline: 2px solid var(--accent-color, #1e87f0);
+}
+
 /* Ensure dropdown menus appear above table rows */
 .uk-dropdown {
   z-index: 1200;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1922,10 +1922,11 @@ document.addEventListener('DOMContentLoaded', function () {
     row.className = 'team-row';
 
     const handleCell = document.createElement('td');
-    const handleSpan = document.createElement('span');
-    handleSpan.className = 'uk-sortable-handle uk-icon';
-    handleSpan.setAttribute('uk-icon', 'icon: table');
-    handleCell.appendChild(handleSpan);
+    const handleBtn = document.createElement('button');
+    handleBtn.className = 'uk-button uk-button-default qr-handle';
+    handleBtn.setAttribute('uk-icon', 'menu');
+    handleBtn.setAttribute('aria-label', 'Reihenfolge ändern');
+    handleCell.appendChild(handleBtn);
 
     const nameCell = document.createElement('td');
     nameCell.className = 'team-name';

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -487,7 +487,7 @@
                 <th scope="col"></th>
               </tr>
             </thead>
-            <tbody id="teamsList" uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
+            <tbody id="teamsList" uk-sortable="handle: .qr-handle; group: sortable-group"></tbody>
           </table>
         </div>
         <div class="uk-margin">


### PR DESCRIPTION
## Summary
- replace span drag handle with a button in team rows
- target new `.qr-handle` button in team sortable container
- style `.qr-handle` for consistent size and focus outline

## Testing
- `vendor/bin/phpunit --stop-on-error` *(fails: Unknown "t" function in base.twig)*
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`
- `node tests/test_onboarding_flow.js`
- `python3 tests/test_html_validity.py`
- `python3 -m pytest tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68b73ba7ec54832bbaebbbaa94cab3b7