### PR TITLE
Ensure catalogs have IDs for admin operations

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -757,7 +757,14 @@ document.addEventListener('DOMContentLoaded', function () {
   apiFetch('/kataloge/catalogs.json', { headers: { 'Accept': 'application/json' } })
     .then(r => r.json())
     .then(list => {
-      catalogs = list.map(c => ({ ...c, id: c.uid || c.slug || c.sort_order }));
+      let needsRender = false;
+      catalogs = list.map((c, i) => {
+        if (!c.uid && !c.slug) {
+          needsRender = true;
+          return { ...c, id: Date.now() + i };
+        }
+        return { ...c, id: c.uid || c.slug };
+      });
       catSelect.innerHTML = '';
       catalogs.forEach(c => {
         const opt = document.createElement('option');
@@ -766,6 +773,9 @@ document.addEventListener('DOMContentLoaded', function () {
         catSelect.appendChild(opt);
       });
       catalogManager.render(catalogs);
+      if (needsRender) {
+        catalogManager.render(catalogs);
+      }
       const params = new URLSearchParams(window.location.search);
       const slug = params.get('katalog');
       const selected = catalogs.find(c => (c.slug || c.sort_order) === slug) || catalogs[0];


### PR DESCRIPTION
## Summary
- Generate unique IDs for catalogs missing `uid` or `slug`
- Re-render catalog list after ID generation so edit/delete work

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b7db849738832b88922e3ae7e54e1b