### PR TITLE
feat: add mobile labels for table columns

### DIFF
--- a/docs/table-framework.md
+++ b/docs/table-framework.md
@@ -66,6 +66,8 @@ Enthält eine mobile Karte mehrere Elemente mit der Klasse `qr-action`, fasst de
 
 Auf Mobilgeräten erscheinen die Spalten einer Karte untereinander. Überlange Inhalte werden automatisch mit `…` gekürzt, damit sie den verfügbaren Platz nicht überschreiten.
 
+Für jede Spalte kann in der JavaScript-Konfiguration ein optionales `label` definiert werden. Dieses wird in der mobilen Ansicht oberhalb des Wertes angezeigt. Fehlt das Feld, nutzt der `TableManager` den Text aus der Tabellenüberschrift.
+
 ### Katalogtabelle
 
 Beim Bearbeiten der Katalogtabelle kommen Modalfenster zum Einsatz, um Felder wie `slug`, `name` oder `description` zu ändern. Browser-Prompts werden dabei nicht mehr verwendet.

--- a/public/css/table.css
+++ b/public/css/table.css
@@ -105,6 +105,18 @@
   white-space: nowrap;
 }
 
+.qr-card-label {
+  font-size: 0.75rem;
+  color: var(--color-text);
+  opacity: 0.6;
+}
+
+@media (min-width: 960px) {
+  .qr-card-label {
+    display: none;
+  }
+}
+
 .qr-action {
   width: 44px;
   height: 44px;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -686,11 +686,11 @@ document.addEventListener('DOMContentLoaded', function () {
   newCatBtn?.parentElement?.before(catalogPaginationEl);
 
   const catalogColumns = [
-    { key: 'slug', className: 'uk-table-shrink', editable: true },
-    { key: 'name', className: 'uk-table-expand', editable: true },
-    { key: 'description', className: 'uk-table-expand', editable: true },
-    { key: 'raetsel_buchstabe', className: 'uk-table-shrink', editable: true },
-    { key: 'comment', className: 'uk-table-expand', editable: true, ariaDesc: 'Kommentar bearbeiten' }
+    { key: 'slug', label: 'Slug', className: 'uk-table-shrink', editable: true },
+    { key: 'name', label: 'Name', className: 'uk-table-expand', editable: true },
+    { key: 'description', label: 'Beschreibung', className: 'uk-table-expand', editable: true },
+    { key: 'raetsel_buchstabe', label: 'Rätsel-Buchstabe', className: 'uk-table-shrink', editable: true },
+    { key: 'comment', label: 'Kommentar', className: 'uk-table-expand', editable: true, ariaDesc: 'Kommentar bearbeiten' }
   ];
 
   let catalogManager;
@@ -2020,7 +2020,7 @@ document.addEventListener('DOMContentLoaded', function () {
       tbody: teamListEl,
       mobileCards: { container: teamCardsEl },
       columns: [
-        { key: 'name', className: 'team-name', editable: true },
+        { key: 'name', label: 'Name', className: 'team-name', editable: true },
         {
           className: 'uk-table-shrink',
           render: item => {

--- a/public/js/table-manager.js
+++ b/public/js/table-manager.js
@@ -192,7 +192,15 @@ export default class TableManager {
       } else if (col.key) {
         c = item[col.key];
       }
+      const labelText = col.label || this.thead?.querySelector(`th[data-key="${col.key}"]`)?.textContent;
+      let lbl = null;
+      if (labelText) {
+        lbl = document.createElement('span');
+        lbl.className = 'qr-card-label';
+        lbl.textContent = labelText;
+      }
       if (col.editable) {
+        if (lbl) contentWrap.appendChild(lbl);
         const wrapper = document.createElement('span');
         wrapper.className = 'qr-cell';
         wrapper.tabIndex = 0;
@@ -224,9 +232,11 @@ export default class TableManager {
           if (c.classList && c.classList.contains('qr-action')) {
             actions.push(c);
           } else {
+            if (lbl) contentWrap.appendChild(lbl);
             contentWrap.appendChild(c);
           }
         } else {
+          if (lbl) contentWrap.appendChild(lbl);
           const span = document.createElement('span');
           span.innerHTML = c ?? '';
           contentWrap.appendChild(span);


### PR DESCRIPTION
## Summary
- add optional `label` field to column configs for mobile cards
- render column labels in TableManager default cards and style with `.qr-card-label`
- document mobile label usage in table framework guide

## Testing
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY)*
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`
- `node tests/test_onboarding_flow.js`


------
https://chatgpt.com/codex/tasks/task_e_68b832b36e64832b9f37527d61a3cf35