### PR TITLE
Expose base path in admin base template

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -53,5 +53,6 @@
             <a href="{{ basePath }}/lizenz">{{ t('license') }}</a>
         </div>
     </footer>
+    <script>window.basePath = '{{ basePath }}';</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `basePath` to client scripts in `base.twig`

## Testing
- `vendor/bin/phpunit` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b76d654ae8832b8a6a08cf15fae1aa