### PR TITLE
Punch out logo area in SVG QR codes

### DIFF
--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -237,7 +237,8 @@ class QrCodeService
 
         if ($p['format'] === 'svg') {
             $options['outputType'] = QROutputInterface::MARKUP_SVG;
-            $options['bgColor'] = sprintf('#%02x%02x%02x', $p['bg'][0], $p['bg'][1], $p['bg'][2]);
+            $bgColor = sprintf('#%02x%02x%02x', $p['bg'][0], $p['bg'][1], $p['bg'][2]);
+            $options['bgColor'] = $bgColor;
             $fg = sprintf('#%02x%02x%02x', $p['fg'][0], $p['fg'][1], $p['fg'][2]);
             $options['moduleValues'] = [
                 QRMatrix::M_FINDER_DARK => $fg,
@@ -259,6 +260,17 @@ class QrCodeService
                     $logoData = base64_encode(file_get_contents($p['logoPath']));
                     $x = (int)(($dim - $p['logoWidth']) / 2);
                     $y = (int)(($dim - $p['logoWidth']) / 2);
+                    $rect = '';
+                    if ($p['logoPunchout']) {
+                        $rect = sprintf(
+                            '<rect x="%d" y="%d" width="%d" height="%d" fill="%s" />',
+                            $x,
+                            $y,
+                            $p['logoWidth'],
+                            $p['logoWidth'],
+                            $bgColor
+                        );
+                    }
                     $image = sprintf(
                         '<image x="%d" y="%d" width="%d" height="%d" href="data:%s;base64,%s" />',
                         $x,
@@ -268,7 +280,7 @@ class QrCodeService
                         $mime,
                         $logoData
                     );
-                    $svg = preg_replace('/<\/svg>/', $image . '</svg>', $svg);
+                    $svg = preg_replace('/<\/svg>/', $rect . $image . '</svg>', $svg);
                 }
             }
             return ['mime' => 'image/svg+xml', 'body' => $svg];

--- a/tests/Service/QrCodeServiceTest.php
+++ b/tests/Service/QrCodeServiceTest.php
@@ -46,4 +46,33 @@ class QrCodeServiceTest extends TestCase
 
         $this->assertNotSame($with['body'], $without['body']);
     }
+
+    public function testSvgPunchOutAddsRectBehindLogo(): void
+    {
+        $svc = new QrCodeService();
+
+        $dir = dirname(__DIR__, 2) . '/data';
+        $logo = imagecreatetruecolor(40, 40);
+        imagesavealpha($logo, true);
+        $trans = imagecolorallocatealpha($logo, 0, 0, 0, 127);
+        imagefill($logo, 0, 0, $trans);
+        imagepng($logo, $dir . '/logo-svg.png');
+        imagedestroy($logo);
+
+        $result = $svc->generateCatalog([
+            't' => 'https://example.com',
+            'format' => 'svg',
+            'logo_path' => 'logo-svg.png',
+            'logo_punchout' => '1',
+        ]);
+
+        $svg = $result['body'];
+        $rectPos = strpos($svg, '<rect');
+        $imagePos = strpos($svg, '<image');
+
+        $this->assertIsInt($rectPos);
+        $this->assertIsInt($imagePos);
+        $this->assertLessThan($imagePos, $rectPos);
+        $this->assertMatchesRegularExpression('/<rect[^>]*fill="#ffffff"/i', $svg);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure SVG QR codes draw a background rectangle for the logo area
- test that SVG output punches out modules behind centered logo

## Testing
- `vendor/bin/phpcs src/Service/QrCodeService.php tests/Service/QrCodeServiceTest.php`
- `vendor/bin/phpunit tests/Service/QrCodeServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b853aebe68832b9505966361983e78