### PR TITLE
chore: load admin script as module

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1194,7 +1194,7 @@
     window.stripeDashboard = '{{ stripe_sandbox ? 'https://dashboard.stripe.com/test' : 'https://dashboard.stripe.com' }}';
   </script>
   <script src="{{ basePath }}/js/dashboard.js"></script>
-  <script src="{{ basePath }}/js/admin.js"></script>
+  <script type="module" src="{{ basePath }}/js/admin.js"></script>
   <script src="{{ basePath }}/js/subscription.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/results.js"></script>


### PR DESCRIPTION
## Summary
- mark admin.js as an ES module to avoid syntax errors in the admin template

## Testing
- `composer test` *(fails: missing Stripe env vars, Slim application errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b788f3d644832b9a40b5bf3f7db8fc