### PR TITLE
docs: escape twig snippet to avoid Liquid parsing

### DIFF
--- a/docs/landing-style-overrides.md
+++ b/docs/landing-style-overrides.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Landing-Seite: Styles
+title: "Landing-Seite: Styles"
 ---
 
 ## CSS-Variablen der Landing-Seite

--- a/docs/table-framework.md
+++ b/docs/table-framework.md
@@ -9,6 +9,7 @@ Die Makros erzeugen das HTML-Grundgerüst:
 - `qr_table(headings, body_id, sortable=true)`
 - `qr_rowcards(list_id)`
 
+{% raw %}
 ```twig
 {% from 'components/table.twig' import qr_table, qr_rowcards %}
 {{ qr_table([
@@ -18,6 +19,7 @@ Die Makros erzeugen das HTML-Grundgerüst:
 ], 'teamsBody', true) }}
 {{ qr_rowcards('teamsCards') }}
 ```
+{% endraw %}
 
 ## TableManager
 


### PR DESCRIPTION
## Summary
- prevent Liquid from interpreting Twig macro example in `table-framework.md`
- quote landing page title to satisfy YAML parser

## Testing
- `PAGES_REPO_NWO=bastelix/sommerfest-quiz bundle exec ruby -S jekyll build`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b794d38df4832bbf6639c888a8ff44