### PR TITLE
Display catalog description and comment

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -236,6 +236,18 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     const container = document.getElementById('quiz');
     if(!container) return;
     container.textContent = '';
+    const desc = sessionStorage.getItem('quizCatalogDesc');
+    if(desc){
+      const p = document.createElement('p');
+      p.textContent = desc;
+      container.appendChild(p);
+    }
+    const comment = sessionStorage.getItem('quizCatalogComment');
+    if(comment){
+      const p = document.createElement('p');
+      p.textContent = comment;
+      container.appendChild(p);
+    }
     const btn = document.createElement('button');
     btn.className = 'uk-button uk-button-primary uk-button-large uk-align-right';
     btn.textContent = 'Los geht es!';


### PR DESCRIPTION
## Summary
- show stored catalog description before start button
- display optional catalog comment prior to quiz start

## Testing
- `vendor/bin/phpunit` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a8cf01c832baa9f7db54c3622ba