### PR TITLE
Add swipe question to station 1 catalog

### DIFF
--- a/data-default/kataloge/station_1.json
+++ b/data-default/kataloge/station_1.json
@@ -23,5 +23,16 @@
     "type": "flip",
     "prompt": "Wie viele Bits ergeben ein Byte?",
     "answer": "8"
+  },
+  {
+    "type": "swipe",
+    "prompt": "Wische nach rechts für 'Richtig' und nach links für 'Falsch'",
+    "rightLabel": "Richtig",
+    "leftLabel": "Falsch",
+    "cards": [
+      { "text": "Ein Byte besteht aus 8 Bits.", "correct": true },
+      { "text": "SSD steht für Super Speed Drive.", "correct": false },
+      { "text": "RAM ist ein flüchtiger Speicher.", "correct": true }
+    ]
   }
 ]

--- a/data/kataloge/station_1.json
+++ b/data/kataloge/station_1.json
@@ -23,5 +23,16 @@
     "type": "flip",
     "prompt": "Wie viele Bits ergeben ein Byte?",
     "answer": "8"
+  },
+  {
+    "type": "swipe",
+    "prompt": "Wische nach rechts für 'Richtig' und nach links für 'Falsch'",
+    "rightLabel": "Richtig",
+    "leftLabel": "Falsch",
+    "cards": [
+      { "text": "Ein Byte besteht aus 8 Bits.", "correct": true },
+      { "text": "SSD steht für Super Speed Drive.", "correct": false },
+      { "text": "RAM ist ein flüchtiger Speicher.", "correct": true }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add swipe-based question with labels and cards to station 1 catalog
- same swipe question added to default data set

## Testing
- `composer test` *(fails: Tests: 280, Assertions: 582, Errors: 27, Failures: 23, Warnings: 6, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b770d29590832ba1b68538929f97fd