### PR TITLE
Add sortable header placeholder in tables

### DIFF
--- a/docs/table-framework.md
+++ b/docs/table-framework.md
@@ -12,7 +12,6 @@ Die Makros erzeugen das HTML-Grundgerüst:
 ```twig
 {% from 'components/table.twig' import qr_table, qr_rowcards %}
 {{ qr_table([
-  {'label': '', 'class': 'uk-table-shrink'},
   {'label': 'Team', 'class': 'uk-table-expand'},
   {'label': 'Punkte', 'class': 'uk-table-shrink uk-text-right'}
 ], 'teamsBody', true) }}

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -394,14 +394,13 @@
           <h2 class="uk-heading-bullet">{{ t('heading_catalogs') }}</h2>
         {% from 'components/table.twig' import qr_table, qr_rowcards %}
         {{ qr_table([
-          { 'label': ('<span uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_sort_rows') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink' },
           { 'label': (t('column_slug') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_slug') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink' },
           { 'label': (t('column_name') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_name') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-expand' },
           { 'label': (t('column_description') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_desc') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-expand' },
           { 'label': (t('column_letter') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_puzzle_letter') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink' },
           { 'label': (t('column_comment') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_comment') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-expand' },
           { 'label': ('<span uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_remove') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink uk-text-center' }
-        ], 'catalogList') }}
+        ], 'catalogList', true) }}
         {{ qr_rowcards('catalogCards') }}
         <div class="uk-margin">
           <button id="newCatBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_cat_add') }}; pos: left" aria-label="{{ t('tip_cat_add') }}"></button>
@@ -442,8 +441,8 @@
     <li class="{{ activeRoute == 'teams' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_teams') }}</h2>
-        {% from 'components/table.twig' import qr_table, qr_rowcards %}
-        {{ qr_table([{ 'label': '', 'class': 'uk-table-shrink' }, { 'label': t('column_name'), 'class': 'uk-table-expand' }, { 'label': '', 'class': 'uk-table-shrink uk-text-center' }], 'teamsList') }}
+          {% from 'components/table.twig' import qr_table, qr_rowcards %}
+          {{ qr_table([{ 'label': t('column_name'), 'class': 'uk-table-expand' }, { 'label': '', 'class': 'uk-table-shrink uk-text-center' }], 'teamsList', true) }}
         {{ qr_rowcards('teamsCards') }}
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_team_add') }}; pos: left" aria-label="{{ t('tip_team_add') }}"></button>

--- a/templates/components/table.twig
+++ b/templates/components/table.twig
@@ -3,6 +3,9 @@
     <table class="uk-table uk-table-divider uk-table-small uk-table-hover qr-table">
         <thead class="table-headings">
             <tr>
+            {% if sortable %}
+                <th scope="col" class="uk-table-shrink"></th>
+            {% endif %}
             {% for heading in headings %}
                 <th scope="col"{% if heading.class is defined and heading.class %} class="{{ heading.class }}"{% endif %}>{{ heading.label }}</th>
             {% endfor %}


### PR DESCRIPTION
## Summary
- Prepend empty header cell for sortable tables
- Update admin templates to set sortable flag and omit manual handle columns
- Refresh table framework docs for new macro behavior

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables)*
- Rendered `components/table.twig` macro with sortable table to confirm header alignment

------
https://chatgpt.com/codex/tasks/task_e_68b7935ea3a0832bb7862cba2255a577