### PR TITLE
Include event UID when fetching quiz catalogs and questions

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -158,7 +158,8 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
   }
   async function loadCatalogList(){
     try{
-      const res = await fetch(withBase('/kataloge/catalogs.json'), { headers: { 'Accept': 'application/json' } });
+      const url = '/kataloge/catalogs.json' + (eventUid ? '?event=' + encodeURIComponent(eventUid) : '');
+      const res = await fetch(withBase(url), { headers: { 'Accept': 'application/json' } });
       if(res.ok){
         return await res.json();
       }
@@ -212,7 +213,10 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     }
     let loaded = false;
     try{
-      const res = await fetch(withBase('/kataloge/' + file), { headers: { 'Accept': 'application/json' } });
+      if(!eventUid){
+        console.warn('eventUid not set when loading questions');
+      }
+      const res = await fetch(withBase('/kataloge/' + file + '?event=' + encodeURIComponent(eventUid)), { headers: { 'Accept': 'application/json' } });
       const data = await res.json();
       window.quizQuestions = data;
       loaded = true;


### PR DESCRIPTION
## Summary
- Append event UID to catalog list requests when available
- Pass event UID to question file requests and log missing IDs

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b92ab9d780832ba019e8e0d2e7f178