### PR TITLE
Highlight team name cells for accessibility

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -155,6 +155,19 @@ body.uk-padding {
 .qr-table td {
   padding: 0.6rem;
 }
+.qr-cell {
+  background-color: var(--qr-card);
+  outline: 2px solid transparent;
+  border-radius: 8px;
+  transition: background-color 0.2s;
+}
+.qr-cell:hover {
+  background-color: var(--qr-bg-soft);
+}
+.qr-cell:focus-within {
+  background-color: var(--qr-bg-soft);
+  outline: 2px solid var(--accent-color);
+}
 .qr-mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1930,7 +1930,7 @@ document.addEventListener('DOMContentLoaded', function () {
     handleCell.appendChild(handleSpan);
 
     const nameCell = document.createElement('td');
-    nameCell.className = 'team-name';
+    nameCell.className = 'team-name qr-cell';
     nameCell.dataset.teamId = id;
     nameCell.tabIndex = 0;
     const span = document.createElement('span');


### PR DESCRIPTION
## Summary
- Apply `qr-cell` styling to team names in admin panel
- Add hover and focus styles for `.qr-cell`

## Testing
- `composer test` *(fails: Missing STRIPE_* keys and multiple PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b73dbb4338832b83f0ed2565faea13