### PR TITLE
feat: use table layout for admin events

### DIFF
--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -18,28 +18,30 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-large">
-    <div class="uk-grid-match uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m" uk-grid aria-label="Veranstaltungsliste">
+    {% from 'components/table.twig' import qr_table %}
+    {% set rows %}
       {% for ev in events %}
-      <div>
-        <div class="uk-card qr-card uk-card-hover">
-          <div class="uk-card-body">
-            <a href="{{ basePath }}/?event={{ ev.uid }}" class="uk-link-toggle">
-              <h3 class="uk-card-title">{{ ev.name }}</h3>
-              {% if ev.description %}<p>{{ ev.description }}</p>{% endif %}
-            </a>
-          </div>
-          <div class="uk-card-footer">
+        <tr>
+          <td>
+            <a href="{{ basePath }}/?event={{ ev.uid }}" class="uk-link-heading">{{ ev.name }}</a>
+          </td>
+          <td>{{ ev.description }}</td>
+          <td class="uk-text-nowrap">
             {% if role in ['admin','event-manager'] %}
             <button type="button" class="uk-button uk-button-primary event-action toggle-publish" data-uid="{{ ev.uid }}" data-published="{{ ev.published ? 'true' : 'false' }}">
               {{ ev.published ? 'Nicht veröffentlichen' : 'Veröffentlichen' }}
             </button>
             {% endif %}
             <button type="button" class="uk-button uk-button-default event-action copy-link" data-link="{{ basePath }}/?event={{ ev.uid }}">Link kopieren</button>
-          </div>
-        </div>
-      </div>
+          </td>
+        </tr>
       {% endfor %}
-    </div>
+    {% endset %}
+    {{ qr_table([
+      { 'label': t('column_name'), 'key': 'name' },
+      { 'label': t('column_description'), 'key': 'description' },
+      { 'label': t('column_actions'), 'class': 'uk-table-shrink' }
+    ], 'eventsTableBody', false, table_id='eventsTable', wrap_class='uk-overflow-auto qr-table-wrap', body_html=rows) }}
   </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Replace event overview card grid with responsive table using shared table macro for consistent admin design

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET, Slim Application Error, runSyncProcess failed: boom)*

------
https://chatgpt.com/codex/tasks/task_e_68b8392d5fd0832bbdadda16f2d26570