### PR TITLE
Add edit icon for team rows

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -195,6 +195,15 @@ body.uk-padding {
   background-color: var(--qr-bg-soft);
   outline: 2px solid var(--accent-color);
 }
+.qr-editable-icon {
+  margin-left: 4px;
+  color: var(--color-text);
+  opacity: 0.4;
+  transition: opacity 0.2s;
+}
+.qr-cell:hover .qr-editable-icon {
+  opacity: 1;
+}
 .qr-mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1953,6 +1953,16 @@ document.addEventListener('DOMContentLoaded', function () {
     span.className = 'uk-text-truncate';
     span.textContent = name;
     nameCell.appendChild(span);
+    const editIcon = document.createElement('span');
+    editIcon.className = 'qr-editable-icon';
+    editIcon.setAttribute('uk-icon', 'pencil');
+    nameCell.appendChild(editIcon);
+    const desc = document.createElement('span');
+    desc.id = 'team-edit-desc-' + id;
+    desc.className = 'uk-hidden-visually';
+    desc.textContent = 'klicken zum Bearbeiten';
+    nameCell.appendChild(desc);
+    nameCell.setAttribute('aria-describedby', desc.id);
     nameCell.title = name;
     nameCell.addEventListener('click', () => openTeamModal(nameCell));
 


### PR DESCRIPTION
## Summary
- show pencil icon beside team name to hint at editing
- style `.qr-editable-icon` and reveal it on row hover
- add accessible description for editable team names

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Errors: 26, Failures: 8)*

------
https://chatgpt.com/codex/tasks/task_e_68b7470e35a8832bb716b5ff805519b2