### PR TITLE
Persist catalog comments after save

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -575,14 +575,20 @@ document.addEventListener('DOMContentLoaded', function () {
     notify('Einladungstext gespeichert', 'success');
   });
 
-  commentSaveBtn?.addEventListener('click', () => {
+  commentSaveBtn?.addEventListener('click', async () => {
     if (!currentCommentItem || !commentTextarea) return;
     currentCommentItem.comment = commentTextarea.value;
     const list = catalogManager.getData();
     catalogManager.render(list);
-    commentModal.hide();
-    saveCatalogs(list, true);
-    currentCommentItem = null;
+    try {
+      await saveCatalogs(list);
+      commentModal.hide();
+      currentCommentItem = null;
+      notify('Kommentar gespeichert', 'success');
+    } catch (err) {
+      console.error(err);
+      notify('Fehler beim Speichern', 'danger');
+    }
   });
 
 


### PR DESCRIPTION
## Summary
- persist comment edits via `saveCatalogs`
- reset state and show success notification after saving comments

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Slim Application Error, failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b87edadbc4832b8c2fa3a931344242