### PR TITLE
Use withBase helper for catalog requests

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -1,4 +1,5 @@
-/* global UIkit, Html5Qrcode, generateUserName, basePath */
+/* global UIkit, Html5Qrcode, generateUserName */
+const basePath = window.basePath || '';
 const withBase = p => basePath + p;
 // Hilfsfunktion, um nur eine Front- und eine Rückkamera zu behalten
 window.filterCameraOrientations = window.filterCameraOrientations || function(cams){
@@ -157,7 +158,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
   }
   async function loadCatalogList(){
     try{
-      const res = await fetch('/kataloge/catalogs.json', { headers: { 'Accept': 'application/json' } });
+      const res = await fetch(withBase('/kataloge/catalogs.json'), { headers: { 'Accept': 'application/json' } });
       if(res.ok){
         return await res.json();
       }
@@ -209,7 +210,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       }
     }
     try{
-      const res = await fetch('/kataloge/' + file, { headers: { 'Accept': 'application/json' } });
+      const res = await fetch(withBase('/kataloge/' + file), { headers: { 'Accept': 'application/json' } });
       const data = await res.json();
       window.quizQuestions = data;
       showCatalogIntro(data);
@@ -602,7 +603,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     let solved = new Set(JSON.parse(sessionStorage.getItem('quizSolved') || '[]'));
     if(cfg.competitionMode){
       try{
-        const r = await fetch('/results.json', {headers:{'Accept':'application/json'}});
+        const r = await fetch(withBase('/results.json'), {headers:{'Accept':'application/json'}});
         if(r.ok){
           const data = await r.json();
           const key = typeof playerNameKey !== 'undefined' ? playerNameKey : 'quizUser';

--- a/tests/test_competition_mode.js
+++ b/tests/test_competition_mode.js
@@ -19,7 +19,8 @@ const context = {
         ok: true,
         json: async() => [{ name: 'Team1', catalog: 'uid1' }]
     }),
-    console
+    console,
+    withBase: p => p
 };
 
 const buildSolvedSet = vm.runInNewContext('(' + match[0] + ')', context);


### PR DESCRIPTION
## Summary
- ensure catalog-related fetch calls respect `window.basePath` via `withBase`
- define `basePath` in `catalog.js` like other scripts
- update competition mode test to stub `withBase`

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET, Slim Application Error, Tests: 289, Assertions: 623, Errors: 29, Failures: 8, Warnings: 5, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1)*
- Manual test: attempted to serve app under subdirectory via `php -S` and fetch `/subdir/kataloge/catalogs.json`; server emitted missing Stripe key warnings and did not return expected data

------
https://chatgpt.com/codex/tasks/task_e_68b85ff07304832b8e2d2f76349be226