### PR TITLE
Preserve catalog questions on slug change

### DIFF
--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -313,6 +313,7 @@ class CatalogService
                 $updates[] = 'design_path=excluded.design_path';
             }
 
+            // Upsert catalogs by UID so renaming a slug keeps its questions
             $insertSql = sprintf(
                 'INSERT INTO catalogs(%s) VALUES(%s) ON CONFLICT(uid) DO UPDATE SET %s',
                 implode(',', $fields),
@@ -364,6 +365,7 @@ class CatalogService
             }
 
             if ($uids !== []) {
+                // Remove catalogs that are no longer present in the input set
                 $in = implode(',', array_fill(0, count($uids), '?'));
                 if ($uid !== '') {
                     $del = $this->pdo->prepare("DELETE FROM catalogs WHERE uid NOT IN ($in) AND event_uid=?");

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -247,6 +247,10 @@ class CatalogServiceTest extends TestCase
 
         $stmt = $pdo->query("SELECT COUNT(*) FROM questions WHERE catalog_uid='uid8'");
         $this->assertSame(1, (int) $stmt->fetchColumn());
+        $this->assertSame(
+            $questions,
+            json_decode((string) $service->read('old.json'), true)
+        );
     }
 
     public function testReorderCatalogs(): void


### PR DESCRIPTION
## Summary
- Clarify catalog upsert logic to emphasize UID-based updates
- Extend CatalogService tests to ensure questions survive slug renames

## Testing
- `vendor/bin/phpunit tests/Service/CatalogServiceTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b7547f24e4832bbad1e9462a51d425