### PR TITLE
feat: allow custom QR code options

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2613,6 +2613,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const qrColorInput = document.getElementById('qrColorInput');
   const qrRoundedInput = document.getElementById('qrRoundedInput');
   const qrLogoWidthInput = document.getElementById('qrLogoWidthInput');
+  const qrOptionsInput = document.getElementById('qrOptionsInput');
   const qrPreview = document.getElementById('qrDesignPreview');
   const qrApplyBtn = document.getElementById('qrDesignApply');
   const qrLogoFile = document.getElementById('qrLogoFile');
@@ -2661,6 +2662,12 @@ document.addEventListener('DOMContentLoaded', function () {
     params.set('round_mode', roundMode);
     params.set('rounded', rounded ? '1' : '0');
     params.set('logo_punchout', qrPunchoutInput?.checked ? '1' : '0');
+    const extra = qrOptionsInput?.value || '';
+    if (extra) {
+      try {
+        new URLSearchParams(extra).forEach((v, k) => params.set(k, v));
+      } catch (_) { /* ignore invalid */ }
+    }
     if (qrPreview) qrPreview.src = withBase(currentQrEndpoint + '?' + params.toString());
   }
 
@@ -2709,7 +2716,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (qrDesignModal) UIkit.modal(qrDesignModal).show();
   }
 
-  [qrLabelInput, qrPunchoutInput, qrRoundModeSelect, qrColorInput, qrRoundedInput, qrLogoWidthInput].forEach(el => {
+  [qrLabelInput, qrPunchoutInput, qrRoundModeSelect, qrColorInput, qrRoundedInput, qrLogoWidthInput, qrOptionsInput].forEach(el => {
     el?.addEventListener('input', updateQrPreview);
     el?.addEventListener('change', updateQrPreview);
   });

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -147,6 +147,7 @@ return [
     'label_check_button' => 'Antwort-Prüfen-Button anzeigen',
     'label_qr_login' => 'QR-Code-Login (Name merken)',
     'label_custom_logo' => 'Eigenes Logo',
+    'label_qr_options' => 'QR-Bibliotheks-Optionen',
     'label_random_names' => 'Teamnamen eingeben lassen',
     'label_team_restrict' => 'Nur Teams/Personen aus der Liste dürfen teilnehmen.',
     'label_plan' => 'Abo',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -149,6 +149,7 @@ return [
     'label_qr_login' => 'Use QR code login',
     'label_qr_remember' => 'Remember scanned login',
     'label_custom_logo' => 'Custom logo',
+    'label_qr_options' => 'QR library options',
     'label_random_names' => 'Prompt for team names',
     'label_team_restrict' => 'Only listed teams may join',
     'label_plan' => 'Plan',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -602,6 +602,10 @@
                 <option value="none">None</option>
               </select>
             </div>
+            <div class="uk-margin">
+              <label class="uk-form-label" for="qrOptionsInput">{{ t('label_qr_options') }}</label>
+              <input class="uk-input" id="qrOptionsInput" type="text" placeholder="size=300&margin=10&ec=H">
+            </div>
             <div class="uk-margin uk-text-center">
               <img id="qrDesignPreview" src="" alt="Preview" width="150" height="150">
             </div>


### PR DESCRIPTION
## Summary
- extend QR design modal with free-form options field
- support applying custom QR parameters in preview logic
- add translations for new field

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b834b46c44832ba2a6b95856513a1b