### PR TITLE
Add error handling for QR code controller endpoints

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -11,6 +11,7 @@ use App\Service\CatalogService;
 use App\Service\QrCodeService;
 use App\Service\ResultService;
 use App\Service\Pdf;
+use App\Service\LogService;
 use FPDF;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -60,7 +61,15 @@ class QrController
     public function catalog(Request $request, Response $response): Response
     {
         $cfg = $this->config->getConfig();
-        $out = $this->qrService->generateCatalog($request->getQueryParams(), $cfg);
+
+        try {
+            $out = $this->qrService->generateCatalog($request->getQueryParams(), $cfg);
+        } catch (Throwable $e) {
+            LogService::create('qr')->error('Catalog QR generation failed', ['exception' => $e]);
+            $response->getBody()->write('Error generating catalog QR code');
+            return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
+        }
+
         $response->getBody()->write($out['body']);
         return $response
             ->withHeader('Content-Type', $out['mime'])
@@ -73,7 +82,15 @@ class QrController
     public function team(Request $request, Response $response): Response
     {
         $cfg = $this->config->getConfig();
-        $out = $this->qrService->generateTeam($request->getQueryParams(), $cfg);
+
+        try {
+            $out = $this->qrService->generateTeam($request->getQueryParams(), $cfg);
+        } catch (Throwable $e) {
+            LogService::create('qr')->error('Team QR generation failed', ['exception' => $e]);
+            $response->getBody()->write('Error generating team QR code');
+            return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
+        }
+
         $response->getBody()->write($out['body']);
         return $response
             ->withHeader('Content-Type', $out['mime'])
@@ -86,7 +103,15 @@ class QrController
     public function event(Request $request, Response $response): Response
     {
         $cfg = $this->config->getConfig();
-        $out = $this->qrService->generateEvent($request->getQueryParams(), $cfg);
+
+        try {
+            $out = $this->qrService->generateEvent($request->getQueryParams(), $cfg);
+        } catch (Throwable $e) {
+            LogService::create('qr')->error('Event QR generation failed', ['exception' => $e]);
+            $response->getBody()->write('Error generating event QR code');
+            return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');
+        }
+
         $response->getBody()->write($out['body']);
         return $response
             ->withHeader('Content-Type', $out['mime'])


### PR DESCRIPTION
## Summary
- add try/catch with logging to catalog, team, and event QR endpoints
- return 500 status with message when QR generation fails

## Testing
- `composer phpunit` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e9440168832b87b4b46ea8048da8