### PR TITLE
Add event-specific config endpoint

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2620,7 +2620,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const uploadPath = '/qrlogo.' + ext + (activeEventUid ? `?event_uid=${encodeURIComponent(activeEventUid)}` : '');
     apiFetch(uploadPath, { method: 'POST', body: fd })
       .then(() => {
-        const cfgPath = activeEventUid ? `/admin/event/${activeEventUid}` : '/config.json';
+        const cfgPath = activeEventUid ? `/events/${activeEventUid}/config.json` : '/config.json';
         return apiFetch(cfgPath, { headers: { 'Accept': 'application/json' } });
       })
       .then(r => r.json())
@@ -2727,8 +2727,11 @@ document.addEventListener('DOMContentLoaded', function () {
     const teamsEl = document.getElementById('summaryTeams');
     if (!nameEl || !catalogsEl || !teamsEl) return;
     const opts = { headers: { 'Accept': 'application/json' } };
+    const cfgPromise = activeEventUid
+      ? apiFetch(`/events/${activeEventUid}/config.json`, opts).then(r => r.json()).catch(() => ({}))
+      : apiFetch('/config.json', opts).then(r => r.json()).catch(() => ({}));
     Promise.all([
-      apiFetch('/config.json', opts).then(r => r.json()).catch(() => ({})),
+      cfgPromise,
       apiFetch('/events.json', opts).then(r => r.json()).catch(() => []),
       apiFetch('/kataloge/catalogs.json', opts).then(r => r.json()).catch(() => []),
       apiFetch('/teams.json', opts).then(r => r.json()).catch(() => [])

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -50,6 +50,28 @@ class ConfigController
     }
 
     /**
+     * Return configuration for the specified event UID.
+     */
+    public function getByEvent(string $uid, Response $response): Response
+    {
+        $cfg = $this->service->getConfigForEvent($uid);
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $role = $_SESSION['user']['role'] ?? null;
+        if ($role !== 'admin') {
+            $cfg = ConfigService::removePuzzleInfo($cfg);
+        }
+        if ($cfg === []) {
+            return $response->withStatus(404);
+        }
+
+        $content = json_encode($cfg, JSON_PRETTY_PRINT);
+        $response->getBody()->write($content);
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    /**
      * Persist a new configuration payload.
      */
     public function post(Request $request, Response $response): Response

--- a/src/routes.php
+++ b/src/routes.php
@@ -801,6 +801,10 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('configController')->get($request, $response);
     });
 
+    $app->get('/events/{uid}/config.json', function (Request $request, Response $response, array $args) {
+        return $request->getAttribute('configController')->getByEvent((string) $args['uid'], $response);
+    });
+
     $app->post('/config.json', function (Request $request, Response $response) {
         return $request->getAttribute('configController')->post($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::EVENT_MANAGER));

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -98,6 +98,22 @@ class ConfigControllerTest extends TestCase
         session_destroy();
     }
 
+    public function testGetByEvent(): void
+    {
+        $pdo = $this->createDatabase();
+        $service = new ConfigService($pdo);
+        $service->saveConfig(['event_uid' => 'ev1', 'pageTitle' => 'Demo']);
+        $controller = new ConfigController($service, new ConfigValidator());
+
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+
+        $response = $controller->getByEvent('ev1', new Response());
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('Demo', (string) $response->getBody());
+        session_destroy();
+    }
+
     public function testPostDeniedForNonAdmin(): void
     {
         $app = $this->getAppInstance();


### PR DESCRIPTION
## Summary
- expose `ConfigController::getByEvent` for per-event configuration lookup
- wire `GET /events/{uid}/config.json` to the new controller method
- fetch event-specific config in admin UI when an event is selected
- cover event config retrieval with a dedicated unit test

## Testing
- `vendor/bin/phpcs src/Controller/ConfigController.php tests/Controller/ConfigControllerTest.php`
- `composer test` *(fails: Slim Application Error, RoleAccessTest, ConfigServiceTest, TenantServiceTest)*

------
https://chatgpt.com/codex/tasks/task_e_68b89e8b97f4832bb17ed38dc4ec2501