### PR TITLE
Fix event switching via config endpoint

### DIFF
--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -72,6 +72,14 @@ class ConfigController
             return $response->withStatus(400);
         }
 
+        if (isset($data['event_uid'])) {
+            $this->service->setActiveEventUid((string) $data['event_uid']);
+            unset($data['event_uid']);
+            if ($data === []) {
+                return $response->withStatus(204);
+            }
+        }
+
         $validation = $this->validator->validate($data);
         if ($validation['errors'] !== []) {
             $response->getBody()->write(json_encode(['errors' => $validation['errors']]));

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -80,6 +80,24 @@ class ConfigControllerTest extends TestCase
         session_destroy();
     }
 
+    public function testPostEventUidOnly(): void
+    {
+        $pdo = $this->createDatabase();
+        $service = new ConfigService($pdo);
+        $controller = new ConfigController($service, new ConfigValidator());
+
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'event-manager'];
+
+        $request = $this->createRequest('POST', '/config.json');
+        $request = $request->withParsedBody(['event_uid' => 'ev1']);
+        $response = $controller->post($request, new Response());
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame('ev1', $service->getActiveEventUid());
+        session_destroy();
+    }
+
     public function testPostDeniedForNonAdmin(): void
     {
         $app = $this->getAppInstance();


### PR DESCRIPTION
## Summary
- Allow updating active event through `config.json` by accepting `event_uid`
- Test posting only an event UID for configuration

## Testing
- `vendor/bin/phpunit --filter ConfigControllerTest`

------
https://chatgpt.com/codex/tasks/task_e_68b85e1571c8832b8618ec01ccbd758b