### PR TITLE
Align swipe question defaults with admin preview

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -842,7 +842,7 @@ async function runQuiz(questions, skipIntro){
     controls.appendChild(rightBtn);
 
     const leftStatic = document.createElement('div');
-    leftStatic.textContent = '\u2B05 ' + insertSoftHyphens(q.leftLabel || 'Falsch');
+    leftStatic.textContent = '\u2B05 ' + insertSoftHyphens(q.leftLabel || 'Nein');
     leftStatic.style.position = 'absolute';
     leftStatic.style.left = '0';
     leftStatic.style.top = '50%';
@@ -854,7 +854,7 @@ async function runQuiz(questions, skipIntro){
     container.appendChild(leftStatic);
 
     const rightStatic = document.createElement('div');
-    rightStatic.textContent = insertSoftHyphens(q.rightLabel || 'Richtig') + ' \u27A1';
+    rightStatic.textContent = insertSoftHyphens(q.rightLabel || 'Ja') + ' \u27A1';
     rightStatic.style.position = 'absolute';
     rightStatic.style.right = '0';
     rightStatic.style.top = '50%';


### PR DESCRIPTION
## Summary
- Use "Nein"/"Ja" as default static labels in swipe questions
- Confirm handleSwipe uses matching dynamic defaults

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET; Slim Application Error; Tests: 287, Assertions: 619, Errors: 29, Failures: 8, Warnings: 5)*

------
https://chatgpt.com/codex/tasks/task_e_68b858158fd0832bb0eabab29707bde6