### PR TITLE
Show team name in edit modal

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1886,6 +1886,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const teamEditSave = document.getElementById('teamEditSave');
   const teamEditCancel = document.getElementById('teamEditCancel');
   const teamEditError = document.getElementById('teamEditError');
+  const teamEditTitle = document.querySelector('#teamEditModal .uk-modal-title');
+  const teamEditTitleBase = teamEditTitle?.textContent.trim();
   let currentTeamId = null;
 
   function collectTeams() {
@@ -1913,7 +1915,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function openTeamModal(cell) {
     currentTeamId = cell.dataset.teamId;
-    teamEditInput.value = cell.textContent.trim();
+    const name = cell.textContent.trim();
+    teamEditInput.value = name;
+    if (teamEditTitle) {
+      teamEditTitle.textContent = name ? `${teamEditTitleBase}: ${name}` : teamEditTitleBase;
+    }
     teamEditError.hidden = true;
     teamEditModal.show();
   }


### PR DESCRIPTION
## Summary
- Update team edit modal title to include the current team name

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b744b2b9dc832ba3bfba990cab9420