### PR TITLE
Validate import directory names

### DIFF
--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -99,10 +99,16 @@ class ImportController
      */
     public function import(Request $request, Response $response, array $args): Response
     {
-        $dir = basename((string)($args['name'] ?? ''));
-        if ($dir === '') {
+        $dir = (string)($args['name'] ?? '');
+        if (
+            $dir === ''
+            || $dir === '.'
+            || $dir === '..'
+            || preg_match('/^[A-Za-z0-9._-]+$/', $dir) !== 1
+        ) {
             return $response->withStatus(400);
         }
+
         return $this->importFromDir($this->backupDir . '/' . $dir, $response);
     }
 

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -138,6 +138,32 @@ class ImportControllerTest extends TestCase
         rmdir($tmp);
     }
 
+    public function testImportRejectsInvalidName(): void
+    {
+        [$catalog, $config, $results, $teams, $consents, $summary, $events] = $this->createServices();
+        $tmp = sys_get_temp_dir() . '/import_' . uniqid();
+        mkdir($tmp, 0777, true);
+
+        $controller = new ImportController(
+            $catalog,
+            $config,
+            $results,
+            $teams,
+            $consents,
+            $summary,
+            $events,
+            $tmp,
+            $tmp
+        );
+
+        $request = $this->createRequest('POST', '/import/../etc');
+        $response = $controller->import($request, new Response(), ['name' => '../etc']);
+
+        $this->assertEquals(400, $response->getStatusCode());
+
+        rmdir($tmp);
+    }
+
     public function testRestoreDefaults(): void
     {
         [$catalog, $config, $results, $teams, $consents, $summary, $events] = $this->createServices();


### PR DESCRIPTION
## Summary
- ensure ImportController only accepts safe directory names
- test ImportController rejects traversal attempts

## Testing
- `vendor/bin/phpunit tests/Controller/ImportControllerTest.php`
- `vendor/bin/phpcs src/Controller/ImportController.php tests/Controller/ImportControllerTest.php`
- `python3 tests/test_html_validity.py`
- `composer test` *(fails: hangs without output)*

------
https://chatgpt.com/codex/tasks/task_e_68b838486b60832b8a5980727f9155af