### PR TITLE
fix: preserve svg logo aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - *(deps)* Bump symfony/process from 7.3.0 to 7.3.3
 - *(deps)* Bump symfony/mailer from 7.3.2 to 7.3.3
 - *(deps)* Bump stripe/stripe-php from 17.5.0 to 17.6.0
+
+### Fix
+
+- Preserve logo aspect ratio in SVG QR codes
 - *(deps)* Bump slim/slim from 4.14.0 to 4.15.0
 - *(deps)* Bump guzzlehttp/guzzle from 7.9.3 to 7.10.0
 - Normalize invite setup indentation

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -258,16 +258,24 @@ class QrCodeService
                     $matrix = $qr->getMatrix();
                     $dim = ($matrix->getSize() + 2 * $marginModules) * $scale;
                     $logoData = base64_encode(file_get_contents($p['logoPath']));
-                    $x = (int)(($dim - $p['logoWidth']) / 2);
-                    $y = (int)(($dim - $p['logoWidth']) / 2);
+                    $size = @getimagesize($p['logoPath']);
+                    $lw = (int)($size[0] ?? 0);
+                    $lh = (int)($size[1] ?? 0);
+                    if ($lw <= 0 || $lh <= 0) {
+                        $lw = $lh = 1; // prevent division by zero
+                    }
+                    $targetW = $p['logoWidth'];
+                    $targetH = (int)($lh * $targetW / $lw);
+                    $x = (int)(($dim - $targetW) / 2);
+                    $y = (int)(($dim - $targetH) / 2);
                     $rect = '';
                     if ($p['logoPunchout']) {
                         $rect = sprintf(
                             '<rect x="%d" y="%d" width="%d" height="%d" fill="%s" />',
                             $x,
                             $y,
-                            $p['logoWidth'],
-                            $p['logoWidth'],
+                            $targetW,
+                            $targetH,
                             $bgColor
                         );
                     }
@@ -275,8 +283,8 @@ class QrCodeService
                         '<image x="%d" y="%d" width="%d" height="%d" href="data:%s;base64,%s" />',
                         $x,
                         $y,
-                        $p['logoWidth'],
-                        $p['logoWidth'],
+                        $targetW,
+                        $targetH,
                         $mime,
                         $logoData
                     );

--- a/tests/Service/QrCodeServiceTest.php
+++ b/tests/Service/QrCodeServiceTest.php
@@ -75,4 +75,29 @@ class QrCodeServiceTest extends TestCase
         $this->assertLessThan($imagePos, $rectPos);
         $this->assertMatchesRegularExpression('/<rect[^>]*fill="#ffffff"/i', $svg);
     }
+
+    public function testSvgLogoKeepsAspectRatio(): void
+    {
+        $svc = new QrCodeService();
+
+        $dir = dirname(__DIR__, 2) . '/data';
+        $logo = imagecreatetruecolor(80, 40); // rectangular logo
+        imagesavealpha($logo, true);
+        $trans = imagecolorallocatealpha($logo, 0, 0, 0, 127);
+        imagefill($logo, 0, 0, $trans);
+        imagepng($logo, $dir . '/logo-rect.png');
+        imagedestroy($logo);
+
+        $result = $svc->generateCatalog([
+            't' => 'https://example.com',
+            'format' => 'svg',
+            'logo_path' => 'logo-rect.png',
+            'logo_punchout' => '1',
+            'logo_width' => '100',
+        ]);
+
+        $svg = $result['body'];
+        $this->assertMatchesRegularExpression('/<image[^>]*width="100"[^>]*height="50"/i', $svg);
+        $this->assertMatchesRegularExpression('/<rect[^>]*width="100"[^>]*height="50"/i', $svg);
+    }
 }


### PR DESCRIPTION
## Summary
- compute SVG logo dimensions from source image to preserve aspect ratio
- add regression test for rectangular logos and update changelog

## Testing
- `vendor/bin/phpunit tests/Service/QrCodeServiceTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68b857da6978832bb42d01938ddd7f64