### PR TITLE
Mount tenant data volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Note landing page style overrides
 - Clarify tenant wait probing and HTTPS upgrade
 - Document Docker Compose project name
+- Explain persistent data volume for tenants
 
 ### Feat
 
@@ -114,6 +115,7 @@
 - Update phpstan config for v2
 - Ensure page content respects dynamic topbar height
 - *(events)* Prevent table frame from clipping actions
+- Mount tenant data directory for persistence
 - Respect flex-wrap when sizing nav placeholder
 - Remove empty hamburger menu and align settings toggle
 - Always show topbar icons

--- a/README.md
+++ b/README.md
@@ -303,8 +303,10 @@ Haupt-Stack dieses Netzwerk erstellt oder verwaltet. Den Namen kannst du
 
 Das Skript `scripts/onboard_tenant.sh` steht weiterhin zur Verfügung, um
 einen Container manuell zu starten oder neu aufzusetzen. Es schreibt unter
-`tenants/<slug>/` eine eigene `docker-compose.yml` und fordert ebenfalls das
-SSL-Zertifikat an.
+`tenants/<slug>/` eine eigene `docker-compose.yml`, legt dort ein
+persistentes `data/`-Verzeichnis an und bindet es im Container unter
+`/var/www/data` ein. So bleiben hochgeladene Logos oder Fotos auch bei
+Upgrades erhalten. Zusätzlich fordert das Skript das SSL-Zertifikat an.
 Welches Docker-Image dabei verwendet wird, lässt sich über die Variable `APP_IMAGE` in der `.env` steuern.
 Dieses Tag sollte dem lokal gebauten Slim-Image entsprechen (`docker build -t <tag> .`),
 da das Onboarding-Skript diese Variable nutzt.

--- a/scripts/onboard_tenant.sh
+++ b/scripts/onboard_tenant.sh
@@ -25,6 +25,7 @@ fi
 
 SLUG=$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
 TENANT_DIR="$(dirname "$0")/../tenants/$SLUG"
+DATA_DIR="$TENANT_DIR/data"
 COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
 DOMAIN_SUFFIX="${MAIN_DOMAIN:-$DOMAIN}"
 EMAIL="${LETSENCRYPT_EMAIL:-admin@quizrace.app}"
@@ -89,13 +90,13 @@ if [ "$AVAILABLE_MB" -lt "$MIN_DISK_MB" ]; then
   error_exit "Zu wenig Speicherplatz (nur ${AVAILABLE_MB}MB verfügbar)."
 fi
 
-log "Erstelle Tenant-Verzeichnis"
+log "Erstelle Tenant- und Datenverzeichnis"
 if [ -d "$TENANT_DIR" ]; then
   error_exit "Tenant directory '$TENANT_DIR' already exists"
 fi
 
-if ! mkdir -p "$TENANT_DIR"; then
-  error_exit "Konnte Verzeichnis '$TENANT_DIR' nicht anlegen"
+if ! mkdir -p "$DATA_DIR"; then
+  error_exit "Konnte Verzeichnis '$DATA_DIR' nicht anlegen"
 fi
 
 log "Erstelle docker-compose Datei"
@@ -113,6 +114,8 @@ services:
     command: php -S 0.0.0.0:8080 -t public public/router.php
     expose:
       - "8080"
+    volumes:
+      - ./data:/var/www/data
     networks:
       - ${NETWORK}
     labels:


### PR DESCRIPTION
## Summary
- mount per-tenant data directory at `/var/www/data` in onboarding script
- document persistent data volume in README
- record change in changelog

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b73fbf3dfc832ba08ef5f3082f4c69