### PR TITLE
Fix admin topbar center width to restore config menu access

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -572,11 +572,14 @@ body.admin-page {
 
 .admin-page .topbar .uk-navbar-right {
   order: 2;
+  position: relative;
+  z-index: 1;
 }
 
 .admin-page .topbar .uk-navbar-center {
   order: 3;
-  width: 100%;
+  width: auto;
+  flex: 1 1 auto;
   position: static;
   transform: none;
 }


### PR DESCRIPTION
## Summary
- ensure admin topbar center element no longer spans full width and allow right menu clickability
- keep config menu above center via z-index

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b77241f460832bac94e4e16c34211d