### PR TITLE
Support additional event configuration fields

### DIFF
--- a/migrations/20250301_add_event_config_fields.sql
+++ b/migrations/20250301_add_event_config_fields.sql
@@ -1,0 +1,7 @@
+-- Add additional event configuration fields
+ALTER TABLE config ADD COLUMN IF NOT EXISTS title TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS loginRequired BOOLEAN;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS whitelist TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS countdown INTEGER;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS webhookUrl TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS analyticsId TEXT;

--- a/public/js/event-config.js
+++ b/public/js/event-config.js
@@ -37,7 +37,7 @@
   const puzzleFeedback = document.getElementById('puzzleFeedback');
   const optCompetition = document.getElementById('optCompetition');
   const optResults = document.getElementById('optResults');
-  const optQrLogin = document.getElementById('optQrLogin');
+  const optQrLogin = document.getElementById('QRUser');
   const optTeamname = document.getElementById('optTeamname');
   const logoInput = document.getElementById('logo');
   const logoPreview = document.getElementById('logoPreview');

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -33,6 +33,7 @@ class ConfigService
         'photoUpload',
         'puzzleWordEnabled',
         'collectPlayerUid',
+        'loginRequired',
         'qrLogoPunchout',
         'qrRounded',
     ];
@@ -184,13 +185,19 @@ class ConfigService
      */
     public function saveConfig(array $data): void
     {
+        if (isset($data['pageTitle']) && !isset($data['title'])) {
+            $data['title'] = $data['pageTitle'];
+        }
+        if (isset($data['QRUser']) && !isset($data['loginRequired'])) {
+            $data['loginRequired'] = $data['QRUser'];
+        }
         $keys = [
             'displayErrorDetails',
-            'QRUser',
+            'title',
+            'loginRequired',
             'QRRemember',
             'logoPath',
             'ogImagePath',
-            'pageTitle',
             'backgroundColor',
             'buttonColor',
             'CheckAnswerButton',
@@ -198,14 +205,18 @@ class ConfigService
             'randomNames',
             'competitionMode',
             'teamResults',
-        'photoUpload',
-        'puzzleWordEnabled',
-        'puzzleWord',
-        'puzzleFeedback',
-        'collectPlayerUid',
-        'inviteText',
-        'colors',
-        'event_uid',
+            'photoUpload',
+            'puzzleWordEnabled',
+            'puzzleWord',
+            'puzzleFeedback',
+            'collectPlayerUid',
+            'inviteText',
+            'whitelist',
+            'countdown',
+            'webhookUrl',
+            'analyticsId',
+            'colors',
+            'event_uid',
             'qrLabelLine1',
             'qrLabelLine2',
             'qrLogoPath',
@@ -342,6 +353,10 @@ class ConfigService
             'puzzleWord',
             'puzzleFeedback',
             'inviteText',
+            'whitelist',
+            'countdown',
+            'webhookUrl',
+            'analyticsId',
             'colors',
             'event_uid',
             'qrLabelLine1',
@@ -359,6 +374,8 @@ class ConfigService
         foreach ($keys as $k) {
             $map[strtolower($k)] = $k;
         }
+        $map['title'] = 'pageTitle';
+        $map['loginrequired'] = 'QRUser';
         $normalized = [];
         foreach ($row as $k => $v) {
             $key = $map[strtolower($k)] ?? $k;

--- a/templates/admin/event_config.twig
+++ b/templates/admin/event_config.twig
@@ -39,9 +39,9 @@
           <li>
             <form class="uk-form-stacked">
               <div class="uk-margin">
-                <label class="uk-form-label" for="title">Titel</label>
+                <label class="uk-form-label" for="pageTitle">Titel</label>
                 <div class="uk-form-controls">
-                  <input class="uk-input" id="title" name="title" type="text" placeholder="Titel">
+                    <input class="uk-input" id="pageTitle" name="pageTitle" type="text" placeholder="Titel">
                 </div>
                 <div class="uk-text-meta">Titel des Events für Teilnehmende.</div>
               </div>
@@ -69,9 +69,9 @@
           <li>
             <form class="uk-form-stacked">
               <div class="uk-margin">
-                <label class="uk-form-label" for="loginRequired">Login erforderlich</label>
+                <label class="uk-form-label" for="QRUser">Login erforderlich</label>
                 <div class="uk-form-controls">
-                  <input class="uk-checkbox" id="loginRequired" name="loginRequired" type="checkbox">
+                    <input class="uk-checkbox" id="QRUser" name="QRUser" type="checkbox">
                 </div>
                 <div class="uk-text-meta">Teilnehmende m&uuml;ssen sich anmelden.</div>
               </div>


### PR DESCRIPTION
## Summary
- handle new config options such as title, loginRequired, whitelist, countdown, webhookUrl and analyticsId
- add migration adding corresponding columns to the config table
- rename event configuration form fields to match existing backend keys

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b89a0c7a80832bad5e1ab652dbf5d8