### PR TITLE
Add identifier for event configuration save button

### DIFF
--- a/public/js/event-config.js
+++ b/public/js/event-config.js
@@ -48,7 +48,7 @@
   const optQrLogin = document.getElementById('QRUser');
   const logoInput = document.getElementById('logo');
   const logoPreview = document.getElementById('logoPreview');
-  const saveBtn = document.querySelector('.event-config-sidebar .uk-button-secondary');
+  const saveBtn = document.getElementById('saveConfig');
   const publishBtn = document.querySelector('.event-config-sidebar .uk-button-primary');
 
   function applyRules(shouldQueue) {

--- a/templates/admin/event_config.twig
+++ b/templates/admin/event_config.twig
@@ -179,7 +179,7 @@
             </div>
           </div>
           <div class="uk-margin-top">
-            <button class="uk-button uk-button-primary uk-width-1-1">Speichern</button>
+            <button id="saveConfig" class="uk-button uk-button-primary uk-width-1-1">Speichern</button>
           </div>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- assign id `saveConfig` to event configuration save button
- update client script to bind save handler via new id

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other environment variables; multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b928816ea4832bb53a3a69d0ed5711