### PR TITLE
Add speed dial for team actions

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1878,8 +1878,8 @@ document.addEventListener('DOMContentLoaded', function () {
   // --------- Teams/Personen ---------
   const teamListEl = document.getElementById('teamsList');
   const teamCardsEl = document.getElementById('teamsCards');
-  const teamAddBtn = document.getElementById('teamAddBtn');
-  const teamSaveBtn = document.getElementById('teamsSaveBtn');
+  const teamAddAction = document.getElementById('teamAddAction');
+  const teamConfirmAction = document.getElementById('teamConfirmAction');
   const teamRestrictTeams = document.getElementById('teamRestrict');
   const teamEditModal = UIkit.modal('#teamEditModal');
   const teamEditInput = document.getElementById('teamEditInput');
@@ -2025,7 +2025,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
-  teamAddBtn?.addEventListener('click', e => {
+  teamAddAction?.addEventListener('click', e => {
     e.preventDefault();
     const id = crypto.randomUUID();
     const row = createTeamRow('', id);
@@ -2054,7 +2054,7 @@ document.addEventListener('DOMContentLoaded', function () {
     teamEditModal.hide();
   });
 
-  teamSaveBtn?.addEventListener('click', e => {
+  teamConfirmAction?.addEventListener('click', e => {
     e.preventDefault();
     saveTeamList(true);
     if (teamRestrictTeams) {

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -173,6 +173,8 @@ return [
     'action_open_invitations' => 'Einladungen öffnen',
     'action_print_summary' => 'Übersicht Drucken',
     'action_design_qrcodes' => 'QR-Codes gestalten',
+    'action_team_add' => 'Team hinzufügen',
+    'action_team_confirm' => 'Auswahl bestätigen',
     'column_username' => 'Benutzername',
     'column_role' => 'Rolle',
     'column_subdomain' => 'Subdomain',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -175,6 +175,8 @@ return [
     'action_open_invitations' => 'Open invitations',
     'action_print_summary' => 'Print summary',
     'action_design_qrcodes' => 'Design QR codes',
+    'action_team_add' => 'Add team',
+    'action_team_confirm' => 'Confirm selection',
     'column_username' => 'Username',
     'column_role' => 'Role',
     'column_subdomain' => 'Subdomain',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -493,11 +493,24 @@
           </div>
         </div>
         <ul id="teamsCards" class="uk-hidden@m uk-list" uk-sortable="handle: .qr-handle; group: sortable-group"></ul>
-        <div class="uk-margin">
-          <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_team_add') }}; pos: left"></button>
-        </div>
-        <div class="uk-margin uk-flex uk-flex-right">
-          <button id="teamsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: {{ t('tip_team_save') }}; pos: left"></button>
+        <div class="uk-inline">
+          <button class="uk-icon-button uk-button-primary fab" type="button" uk-icon="plus"></button>
+          <div uk-drop="mode: click; pos: top-right; offset: 4">
+            <div class="uk-card uk-card-body uk-card-default uk-card-small">
+              <ul class="uk-nav uk-dropdown-nav">
+                <li>
+                  <button id="teamAddAction" class="uk-button uk-button-text" type="button">
+                    <span uk-icon="plus"></span> {{ t('action_team_add') }}
+                  </button>
+                </li>
+                <li>
+                  <button id="teamConfirmAction" class="uk-button uk-button-text" type="button">
+                    <span uk-icon="check"></span> {{ t('action_team_confirm') }}
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
         </div>
         <div id="teamEditModal" uk-modal>
           <div class="uk-modal-dialog uk-modal-body">


### PR DESCRIPTION
## Summary
- replace separate team action FABs with a combined speed-dial menu
- update admin JS to use new speed-dial IDs
- add translations for new team action labels

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b741473468832b91deb0edea99746a