### PR TITLE
Align team table text vertically

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -242,6 +242,7 @@ body.uk-padding {
   max-width: 36ch;
   display: inline-block;
   vertical-align: middle;
+  line-height: 44px;
 }
 .uk-iconnav > li > a {
   padding: 4px;
@@ -995,6 +996,8 @@ body.admin-page {
   #teamsList td {
     display: table-cell;
     padding: 8px 4px;
+    vertical-align: middle;
+    line-height: 44px;
   }
   #teamsList td:first-child {
     position: static;


### PR DESCRIPTION
## Summary
- Center truncated text inside table cells by giving `.uk-text-truncate` a 44px line height
- Vertically align team list table cells and match button height

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b74cd7be38832b94f7572a9d135555