### PR TITLE
Remove quotes from contact heading and align size

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -518,7 +518,7 @@
 <!-- Kontakt -->
 <section id="contact-us" class="uk-section">
   <div class="uk-container">
-    <h3 class="uk-heading-medium uk-text-center" uk-scrollspy="cls: uk-animation-slide-top-small">„Noch Fragen? Wir sind für Sie da.“</h3>
+    <h2 class="uk-heading-medium uk-text-center" uk-scrollspy="cls: uk-animation-slide-top-small">Noch Fragen? Wir sind für Sie da.</h2>
     <p class="uk-text-lead uk-text-center" uk-scrollspy="cls: uk-animation-fade; delay: 150">Ob Testzugang, Angebot oder individuelle Beratung – wir melden uns garantiert persönlich zurück.</p>
     <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
       <div>


### PR DESCRIPTION
## Summary
- remove quotation marks from contact section heading
- use `h2` for contact heading to match other section sizes

## Testing
- `composer test` *(fails: E.....)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`
- `node tests/test_onboarding_flow.js`


------
https://chatgpt.com/codex/tasks/task_e_68b74e22da68832bb8306a21497f6140