### PR TITLE
Inject ConfigService into catalog controller

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -181,7 +181,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $request = $request
             ->withAttribute('plan', $plan)
             ->withAttribute('configController', new ConfigController($configService, new ConfigValidator()))
-            ->withAttribute('catalogController', new CatalogController($catalogService))
+            ->withAttribute('catalogController', new CatalogController($catalogService, $configService))
             ->withAttribute('adminCatalogController', new AdminCatalogController($catalogService))
             ->withAttribute('resultController', new ResultController(
                 $resultService,

--- a/tests/Controller/CatalogControllerLimitTest.php
+++ b/tests/Controller/CatalogControllerLimitTest.php
@@ -24,7 +24,7 @@ class CatalogControllerLimitTest extends TestCase
         $cfg->setActiveEventUid('e1');
         $tenantSvc = new TenantService($pdo);
         $service = new CatalogService($pdo, $cfg, $tenantSvc, 'sub1');
-        $controller = new CatalogController($service);
+        $controller = new CatalogController($service, $cfg);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 
@@ -71,7 +71,7 @@ class CatalogControllerLimitTest extends TestCase
         $tenantSvc = new TenantService($pdo);
         $service = new CatalogService($pdo, $cfg, $tenantSvc, 'sub1');
         $service->createCatalog('test.json');
-        $controller = new CatalogController($service);
+        $controller = new CatalogController($service, $cfg);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -53,7 +53,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service);
+        $controller = new CatalogController($service, $cfg);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
         $request = $this->createRequest('GET', '/kataloge/missing.json', ['HTTP_ACCEPT' => 'application/json']);
@@ -103,7 +103,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service);
+        $controller = new CatalogController($service, $cfg);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 
@@ -157,7 +157,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service);
+        $controller = new CatalogController($service, $cfg);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 
@@ -231,7 +231,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service);
+        $controller = new CatalogController($service, $cfg);
         session_start();
         $_SESSION["user"] = ["id" => 1, "role" => "catalog-editor"];
 
@@ -310,7 +310,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service);
+        $controller = new CatalogController($service, $cfg);
         session_start();
         $_SESSION["user"] = ["id" => 1, "role" => "catalog-editor"];
 
@@ -370,7 +370,7 @@ class CatalogControllerTest extends TestCase
             SQL
         );
         $cfg = new ConfigService($pdo);
-        $controller = new CatalogController(new CatalogService($pdo, $cfg));
+        $controller = new CatalogController(new CatalogService($pdo, $cfg), $cfg);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 


### PR DESCRIPTION
## Summary
- Inject `ConfigService` into `CatalogController` and handle `event` query parameter before reading catalogs
- Update route wiring and tests for new `CatalogController` signature

## Testing
- `vendor/bin/phpunit tests/Controller/CatalogControllerTest.php tests/Controller/CatalogControllerLimitTest.php`
- `composer test` *(fails: process hangs, missing STRIPE_* env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b92ace2288832bb4af9653aeced03c