### PR TITLE
Define qr foreground color

### DIFF
--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -12,6 +12,7 @@
   --qr-border: rgba(0, 0, 0, 0.1);
   --qr-head: #ffffff;
   --qr-bg-soft: #f3f4f6;
+  --qr-fg: #000000;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -27,5 +28,6 @@
     --qr-head: #1e1e1e;
     --qr-border: rgba(255, 255, 255, 0.1);
     --qr-bg-soft: #161b22;
+    --qr-fg: #e6e9ef;
   }
 }


### PR DESCRIPTION
## Summary
- define `--qr-fg` CSS variable with light and dark values to ensure dropdown/offcanvas text inherits proper color

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b76a3721e4832ba195db338548417d