### PR TITLE
Ensure catalog services use active event configuration

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -30,7 +30,7 @@ class HomeController
             $pdo = Database::connectFromEnv();
         }
         $cfgSvc = new ConfigService($pdo);
-        $eventSvc = new EventService($pdo);
+        $eventSvc = new EventService($pdo, $cfgSvc);
         $settingsSvc = new SettingsService($pdo);
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
@@ -39,6 +39,7 @@ class HomeController
 
         $params = $request->getQueryParams();
         $uid = (string)($params['event'] ?? '');
+        $cfgSvc->setActiveEventUid($uid);
         if ($uid !== '') {
             $cfg = $cfgSvc->getConfigForEvent($uid);
             $event = $eventSvc->getByUid($uid) ?? $eventSvc->getFirst();
@@ -80,7 +81,7 @@ class HomeController
             $cfg = ConfigService::removePuzzleInfo($cfg);
         }
 
-        $catalogService = new CatalogService($pdo, new ConfigService($pdo));
+        $catalogService = new CatalogService($pdo, $cfgSvc);
 
         $catalogsJson = $catalogService->read('catalogs.json');
         $catalogs = [];


### PR DESCRIPTION
## Summary
- set active event UID from `event` query parameter in HomeController
- reuse ConfigService for EventService and CatalogService to honor active event

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml src/Controller/HomeController.php`
- `composer test` *(fails: Missing STRIPE_* env vars, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68b9213123b4832b9ecc844d39dcd33a