### PR TITLE
Use table macros on results page

### DIFF
--- a/templates/results.twig
+++ b/templates/results.twig
@@ -1,5 +1,7 @@
 {% extends 'layout.twig' %}
 
+{% from 'components/table.twig' import qr_table, qr_rowcards %}
+
 {% block title %}Ergebnisse{% endblock %}
 
 {% block head %}
@@ -32,41 +34,25 @@
       <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="Aktualisieren" aria-label="Aktualisieren"></button>
     </div>
     <div id="rankingGrid" class="uk-grid-small uk-child-width-1-1 uk-child-width-1-3@m uk-margin-bottom" uk-grid uk-height-match="target: > div > .uk-card"></div>
-    <table class="uk-table uk-table-divider">
-      <thead>
-        <tr><th>Name</th><th>Versuch</th><th>Katalog</th><th>Richtige</th><th>Zeit</th><th>Rätselwort gelöst</th><th>Beweisfoto</th></tr>
-      </thead>
-      <tbody id="resultsTableBody" uk-lightbox="nav: thumbnav; slidenav: false">
-        {% for r in results %}
-        <tr>
-          <td>{{ r.name }}</td>
-          <td>{{ r.attempt }}</td>
-          <td>{{ r.catalogName ?? r.catalog }}</td>
-          <td>{{ r.correct }}/{{ r.total }}</td>
-          <td>{{ r.time | date('Y-m-d H:i') }}</td>
-          <td>{% if r.puzzleTime is defined %}{{ r.puzzleTime | date('Y-m-d H:i') }}{% endif %}</td>
-          <td>
-            {% if r.photo is defined and r.photo %}
-            <span class="photo-wrapper">
-              <a class="uk-inline rotate-link" href="{{ basePath ~ r.photo }}" data-caption='<button class="uk-icon-button lightbox-rotate-btn" type="button" uk-icon="history" data-path="{{ basePath ~ r.photo }}" aria-label="Drehen"></button>' data-attrs="class: uk-inverse-light">
-                <img src="{{ basePath ~ r.photo }}" alt="Beweisfoto" class="proof-thumb">
-              </a>
-            </span>
-            {% endif %}
-          </td>
-        </tr>
-        {% else %}
-        <tr><td colspan="7">Keine Daten</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div uk-lightbox="nav: thumbnav; slidenav: false">
+      {{ qr_table([
+        {'label': 'Name', 'class': 'uk-table-expand'},
+        {'label': 'Versuch'},
+        {'label': 'Katalog'},
+        {'label': 'Richtige'},
+        {'label': 'Zeit'},
+        {'label': 'Rätselwort gelöst'},
+        {'label': 'Beweisfoto'}
+      ], 'resultsTableBody', false) }}
+      {{ qr_rowcards('resultsCards', false) }}
+    </div>
     <h3 class="uk-heading-bullet">Falsch beantwortete Fragen</h3>
-    <table class="uk-table uk-table-divider">
-      <thead>
-        <tr><th>Name</th><th>Katalog</th><th>Frage</th></tr>
-      </thead>
-      <tbody id="wrongTableBody"></tbody>
-    </table>
+    {{ qr_table([
+      {'label': 'Name', 'class': 'uk-table-expand'},
+      {'label': 'Katalog'},
+      {'label': 'Frage'}
+    ], 'wrongTableBody', false) }}
+    {{ qr_rowcards('wrongCards', false) }}
     <ul id="resultsPagination" class="uk-pagination uk-flex-center"></ul>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace manual tables in results view with `qr_table` and `qr_rowcards` macros
- keep lightbox wrapper and pagination structure intact

## Testing
- `composer test` *(fails: E...)*


------
https://chatgpt.com/codex/tasks/task_e_68b806f8c570832b995ef33dc06f8be8