### PR TITLE
Use event name as fallback for empty pageTitle

### DIFF
--- a/src/Service/ConfigValidator.php
+++ b/src/Service/ConfigValidator.php
@@ -36,19 +36,21 @@ class ConfigValidator
     /**
      * Validate incoming configuration data.
      *
-     * @param array<string,mixed> $data
+     * @param array<string,mixed> $data   Configuration payload to validate
+     * @param string|null        $eventName Optional event name used as fallback for the page title
+     *
      * @return array{config: array<string,mixed>, errors: array<string,string>}
      */
-    public function validate(array $data): array
+    public function validate(array $data, ?string $eventName = null): array
     {
         $config = [];
         $errors = [];
 
         // pageTitle
-        $title = trim((string)($data['pageTitle'] ?? self::DEFAULTS['pageTitle']));
+        $title = trim((string)($data['pageTitle'] ?? ''));
         if ($title === '') {
-            $errors['pageTitle'] = 'Page title is required';
-            $title = self::DEFAULTS['pageTitle'];
+            $fallback = $eventName !== null ? trim($eventName) : '';
+            $title = $fallback !== '' ? $fallback : self::DEFAULTS['pageTitle'];
         }
         $config['pageTitle'] = $title;
 


### PR DESCRIPTION
## Summary
- allow ConfigValidator::validate to accept optional event name
- use event name or default when pageTitle is empty instead of returning error

## Testing
- `vendor/bin/phpcs src/Service/ConfigValidator.php`
- `composer phpunit` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ae68b02c832bb21aa96b2af2dbef