### PR TITLE
feat: add swipe card styles

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1122,4 +1122,28 @@ body.admin-page {
   outline: 2px solid var(--accent-color);
 }
 
+/* Swipe card layout */
+.swipe-container {
+  position: relative;
+  height: 250px;
+  user-select: none;
+  touch-action: none;
+}
+
+.swipe-card {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 2rem;
+  right: 2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  transition: transform 0.3s;
+}
+
 

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -811,10 +811,6 @@ async function runQuiz(questions, skipIntro){
 
     const container = document.createElement('div');
     container.className = 'swipe-container';
-    container.style.position = 'relative';
-    container.style.height = '250px';
-    container.style.userSelect = 'none';
-    container.style.touchAction = 'none';
     div.appendChild(container);
 
     const controls = document.createElement('div');
@@ -886,19 +882,6 @@ async function runQuiz(questions, skipIntro){
       cards.forEach((c,i) => {
         const card = document.createElement('div');
         card.className = 'swipe-card';
-        card.style.position = 'absolute';
-        card.style.left = '2rem';
-        card.style.right = '2rem';
-        card.style.top = '0';
-        card.style.bottom = '0';
-        card.style.background = 'white';
-        card.style.borderRadius = '8px';
-        card.style.boxShadow = '0 2px 6px rgba(0,0,0,0.2)';
-        card.style.display = 'flex';
-        card.style.alignItems = 'center';
-        card.style.justifyContent = 'center';
-        card.style.padding = '1rem';
-        card.style.transition = 'transform 0.3s';
         const off = (cards.length - i - 1) * 4;
         card.style.transform = `translate(0,-${off}px)`;
         card.style.zIndex = i;


### PR DESCRIPTION
## Summary
- define reusable `.swipe-container` and `.swipe-card` styles for swipe questions
- remove inline styling in `createSwipeQuestion` to use new classes

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b7678edda0832b952fd64494466341