### PR TITLE
refactor admin editing helpers

### DIFF
--- a/public/js/edit-helpers.js
+++ b/public/js/edit-helpers.js
@@ -1,0 +1,50 @@
+export function createCellEditor(manager, {
+  modalSelector,
+  inputSelector,
+  saveSelector,
+  cancelSelector,
+  getTitle = () => '',
+  getType = () => 'text',
+  validate = () => true,
+  onSave = () => {}
+} = {}) {
+  const modal = UIkit.modal(modalSelector);
+  const input = document.querySelector(inputSelector);
+  const saveBtn = document.querySelector(saveSelector);
+  const cancelBtn = document.querySelector(cancelSelector);
+  const titleEl = document.querySelector(`${modalSelector} .uk-modal-title`);
+  let currentId = null;
+  let currentKey = null;
+
+  cancelBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    modal.hide();
+  });
+
+  saveBtn?.addEventListener('click', () => {
+    const val = input.value.trim();
+    if (!validate(val, currentKey, input)) return;
+    const list = manager.getData();
+    const item = list.find(it => it.id === currentId);
+    if (item && currentKey) {
+      item[currentKey] = val;
+      manager.render(list);
+      onSave(list, item, currentKey);
+    }
+    modal.hide();
+  });
+
+  return {
+    open(cell) {
+      currentId = cell?.dataset.id || null;
+      currentKey = cell?.dataset.key || null;
+      const item = manager.getData().find(it => it.id === currentId) || {};
+      input.type = getType(currentKey, item);
+      input.value = item[currentKey] || '';
+      if (titleEl) {
+        titleEl.textContent = getTitle(currentKey, item);
+      }
+      modal.show();
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- share modal editing logic across admin tables with new `createCellEditor` helper
- update teams, events and catalogs to use unified edit flow

## Testing
- `composer test` *(fails: missing STRIPE_* env vars and PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8553d8884832ba45d1833da9ecb5b