### PR TITLE
Style admin heading and adjust table header spacing

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -83,6 +83,10 @@ body.uk-padding {
   text-decoration: none;
 }
 
+.qr-section-title {
+  letter-spacing: .03em;
+}
+
 .sortable-list li,
 .terms li,
 .dropzone,
@@ -147,6 +151,7 @@ body.uk-padding {
 }
 .qr-table thead th {
   font-weight: 600;
+  letter-spacing: .04em;
   position: sticky;
   top: 0;
   background: var(--qr-card);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -56,7 +56,7 @@
       {% endif %}
       {% if activeRoute == 'dashboard' %}
         <div class="uk-container uk-container-large">
-          <h2 class="uk-heading-bullet">Willkommen {{ username }}</h2>
+          <h2 class="uk-heading-bullet qr-section-title">Willkommen {{ username }}</h2>
         </div>
       {% endif %}
     {% endblock %}


### PR DESCRIPTION
## Summary
- tag admin dashboard heading with new `qr-section-title` class
- introduce `.qr-section-title` styles and widen table header letter spacing

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b73dd39da8832b87306cf8c781e8fa