### PR TITLE
feat: add table macros for admin views

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -31,3 +31,29 @@ Weitere Funktionen wie der QR-Code-Login mit Namensspeicherung oder der Wettkamp
 Im Tab **Seiten** können Administratoren die HTML-Dateien `landing`, `impressum`, `datenschutz` und `faq` anpassen. Über das Untermenü wird die gewünschte Seite ausgewählt und im **Trumbowyg**-Editor bearbeitet. Zusätzlich stehen eigene UIkit-Blöcke zur Verfügung, etwa ein Hero-Abschnitt oder eine Card. Mit **Speichern** werden die Änderungen im Ordner `content/` abgelegt. Die Schaltfläche *Vorschau* zeigt den aktuellen Stand direkt im Modal an. Alternativ kann der Editor weiterhin über `/admin/pages/{slug}` aufgerufen werden.
 
 Wird die dunkle Hero-Vorlage (`uk-section-primary uk-light`) genutzt, sollte anschließend ein Abschnitt mit einer Hintergrundklasse wie `section--alt` eingefügt werden, damit der Seitenhintergrund wieder aufgehellt wird.
+
+## Template-Makros
+
+Wiederverwendbare Tabellen für die Administrations-Ansichten befinden sich in `templates/components/table.twig`. Die Makros werden in einer Twig-Vorlage eingebunden mit:
+
+```twig
+{% from 'components/table.twig' import qr_table, qr_rowcards %}
+```
+
+`qr_table(headings, body_id, sortable=true)` rendert die Desktop-Tabelle. Die Überschriften werden als Array mit `label` und optional `class` übergeben. Beispiel:
+
+```twig
+{{ qr_table([
+  {'label': '', 'class': 'uk-table-shrink uk-text-center'},
+  {'label': t('column_name'), 'class': 'uk-table-expand'},
+  {'label': '', 'class': 'uk-table-shrink uk-text-center'}
+], 'teamsList') }}
+```
+
+Für die mobile Darstellung steht `qr_rowcards(list_id)` zur Verfügung:
+
+```twig
+{{ qr_rowcards('teamsCards') }}
+```
+
+Weitere Admin-Views können die Makros entsprechend einbinden und anpassen.

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1,4 +1,5 @@
 {% extends 'layout.twig' %}
+{% from 'components/table.twig' import qr_table, qr_rowcards %}
 
 {% block title %}{{ t('admin_title') }}{% endblock %}
 
@@ -468,21 +469,14 @@
     <li class="{{ activeRoute == 'teams' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_teams') }}</h2>
-        <div class="uk-visible@m">
-          <div class="uk-overflow-auto">
-            <table id="teamsTable" class="uk-table uk-table-divider uk-table-small qr-table">
-              <thead class="table-headings">
-                <tr>
-                  <th scope="col" class="uk-table-shrink uk-text-center"></th>
-                  <th scope="col" class="uk-table-expand">{{ t('column_name') }}</th>
-                  <th scope="col" class="uk-table-shrink uk-text-center"></th>
-                </tr>
-              </thead>
-              <tbody id="teamsList" role="rowgroup" uk-sortable="handle: .qr-handle; group: sortable-group"></tbody>
-            </table>
-          </div>
-        </div>
-        <ul id="teamsCards" class="uk-hidden@m uk-list" uk-sortable="handle: .qr-handle; group: sortable-group"></ul>
+        {{
+          qr_table([
+            {'label': '', 'class': 'uk-table-shrink uk-text-center'},
+            {'label': t('column_name'), 'class': 'uk-table-expand'},
+            {'label': '', 'class': 'uk-table-shrink uk-text-center'}
+          ], 'teamsList')
+        }}
+        {{ qr_rowcards('teamsCards') }}
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_team_add') }}; pos: left" aria-label="{{ t('tip_team_add') }}"></button>
         </div>

--- a/templates/components/table.twig
+++ b/templates/components/table.twig
@@ -1,0 +1,20 @@
+{% macro qr_table(headings, body_id, sortable=true) %}
+<div class="uk-visible@m">
+  <div class="uk-overflow-auto">
+    <table class="uk-table uk-table-divider uk-table-small qr-table">
+      <thead class="table-headings">
+        <tr>
+          {% for h in headings %}
+          <th scope="col"{% if h.class is defined %} class="{{ h.class }}"{% endif %}>{{ h.label|raw }}</th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody id="{{ body_id }}" role="rowgroup"{% if sortable %} uk-sortable="handle: .qr-handle; group: sortable-group"{% endif %}></tbody>
+    </table>
+  </div>
+</div>
+{% endmacro %}
+
+{% macro qr_rowcards(list_id) %}
+<ul id="{{ list_id }}" class="uk-hidden@m uk-list" uk-sortable="handle: .qr-handle; group: sortable-group"></ul>
+{% endmacro %}


### PR DESCRIPTION
## Summary
- add reusable qr_table and qr_rowcards Twig macros
- use new macros in admin team section
- document macro usage for other admin views

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY; Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b76a8ed12c832b80b2a26e5dfd035d