### PR TITLE
chore: preserve query string on rewrite

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,7 +10,7 @@ deny from all
   RewriteEngine On
   # RewriteBase /
   RewriteRule ^$ public/ [L]
-  RewriteRule (.*) public/$1 [L]
+  RewriteRule (.*) public/$1 [QSA,L]
 
   # Redirect to HTTPS
   # RewriteEngine On


### PR DESCRIPTION
## Summary
- append QSA flag to .htaccess rewrite rule so query strings survive forwarding to the public folder

## Testing
- `curl 'http://127.0.0.1:8090/qr/team?t=SchnellerAdler75'`
- `composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b800821500832ba845bda8f325f39a