### PR TITLE
Set event_uid on existing catalogs

### DIFF
--- a/migrations/20250302_set_event_uid_on_catalogs.sql
+++ b/migrations/20250302_set_event_uid_on_catalogs.sql
@@ -1,0 +1,8 @@
+-- Set event_uid on existing catalogs based on active event or config
+UPDATE catalogs
+SET event_uid = (SELECT event_uid FROM active_event LIMIT 1)
+WHERE event_uid IS NULL;
+
+UPDATE catalogs
+SET event_uid = (SELECT event_uid FROM config LIMIT 1)
+WHERE event_uid IS NULL;


### PR DESCRIPTION
## Summary
- backfill missing catalog `event_uid` from `active_event` or `config`

## Testing
- `sqlite3 /tmp/test.db <<'EOF'
CREATE TABLE events (uid TEXT PRIMARY KEY);
CREATE TABLE config (event_uid TEXT);
CREATE TABLE active_event (event_uid TEXT PRIMARY KEY);
CREATE TABLE catalogs (
    uid TEXT PRIMARY KEY,
    sort_order INTEGER,
    slug TEXT,
    file TEXT,
    name TEXT,
    event_uid TEXT
);
INSERT INTO events(uid) VALUES('event1');
INSERT INTO config(event_uid) VALUES('event1');
INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES('cat1',1,'slug','file','name');
.read migrations/20250302_set_event_uid_on_catalogs.sql
SELECT COUNT(*) FROM catalogs WHERE event_uid IS NULL;
EOF`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b12adcb0832bafb172b24105b16a