### PR TITLE
Load quiz module before catalog and add fallback

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -243,9 +243,31 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       btn.style.borderColor = cfg.colors.accent;
       btn.style.color = '#fff';
     }
-    btn.addEventListener('click', () => {
-      if(window.startQuiz){
-        window.startQuiz(data, true);
+    btn.addEventListener('click', async () => {
+      const runQuiz = () => {
+        if(typeof window.startQuiz === 'function'){
+          window.startQuiz(data, true);
+          return true;
+        }
+        return false;
+      };
+      if(runQuiz()) return;
+      try{
+        await new Promise((resolve, reject) => {
+          const s = document.createElement('script');
+          s.src = withBase('/js/quiz.js');
+          s.defer = true;
+          s.onload = resolve;
+          s.onerror = reject;
+          document.head.appendChild(s);
+        });
+        if(!runQuiz()){
+          console.warn('startQuiz is still undefined after loading quiz.js');
+          alert('Quiz kann nicht gestartet werden.');
+        }
+      }catch(e){
+        console.warn('quiz.js could not be loaded', e);
+        alert('Quiz kann nicht gestartet werden.');
       }
     });
     container.appendChild(btn);

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -69,9 +69,9 @@
   <script id="catalogs-data" type="application/json">
     {{ catalogs|json_encode|raw }}
   </script>
+  <script src="{{ basePath }}/js/quiz.js" defer></script>
   <script src="{{ basePath }}/js/catalog.js" defer></script>
   <script src="{{ basePath }}/js/confetti.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js" defer></script>
-  <script src="{{ basePath }}/js/quiz.js" defer></script>
   <script src="{{ basePath }}/js/app.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Load quiz.js before catalog logic to ensure availability
- Add fallback in catalog start button to dynamically load quiz.js and report errors

## Testing
- `composer test` *(fails: process hung after phpunit run)*

------
https://chatgpt.com/codex/tasks/task_e_68b86683597c832b90eaf92a900c33dc