### PR TITLE
Validate event config updates

### DIFF
--- a/tests/Controller/EventConfigControllerTest.php
+++ b/tests/Controller/EventConfigControllerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Controller\EventConfigController;
+use App\Service\ConfigService;
+use App\Service\EventService;
+use Slim\Psr7\Response;
+use Tests\TestCase;
+
+class EventConfigControllerTest extends TestCase
+{
+    public function testUpdateInvalidData(): void
+    {
+        $pdo = $this->createDatabase();
+        $eventService = new EventService($pdo);
+        $eventService->saveAll([['uid' => 'ev1', 'name' => 'Test']]);
+        $controller = new EventConfigController($eventService, new ConfigService($pdo));
+
+        $request = $this->createRequest('PUT', '/events/ev1/config.json');
+        $request = $request->withParsedBody(['backgroundColor' => 'blue']);
+
+        $response = $controller->update($request, new Response(), ['id' => 'ev1']);
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertStringContainsString('errors', (string) $response->getBody());
+    }
+
+    public function testUpdateValidData(): void
+    {
+        $pdo = $this->createDatabase();
+        $eventService = new EventService($pdo);
+        $eventService->saveAll([['uid' => 'ev1', 'name' => 'Test']]);
+        $configService = new ConfigService($pdo);
+        $controller = new EventConfigController($eventService, $configService);
+
+        $request = $this->createRequest('PUT', '/events/ev1/config.json');
+        $request = $request->withParsedBody(['pageTitle' => 'Demo']);
+
+        $response = $controller->update($request, new Response(), ['id' => 'ev1']);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+        $this->assertSame('ev1', $payload['event']['uid'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary
- validate event configuration updates and return JSON errors for invalid data
- add tests covering event config update validation

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars)*
- `vendor/bin/phpunit tests/Controller/EventConfigControllerTest.php`
- `vendor/bin/phpcs src/Controller/EventConfigController.php tests/Controller/EventConfigControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8ae61c084832bba78c8fcd58760a6