### PR TITLE
feat: add autosave for loaded config

### DIFF
--- a/public/js/event-config.js
+++ b/public/js/event-config.js
@@ -49,6 +49,7 @@
   const logoInput = document.getElementById('logo');
   const logoPreview = document.getElementById('logoPreview');
   const saveBtn = document.getElementById('saveConfig');
+  const saveHeaderBtn = document.getElementById('saveConfigHeader');
   const publishBtn = document.querySelector('.event-config-sidebar .uk-button-primary');
 
   function applyRules(shouldQueue) {
@@ -103,6 +104,7 @@
             logoPreview.hidden = false;
           }
           applyRules(false);
+          queueAutosave();
         })
         .catch(() => {
           UIkit?.notification({ message: 'Konfiguration konnte nicht geladen werden', status: 'danger' });
@@ -115,6 +117,7 @@
     competitionMode?.addEventListener('change', queueAutosave);
     optQrLogin?.addEventListener('change', queueAutosave);
     saveBtn?.addEventListener('click', (e) => { e.preventDefault(); save(); });
+    saveHeaderBtn?.addEventListener('click', (e) => { e.preventDefault(); save(); });
     publishBtn?.addEventListener('click', (e) => { e.preventDefault(); save(); });
     document.querySelectorAll('input, textarea, select').forEach((el) => {
       el.addEventListener('input', queueAutosave);

--- a/templates/admin/event_config.twig
+++ b/templates/admin/event_config.twig
@@ -20,7 +20,7 @@
         </div>
         <div class="uk-button-group">
           <a class="uk-button uk-button-default" href="{{ basePath }}/?event={{ event.slug|default('demo') }}" target="_blank">Vorschau</a>
-          <button class="uk-button uk-button-primary">Speichern</button>
+          <button id="saveConfigHeader" class="uk-button uk-button-primary">Speichern</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add id for header save button and wire to save()
- autosave initial values after configuration load

## Testing
- `composer test` *(fails: process hung, interrupted after partial output)*

------
https://chatgpt.com/codex/tasks/task_e_68b92a8d3ce8832bba8a438ee544d885