### PR TITLE
Refactor catalog editing to use TableManager

### DIFF
--- a/public/js/table-manager.js
+++ b/public/js/table-manager.js
@@ -129,7 +129,7 @@ export default class TableManager {
       delCell.classList.add('uk-text-center');
       const delBtn = document.createElement('button');
       delBtn.type = 'button';
-      delBtn.className = 'uk-icon-button qr-action';
+      delBtn.className = 'uk-icon-button qr-action uk-text-center';
       delBtn.setAttribute('uk-icon', 'trash');
       delBtn.setAttribute('aria-label', 'Löschen');
       delBtn.addEventListener('click', () => this.onDelete(item.id));
@@ -223,7 +223,7 @@ export default class TableManager {
     if (typeof this.onDelete === 'function') {
       const delBtn = document.createElement('button');
       delBtn.type = 'button';
-      delBtn.className = 'uk-icon-button uk-button-danger';
+      delBtn.className = 'uk-icon-button qr-action uk-text-center';
       delBtn.setAttribute('uk-icon', 'trash');
       delBtn.setAttribute('aria-label', 'Löschen');
       delBtn.addEventListener('click', () => this.onDelete(item.id));


### PR DESCRIPTION
## Summary
- use TableManager editable columns for catalogs and handle comment editing via modal
- standardize table-manager delete button classes

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d66b1c9c832b8aea846fdd4e3881