### PR TITLE
Define qr foreground color

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -58,6 +58,10 @@ body:not(.dark-mode) .topbar .uk-navbar-nav>li>a{
   color: var(--qr-fg);
   border: 1px solid var(--drop-border, var(--qr-border));
 }
+.uk-offcanvas-bar .uk-nav-default>li>a,
+.uk-offcanvas-bar .uk-nav-default .uk-nav-sub a {
+  color: var(--qr-fg);
+}
 .git-btn{
   width:40px;height:40px;padding:0;
   border-radius:6px;

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -12,6 +12,7 @@
   --qr-border: rgba(0, 0, 0, 0.1);
   --qr-head: #ffffff;
   --qr-bg-soft: #f3f4f6;
+  --qr-fg: #000000;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -27,5 +28,6 @@
     --qr-head: #1e1e1e;
     --qr-border: rgba(255, 255, 255, 0.1);
     --qr-bg-soft: #161b22;
+    --qr-fg: #e6e9ef;
   }
 }


### PR DESCRIPTION
## Summary
- define `--qr-fg` CSS variable with light and dark values to ensure dropdown/offcanvas text inherits proper color
- force offcanvas navigation links to use `--qr-fg` so mobile menu text is visible in light mode

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b76a3721e4832ba195db338548417d