### PR TITLE
Replace deprecated withJson usage

### DIFF
--- a/src/Controller/EventConfigController.php
+++ b/src/Controller/EventConfigController.php
@@ -35,7 +35,9 @@ class EventConfigController
         }
         $cfg = $this->config->getConfigForEvent($uid);
         $payload = ['event' => $event, 'config' => $cfg];
-        return $response->withJson($payload);
+        $content = json_encode($payload, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+        $response->getBody()->write($content);
+        return $response->withHeader('Content-Type', 'application/json');
     }
 
     /**
@@ -59,6 +61,8 @@ class EventConfigController
         $this->config->saveConfig($data);
         $cfg = $this->config->getConfigForEvent($uid);
         $payload = ['event' => $event, 'config' => $cfg];
-        return $response->withJson($payload);
+        $content = json_encode($payload, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+        $response->getBody()->write($content);
+        return $response->withHeader('Content-Type', 'application/json');
     }
 }


### PR DESCRIPTION
## Summary
- avoid deprecated Response::withJson calls in EventConfigController

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`
- `node tests/test_onboarding_flow.js`
- `vendor/bin/phpunit` *(fails: process did not complete, repeated output)*

------
https://chatgpt.com/codex/tasks/task_e_68b7da6b1d5c832bbb1d95e0f9b8d68f