### PR TITLE
feat(admin): add missing events table

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -166,6 +166,29 @@
       <div class="uk-container uk-container-large">
         <h2 class="uk-heading-bullet">{{ t('heading_events') }}</h2>
         <p class="uk-hidden">Professionelles Quiz-Hosting</p>
+        <div class="uk-overflow-auto uk-visible@m">
+          <table class="uk-table uk-table-divider uk-table-small uk-table-hover uk-table-responsive">
+            <thead>
+              <tr>
+                <th class="uk-table-shrink"></th>
+                <th>{{ t('column_number') }}</th>
+                <th>{{ t('column_name') }}</th>
+                <th>{{ t('column_start') }}</th>
+                <th>{{ t('column_end') }}</th>
+                <th>{{ t('column_description') }}</th>
+                <th class="uk-table-shrink">{{ t('column_current') }}</th>
+              </tr>
+            </thead>
+            <tbody
+              id="eventsList"
+              data-label-name="{{ t('column_name') }}"
+              data-label-start="{{ t('column_start') }}"
+              data-label-end="{{ t('column_end') }}"
+              data-label-description="{{ t('column_description') }}"
+              data-tip-select-event="{{ t('tip_select_event') }}"
+            ></tbody>
+          </table>
+        </div>
         {% from 'components/table.twig' import qr_rowcards %}
         {{ qr_rowcards('eventsCards') }}
         <div class="uk-margin">


### PR DESCRIPTION
## Summary
- restore Veranstaltungen table in admin view with columns for details and selection

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b8800337c8832bbcb2262e7fefeea8