### PR TITLE
feat: add accessible table loading spinners

### DIFF
--- a/docs/table-framework.md
+++ b/docs/table-framework.md
@@ -6,7 +6,7 @@ Die Listenansichten im Admin-Bereich nutzen Twig-Makros und den JavaScript-`Tabl
 
 Die Makros erzeugen das HTML-Grundgerüst:
 
-- `qr_table(headings, body_id, sortable=true)`
+- `qr_table(headings, body_id, sortable=true)`: Jede Spaltenüberschrift enthält einen versteckten Spinner mit `aria-live="polite"`.
 - `qr_rowcards(list_id)`
 
 {% raw %}
@@ -56,6 +56,7 @@ manager.render(teams);
 - `render(list)`: Rendert die übergebene Datenliste.
 - `addRow(item)`: Fügt eine Zeile hinzu.
 - `bindPagination(el, perPage)`: Fügt Pagination hinzu.
+- `setColumnLoading(key, loading)`: Blendet den Spinner einer Spalte ein oder aus.
 
 ### Mobile Aktionsmenüs
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -808,6 +808,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   async function loadCatalogs(page = 1) {
+    catalogManager?.setColumnLoading('name', true);
     try {
       const res = await fetch(withBase('/admin/catalogs?page=' + page));
       if (!res.ok) throw new Error('fail');
@@ -865,6 +866,8 @@ document.addEventListener('DOMContentLoaded', function () {
           }
         })
         .catch(e => console.error(e));
+    } finally {
+      catalogManager?.setColumnLoading('name', false);
     }
   }
 
@@ -2048,14 +2051,16 @@ document.addEventListener('DOMContentLoaded', function () {
     window.open(withBase('/results.pdf?team=' + encodeURIComponent(teamName)), '_blank');
   }
 
-  if(teamListEl){
-    apiFetch('/teams.json', { headers: { 'Accept':'application/json' } })
+  if (teamListEl) {
+    teamManager.setColumnLoading('name', true);
+    apiFetch('/teams.json', { headers: { 'Accept': 'application/json' } })
       .then(r => r.json())
       .then(data => {
         const list = data.map(n => ({ id: crypto.randomUUID(), name: n }));
         teamManager.render(list);
       })
-      .catch(()=>{});
+      .catch(() => {})
+      .finally(() => teamManager.setColumnLoading('name', false));
     if (teamRestrictTeams) {
       teamRestrictTeams.checked = !!cfgInitial.QRRestrict;
     }

--- a/public/js/table-manager.js
+++ b/public/js/table-manager.js
@@ -7,6 +7,7 @@ export default class TableManager {
     this.onEdit = onEdit;
     this.onDelete = onDelete;
     this.onReorder = onReorder;
+    this.thead = this.tbody?.closest('table')?.querySelector('thead');
     this.data = [];
     if (this.sortable) {
       this.#initSortable();
@@ -51,6 +52,14 @@ export default class TableManager {
     this.data.forEach(item => this.addRow(item));
     if (this.pagination) {
       this.#updatePagination();
+    }
+  }
+
+  setColumnLoading(key, loading = true) {
+    const th = this.thead?.querySelector(`th[data-key="${key}"]`);
+    const spinner = th?.querySelector('.qr-col-spinner');
+    if (spinner) {
+      spinner.hidden = !loading;
     }
   }
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -409,11 +409,11 @@
           <h2 class="uk-heading-bullet">{{ t('heading_catalogs') }}</h2>
         {% from 'components/table.twig' import qr_table, qr_rowcards %}
         {{ qr_table([
-          { 'label': (t('column_slug') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_slug') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink' },
-          { 'label': (t('column_name') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_name') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-expand' },
-          { 'label': (t('column_description') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_desc') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-expand' },
-          { 'label': (t('column_letter') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_puzzle_letter') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink' },
-          { 'label': (t('column_comment') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_comment') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-expand' },
+          { 'label': (t('column_slug') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_slug') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink', 'key': 'slug' },
+          { 'label': (t('column_name') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_name') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-expand', 'key': 'name' },
+          { 'label': (t('column_description') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_desc') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-expand', 'key': 'description' },
+          { 'label': (t('column_letter') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_puzzle_letter') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink', 'key': 'raetsel_buchstabe' },
+          { 'label': (t('column_comment') ~ '<span class="uk-margin-small-left" uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_comment') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-expand', 'key': 'comment' },
           { 'label': ('<span uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_cat_remove') ~ '; pos: top" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink uk-text-center' }
         ], 'catalogList', true) }}
         {{ qr_rowcards('catalogCards') }}
@@ -457,7 +457,7 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_teams') }}</h2>
           {% from 'components/table.twig' import qr_table, qr_rowcards %}
-          {{ qr_table([{ 'label': t('column_name'), 'class': 'uk-table-expand' }, { 'label': '', 'class': 'uk-table-shrink uk-text-center' }], 'teamsList', true) }}
+          {{ qr_table([{ 'label': t('column_name'), 'class': 'uk-table-expand', 'key': 'name' }, { 'label': '', 'class': 'uk-table-shrink uk-text-center' }], 'teamsList', true) }}
         {{ qr_rowcards('teamsCards') }}
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_team_add') }}; pos: left" aria-label="{{ t('tip_team_add') }}"></button>

--- a/templates/components/table.twig
+++ b/templates/components/table.twig
@@ -7,7 +7,10 @@
                 <th scope="col" class="uk-table-shrink"></th>
             {% endif %}
             {% for heading in headings %}
-                <th scope="col"{% if heading.class is defined and heading.class %} class="{{ heading.class }}"{% endif %}>{{ heading.label|raw }}</th>
+                <th scope="col"{% if heading.class is defined and heading.class %} class="{{ heading.class }}"{% endif %}{% if heading.key is defined %} data-key="{{ heading.key }}"{% endif %}>
+                    {{ heading.label|raw }}
+                    <span class="qr-col-spinner uk-margin-small-left" uk-spinner hidden aria-live="polite"></span>
+                </th>
             {% endfor %}
             </tr>
         </thead>


### PR DESCRIPTION
## Summary
- add hidden spinner to table headers for screen reader loading announcements
- expose `setColumnLoading` in TableManager
- toggle loading spinners when fetching catalog and team data in admin

## Testing
- `composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fd4bae3c832ba10e085ed84b7a24