### PR TITLE
Ensure QR code library is installed during startup

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,8 +11,8 @@ if [ -r .env ]; then
     done < .env
 fi
 
-# Install composer dependencies if autoloader is missing
-if [ ! -f vendor/autoload.php ]; then
+# Install composer dependencies if autoloader or QR code library is missing
+if [ ! -f vendor/autoload.php ] || [ ! -d vendor/chillerlan/php-qrcode ]; then
     composer install --no-interaction --prefer-dist --no-progress
 fi
 


### PR DESCRIPTION
## Summary
- Reinstall composer deps when the QR code library is missing

## Testing
- `composer test` *(fails: Script vendor/bin/phpunit handling the phpunit event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b829cd6b80832b938081f4ded4cc3c