### PR TITLE
Add light mode row styling variables

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -16,10 +16,13 @@ html {
   --danger-500: #8b0000;
   --danger-600: #660000;
   --qr-card: #ffffff;
-  --qr-row: #f3f7fa;
-  --qr-row-alt: #e0f7fa;
+  --qr-row-light: #f3f7fa;
+  --qr-row-alt-light: #e0f7fa;
+  --qr-border-light: rgba(0, 0, 0, 0.1);
+  --qr-row: var(--qr-row-light);
+  --qr-row-alt: var(--qr-row-alt-light);
   --qr-head: #ffffff;
-  --qr-border: rgba(0, 0, 0, 0.1);
+  --qr-border: var(--qr-border-light);
   --qr-bg-soft: #f3f4f6;
 }
 
@@ -110,6 +113,26 @@ body.uk-padding {
 .mc-option input {
   transform: scale(1.2);
   margin-right: 8px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --qr-row: var(--qr-row-light);
+    --qr-row-alt: var(--qr-row-alt-light);
+    --qr-border: var(--qr-border-light);
+  }
+
+  .sortable-list li:nth-child(2n),
+  .terms li:nth-child(2n),
+  .mc-option:nth-child(2n) {
+    background: var(--qr-row-alt);
+  }
+
+  .sortable-list li,
+  .terms li,
+  .mc-option {
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  }
 }
 
 .sortable-list li:focus {


### PR DESCRIPTION
## Summary
- expand CSS variables with light-mode row colors and border definitions
- apply these variables under `prefers-color-scheme: light` and alternate row styling with subtle shadows

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b748268e3c832ba21e9a99ea4ab4ee