### PR TITLE
Make QR logo punch-out configurable

### DIFF
--- a/tests/Service/QrCodeServiceTest.php
+++ b/tests/Service/QrCodeServiceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\QrCodeService;
+use Tests\TestCase;
+
+class QrCodeServiceTest extends TestCase
+{
+    public function testPunchOutCanBeToggled(): void
+    {
+        $svc = new QrCodeService();
+
+        // create transparent logo for first call
+        $dir = dirname(__DIR__, 2) . '/data';
+        $logo1 = imagecreatetruecolor(40, 40);
+        imagesavealpha($logo1, true);
+        $trans = imagecolorallocatealpha($logo1, 0, 0, 0, 127);
+        imagefill($logo1, 0, 0, $trans);
+        imagepng($logo1, $dir . '/logo1.png');
+        imagedestroy($logo1);
+
+        $with = $svc->generateCatalog([
+            't' => 'https://example.com',
+            'format' => 'png',
+            'logo_path' => 'logo1.png',
+            'logo_punchout' => '1',
+        ]);
+
+        // create transparent logo for second call
+        $logo2 = imagecreatetruecolor(40, 40);
+        imagesavealpha($logo2, true);
+        $trans2 = imagecolorallocatealpha($logo2, 0, 0, 0, 127);
+        imagefill($logo2, 0, 0, $trans2);
+        imagepng($logo2, $dir . '/logo2.png');
+        imagedestroy($logo2);
+
+        $without = $svc->generateCatalog([
+            't' => 'https://example.com',
+            'format' => 'png',
+            'logo_path' => 'logo2.png',
+            'logo_punchout' => '0',
+        ]);
+
+        $this->assertNotSame($with['body'], $without['body']);
+    }
+}


### PR DESCRIPTION
## Summary
- allow `logo_punchout` query option and config default to control QR logo punch-out
- respect `logoPunchout` in renderer and skip background rectangle when disabled
- add unit test ensuring punch-out toggling works

## Testing
- `./vendor/bin/phpcs src/Service/QrCodeService.php tests/Service/QrCodeServiceTest.php`
- `./vendor/bin/phpunit tests/Service/QrCodeServiceTest.php`
- `./vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b84dfd131c832ba9415657d41b22b1