### PR TITLE
Detect logo MIME type for SVG QR codes

### DIFF
--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -211,13 +211,21 @@ class QrCodeService
             $qr = new QRCode(new QROptions($options));
             $svg = $qr->render($data);
             if ($p['logoPath'] !== null && is_readable($p['logoPath'])) {
-                $matrix = $qr->getMatrix();
-                $dim = ($matrix->getSize() + 2 * $marginModules) * $scale;
-                $logoData = base64_encode(file_get_contents($p['logoPath']));
-                $x = (int)(($dim - $p['logoWidth']) / 2);
-                $y = (int)(($dim - $p['logoWidth']) / 2);
-                $image = '<image x="' . $x . '" y="' . $y . '" width="' . $p['logoWidth'] . '" height="' . $p['logoWidth'] . '" href="data:image/png;base64,' . $logoData . '" />';
-                $svg = preg_replace('/<\/svg>/', $image . '</svg>', $svg);
+                $ext = strtolower(pathinfo($p['logoPath'], PATHINFO_EXTENSION));
+                $mime = match ($ext) {
+                    'png' => 'image/png',
+                    'webp' => 'image/webp',
+                    default => null,
+                };
+                if ($mime !== null) {
+                    $matrix = $qr->getMatrix();
+                    $dim = ($matrix->getSize() + 2 * $marginModules) * $scale;
+                    $logoData = base64_encode(file_get_contents($p['logoPath']));
+                    $x = (int)(($dim - $p['logoWidth']) / 2);
+                    $y = (int)(($dim - $p['logoWidth']) / 2);
+                    $image = '<image x="' . $x . '" y="' . $y . '" width="' . $p['logoWidth'] . '" height="' . $p['logoWidth'] . '" href="data:' . $mime . ';base64,' . $logoData . '" />';
+                    $svg = preg_replace('/<\/svg>/', $image . '</svg>', $svg);
+                }
             }
             return ['mime' => 'image/svg+xml', 'body' => $svg];
         }


### PR DESCRIPTION
## Summary
- detect logo file extension in `renderQr`
- embed SVG `<image>` with correct `data:` URI for PNG or WebP
- skip unsupported logo formats

## Testing
- `php -l src/Service/QrCodeService.php`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e9421c04832b9f66234fbaf53638