### PR TITLE
feat: add paginated catalog endpoint

### DIFF
--- a/src/Controller/AdminCatalogController.php
+++ b/src/Controller/AdminCatalogController.php
@@ -74,4 +74,28 @@ class AdminCatalogController
             'qrOptions' => $qrOptions,
         ]);
     }
+
+    /**
+     * Provide paginated catalog data as JSON.
+     */
+    public function catalogs(Request $request, Response $response): Response
+    {
+        $params = $request->getQueryParams();
+        $page = max(1, (int) ($params['page'] ?? 1));
+        $perPage = max(1, (int) ($params['perPage'] ?? 50));
+        $order = (string) ($params['order'] ?? 'asc');
+        $offset = ($page - 1) * $perPage;
+        $items = $this->service->fetchPagedCatalogs($offset, $perPage, $order);
+        $total = $this->service->countCatalogs();
+
+        $payload = [
+            'items' => $items,
+            'total' => $total,
+            'page' => $page,
+            'perPage' => $perPage,
+        ];
+
+        $response->getBody()->write((string) json_encode($payload));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -705,6 +705,8 @@ return function (\Slim\App $app, TranslationService $translator) {
     })->add(new RoleAuthMiddleware(Roles::ADMIN));
     $app->get('/admin/kataloge', AdminCatalogController::class)
         ->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
+    $app->get('/admin/catalogs', [AdminCatalogController::class, 'catalogs'])
+        ->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
 
     $app->get('/admin/pages/{slug}', function (Request $request, Response $response, array $args) {
         $controller = new PageController();

--- a/tests/Controller/AdminCatalogControllerTest.php
+++ b/tests/Controller/AdminCatalogControllerTest.php
@@ -89,4 +89,31 @@ class AdminCatalogControllerTest extends TestCase
         session_destroy();
         unlink($db);
     }
+
+    public function testCatalogsEndpointReturnsPagedJson(): void
+    {
+        $db = tempnam(sys_get_temp_dir(), 'db');
+        putenv('POSTGRES_DSN=sqlite:' . $db);
+        putenv('POSTGRES_USER=');
+        putenv('POSTGRES_PASSWORD=');
+        $pdo = new PDO('sqlite:' . $db);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        Migrator::migrate($pdo, dirname(__DIR__, 2) . '/migrations');
+        $pdo->exec("INSERT INTO events(uid,name) VALUES('e1','Event')");
+        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('c1',1,'s1','s1.json','Cat1','e1')");
+        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('c2',2,'s2','s2.json','Cat2','e1')");
+        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('c3',3,'s3','s3.json','Cat3','e1')");
+
+        $cfgSvc = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfgSvc);
+        $controller = new AdminCatalogController($service);
+
+        $request = $this->createRequest('GET', '/admin/catalogs?page=1&perPage=2&order=asc');
+        $response = $controller->catalogs($request, new Response());
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getBody(), true);
+        $this->assertCount(2, $data['items']);
+        $this->assertEquals(3, $data['total']);
+        unlink($db);
+    }
 }


### PR DESCRIPTION
## Summary
- support JSON endpoint `/admin/catalogs` with pagination
- load catalog lists page-wise via new API
- cover paginated retrieval in CatalogService and tests

## Testing
- `composer test` *(fails: Tests: 283, Assertions: 455, Errors: 30, Failures: 102, Warnings: 6, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f9a26c0c832b92e345d2b968c247