### PR TITLE
Use SVG QR codes by default

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -123,10 +123,11 @@ class QrController
 
         $response->getBody()->write($result->getString());
 
-        $extension = $format === 'svg' ? 'svg' : 'png';
+        $mime = $result->getMimeType();
+        $extension = str_contains($mime, 'svg') ? 'svg' : 'png';
 
         return $response
-            ->withHeader('Content-Type', $result->getMimeType())
+            ->withHeader('Content-Type', $mime)
             ->withHeader('Content-Disposition', 'inline; filename="qr.' . $extension . '"');
     }
 

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -37,7 +37,7 @@ class QrCodeService
      * @param array{fg?:string,bg?:string,logoText?:string} $options
      * @throws Throwable
      */
-    public function generateQrCode(string $data, string $format = 'png', array $options = []): ResultInterface
+    public function generateQrCode(string $data, string $format = 'svg', array $options = []): ResultInterface
     {
         $fgHex = $options['fg'] ?? '2E2E2E';
         $bgHex = $options['bg'] ?? 'F9F9F9';
@@ -59,7 +59,12 @@ class QrCodeService
             }
         }
 
-        $writer = strtolower($format) === 'svg' ? new SvgWriter() : new PngWriter();
+        $format = strtolower($format);
+        if ($format === 'png' && !extension_loaded('gd')) {
+            $format = 'svg';
+        }
+
+        $writer = $format === 'svg' ? new SvgWriter() : new PngWriter();
         $punchout = $logoPath !== null && !($writer instanceof SvgWriter);
 
         try {


### PR DESCRIPTION
## Summary
- Default QR code generation to SVG and fall back to SVG when GD extension is missing
- Derive content headers for QR code responses from the generated result to ensure `image/svg+xml` is sent when appropriate

## Testing
- `composer test` *(fails: Tests: 280, Assertions: 582, Errors: 27, Failures: 23, Warnings: 6, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b7792f0a58832b85cce3f4354b0f0e