### PR TITLE
Remove obsolete teams save button

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1875,7 +1875,6 @@ document.addEventListener('DOMContentLoaded', function () {
   const teamListEl = document.getElementById('teamsList');
   const teamCardsEl = document.getElementById('teamsCards');
   const teamAddBtn = document.getElementById('teamAddBtn');
-  const teamSaveBtn = document.getElementById('teamsSaveBtn');
   const teamRestrictTeams = document.getElementById('teamRestrict');
   const teamEditModal = UIkit.modal('#teamEditModal');
   const teamEditInput = document.getElementById('teamEditInput');
@@ -2137,18 +2136,6 @@ document.addEventListener('DOMContentLoaded', function () {
     teamEditModal.hide();
   });
 
-  teamSaveBtn?.addEventListener('click', e => {
-    e.preventDefault();
-    saveTeamList(true);
-    if (teamRestrictTeams) {
-      cfgInitial.QRRestrict = teamRestrictTeams.checked;
-      apiFetch('/config.json', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(cfgInitial)
-      }).catch(() => {});
-    }
-  });
 
   // --------- Benutzer ---------
   const usersListEl = document.getElementById('usersList');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -486,9 +486,6 @@
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_team_add') }}; pos: left" aria-label="{{ t('tip_team_add') }}"></button>
         </div>
-        <div class="uk-margin uk-flex uk-flex-right">
-          <button id="teamsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: {{ t('tip_team_save') }}; pos: left" aria-label="{{ t('tip_team_save') }}"></button>
-        </div>
         <div id="teamEditModal" uk-modal>
           <div class="uk-modal-dialog uk-modal-body">
             <h3 class="uk-modal-title">{{ t('heading_team_edit') }}</h3>


### PR DESCRIPTION
## Summary
- remove unused Teams/Personen save button from admin panel
- drop corresponding JS references and click handler

## Testing
- `composer test` *(fails: PHPUnit 10.5.49 by Sebastian Bergmann and contributors. E..........)*

------
https://chatgpt.com/codex/tasks/task_e_68b766be98a0832b97b678b6035b70d1