### PR TITLE
feat: expose event config endpoints

### DIFF
--- a/src/Controller/EventConfigController.php
+++ b/src/Controller/EventConfigController.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\EventService;
+use App\Service\ConfigService;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+/**
+ * Provides endpoints to retrieve and update configuration for a specific event.
+ */
+class EventConfigController
+{
+    private EventService $events;
+    private ConfigService $config;
+
+    public function __construct(EventService $events, ConfigService $config)
+    {
+        $this->events = $events;
+        $this->config = $config;
+    }
+
+    /**
+     * Return configuration details for the given event UID.
+     */
+    public function show(Request $request, Response $response, array $args): Response
+    {
+        $uid = (string) ($args['id'] ?? '');
+        $event = $this->events->getByUid($uid);
+        if ($event === null) {
+            return $response->withStatus(404);
+        }
+        $cfg = $this->config->getConfigForEvent($uid);
+        $payload = ['event' => $event, 'config' => $cfg];
+        return $response->withJson($payload);
+    }
+
+    /**
+     * Update configuration for the specified event UID.
+     */
+    public function update(Request $request, Response $response, array $args): Response
+    {
+        $uid = (string) ($args['id'] ?? '');
+        $event = $this->events->getByUid($uid);
+        if ($event === null) {
+            return $response->withStatus(404);
+        }
+        $data = $request->getParsedBody();
+        if ($request->getHeaderLine('Content-Type') === 'application/json') {
+            $data = json_decode((string) $request->getBody(), true);
+        }
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+        $data['event_uid'] = $uid;
+        $this->config->saveConfig($data);
+        $cfg = $this->config->getConfigForEvent($uid);
+        $payload = ['event' => $event, 'config' => $cfg];
+        return $response->withJson($payload);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -59,6 +59,7 @@ use App\Controller\SummaryController;
 use App\Controller\EvidenceController;
 use App\Controller\EventController;
 use App\Controller\EventListController;
+use App\Controller\EventConfigController;
 use App\Controller\SettingsController;
 use App\Controller\Admin\PageController;
 use App\Controller\Admin\LandingpageController;
@@ -111,6 +112,7 @@ require_once __DIR__ . '/Controller/EvidenceController.php';
 require_once __DIR__ . '/Controller/ExportController.php';
 require_once __DIR__ . '/Controller/EventController.php';
 require_once __DIR__ . '/Controller/EventListController.php';
+require_once __DIR__ . '/Controller/EventConfigController.php';
 require_once __DIR__ . '/Controller/SettingsController.php';
 require_once __DIR__ . '/Controller/BackupController.php';
 require_once __DIR__ . '/Controller/UserController.php';
@@ -189,6 +191,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             ))
             ->withAttribute('teamController', new TeamController($teamService))
             ->withAttribute('eventController', new EventController($eventService))
+            ->withAttribute('eventConfigController', new EventConfigController($eventService, $configService))
             ->withAttribute(
                 'tenantController',
                 new TenantController(
@@ -421,6 +424,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/admin/dashboard', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/events', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/event/settings', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
+    $app->get('/admin/konfig', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/catalogs', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/questions', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/teams', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
@@ -837,6 +841,13 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
     $app->post('/events/{uid}/publish', function (Request $request, Response $response, array $args) {
         return $request->getAttribute('eventController')->publish($request, $response, $args);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
+
+    $app->get('/admin/event/{id}', function (Request $request, Response $response, array $args) {
+        return $request->getAttribute('eventConfigController')->show($request, $response, $args);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
+    $app->patch('/admin/event/{id}', function (Request $request, Response $response, array $args) {
+        return $request->getAttribute('eventConfigController')->update($request, $response, $args);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));
 
     $app->post('/invite', function (Request $request, Response $response) {


### PR DESCRIPTION
## Summary
- add controller for per-event config retrieval and updates
- register admin routes for event config and konfig page

## Testing
- `vendor/bin/phpcs --standard=PSR12 src/Controller/EventConfigController.php`
- `composer test` *(fails: Failed asserting that 500 is identical to 204, others)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d31d11f0832b97c131cb40e6fa9b