### PR TITLE
Fix duplicate catalog route and update admin navigation

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -7,7 +7,7 @@ Die Administrationsoberfläche erreichen Sie über `/admin/dashboard` (kurz `/ad
   * **Events** – `/admin/events`
   * **Event-Konfiguration** – `/admin/event/settings`
 * **Inhalte**
-  * **Kataloge** – `/admin/catalogs`
+* **Kataloge** – `/admin/kataloge`
   * **Fragen bearbeiten** – `/admin/questions`
   * **Seiten** – `/admin/pages` (nur Administratoren)
 * **Teams**

--- a/src/routes.php
+++ b/src/routes.php
@@ -426,7 +426,6 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/admin/events', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/event/settings', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/konfig', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
-    $app->get('/admin/catalogs', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/questions', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/teams', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/admin/summary', AdminController::class)->add(new RoleAuthMiddleware(...Roles::ALL));

--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -14,7 +14,7 @@
   {
     header: t('menu_content'),
     items: [
-      { href: basePath ~ '/admin/catalogs', icon: 'file-text', text: t('tab_catalogs') },
+      { href: basePath ~ '/admin/kataloge', icon: 'file-text', text: t('tab_catalogs') },
       { href: basePath ~ '/admin/questions', icon: 'question', text: t('tab_questions') },
       { href: basePath ~ '/admin/pages', icon: 'file-text', text: t('tab_pages'), admin: true },
     ]


### PR DESCRIPTION
## Summary
- remove legacy /admin/catalogs route to avoid FastRoute conflicts
- point admin navigation to new /admin/kataloge path
- update docs to reflect catalog admin URL

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars; Tests: 283, Errors: 27, Failures: 8)*

------
https://chatgpt.com/codex/tasks/task_e_68b800195a90832ba08689d714b380d7