### PR TITLE
Render HTML headings in table component

### DIFF
--- a/templates/components/table.twig
+++ b/templates/components/table.twig
@@ -7,7 +7,7 @@
                 <th scope="col" class="uk-table-shrink"></th>
             {% endif %}
             {% for heading in headings %}
-                <th scope="col"{% if heading.class is defined and heading.class %} class="{{ heading.class }}"{% endif %}>{{ heading.label }}</th>
+                <th scope="col"{% if heading.class is defined and heading.class %} class="{{ heading.class }}"{% endif %}>{{ heading.label|raw }}</th>
             {% endfor %}
             </tr>
         </thead>


### PR DESCRIPTION
## Summary
- render table headings as raw HTML to support tooltip spans

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables and Slim application error)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d665362c832bb5364f71ccfbfabd