### PR TITLE
Set landing page event button text to white

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -486,6 +486,10 @@ body.dark-mode .qr-landing .qr-badge{
   opacity:.85;
 }
 
+.qr-landing .uk-button-primary{
+  color:#fff!important;
+}
+
 .qr-landing .cta-main.uk-button-primary{
   background:var(--qr-landing-primary)!important;
   color:var(--qr-landing-text)!important;


### PR DESCRIPTION
## Summary
- Force white text color for primary buttons on landing page

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars, Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b74b16a2c0832b986b79eea64159f6