### PR TITLE
Add CSRF meta and dataset attributes for event config page

### DIFF
--- a/templates/admin/event_config.twig
+++ b/templates/admin/event_config.twig
@@ -3,6 +3,7 @@
 {% block title %}Event konfigurieren{% endblock %}
 
 {% block head %}
+  <meta name="csrf-token" content="{{ csrf_token }}">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
   <link rel="stylesheet" href="{{ basePath }}/css/admin-config.css">
 {% endblock %}
@@ -187,6 +188,6 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ basePath }}/js/event-config.js"></script>
+  <script src="{{ basePath }}/js/event-config.js" data-event-id="{{ event.uid }}" data-csrf="{{ csrf_token }}"></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- expose `csrf_token` via meta tag for event config page
- pass event ID and CSRF token to `event-config.js` via data attributes

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other Stripe variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b926672ab4832b99dcd9390b2844fa