### PR TITLE
Handle missing catalog data in quiz catalog

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -210,24 +210,34 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
         sessionStorage.removeItem('quizLetter');
       }
     }
+    let loaded = false;
     try{
       const res = await fetch(withBase('/kataloge/' + file), { headers: { 'Accept': 'application/json' } });
       const data = await res.json();
       window.quizQuestions = data;
+      loaded = true;
       showCatalogIntro(data);
       return;
     }catch(e){
-      console.warn('Fragen konnten nicht geladen werden, versuche inline Daten', e);
-    }
-    const inlineId = slug ?? sort_order;
-    const inline = inlineId ? document.getElementById(inlineId + '-data') : null;
-    if(inline){
-      try{
-        const data = JSON.parse(inline.textContent);
-        window.quizQuestions = data;
-        showCatalogIntro(data);
-      }catch(err){
-        console.error('Inline-Daten ungültig.', err);
+      console.error('Fragen konnten nicht geladen werden, versuche inline Daten', e);
+    }finally{
+      if(!loaded){
+        const inlineId = slug ?? sort_order;
+        const inline = inlineId ? document.getElementById(inlineId + '-data') : null;
+        if(inline){
+          try{
+            const data = JSON.parse(inline.textContent);
+            window.quizQuestions = data;
+            loaded = true;
+            showCatalogIntro(data);
+          }catch(err){
+            console.error('Inline-Daten ungültig.', err);
+          }
+        }
+        if(!loaded){
+          alert('Fragen konnten nicht geladen werden.');
+          showCatalogIntro([]);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Gracefully handle failed catalog fetch by attempting inline fallback or showing an error message
- Log catalog loading errors to console for easier debugging

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*


------
https://chatgpt.com/codex/tasks/task_e_68b86a8074ec832b92bf24238058de07