### PR TITLE
Add column-loading spinners

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -767,6 +767,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const cat = catalogs.find(c => c.id === identifier || c.uid === identifier || (c.slug || c.sort_order) === identifier);
     if (!cat) return;
     catalogFile = cat.file;
+    catalogManager?.setColumnLoading('slug', true);
     apiFetch('/kataloge/' + catalogFile, { headers: { 'Accept': 'application/json' } })
       .then(r => r.json())
       .then(data => {
@@ -776,9 +777,11 @@ document.addEventListener('DOMContentLoaded', function () {
       .catch(() => {
         initial = [];
         renderAll(initial);
-      });
+      })
+      .finally(() => catalogManager?.setColumnLoading('slug', false));
   }
 
+  catalogManager?.setColumnLoading('slug', true);
   apiFetch('/kataloge/catalogs.json', { headers: { 'Accept': 'application/json' } })
     .then(r => r.json())
     .then(list => {
@@ -810,7 +813,8 @@ document.addEventListener('DOMContentLoaded', function () {
         loadCatalog(selected.id);
       }
     })
-    .catch(err => console.error(err));
+    .catch(err => console.error(err))
+    .finally(() => catalogManager?.setColumnLoading('slug', false));
 
   catSelect.addEventListener('change', () => loadCatalog(catSelect.value));
 
@@ -1991,13 +1995,15 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   if(teamListEl){
+    teamManager?.setColumnLoading('name', true);
     apiFetch('/teams.json', { headers: { 'Accept':'application/json' } })
       .then(r => r.json())
       .then(data => {
         const list = data.map(n => ({ id: crypto.randomUUID(), name: n }));
         teamManager.render(list);
       })
-      .catch(()=>{});
+      .catch(()=>{})
+      .finally(() => teamManager?.setColumnLoading('name', false));
     if (teamRestrictTeams) {
       teamRestrictTeams.checked = !!cfgInitial.QRRestrict;
     }

--- a/public/js/table-manager.js
+++ b/public/js/table-manager.js
@@ -297,6 +297,13 @@ export default class TableManager {
     }
   }
 
+  setColumnLoading(key, isLoading) {
+    const spinner = document.querySelector(`[data-spinner="${key}"]`);
+    if (spinner) {
+      spinner.hidden = !isLoading;
+    }
+  }
+
   getData() {
     return this.data;
   }

--- a/templates/components/table.twig
+++ b/templates/components/table.twig
@@ -7,7 +7,7 @@
                 <th scope="col" class="uk-table-shrink"></th>
             {% endif %}
             {% for heading in headings %}
-                <th scope="col"{% if heading.class is defined and heading.class %} class="{{ heading.class }}"{% endif %}>{{ heading.label|raw }}</th>
+                <th scope="col"{% if heading.class is defined and heading.class %} class="{{ heading.class }}"{% endif %}>{{ heading.label|raw }}<span class="uk-spinner" aria-live="polite" data-spinner="{{ heading.key }}" hidden></span></th>
             {% endfor %}
             </tr>
         </thead>


### PR DESCRIPTION
## Summary
- show hidden spinner in each table header with screen reader hint
- allow TableManager to toggle header spinners via `setColumnLoading`
- indicate loading of catalog and team data in admin panel

## Testing
- `composer test` *(fails: Missing STRIPE_* env variables and PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f9a5d9c0832bb753e1dca21113fa