### PR TITLE
Remove help icons from table headers

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -174,7 +174,7 @@
           { 'label': t('column_end'), 'key': 'end' },
           { 'label': t('column_description'), 'key': 'description' },
           { 'label': t('column_current'), 'key': 'current' },
-          { 'label': '<span class="help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_event_remove') ~ '; pos: top" aria-label="' ~ t('tip_event_remove') ~ '" tabindex="0"></span>', 'class': 'uk-table-shrink' }
+          { 'label': '', 'class': 'uk-table-shrink', 'tooltip': t('tip_event_remove') }
         ], 'eventsList', true, table_id='eventsTable', wrap_class='uk-overflow-auto qr-table-wrap', tbody_attrs={
           'data-label-number': t('column_number'),
           'data-label-name': t('column_name'),
@@ -184,7 +184,7 @@
           'data-label-current': t('column_current'),
           'data-tip-select-event': t('tip_select_event'),
           'data-label-actions': t('column_actions')
-        }, handle_label='<span class="help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_sort_rows') ~ '; pos: top" aria-label="' ~ t('tip_sort_rows') ~ '" tabindex="0"></span>') }}
+        }, handle_tooltip=t('tip_sort_rows')) }}
         {{ qr_rowcards('eventsCards') }}
         <div class="uk-margin">
           <button
@@ -391,12 +391,12 @@
           <h2 class="uk-heading-bullet">{{ t('heading_catalogs') }}</h2>
         {% from 'components/table.twig' import qr_table, qr_rowcards %}
         {{ qr_table([
-          { 'label': (t('column_slug') ~ '<span class="uk-margin-small-left help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_slug') ~ '; pos: top" aria-label="' ~ t('tip_slug') ~ '" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink', 'key': 'slug' },
-          { 'label': (t('column_name') ~ '<span class="uk-margin-small-left help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_cat_name') ~ '; pos: top" aria-label="' ~ t('tip_cat_name') ~ '" tabindex="0"></span>')|raw, 'class': 'uk-table-expand', 'key': 'name' },
-          { 'label': (t('column_description') ~ '<span class="uk-margin-small-left help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_cat_desc') ~ '; pos: top" aria-label="' ~ t('tip_cat_desc') ~ '" tabindex="0"></span>')|raw, 'class': 'uk-table-expand', 'key': 'description' },
-          { 'label': (t('column_letter') ~ '<span class="uk-margin-small-left help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_cat_puzzle_letter') ~ '; pos: top" aria-label="' ~ t('tip_cat_puzzle_letter') ~ '" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink', 'key': 'raetsel_buchstabe' },
-          { 'label': (t('column_comment') ~ '<span class="uk-margin-small-left help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_cat_comment') ~ '; pos: top" aria-label="' ~ t('tip_cat_comment') ~ '" tabindex="0"></span>')|raw, 'class': 'uk-table-expand', 'key': 'comment' },
-          { 'label': ('<span class="help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_cat_remove') ~ '; pos: top" aria-label="' ~ t('tip_cat_remove') ~ '" tabindex="0"></span>')|raw, 'class': 'uk-table-shrink uk-text-center' }
+          { 'label': t('column_slug'), 'class': 'uk-table-shrink', 'key': 'slug', 'tooltip': t('tip_slug') },
+          { 'label': t('column_name'), 'class': 'uk-table-expand', 'key': 'name', 'tooltip': t('tip_cat_name') },
+          { 'label': t('column_description'), 'class': 'uk-table-expand', 'key': 'description', 'tooltip': t('tip_cat_desc') },
+          { 'label': t('column_letter'), 'class': 'uk-table-shrink', 'key': 'raetsel_buchstabe', 'tooltip': t('tip_cat_puzzle_letter') },
+          { 'label': t('column_comment'), 'class': 'uk-table-expand', 'key': 'comment', 'tooltip': t('tip_cat_comment') },
+          { 'label': '', 'class': 'uk-table-shrink uk-text-center', 'tooltip': t('tip_cat_remove') }
         ], 'catalogList', true) }}
         {{ qr_rowcards('catalogCards') }}
         <div class="uk-margin">
@@ -804,8 +804,8 @@
           { 'label': t('column_role') },
           { 'label': 'Aktiv' },
           { 'label': '<span uk-icon="icon: key" uk-tooltip="title: ' ~ t('tip_user_pass') ~ '; pos: top" tabindex="0"></span>', 'class': 'uk-table-shrink' },
-          { 'label': '<span class="help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_user_remove') ~ '; pos: top" aria-label="' ~ t('tip_user_remove') ~ '" tabindex="0"></span>', 'class': 'uk-table-shrink' }
-        ], 'usersList', true, wrap_class='uk-overflow-auto qr-table-wrap', handle_label='<span class="help-icon" uk-icon="icon: info" uk-tooltip="title: ' ~ t('tip_sort_rows') ~ '; pos: top" aria-label="' ~ t('tip_sort_rows') ~ '" tabindex="0"></span>') }}
+          { 'label': '', 'class': 'uk-table-shrink', 'tooltip': t('tip_user_remove') }
+        ], 'usersList', true, wrap_class='uk-overflow-auto qr-table-wrap', handle_tooltip=t('tip_sort_rows')) }}
         <div class="uk-margin">
           <button id="userAddBtn" class="uk-icon-button uk-button-default" uk-icon="plus" uk-tooltip="title: {{ t('tip_user_add') }}; pos: right" aria-label="{{ t('tip_user_add') }}"></button>
         </div>

--- a/templates/components/table.twig
+++ b/templates/components/table.twig
@@ -1,13 +1,13 @@
-{% macro qr_table(headings, body_id, sortable=true, table_id='', table_class='', wrap_class='uk-overflow-auto qr-table-wrap uk-visible@m', body_html='', tbody_attrs={}, handle_label='') %}
+{% macro qr_table(headings, body_id, sortable=true, table_id='', table_class='', wrap_class='uk-overflow-auto qr-table-wrap uk-visible@m', body_html='', tbody_attrs={}, handle_label='', handle_tooltip='') %}
 <div class="{{ wrap_class }}">
     <table{% if table_id %} id="{{ table_id }}"{% endif %} class="uk-table uk-table-divider uk-table-small uk-table-hover qr-table{% if table_class %} {{ table_class }}{% endif %}">
         <thead class="table-headings">
             <tr>
             {% if sortable %}
-                <th scope="col" class="uk-table-shrink">{{ handle_label|raw }}</th>
+                <th scope="col" class="uk-table-shrink"{% if handle_tooltip %} uk-tooltip="title: {{ handle_tooltip }}; pos: top" aria-label="{{ handle_tooltip }}" tabindex="0"{% endif %}>{{ handle_label|raw }}</th>
             {% endif %}
             {% for heading in headings %}
-                <th scope="col"{% if heading.class is defined and heading.class %} class="{{ heading.class }}"{% endif %}{% if heading.key is defined %} data-key="{{ heading.key }}"{% endif %}>
+                <th scope="col"{% if heading.class is defined and heading.class %} class="{{ heading.class }}"{% endif %}{% if heading.key is defined %} data-key="{{ heading.key }}"{% endif %}{% if heading.tooltip is defined %} uk-tooltip="title: {{ heading.tooltip }}; pos: top" aria-label="{{ heading.tooltip }}" tabindex="0"{% endif %}>
                     {{ heading.label|raw }}
                     <span class="qr-col-spinner uk-margin-small-left" uk-spinner hidden aria-live="polite"></span>
                 </th>


### PR DESCRIPTION
## Summary
- replace help icons in table headers with tooltips triggered by header text
- support header tooltips in table macro

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b85932c7e0832b9eadd935dbe0c4cf