### PR TITLE
fix stray array bracket causing admin.js parse error

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -609,11 +609,8 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     }).catch(() => notify('Fehler beim Speichern', 'danger'));
   });
-  [
-    cfgFields.pageTitle,
-    cfgFields.backgroundColor,
-    cfgFields.buttonColor,
-    // Former auto-save fields removed; form submission handled by backend.
+  // Former auto-save fields removed; form submission handled by backend.
+
   const summaryPrintBtn = document.getElementById('summaryPrintBtn');
   summaryPrintBtn?.addEventListener('click', function (e) {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- fix admin.js syntax: remove stray array and place summary print declaration outside

## Testing
- `node --experimental-vm-modules -e "const fs=require('fs');const {SourceTextModule}=require('vm');new SourceTextModule(fs.readFileSync('public/js/admin.js','utf8'));console.log('syntax ok');"`
- `composer test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e1dc8a14832b86edabec292e0e8d