### PR TITLE
Align catalog modals with table framework

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -376,9 +376,9 @@
               <button class="uk-button uk-button-default" type="button" data-format="italic"><em>I</em></button>
             </div>
             <textarea id="catalogCommentTextarea" class="uk-textarea" rows="5" placeholder="{{ t('placeholder_catalog_comment') }}"></textarea>
-            <div class="uk-flex uk-flex-right uk-margin-top">
-              <button id="catalogCommentSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="button" aria-label="{{ t('action_save') }}"></button>
+            <div class="uk-margin-top uk-text-right">
               <button class="uk-button uk-button-default uk-modal-close" type="button">{{ t('action_cancel') }}</button>
+              <button id="catalogCommentSave" class="uk-button uk-button-primary" type="button">{{ t('action_save') }}</button>
             </div>
           </div>
         </div>
@@ -388,9 +388,9 @@
             <h2 class="uk-modal-title">{{ t('heading_catalog_edit') }}</h2>
             <input id="catalogEditInput" class="uk-input" type="text">
             <div id="catalogEditError" class="uk-text-danger uk-margin-small-top" hidden></div>
-            <div class="uk-flex uk-flex-right uk-margin-top">
-              <button id="catalogEditSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="button" aria-label="{{ t('action_save') }}"></button>
+            <div class="uk-margin-top uk-text-right">
               <button id="catalogEditCancel" class="uk-button uk-button-default uk-modal-close" type="button">{{ t('action_cancel') }}</button>
+              <button id="catalogEditSave" class="uk-button uk-button-primary" type="button">{{ t('action_save') }}</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace icon-only buttons in catalog modals with standard Save/Cancel buttons for consistency with table framework

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ... Failed asserting that 500 is identical to 204)*

------
https://chatgpt.com/codex/tasks/task_e_68b871196ec4832b9dafedda755f4f9d