### PR TITLE
Remove QR labels from admin overview

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -869,15 +869,6 @@ body.admin-page {
   image-rendering: pixelated;
 }
 
-.qr-label {
-  display: inline-block;
-  margin-top: 0;
-  padding: 2px 6px;
-  border: 0.5px solid var(--qr-border);
-  border-radius: 0 0 4px 4px;
-  white-space: pre-line;
-}
-
 /* Dashboard calendar */
 #calendar table {
   width: 100%;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2756,7 +2756,6 @@ document.addEventListener('DOMContentLoaded', function () {
     const nameEl = document.getElementById('summaryEventName');
     const descEl = document.getElementById('summaryEventDesc');
     const qrImg = document.getElementById('summaryEventQr');
-    const qrLabel = document.getElementById('summaryEventLabel');
     const catalogsEl = document.getElementById('summaryCatalogs');
     const teamsEl = document.getElementById('summaryTeams');
     if (!nameEl || !catalogsEl || !teamsEl) return;
@@ -2801,7 +2800,6 @@ document.addEventListener('DOMContentLoaded', function () {
         applyDesign(params, 'qrColorEvent');
         qrImg.src = withBase('/qr/event?' + params.toString());
       }
-      if (qrLabel) qrLabel.textContent = ev.name || '';
       catalogsEl.innerHTML = '';
       catalogs.forEach(c => {
         const wrapper = document.createElement('div');
@@ -2832,9 +2830,6 @@ document.addEventListener('DOMContentLoaded', function () {
         img.alt = 'QR';
         img.width = 96;
         img.height = 96;
-        const label = document.createElement('div');
-        label.className = 'qr-label';
-        label.textContent = c.name || '';
         const designBtn = document.createElement('button');
         designBtn.className = 'uk-icon-button uk-margin-small-top';
         designBtn.setAttribute('uk-icon', 'icon: paint-bucket');
@@ -2845,7 +2840,6 @@ document.addEventListener('DOMContentLoaded', function () {
         card.appendChild(h4);
         card.appendChild(p);
         card.appendChild(img);
-        card.appendChild(label);
         card.appendChild(designBtn);
         wrapper.appendChild(card);
         catalogsEl.appendChild(wrapper);
@@ -2874,9 +2868,6 @@ document.addEventListener('DOMContentLoaded', function () {
         img.alt = 'QR';
         img.width = 96;
         img.height = 96;
-        const label = document.createElement('div');
-        label.className = 'qr-label';
-        label.textContent = t;
         const designBtn = document.createElement('button');
         designBtn.className = 'uk-icon-button uk-position-top-left';
         designBtn.setAttribute('uk-icon', 'icon: paint-bucket');
@@ -2887,7 +2878,6 @@ document.addEventListener('DOMContentLoaded', function () {
         card.appendChild(btn);
         card.appendChild(h4);
         card.appendChild(img);
-        card.appendChild(label);
         card.appendChild(designBtn);
         wrapper.appendChild(card);
         teamsEl.appendChild(wrapper);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -467,7 +467,6 @@
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
             <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr/event?t={{ (baseUrl ? baseUrl ~ '/?event=' ~ event.uid : '?event=' ~ event.uid)|url_encode }}&size=150&margin=40" alt="QR">
-            <div id="summaryEventLabel" class="qr-label">{{ event.name }}</div>
           </div>
         </div>
 
@@ -484,7 +483,6 @@
               <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
               <p>{{ c.description }}</p>
               <img class="qr-img" src="{{ basePath }}/qr/catalog?t={{ link|url_encode }}&size=150&margin=40" alt="QR">
-              <div class="qr-label">{{ c.name }}</div>
             </div>
           </div>
           {% else %}
@@ -502,7 +500,6 @@
               <button class="qr-print-btn uk-icon-button uk-position-top-right" data-team="{{ t }}" uk-icon="icon: print" aria-label="QR-Code drucken"></button>
               <h4 class="uk-card-title">{{ t }}</h4>
               <img class="qr-img" src="{{ basePath }}/qr/team?t={{ t|url_encode }}&size=150&margin=40" alt="Team QR">
-              <div class="qr-label">{{ t }}</div>
             </div>
           </div>
           {% else %}


### PR DESCRIPTION
## Summary
- remove QR label elements from admin overview template
- drop related JavaScript label generation
- prune unused qr-label styles

## Testing
- `composer test` *(fails: phpunit hangs after initial output)*

------
https://chatgpt.com/codex/tasks/task_e_68b861d59b00832b9adc128cbdee4643