### PR TITLE
Refactor tenant list status filter

### DIFF
--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -165,8 +165,16 @@ class TenantController
         $status = isset($params['status']) ? (string) $params['status'] : '';
         $query = isset($params['query']) ? (string) $params['query'] : '';
         $list = $this->service->getAll($query);
+        /** @var array<array<string, mixed>> $list */
         if ($status !== '') {
-            $list = array_values(array_filter($list, static fn ($t) => ($t['status'] ?? '') === $status));
+            $list = array_values(
+                array_filter(
+                    $list,
+                    static function (array $t) use ($status): bool {
+                        return isset($t['status']) && $t['status'] === $status;
+                    }
+                )
+            );
         }
         $view = Twig::fromRequest($request);
         $html = $view->fetch('admin/tenant_list.twig', [


### PR DESCRIPTION
## Summary
- Ensure tenant list filtering checks for a `status` key before comparing

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `composer test --no-interaction --no-progress` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET, Slim Application Error, runSyncProcess failed: boom, Database error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cc7ebe1c832b8a3d0bbb2303ec00