### PR TITLE
Log QR generation failures with 500 responses

### DIFF
--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -63,6 +63,8 @@ class QrController
         try {
             $out = $this->qrService->generateCatalog($request->getQueryParams(), $cfg);
         } catch (Throwable $e) {
+            error_log('Catalog QR generation failed: ' . $e->getMessage());
+            error_log($e->getTraceAsString());
             return $this->errorResponse($response);
         }
         $response->getBody()->write($out['body']);
@@ -80,6 +82,8 @@ class QrController
         try {
             $out = $this->qrService->generateTeam($request->getQueryParams(), $cfg);
         } catch (Throwable $e) {
+            error_log('Team QR generation failed: ' . $e->getMessage());
+            error_log($e->getTraceAsString());
             return $this->errorResponse($response);
         }
         $response->getBody()->write($out['body']);
@@ -97,6 +101,8 @@ class QrController
         try {
             $out = $this->qrService->generateEvent($request->getQueryParams(), $cfg);
         } catch (Throwable $e) {
+            error_log('Event QR generation failed: ' . $e->getMessage());
+            error_log($e->getTraceAsString());
             return $this->errorResponse($response);
         }
         $response->getBody()->write($out['body']);
@@ -355,8 +361,8 @@ class QrController
 
     private function errorResponse(Response $response): Response
     {
-        $response->getBody()->write('QR code unavailable');
-        return $response->withHeader('Content-Type', 'text/plain')->withStatus(503);
+        $response->getBody()->write('Failed to generate QR code');
+        return $response->withHeader('Content-Type', 'text/plain')->withStatus(500);
     }
 
     /**


### PR DESCRIPTION
## Summary
- log and surface catalog QR generation errors
- add logging for team and event QR code generation
- return plain 500 responses when QR generation fails

## Testing
- `vendor/bin/phpcs src/Controller/QrController.php`
- `composer test` *(fails: Tests: 282, Assertions: 610, Errors: 27, Failures: 8, Warnings: 6, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7eb6f025c832bacb17dabbdff2136