### PR TITLE
Replace team sortable handle with accessible button

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -102,6 +102,22 @@ body .mc-option {
 body .dropzone.over {
   background-color: #2a2a2a;
 }
+
+body .qr-handle {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: grab;
+}
+
+body .qr-handle:focus {
+  outline: 2px solid var(--accent-color);
+}
 body .uk-alert-success {
   background-color: #145214;
   color: #fff;

--- a/public/css/highcontrast.css
+++ b/public/css/highcontrast.css
@@ -64,6 +64,22 @@ body.high-contrast .dropzone.over {
   background: #ffffcc;
   border-color: #000000;
 }
+
+body.high-contrast .qr-handle {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: grab;
+}
+
+body.high-contrast .qr-handle:focus {
+  outline: 2px solid #000000;
+}
 body.high-contrast .uk-alert-success {
   background-color: #006400;
   color: #ffffff;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -109,6 +109,22 @@ body.uk-padding {
   outline: 2px solid var(--accent-color);
 }
 
+.qr-handle {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: grab;
+}
+
+.qr-handle:focus {
+  outline: 2px solid var(--accent-color);
+}
+
 .dropzone {
   min-height: 3.5em;
   background: #f3f7fa;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1924,10 +1924,12 @@ document.addEventListener('DOMContentLoaded', function () {
     row.dataset.teamId = id;
 
     const handleCell = document.createElement('td');
-    const handleSpan = document.createElement('span');
-    handleSpan.className = 'uk-sortable-handle uk-icon';
-    handleSpan.setAttribute('uk-icon', 'icon: table');
-    handleCell.appendChild(handleSpan);
+    const handleBtn = document.createElement('button');
+    handleBtn.type = 'button';
+    handleBtn.className = 'qr-handle';
+    handleBtn.setAttribute('uk-icon', 'icon: menu');
+    handleBtn.setAttribute('aria-label', 'Verschieben');
+    handleCell.appendChild(handleBtn);
 
     const nameCell = document.createElement('td');
     nameCell.className = 'team-name';
@@ -1963,9 +1965,11 @@ document.addEventListener('DOMContentLoaded', function () {
     li.className = 'qr-rowcard uk-flex uk-flex-middle uk-flex-between';
     li.dataset.teamId = id;
 
-    const handleSpan = document.createElement('span');
-    handleSpan.className = 'uk-sortable-handle uk-icon';
-    handleSpan.setAttribute('uk-icon', 'icon: table');
+    const handleBtn = document.createElement('button');
+    handleBtn.type = 'button';
+    handleBtn.className = 'qr-handle';
+    handleBtn.setAttribute('uk-icon', 'icon: menu');
+    handleBtn.setAttribute('aria-label', 'Verschieben');
 
     const nameSpan = document.createElement('span');
     nameSpan.className = 'team-name uk-flex-1';
@@ -1988,7 +1992,7 @@ document.addEventListener('DOMContentLoaded', function () {
       saveTeamList();
     };
 
-    li.appendChild(handleSpan);
+    li.appendChild(handleBtn);
     li.appendChild(nameSpan);
     li.appendChild(del);
     return li;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -488,11 +488,11 @@
                   <th scope="col"></th>
                 </tr>
               </thead>
-              <tbody id="teamsList" uk-sortable="handle: .uk-sortable-handle; group: sortable-group"></tbody>
+              <tbody id="teamsList" uk-sortable="handle: .qr-handle; group: sortable-group"></tbody>
             </table>
           </div>
         </div>
-        <ul id="teamsCards" class="uk-hidden@m uk-list"></ul>
+        <ul id="teamsCards" class="uk-hidden@m uk-list" uk-sortable="handle: .qr-handle; group: sortable-group"></ul>
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_team_add') }}; pos: left"></button>
         </div>


### PR DESCRIPTION
## Summary
- Use `.qr-handle` buttons as sortable handles for teams in admin UI
- Target new handle in team list templates and enable sorting on card view
- Style `.qr-handle` for consistent sizing and focus outlines across themes

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b73d5f378c832bbb0f701ba804e0bb