### PR TITLE
Use base path helper for results fetches

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -63,6 +63,9 @@ const eventUid = (window.quizConfig || {}).event_uid || '';
 const playerNameKey = eventUid ? `qr_player_name:${eventUid}` : 'quizUser';
 const playerUidKey = `qr_player_uid:${eventUid}`;
 
+const basePath = window.basePath || '';
+const withBase = path => basePath + path;
+
 function setStored(key, value){
   if(key === 'quizUser') key = playerNameKey;
   try{
@@ -83,7 +86,7 @@ function formatPuzzleTime(ts){
 
 async function fetchLatestPuzzleEntry(name, catalog){
   try{
-    const list = await fetch('/results.json').then(r => r.json());
+    const list = await fetch(withBase('/results.json')).then(r => r.json());
     if(Array.isArray(list)){
       return list.slice().reverse().find(e => e.name === name && e.catalog === catalog && e.puzzleTime);
     }
@@ -165,8 +168,6 @@ async function runQuiz(questions, skipIntro){
   // Konfiguration laden und einstellen, ob der "Antwort prüfen"-Button
   // eingeblendet werden soll
   const cfg = window.quizConfig || {};
-  const basePath = window.basePath || '';
-  const withBase = path => basePath + path;
   const showCheck = cfg.CheckAnswerButton !== 'no';
   if(cfg.colors){
     if(cfg.colors.primary){
@@ -326,7 +327,7 @@ async function runQuiz(questions, skipIntro){
     if(puzzleSolved && puzzleTs){
       data.puzzleTime = parseInt(puzzleTs, 10) || Math.floor(Date.now()/1000);
     }
-    fetch('/results', {
+    fetch(withBase('/results'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
@@ -1346,7 +1347,7 @@ async function runQuiz(questions, skipIntro){
           const uid = getStored(playerUidKey);
           if(uid) data.player_uid = uid;
         }
-        fetch('/results?debug=1', {
+        fetch(withBase('/results?debug=1'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)


### PR DESCRIPTION
## Summary
- reference `window.basePath` via `withBase` for all results endpoints
- ensure puzzle result lookups and submissions respect custom base paths

## Testing
- `node - <<'NODE' ...` (verified URLs `/base/results.json` and `/base/results`)
- `composer test` *(fails: PHPUnit reports multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b85fed1364832b8ddd0127add3e717