### PR TITLE
Remove redundant trailing newline in BackupController

### DIFF
--- a/src/Controller/BackupController.php
+++ b/src/Controller/BackupController.php
@@ -132,4 +132,3 @@ class BackupController
         return $response->withStatus(204);
     }
 }
-


### PR DESCRIPTION
## Summary
- trim extra blank line at end of `BackupController.php`

## Testing
- `vendor/bin/phpcs src/Controller/BackupController.php`


------
https://chatgpt.com/codex/tasks/task_e_68b830af4154832bb8be827d892fdc72