### PR TITLE
Refactor team restriction settings

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1876,7 +1876,6 @@ document.addEventListener('DOMContentLoaded', function () {
   const teamCardsEl = document.getElementById('teamsCards');
   const teamAddBtn = document.getElementById('teamAddBtn');
   const teamSaveBtn = document.getElementById('teamsSaveBtn');
-  const teamRestrictTeams = document.getElementById('teamRestrict');
   const teamEditModal = UIkit.modal('#teamEditModal');
   const teamEditInput = document.getElementById('teamEditInput');
   const teamEditSave = document.getElementById('teamEditSave');
@@ -2104,9 +2103,6 @@ document.addEventListener('DOMContentLoaded', function () {
         renderTeamsPage(1);
       })
       .catch(()=>{});
-    if (teamRestrictTeams) {
-      teamRestrictTeams.checked = !!cfgInitial.QRRestrict;
-    }
   }
 
   teamAddBtn?.addEventListener('click', e => {
@@ -2140,14 +2136,7 @@ document.addEventListener('DOMContentLoaded', function () {
   teamSaveBtn?.addEventListener('click', e => {
     e.preventDefault();
     saveTeamList(true);
-    if (teamRestrictTeams) {
-      cfgInitial.QRRestrict = teamRestrictTeams.checked;
-      apiFetch('/config.json', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(cfgInitial)
-      }).catch(() => {});
-    }
+    saveConfig(false);
   });
 
   // --------- Benutzer ---------

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -292,16 +292,6 @@
                 </div>
               </div>
               <div class="uk-width-1-1">
-                <h4 class="uk-heading-bullet">{{ t('heading_access') }}</h4>
-              </div>
-              <div>
-                <div class="uk-margin">
-                  <label><input class="uk-checkbox" type="checkbox" id="cfgTeamRestrict"> {{ t('label_team_restrict') }}
-                    <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: {{ t('tip_team_restrict') }}; pos: right" tabindex="0"></span>
-                  </label>
-                </div>
-              </div>
-              <div class="uk-width-1-1">
                 <h4 class="uk-heading-bullet">{{ t('heading_gameplay') }}</h4>
               </div>
               <div>
@@ -485,6 +475,11 @@
         <ul id="teamsCards" class="uk-hidden@m uk-list" uk-sortable="handle: .qr-handle; group: sortable-group"></ul>
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_team_add') }}; pos: left" aria-label="{{ t('tip_team_add') }}"></button>
+        </div>
+        <div class="uk-margin">
+          <label><input class="uk-checkbox" type="checkbox" id="cfgTeamRestrict"> {{ t('label_team_restrict') }}
+            <span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: {{ t('tip_team_restrict') }}; pos: right" tabindex="0"></span>
+          </label>
         </div>
         <div class="uk-margin uk-flex uk-flex-right">
           <button id="teamsSaveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: {{ t('tip_team_save') }}; pos: left" aria-label="{{ t('tip_team_save') }}"></button>


### PR DESCRIPTION
## Summary
- remove obsolete `teamRestrictTeams` handling in admin script
- expose team restriction checkbox in team editor

## Testing
- `composer test` *(fails: Missing STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b766bfbfc8832b8f4d834e249e74e7