### PR TITLE
Fix table header width for teams

### DIFF
--- a/public/css/table.css
+++ b/public/css/table.css
@@ -17,6 +17,7 @@
 }
 
 .qr-table-wrap {
+  width: 100%;
   max-height: 60vh;
   scrollbar-gutter: stable;
 }


### PR DESCRIPTION
## Summary
- ensure qr-table wrapper uses full width so headers align with content

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b8630c4ee4832bacb5e426cf0b0a5f