### PR TITLE
Handle WebP logos in QR codes

### DIFF
--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -107,6 +107,25 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
+    public function testTeamQrWebpLogo(): void
+    {
+        $logoFile = dirname(__DIR__, 2) . '/data/test-logo.webp';
+        imagewebp(imagecreatetruecolor(10, 10), $logoFile);
+
+        $pdo = $this->getDatabase();
+        $cfg = new \App\Service\ConfigService($pdo);
+        $cfg->saveConfig(['qrLogoPath' => '/test-logo.webp']);
+
+        $app = $this->getAppInstance();
+        $response = $app->handle($this->createRequest('GET', '/qr/team'));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/png', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
+
+        @unlink($logoFile);
+    }
+
     public function testQrPdfIsGenerated(): void
     {
         $app = $this->getAppInstance();


### PR DESCRIPTION
## Summary
- Extend QR code logo embedding to detect file extension and support PNG or WebP logos safely.
- Skip logo embedding when unsupported or malformed files are supplied.
- Add regression test ensuring WebP logos in configuration still yield valid team QR codes.

## Testing
- `vendor/bin/phpunit tests/Controller/QrControllerTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d93746ac832bbdfeabb3fcb53b3f