### PR TITLE
feat: apply default QR code layout

### DIFF
--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -204,10 +204,18 @@ class QrCodeService
     {
         $scale = max(1, (int)round($p['size'] / 41));
         $marginModules = max(0, (int)round($p['margin'] / $scale));
+
         $options = [
+            'version' => 5,
             'eccLevel' => $p['ecc'],
-            'scale' => $scale,
+            'addQuietzone' => true,
             'quietzoneSize' => $marginModules,
+            'drawCircularModules' => true,
+            'circleRadius' => 0.45,
+            'drawSquareFinder' => true,
+            'drawSquareAlignment' => true,
+            'connectPaths' => true,
+            'scale' => $scale,
             'outputBase64' => false,
         ];
 


### PR DESCRIPTION
## Summary
- implement consistent base QROptions with circular modules and finder patterns

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b8384056bc832b94a60d0d82601414