### PR TITLE
refactor: streamline catalog and team tables

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -383,18 +383,6 @@
           </div>
         </div>
 
-        <div id="catalogEditModal" uk-modal>
-          <div class="uk-modal-dialog uk-modal-body">
-            <h3 class="uk-modal-title">{{ t('heading_catalog_edit') }}</h3>
-            <input id="catalogEditInput" class="uk-input" type="text">
-            <p id="catalogEditError" class="uk-text-danger uk-margin-small-top" hidden></p>
-            <div class="uk-margin-top uk-text-right">
-              <button id="catalogEditCancel" class="uk-button uk-button-default" type="button">{{ t('action_cancel') }}</button>
-              <button id="catalogEditSave" class="uk-button uk-button-primary" type="button">{{ t('action_save') }}</button>
-            </div>
-          </div>
-        </div>
-
       </div>
     </li>
     <li class="{{ activeRoute == 'catalogs' ? 'uk-active' }}">
@@ -455,17 +443,6 @@
         {{ qr_rowcards('teamsCards') }}
         <div class="uk-margin">
           <button id="teamAddBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_team_add') }}; pos: left" aria-label="{{ t('tip_team_add') }}"></button>
-        </div>
-        <div id="teamEditModal" uk-modal>
-          <div class="uk-modal-dialog uk-modal-body">
-            <h3 class="uk-modal-title">{{ t('heading_team_edit') }}</h3>
-            <input id="teamEditInput" class="uk-input" type="text">
-            <p id="teamEditError" class="uk-text-danger uk-margin-small-top" hidden></p>
-            <div class="uk-margin-top uk-text-right">
-              <button id="teamEditCancel" class="uk-button uk-button-default" type="button">{{ t('action_cancel') }}</button>
-              <button id="teamEditSave" class="uk-button uk-button-primary" type="button">{{ t('action_save') }}</button>
-            </div>
-          </div>
         </div>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- remove catalog and team edit modals
- keep qr_table for catalogs and teams with empty bodies to be managed by TableManager
- ensure mobile rowcard elements remain for catalogs and teams

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, etc., Slim Application Error, PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b85272db78832b90402e4a1485fe70