### PR TITLE
Improve team list save error handling

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1909,21 +1909,26 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   teamManager.bindPagination(teamPaginationEl, TEAMS_PER_PAGE);
 
-  function saveTeamList(list = teamManager.getData(), show = false) {
+  function saveTeamList(list = teamManager.getData(), show = false, retries = 1) {
     const names = list.map(t => t.name);
     apiFetch('/teams.json', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(names)
-    }).then(r => {
-      if (!r.ok) throw new Error(r.statusText);
-      if (show) notify('Liste gespeichert', 'success');
-    }).catch(err => {
-      if (show) {
+    })
+      .then(r => {
+        if (!r.ok) throw new Error(r.statusText);
+        if (show) notify('Liste gespeichert', 'success');
+      })
+      .catch(err => {
         console.error(err);
-        notify('Fehler beim Speichern', 'danger');
-      }
-    });
+        if (retries > 0) {
+          notify('Fehler beim Speichern, versuche es erneut …', 'warning');
+          setTimeout(() => saveTeamList(list, show, retries - 1), 1000);
+        } else {
+          notify('Fehler beim Speichern', 'danger');
+        }
+      });
   }
 
   function openTeamModal(cell) {


### PR DESCRIPTION
## Summary
- Always log and notify team list save errors
- Retry saving team list once before showing final error

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other env vars, phpunit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dd929f94832b88eb2681b150fd4d