### PR TITLE
feat: support event-specific QR logo endpoints

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2654,8 +2654,12 @@ document.addEventListener('DOMContentLoaded', function () {
     const ext = file.type === 'image/webp' ? 'webp' : 'png';
     const fd = new FormData();
     fd.append('file', file);
-    apiFetch('/qrlogo.' + ext, { method: 'POST', body: fd })
-      .then(() => apiFetch('/config.json', { headers: { 'Accept': 'application/json' } }))
+    const uploadPath = '/qrlogo.' + ext + (activeEventUid ? `?event_uid=${encodeURIComponent(activeEventUid)}` : '');
+    apiFetch(uploadPath, { method: 'POST', body: fd })
+      .then(() => {
+        const cfgPath = activeEventUid ? `/admin/event/${activeEventUid}` : '/config.json';
+        return apiFetch(cfgPath, { headers: { 'Accept': 'application/json' } });
+      })
       .then(r => r.json())
       .then(cfg => {
         qrLogoPath = cfg.qrLogoPath || '';
@@ -2718,8 +2722,10 @@ document.addEventListener('DOMContentLoaded', function () {
       if (qrLogoPath) data.qrLogoPath = qrLogoPath;
       data[field] = colorVal;
       if (logoWidthVal) data.qrLogoWidth = parseInt(logoWidthVal, 10);
-      apiFetch('/config.json', {
-        method: 'POST',
+      const cfgPath = activeEventUid ? `/admin/event/${activeEventUid}` : '/config.json';
+      const method = activeEventUid ? 'PATCH' : 'POST';
+      apiFetch(cfgPath, {
+        method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
       }).catch(() => {});
@@ -2734,8 +2740,10 @@ document.addEventListener('DOMContentLoaded', function () {
       const data = { qrRounded: rounded };
       data[field] = colorVal;
       if (logoWidthVal) data.qrLogoWidth = parseInt(logoWidthVal, 10);
-      apiFetch('/config.json', {
-        method: 'POST',
+      const cfgPath = activeEventUid ? `/admin/event/${activeEventUid}` : '/config.json';
+      const method = activeEventUid ? 'PATCH' : 'POST';
+      apiFetch(cfgPath, {
+        method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
       }).catch(() => {});


### PR DESCRIPTION
## Summary
- Handle QR logo uploads and saves for active events
- Update config preview after event-specific changes

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c33f9f8832b88b7156ace35068e