### PR TITLE
Render backup list on server

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -220,6 +220,7 @@ return [
     'action_open_subscription' => 'Kundenportal öffnen',
     'action_start_subscription' => 'Buchen',
     'action_open_evaluation' => 'Auswertung öffnen',
+    'action_restore' => 'Wiederherstellen',
     'action_download' => 'Herunterladen',
     'action_delete_tenant' => 'Mandant löschen',
     'action_build_image' => 'Docker-Image bauen',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -222,6 +222,7 @@ return [
     'action_open_subscription' => 'Open customer portal',
     'action_start_subscription' => 'Subscribe',
     'action_open_evaluation' => 'Open evaluation',
+    'action_restore' => 'Restore',
     'action_download' => 'Download',
     'action_delete_tenant' => 'Delete tenant',
     'action_build_image' => 'Build Docker image',

--- a/src/routes.php
+++ b/src/routes.php
@@ -225,7 +225,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             ->withAttribute('logoController', new LogoController($configService))
             ->withAttribute('qrLogoController', new QrLogoController($configService))
             ->withAttribute('summaryController', new SummaryController($configService, $eventService))
-            ->withAttribute('importController', new ImportController(
+            ->withAttribute('importController', $importController = new ImportController(
                 $catalogService,
                 $configService,
                 $resultService,
@@ -247,7 +247,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 __DIR__ . '/../data',
                 __DIR__ . '/../backup'
             ))
-            ->withAttribute('backupController', new BackupController(__DIR__ . '/../backup'))
+            ->withAttribute('backupController', new BackupController(__DIR__ . '/../backup', $importController))
             ->withAttribute('evidenceController', new EvidenceController(
                 $resultService,
                 $consentService,
@@ -1032,19 +1032,16 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('exportController')->post($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
     $app->get('/backups', function (Request $request, Response $response) {
-        return $request->getAttribute('backupController')->list($request, $response);
+        return $request->getAttribute('backupController')->index($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
     $app->get('/backups/{name}/download', function (Request $request, Response $response, array $args) {
-        $req = $request->withAttribute('name', $args['name']);
-        return $request->getAttribute('backupController')->download($req, $response, $args);
+        return $request->getAttribute('backupController')->download($request, $response, $args);
     })->add(new RoleAuthMiddleware('admin'));
     $app->post('/backups/{name}/restore', function (Request $request, Response $response, array $args) {
-        $req = $request->withAttribute('name', $args['name']);
-        return $request->getAttribute('importController')->import($req, $response, $args);
+        return $request->getAttribute('backupController')->restore($request, $response, $args);
     })->add(new RoleAuthMiddleware('admin'));
     $app->delete('/backups/{name}', function (Request $request, Response $response, array $args) {
-        $req = $request->withAttribute('name', $args['name']);
-        return $request->getAttribute('backupController')->delete($req, $response, $args);
+        return $request->getAttribute('backupController')->delete($request, $response, $args);
     })->add(new RoleAuthMiddleware('admin'));
     $app->get('/qr.png', function (Request $request, Response $response) {
         return $request->getAttribute('qrController')->image($request, $response);

--- a/templates/admin/_backup_table.twig
+++ b/templates/admin/_backup_table.twig
@@ -1,0 +1,15 @@
+{% if backups is empty %}
+  <tr><td colspan="2">{{ t('text_no_backups') }}</td></tr>
+{% else %}
+  {% for name in backups %}
+    <tr>
+      <td>{{ name }}</td>
+      <td>
+        <button class="uk-button uk-button-primary uk-margin-small-right" data-action="restore" data-name="{{ name }}">{{ t('action_restore') }}</button>
+        <button class="uk-button uk-button-default uk-margin-small-right" data-action="download" data-name="{{ name }}">{{ t('action_download') }}</button>
+        <button class="uk-button uk-button-danger" data-action="delete" data-name="{{ name }}">{{ t('action_delete') }}</button>
+      </td>
+    </tr>
+  {% endfor %}
+{% endif %}
+


### PR DESCRIPTION
## Summary
- Render backup table server-side via new `BackupController::index`
- Provide backup table partial and simplify client-side loading
- Delegate restore through controller and wire new routes

## Testing
- `composer test` *(fails: Database error, missing env; see log)*


------
https://chatgpt.com/codex/tasks/task_e_68b78f450088832b88796f1959bbd3d4