### PR TITLE
Add dark mode styling for admin config

### DIFF
--- a/public/css/admin-config.css
+++ b/public/css/admin-config.css
@@ -2,3 +2,15 @@
 .event-config-sidebar .uk-card + .uk-card {
   margin-top: 20px;
 }
+
+.uk-card-body {
+  padding: 20px;
+  background: var(--qr-card);
+  border: 1px solid var(--qr-border);
+  color: var(--color-text);
+}
+
+.uk-form-label {
+  font-weight: 600;
+  color: var(--color-text);
+}


### PR DESCRIPTION
## Summary
- style admin config card body and labels using CSS variables
- ensure admin configuration styles loaded via template link

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d72839a8832b8c8030fc823fb383