### PR TITLE
Unify admin catalog route

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -7,7 +7,7 @@ Die Administrationsoberfläche erreichen Sie über `/admin/dashboard` (kurz `/ad
   * **Events** – `/admin/events`
   * **Event-Konfiguration** – `/admin/event/settings`
 * **Inhalte**
-* **Kataloge** – `/admin/kataloge`
+* **Kataloge** – `/admin/catalogs`
   * **Fragen bearbeiten** – `/admin/questions`
   * **Seiten** – `/admin/pages` (nur Administratoren)
 * **Teams**

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -810,7 +810,7 @@ document.addEventListener('DOMContentLoaded', function () {
   async function loadCatalogs(page = 1) {
     catalogManager?.setColumnLoading('name', true);
     try {
-      const res = await fetch(withBase('/admin/catalogs?page=' + page));
+      const res = await fetch(withBase('/admin/catalogs/data?page=' + page));
       if (!res.ok) throw new Error('fail');
       const data = await res.json();
       const list = data.items || data;

--- a/src/routes.php
+++ b/src/routes.php
@@ -703,11 +703,11 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = new AdminController();
         return $controller($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN));
-    $app->get('/admin/kataloge', function (Request $request, Response $response) {
+    $app->get('/admin/catalogs', function (Request $request, Response $response) {
         $controller = $request->getAttribute('adminCatalogController');
         return $controller($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
-    $app->get('/admin/catalogs', function (Request $request, Response $response) {
+    $app->get('/admin/catalogs/data', function (Request $request, Response $response) {
         $controller = $request->getAttribute('adminCatalogController');
         return $controller->catalogs($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));

--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -14,7 +14,7 @@
   {
     header: t('menu_content'),
     items: [
-      { href: basePath ~ '/admin/kataloge', icon: 'file-text', text: t('tab_catalogs') },
+      { href: basePath ~ '/admin/catalogs', icon: 'file-text', text: t('tab_catalogs') },
       { href: basePath ~ '/admin/questions', icon: 'question', text: t('tab_questions') },
       { href: basePath ~ '/admin/pages', icon: 'file-text', text: t('tab_pages'), admin: true },
     ]

--- a/templates/base.twig
+++ b/templates/base.twig
@@ -26,7 +26,7 @@
         <div class="uk-navbar-center">
             <ul class="uk-navbar-nav">
                 <li {% if tab == 'konfig' %}class="uk-active"{% endif %}><a href="/admin/konfig">Veranstaltung konfigurieren</a></li>
-                <li {% if tab == 'kataloge' %}class="uk-active"{% endif %}><a href="/admin/kataloge">Kataloge</a></li>
+                <li {% if tab == 'catalogs' %}class="uk-active"{% endif %}><a href="/admin/catalogs">Kataloge</a></li>
                 <li {% if tab == 'fragen' %}class="uk-active"{% endif %}><a href="/admin/fragen">Fragen anpassen</a></li>
                 <li {% if tab == 'teams' %}class="uk-active"{% endif %}><a href="/admin/teams">Teams/Personen</a></li>
                 <li {% if tab == 'ergebnisse' %}class="uk-active"{% endif %}><a href="/admin/ergebnisse">Ergebnisse</a></li>

--- a/tests/Controller/AdminCatalogControllerTest.php
+++ b/tests/Controller/AdminCatalogControllerTest.php
@@ -43,7 +43,7 @@ class AdminCatalogControllerTest extends TestCase
 
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
-        $request = $this->createRequest('GET', '/admin/kataloge')
+        $request = $this->createRequest('GET', '/admin/catalogs')
             ->withAttribute('view', $twig)
             ->withAttribute('lang', 'de');
         $response = $controller($request, new Response());
@@ -79,7 +79,7 @@ class AdminCatalogControllerTest extends TestCase
 
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
-        $request = $this->createRequest('GET', '/admin/kataloge?event=e1&size=123&round_mode=margin')
+        $request = $this->createRequest('GET', '/admin/catalogs?event=e1&size=123&round_mode=margin')
             ->withAttribute('view', $twig)
             ->withAttribute('lang', 'de');
         $response = $controller($request, new Response());
@@ -108,7 +108,7 @@ class AdminCatalogControllerTest extends TestCase
         $service = new CatalogService($pdo, $cfgSvc);
         $controller = new AdminCatalogController($service);
 
-        $request = $this->createRequest('GET', '/admin/catalogs?page=1&perPage=2&order=asc');
+        $request = $this->createRequest('GET', '/admin/catalogs/data?page=1&perPage=2&order=asc');
         $response = $controller->catalogs($request, new Response());
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode((string) $response->getBody(), true);


### PR DESCRIPTION
## Summary
- Consolidate catalog admin page under `/admin/catalogs` and provide JSON data at `/admin/catalogs/data`
- Update navigation, documentation, JS fetch, and related tests to new route

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b80840b778832bb9769309ea004f5e