### PR TITLE
Refactor admin events to new table framework

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -684,7 +684,8 @@ body.admin-page {
 }
 
 /* Event list enhancements */
-#eventsList .event-row.active-event {
+#eventsList .event-row.active-event,
+#eventsCards .active-event {
   background-color: #e7f9e7;
 }
 #eventsList td {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -166,7 +166,7 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_events') }}</h2>
         <p class="uk-hidden">Professionelles Quiz-Hosting</p>
-        {% from 'components/table.twig' import qr_table %}
+        {% from 'components/table.twig' import qr_table, qr_rowcards %}
         {{ qr_table([
           { 'label': t('column_number'), 'key': 'number' },
           { 'label': t('column_name'), 'key': 'name' },
@@ -185,6 +185,7 @@
           'data-tip-select-event': t('tip_select_event'),
           'data-label-actions': t('column_actions')
         }, handle_label='<span uk-icon="icon: question" uk-tooltip="title: ' ~ t('tip_sort_rows') ~ '; pos: top" tabindex="0"></span>') }}
+        {{ qr_rowcards('eventsCards') }}
         <div class="uk-margin">
           <button
             id="eventAddBtn"


### PR DESCRIPTION
## Summary
- Use TableManager for admin events to align with teams implementation
- Add mobile row cards for events and sync active event handling
- Style active event in table and card views

## Testing
- `STRIPE_SECRET_KEY=1 STRIPE_PUBLISHABLE_KEY=1 STRIPE_PRICE_STARTER=1 STRIPE_PRICE_STANDARD=1 STRIPE_PRICE_PROFESSIONAL=1 STRIPE_PRICING_TABLE_ID=1 STRIPE_WEBHOOK_SECRET=1 composer test` *(fails: no output beyond PHPUnit banner)*

------
https://chatgpt.com/codex/tasks/task_e_68b82a346970832baa072a454b9e271b