### PR TITLE
Use table macros for teams section

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -468,21 +468,9 @@
     <li class="{{ activeRoute == 'teams' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_teams') }}</h2>
-        <div class="uk-visible@m">
-          <div class="uk-overflow-auto">
-            <table id="teamsTable" class="uk-table uk-table-divider uk-table-small qr-table">
-              <thead class="table-headings">
-                <tr>
-                  <th scope="col" class="uk-table-shrink uk-text-center"></th>
-                  <th scope="col" class="uk-table-expand">{{ t('column_name') }}</th>
-                  <th scope="col" class="uk-table-shrink uk-text-center"></th>
-                </tr>
-              </thead>
-              <tbody id="teamsList" role="rowgroup" uk-sortable="handle: .qr-handle; group: sortable-group"></tbody>
-            </table>
-          </div>
-        </div>
-        <ul id="teamsCards" class="uk-hidden@m uk-list" uk-sortable="handle: .qr-handle; group: sortable-group"></ul>
+        {% from 'components/table.twig' import qr_table, qr_rowcards %}
+        {{ qr_table([{ 'label': '', 'class': 'uk-table-shrink' }, { 'label': t('column_name'), 'class': 'uk-table-expand' }, { 'label': '', 'class': 'uk-table-shrink uk-text-center' }], 'teamsList') }}
+        {{ qr_rowcards('teamsCards') }}
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_team_add') }}; pos: left" aria-label="{{ t('tip_team_add') }}"></button>
         </div>

--- a/templates/components/table.twig
+++ b/templates/components/table.twig
@@ -13,6 +13,6 @@
 </div>
 {% endmacro %}
 
-{% macro qr_rowcards(list_id) %}
-<ul class="uk-hidden@m uk-list" id="{{ list_id }}"></ul>
+{% macro qr_rowcards(list_id, sortable=true) %}
+<ul class="uk-hidden@m uk-list" id="{{ list_id }}"{% if sortable %} uk-sortable="handle: .qr-handle; group: sortable-group"{% endif %}></ul>
 {% endmacro %}


### PR DESCRIPTION
## Summary
- Switch admin teams block to use reusable table and rowcard macros
- Add sortable support to rowcard macro to enable drag handles

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b77f82c214832b8297a5ea316fa18f