### PR TITLE
Automatische Speicherung der Fragen

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -407,14 +407,10 @@
         <!-- Bedienleiste fuer Frageneditor -->
         <div id="questionActions">
           <div class="uk-margin">
-            <button id="addBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_question_add') }}; pos: left" aria-label="{{ t('tip_question_add') }}"></button>
-          </div>
-          <div class="uk-margin uk-flex uk-flex-right">
-            <button id="resetBtn" class="uk-button uk-button-default uk-margin-right" uk-tooltip="title: {{ t('tip_question_reset') }}; pos: left">{{ t('action_reset') }}</button>
-            <button id="saveBtn" class="uk-icon-button uk-button-primary fab fab-save" uk-icon="check" uk-tooltip="title: {{ t('tip_question_save') }}; pos: left" aria-label="{{ t('tip_question_save') }}"></button>
-          </div>
+          <button id="addBtn" class="uk-icon-button uk-button-primary fab" uk-icon="plus" uk-tooltip="title: {{ t('tip_question_add') }}; pos: left" aria-label="{{ t('tip_question_add') }}"></button>
         </div>
-        <!-- Ende Hauptdatenbereich -->
+      </div>
+      <!-- Ende Hauptdatenbereich -->
 
       </div>
     </li>


### PR DESCRIPTION
## Summary
- Entfernt manuelle Speichern- und Reset-Schaltflächen aus dem Admin-Frontend.
- Implementiert `saveQuestions` zum automatischen Persistieren des Fragenkatalogs inklusive Undo-Unterstützung.
- Bindet Autosave an Eingabe-, Änderungs-, Lösch- und Sortierereignisse.

## Testing
- `composer test` *(fehlgeschlagen: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b88064fa48832ba3af012c0a3ecab3