### PR TITLE
Use qr-action for catalog delete buttons

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -853,7 +853,7 @@ document.addEventListener('DOMContentLoaded', function () {
         li.appendChild(contentWrap);
         const delBtn = document.createElement('button');
         delBtn.type = 'button';
-        delBtn.className = 'uk-icon-button uk-button-danger';
+        delBtn.className = 'uk-icon-button qr-action';
         delBtn.setAttribute('uk-icon', 'trash');
         delBtn.setAttribute('aria-label', 'Löschen');
         delBtn.addEventListener('click', () => deleteCatalogById(item.id));

--- a/public/js/table-manager.js
+++ b/public/js/table-manager.js
@@ -126,9 +126,10 @@ export default class TableManager {
       const delCell = document.createElement('td');
       delCell.setAttribute('role', 'gridcell');
       delCell.className = 'uk-table-shrink';
+      delCell.classList.add('uk-text-center');
       const delBtn = document.createElement('button');
       delBtn.type = 'button';
-      delBtn.className = 'uk-icon-button uk-button-danger';
+      delBtn.className = 'uk-icon-button qr-action';
       delBtn.setAttribute('uk-icon', 'trash');
       delBtn.setAttribute('aria-label', 'Löschen');
       delBtn.addEventListener('click', () => this.onDelete(item.id));


### PR DESCRIPTION
## Summary
- center table-manager delete column and use qr-action styling
- update admin mobile catalog cards to use qr-action delete button

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d52e82c8832ba32402188631d5de