### PR TITLE
Increase QR code size and margin

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -866,6 +866,7 @@ body.admin-page {
 
 .qr-img {
   border-radius: 8px;
+  image-rendering: pixelated;
 }
 
 .qr-label {

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -44,7 +44,7 @@ use function unlink;
 class QrCodeService
 {
     private const QR_SIZE_DEF = 360;
-    private const QR_MARGIN_DEF = 20;
+    private const QR_MARGIN_DEF = 40;
     private const LOGO_WIDTH_DEF = 120;
     private const FONT_SIZE_DEF = 20;
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -477,7 +477,7 @@
             <p id="summaryEventDesc">{{ event.description }}</p>
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
-            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr/event?t={{ (baseUrl ? baseUrl ~ '/?event=' ~ event.uid : '?event=' ~ event.uid)|url_encode }}" alt="QR" width="96" height="96">
+            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr/event?t={{ (baseUrl ? baseUrl ~ '/?event=' ~ event.uid : '?event=' ~ event.uid)|url_encode }}&size=150&margin=40" alt="QR">
             <div id="summaryEventLabel" class="qr-label">{{ event.name }}</div>
           </div>
         </div>
@@ -494,7 +494,7 @@
               {% endif %}
               <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
               <p>{{ c.description }}</p>
-              <img class="qr-img" src="{{ basePath }}/qr/catalog?t={{ link|url_encode }}" alt="QR" width="96" height="96">
+              <img class="qr-img" src="{{ basePath }}/qr/catalog?t={{ link|url_encode }}&size=150&margin=40" alt="QR">
               <div class="qr-label">{{ c.name }}</div>
             </div>
           </div>
@@ -512,7 +512,7 @@
             <div class="export-card uk-card qr-card uk-card-body uk-position-relative">
               <button class="qr-print-btn uk-icon-button uk-position-top-right" data-team="{{ t }}" uk-icon="icon: print" aria-label="QR-Code drucken"></button>
               <h4 class="uk-card-title">{{ t }}</h4>
-              <img class="qr-img" src="{{ basePath }}/qr/team?t={{ t|url_encode }}" alt="Team QR" width="96" height="96">
+              <img class="qr-img" src="{{ basePath }}/qr/team?t={{ t|url_encode }}&size=150&margin=40" alt="Team QR">
               <div class="qr-label">{{ t }}</div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- enlarge QR code requests in admin interface to 150px with a 40-module quiet zone
- prevent smoothing on QR codes by rendering pixels sharply in CSS
- increase default QR quiet zone to 40 modules in service layer

## Testing
- `composer test` *(fails: phpunit hangs, unable to complete)*


------
https://chatgpt.com/codex/tasks/task_e_68b849b4df08832b8cd0b0cf089ed8d7