### PR TITLE
Remove QR code logo

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -632,7 +632,7 @@ document.addEventListener('DOMContentLoaded', function () {
       e.preventDefault();
       const team = btn.getAttribute('data-team');
       if (team) {
-        window.open(withBase('/qr.pdf?t=' + encodeURIComponent(team) + '&logoText=QUIZ%0ARACE&rounded=1'), '_blank');
+        window.open(withBase('/qr.pdf?t=' + encodeURIComponent(team) + '&rounded=1'), '_blank');
       }
     });
   });

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -130,7 +130,6 @@ class QrController
         $options = [
             'fg' => $params['fg'] ?? null,
             'bg' => $params['bg'] ?? null,
-            'logoText' => $params['logoText'] ?? null,
         ];
 
         try {
@@ -164,12 +163,6 @@ class QrController
 
         $qrParams = $params;
         $qrParams['format'] = 'png';
-        if (isset($qrParams['logoText'])) {
-            $parts = explode("\n", (string)$qrParams['logoText']);
-            $qrParams['text1'] = $parts[0];
-            $qrParams['text2'] = $parts[1] ?? '';
-            unset($qrParams['logoText']);
-        }
 
         try {
             $out = $this->qrService->generateTeam($qrParams, $cfg);
@@ -299,12 +292,6 @@ class QrController
             $q = $params;
             $q['t'] = $team;
             $q['format'] = 'png';
-            if (isset($q['logoText'])) {
-                $parts = explode("\n", (string)$q['logoText']);
-                $q['text1'] = $parts[0];
-                $q['text2'] = $parts[1] ?? '';
-                unset($q['logoText']);
-            }
             try {
                 $out = $this->qrService->generateTeam($q, $cfg);
             } catch (Throwable $e) {

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -53,7 +53,6 @@ class QrControllerTest extends TestCase
                 't' => 'Demo',
                 'fg' => 'ff0000',
                 'bg' => '00ff00',
-                'logoText' => 'TEST',
             ]);
         $response = $app->handle($request);
 


### PR DESCRIPTION
## Summary
- drop automatic center logo generation
- remove logoText handling from QR controller and admin JS
- update tests for QR code colors

## Testing
- `php -l src/Service/QrCodeService.php`
- `composer test` (fails: Missing STRIPE_* environment variables)
- `vendor/bin/phpcs` (fails: coding standard errors)


------
https://chatgpt.com/codex/tasks/task_e_68b86170d9b4832b8ea97922b655ccdb