### PR TITLE
Keep team delete action in rightmost column

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1958,6 +1958,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const delCell = document.createElement('td');
     delCell.setAttribute('role', 'gridcell');
+    delCell.className = 'uk-table-shrink uk-text-center';
     const del = document.createElement('button');
     del.className = 'uk-icon-button qr-action';
     del.setAttribute('uk-icon', 'trash');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -483,9 +483,9 @@
             <table id="teamsTable" class="uk-table uk-table-divider uk-table-small">
               <thead class="table-headings">
                 <tr>
-                  <th scope="col"></th>
-                  <th scope="col">{{ t('column_name') }}</th>
-                  <th scope="col"></th>
+                  <th scope="col" class="uk-table-shrink uk-text-center"></th>
+                  <th scope="col" class="uk-table-expand">{{ t('column_name') }}</th>
+                  <th scope="col" class="uk-table-shrink uk-text-center"></th>
                 </tr>
               </thead>
               <tbody id="teamsList" role="rowgroup" uk-sortable="handle: .qr-handle; group: sortable-group"></tbody>


### PR DESCRIPTION
## Summary
- Ensure team delete button lives in a right-aligned shrink column
- Mark teams table action columns as shrink and centered to keep delete last

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b74823b6dc832bb9569b2708ab408e