### PR TITLE
refactor: unify catalog identifier logic

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -176,9 +176,10 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     return [];
   }
 
-  async function loadQuestions(id, file, letter, uid, name, desc, comment){
-    setStored('quizCatalog', uid || id);
-    sessionStorage.setItem('quizCatalogName', name || id);
+  async function loadQuestions(slug, sort_order, file, letter, uid, name, desc, comment){
+    const catalogKey = uid ?? slug ?? sort_order;
+    setStored('quizCatalog', catalogKey);
+    sessionStorage.setItem('quizCatalogName', name || slug || sort_order);
     if(desc !== undefined){
       sessionStorage.setItem('quizCatalogDesc', desc);
     } else {
@@ -197,7 +198,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
         title.className = 'uk-margin-remove-bottom';
         headerEl.appendChild(title);
       }
-      title.textContent = name || id;
+      title.textContent = name || slug || sort_order;
     }
     setSubHeader(desc || '');
     setComment(comment || '');
@@ -218,7 +219,8 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     }catch(e){
       console.warn('Fragen konnten nicht geladen werden, versuche inline Daten', e);
     }
-    const inline = document.getElementById(id + '-data');
+    const inlineId = slug ?? sort_order;
+    const inline = inlineId ? document.getElementById(inlineId + '-data') : null;
     if(inline){
       try{
         const data = JSON.parse(inline.textContent);
@@ -309,32 +311,37 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     grid.className = 'uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-4@m uk-grid-small uk-text-center';
     grid.setAttribute('uk-grid', '');
     catalogs.forEach(cat => {
+      const catalogKey = cat.uid ?? cat.slug ?? cat.sort_order ?? cat.id;
       const cardWrap = document.createElement('div');
       const card = document.createElement('div');
       card.className = 'uk-card qr-card uk-card-body uk-card-hover';
       card.style.cursor = 'pointer';
       card.addEventListener('click', () => {
         const localSolved = new Set(JSON.parse(sessionStorage.getItem('quizSolved') || '[]'));
-        if((window.quizConfig || {}).competitionMode && localSolved.has(cat.uid)){
-          const remaining = catalogs.filter(c => !localSolved.has(c.uid)).map(c => c.name || c.slug || c.sort_order).join(', ');
-          showCatalogSolvedModal(cat.name || cat.slug || cat.sort_order, remaining);
+        if((window.quizConfig || {}).competitionMode && localSolved.has(catalogKey)){
+          const remaining = catalogs.filter(c => {
+            const key = c.uid ?? c.slug ?? c.sort_order ?? c.id;
+            return !localSolved.has(key);
+          }).map(c => c.name || c.slug || c.sort_order || c.id).join(', ');
+          showCatalogSolvedModal(cat.name || cat.slug || cat.sort_order || cat.id, remaining);
           return;
         }
-        let qs = '?katalog=' + (cat.slug || cat.sort_order);
+        let qs = '?katalog=' + (cat.slug || cat.sort_order || cat.id);
         if(eventUid) qs += '&event=' + encodeURIComponent(eventUid);
         history.replaceState(null, '', qs);
         loadQuestions(
-          cat.slug || cat.sort_order,
+          cat.slug,
+          cat.sort_order || cat.id,
           cat.file,
           cat.raetsel_buchstabe,
           cat.uid,
-          cat.name || cat.slug || cat.sort_order,
+          cat.name || cat.slug || cat.sort_order || cat.id,
           cat.description || cat.beschreibung || '',
           cat.comment || cat.kommentar || ''
         );
       });
       const title = document.createElement('h3');
-      title.textContent = cat.name || cat.slug || cat.sort_order;
+      title.textContent = cat.name || cat.slug || cat.sort_order || cat.id;
       const desc = document.createElement('p');
       desc.textContent = cat.description || cat.beschreibung || '';
       card.appendChild(title);
@@ -643,23 +650,28 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     const id = params.get('katalog');
     const proceed = async () => {
       const solvedNow = await buildSolvedSet(cfg);
-      const selected = catalogs.find(c => (c.slug || c.sort_order) === id);
+      const selected = catalogs.find(c => (c.slug || c.sort_order || c.id || c.uid) === id);
       if(selected){
-          if(cfg.competitionMode && solvedNow.has(selected.uid)){
-            const remaining = catalogs.filter(c => !solvedNow.has(c.uid)).map(c => c.name || c.slug || c.sort_order).join(', ');
-            if(catalogs.length && solvedNow.size === catalogs.length){
-              showAllSolvedModal();
-              return;
-            }
-            showCatalogSolvedModal(selected.name || selected.slug || selected.id, remaining);
+        const selectedKey = selected.uid ?? selected.slug ?? selected.sort_order ?? selected.id;
+        if(cfg.competitionMode && solvedNow.has(selectedKey)){
+          const remaining = catalogs.filter(c => {
+            const key = c.uid ?? c.slug ?? c.sort_order ?? c.id;
+            return !solvedNow.has(key);
+          }).map(c => c.name || c.slug || c.sort_order || c.id).join(', ');
+          if(catalogs.length && solvedNow.size === catalogs.length){
+            showAllSolvedModal();
             return;
           }
+          showCatalogSolvedModal(selected.name || selected.slug || selected.sort_order || selected.id, remaining);
+          return;
+        }
         loadQuestions(
-          selected.slug || selected.id,
+          selected.slug,
+          selected.sort_order || selected.id,
           selected.file,
           selected.raetsel_buchstabe,
           selected.uid,
-          selected.name || selected.slug || selected.id,
+          selected.name || selected.slug || selected.sort_order || selected.id,
           selected.description || selected.beschreibung || '',
           selected.comment || selected.kommentar || ''
         );

--- a/tests/test_competition_mode.js
+++ b/tests/test_competition_mode.js
@@ -17,7 +17,7 @@ const context = {
     },
     fetch: async() => ({
         ok: true,
-        json: async() => [{ name: 'Team1', catalog: 'uid1' }]
+        json: async() => [{ name: 'Team1', catalog: 'slug1' }]
     }),
     console,
     withBase: p => p
@@ -28,7 +28,7 @@ context.sessionStorage.setItem('quizUser', 'Team1');
 
 (async() => {
     const res = await buildSolvedSet({ competitionMode: true });
-    assert(res.has('uid1'));
-    assert.deepStrictEqual(JSON.parse(context.sessionStorage.getItem('quizSolved')), ['uid1']);
+    assert(res.has('slug1'));
+    assert.deepStrictEqual(JSON.parse(context.sessionStorage.getItem('quizSolved')), ['slug1']);
     console.log('ok');
 })().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- standardize catalog identifier via `catalogKey` in catalog loading
- use catalogKey for comparisons and storage
- update competition mode test for new identifier logic

## Testing
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`
- `node tests/test_onboarding_flow.js`
- `python3 tests/test_json_validity.py`
- `python3 tests/test_html_validity.py`
- `vendor/bin/phpunit` *(fails: incomplete due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b8668d62e4832b926dcb7effb97d15