### PR TITLE
Prefill event title and ensure default on save

### DIFF
--- a/public/js/event-config.js
+++ b/public/js/event-config.js
@@ -31,7 +31,11 @@
       } else if (el.type === 'file') {
         if (el.files?.[0]) data.append(key, el.files[0]);
       } else {
-        data.append(key, el.value);
+        let value = el.value;
+        if (key === 'pageTitle' && !value) {
+          value = 'Modernes Quiz mit UIkit';
+        }
+        data.append(key, value);
       }
     });
     return data;

--- a/templates/admin/event_config.twig
+++ b/templates/admin/event_config.twig
@@ -41,7 +41,7 @@
               <div class="uk-margin">
                 <label class="uk-form-label" for="pageTitle">Titel</label>
                 <div class="uk-form-controls">
-                    <input class="uk-input" id="pageTitle" name="pageTitle" type="text" placeholder="Titel">
+                    <input class="uk-input" id="pageTitle" name="pageTitle" type="text" placeholder="Modernes Quiz mit UIkit" value="{{ config.pageTitle|default('') }}">
                 </div>
                 <div class="uk-text-meta">Titel des Events für Teilnehmende.</div>
               </div>


### PR DESCRIPTION
## Summary
- prefill event configuration form with stored title
- default empty title to "Modernes Quiz mit UIkit" when saving

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a4a6f378832b97bfa1b77ee6c03a