### PR TITLE
Allow generating team-specific result PDFs

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1970,11 +1970,18 @@ document.addEventListener('DOMContentLoaded', function () {
     const delCell = document.createElement('td');
     delCell.setAttribute('role', 'gridcell');
     delCell.className = 'uk-table-shrink uk-text-center';
+    const pdf = document.createElement('button');
+    pdf.className = 'uk-icon-button qr-action';
+    pdf.setAttribute('uk-icon', 'file-text');
+    pdf.setAttribute('aria-label', window.transTeamPdf || 'PDF');
+    pdf.setAttribute('uk-tooltip', 'title: ' + (window.transTeamPdf || 'PDF') + '; pos: left');
+    pdf.onclick = () => openTeamPdf(name);
     const del = document.createElement('button');
     del.className = 'uk-icon-button qr-action';
     del.setAttribute('uk-icon', 'trash');
     del.setAttribute('aria-label', 'Löschen');
     del.onclick = () => removeTeam(id);
+    delCell.appendChild(pdf);
     delCell.appendChild(del);
 
     row.appendChild(handleCell);
@@ -2005,6 +2012,12 @@ document.addEventListener('DOMContentLoaded', function () {
     nameSpan.title = name;
     nameSpan.addEventListener('click', () => openTeamModal(nameSpan));
 
+    const pdf = document.createElement('button');
+    pdf.className = 'uk-icon-button qr-action';
+    pdf.setAttribute('uk-icon', 'file-text');
+    pdf.setAttribute('aria-label', window.transTeamPdf || 'PDF');
+    pdf.setAttribute('uk-tooltip', 'title: ' + (window.transTeamPdf || 'PDF') + '; pos: left');
+    pdf.onclick = () => openTeamPdf(name);
     const del = document.createElement('button');
     del.className = 'uk-icon-button uk-button-danger';
     del.setAttribute('uk-icon', 'trash');
@@ -2013,6 +2026,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     li.appendChild(handleBtn);
     li.appendChild(nameSpan);
+    li.appendChild(pdf);
     li.appendChild(del);
     return li;
   }
@@ -2071,6 +2085,10 @@ document.addEventListener('DOMContentLoaded', function () {
       renderTeamsPage(currentPage);
       saveTeamList();
     }
+  }
+
+  function openTeamPdf(teamName){
+    window.open(withBase('/results.pdf?team=' + encodeURIComponent(teamName)), '_blank');
   }
 
   if (teamListEl && window.UIkit && UIkit.util) {

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -100,6 +100,7 @@ return [
     'tip_question_save' => 'Fragenkatalog speichern',
     'tip_team_add' => 'Neues Team oder Person hinzufügen',
     'tip_team_save' => 'Änderungen an Teams oder Personen speichern',
+    'tip_team_pdf' => 'PDF für dieses Team öffnen',
     'tip_invitations_open' => 'Alle Einladungen öffnen',
     'tip_summary_print' => 'Übersicht drucken',
     'tip_results_reset' => 'Löscht alle gespeicherten Ergebnisse',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -101,6 +101,7 @@ return [
     'tip_question_save' => 'Save question catalog',
     'tip_team_add' => 'Add new team or person',
     'tip_team_save' => 'Save teams or people',
+    'tip_team_pdf' => 'Open team PDF',
     'tip_invitations_open' => 'Open all invitations',
     'tip_summary_print' => 'Print summary',
     'tip_results_reset' => 'Delete all stored results',

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -210,6 +210,7 @@ class ResultController
     {
         $results = $this->service->getAll();
         $questionResults = $this->service->getQuestionResults();
+        $allResults = $results;
         $teams = $this->teams->getAll();
 
         if ($teams === []) {
@@ -222,6 +223,23 @@ class ResultController
                 static fn ($n) => is_string($n) && $n !== ''
             );
             $teams = array_values(array_unique($names));
+        }
+
+        $params = $request->getQueryParams();
+        $teamFilter = (string) ($params['team'] ?? $request->getAttribute('team') ?? '');
+        if ($teamFilter !== '') {
+            $results = array_values(array_filter(
+                $results,
+                static fn ($r) => ($r['name'] ?? '') === $teamFilter
+            ));
+            $questionResults = array_values(array_filter(
+                $questionResults,
+                static fn ($r) => ($r['name'] ?? '') === $teamFilter
+            ));
+            $teams = array_values(array_filter(
+                $teams,
+                static fn ($t) => $t === $teamFilter
+            ));
         }
 
         if ($teams === []) {
@@ -269,7 +287,7 @@ class ResultController
         }
 
         $awardService = new AwardService();
-        $rankings = $awardService->computeRankings($results, $catalogCount);
+        $rankings = $awardService->computeRankings($allResults, $catalogCount);
 
         $params = $request->getQueryParams();
         $uid = (string)($params['event'] ?? '');

--- a/src/routes.php
+++ b/src/routes.php
@@ -745,6 +745,11 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::ANALYST));
 
     $app->get('/results.pdf', function (Request $request, Response $response) {
+        $team = $request->getQueryParams()['team'] ?? null;
+        if ($team !== null) {
+            $request = $request->withAttribute('team', (string) $team);
+        }
+
         return $request->getAttribute('resultController')->pdf($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::ANALYST));
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1213,6 +1213,7 @@
     window.transRestartTenant = '{{ t('action_restart_tenant') }}';
     window.transImageReady = '{{ t('text_image_ready') }}';
     window.transEventSettingsHelp = '{{ t('text_event_settings_help')|e('js') }}';
+    window.transTeamPdf = '{{ t('tip_team_pdf') }}';
     window.stripeDashboard = '{{ stripe_sandbox ? 'https://dashboard.stripe.com/test' : 'https://dashboard.stripe.com' }}';
   </script>
   <script src="{{ basePath }}/js/dashboard.js"></script>


### PR DESCRIPTION
## Summary
- Support optional `team` filter for results PDF route
- Generate single-team PDF if `team` query provided and expose helper to open it from admin UI
- Add translation strings and UI elements for per-team PDF download

## Testing
- `vendor/bin/phpcs src/Controller/ResultController.php src/routes.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY; Tests: 280, Assertions: 604, Errors: 27, Failures: 9, Warnings: 7, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7578f8130832b9c92f83dea83b535