### PR TITLE
Improve light mode hero gradient

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -42,8 +42,8 @@ body.qr-landing:not(.dark-mode){
   --qr-bg-soft:#f6f8fa;
   --qr-card:#ffffff;
   --qr-border:rgba(27,31,35,0.12);
-  --qr-hero-grad-start:#f6f8fa;
-  --qr-hero-grad-end:#e8ecff;
+  --qr-hero-grad-start:var(--qr-brand-50);
+  --qr-hero-grad-end:var(--qr-brand-300);
   --qr-hero-gradient:linear-gradient(135deg, var(--qr-hero-grad-start) 0%, var(--qr-hero-grad-end) 100%);
   --qr-link:#1f6feb;
   --qr-muted:#374151;


### PR DESCRIPTION
## Summary
- enhance light mode hero gradient colors for better contrast

## Testing
- `wkhtmltoimage --enable-local-file-access file:///tmp/test.html /tmp/test.png`
- `python3 - <<'PY'\nfrom PIL import Image\nimg = Image.open('/tmp/test.png')\nprint(img.size)\nprint('top pixel:', img.getpixel((10,10)))\nprint('bottom pixel:', img.getpixel((10,img.size[1]-10)))\nPY`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b746e2fd80832baece0fe6b950a033