### PR TITLE
Handle tenant sync errors

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2425,13 +2425,13 @@ document.addEventListener('DOMContentLoaded', function () {
     tenantSyncBtn.disabled = true;
     tenantSyncBtn.innerHTML = '<div uk-spinner></div>';
     apiFetch('/tenants/sync', { method: 'POST' })
-      .then(r => r.json())
+      .then(r => (r.ok ? r.json() : Promise.reject()))
       .then(() => {
         notify('Mandanten eingelesen', 'success');
-        loadTenants(tenantStatusFilter?.value, tenantSearchInput?.value);
       })
       .catch(() => notify('Fehler beim Synchronisieren', 'danger'))
       .finally(() => {
+        loadTenants(tenantStatusFilter?.value, tenantSearchInput?.value);
         tenantSyncBtn.disabled = false;
         tenantSyncBtn.innerHTML = original;
       });


### PR DESCRIPTION
## Summary
- Improve tenant sync handler with response.ok check
- List tenants after sync attempt regardless of outcome
- Notify users when tenant sync fails

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars)*
- `node tests/test_competition_mode.js`

------
https://chatgpt.com/codex/tasks/task_e_68b92a756f38832ba48b2e222136a563