### PR TITLE
feat: improve mobile table layout

### DIFF
--- a/docs/table-framework.md
+++ b/docs/table-framework.md
@@ -61,6 +61,10 @@ manager.render(teams);
 
 Enthält eine mobile Karte mehrere Elemente mit der Klasse `qr-action`, fasst der `TableManager` diese automatisch in einem aufklappbaren Menü zusammen. Dadurch bleibt die Darstellung kompakt, selbst wenn mehrere Aktionen wie PDF-Download und Löschen verfügbar sind.
 
+### Mobile Darstellung
+
+Auf Mobilgeräten erscheinen die Spalten einer Karte untereinander. Überlange Inhalte werden automatisch mit `…` gekürzt, damit sie den verfügbaren Platz nicht überschreiten.
+
 ### Katalogtabelle
 
 Beim Bearbeiten der Katalogtabelle kommen Modalfenster zum Einsatz, um Felder wie `slug`, `name` oder `description` zu ändern. Browser-Prompts werden dabei nicht mehr verwendet.

--- a/public/css/table.css
+++ b/public/css/table.css
@@ -92,6 +92,19 @@
   background: var(--qr-row-alt);
 }
 
+.qr-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.qr-card-content > * {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .qr-action {
   width: 44px;
   height: 44px;

--- a/public/js/table-manager.js
+++ b/public/js/table-manager.js
@@ -172,7 +172,7 @@ export default class TableManager {
       li.appendChild(handleBtn);
     }
     const contentWrap = document.createElement('div');
-    contentWrap.className = 'uk-flex-1';
+    contentWrap.className = 'uk-flex-1 qr-card-content';
     const actions = [];
     this.columns.forEach((col, idx) => {
       let c = '';


### PR DESCRIPTION
## Summary
- stack table columns vertically on mobile cards
- truncate overflowing card content with ellipsis
- document mobile card layout behavior

## Testing
- `composer test` *(fails: Failed to reload nginx: reload failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f7c97864832bab49cad2e29e4ec6