### PR TITLE
Avoid inserting config for empty active event

### DIFF
--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -291,7 +291,9 @@ class ConfigService
             $this->pdo->rollBack();
             throw $e;
         }
-        $this->ensureConfigForEvent($uid);
+        if ($uid !== '') {
+            $this->ensureConfigForEvent($uid);
+        }
         $this->activeEvent = $uid;
     }
 
@@ -300,6 +302,9 @@ class ConfigService
      */
     public function ensureConfigForEvent(string $uid): void
     {
+        if ($uid === '') {
+            return;
+        }
         $stmt = $this->pdo->prepare('SELECT 1 FROM config WHERE event_uid = ? LIMIT 1');
         $stmt->execute([$uid]);
         if ($stmt->fetchColumn() === false) {

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -19,10 +19,10 @@ class ConfigServiceTest extends TestCase
             <<<'SQL'
             CREATE TABLE config(
                 displayErrorDetails INTEGER,
-                QRUser INTEGER,
+                loginRequired INTEGER,
                 QRRemember INTEGER,
                 logoPath TEXT,
-                pageTitle TEXT,
+                title TEXT,
                 backgroundColor TEXT,
                 buttonColor TEXT,
                 CheckAnswerButton TEXT,
@@ -59,10 +59,10 @@ class ConfigServiceTest extends TestCase
             <<<'SQL'
             CREATE TABLE config(
                 displayErrorDetails INTEGER,
-                QRUser INTEGER,
+                loginRequired INTEGER,
                 QRRemember INTEGER,
                 logoPath TEXT,
-                pageTitle TEXT,
+                title TEXT,
                 backgroundColor TEXT,
                 buttonColor TEXT,
                 CheckAnswerButton TEXT,
@@ -107,5 +107,17 @@ class ConfigServiceTest extends TestCase
 
         $uid = $pdo->query('SELECT event_uid FROM active_event')->fetchColumn();
         $this->assertSame('foo', $uid);
+    }
+
+    public function testSetActiveEventUidDoesNotInsertConfigForEmptyEvent(): void
+    {
+        $pdo = $this->createDatabase();
+        $pdo->exec('PRAGMA foreign_keys = ON');
+        $service = new ConfigService($pdo);
+
+        $service->setActiveEventUid('');
+
+        $count = (int) $pdo->query('SELECT COUNT(*) FROM config')->fetchColumn();
+        $this->assertSame(0, $count);
     }
 }


### PR DESCRIPTION
## Summary
- guard setActiveEventUid() to skip config creation when no event is active
- harden ensureConfigForEvent against empty UIDs
- modernize config service tests and add coverage for empty event case

## Testing
- `vendor/bin/phpunit tests/Service/ConfigServiceTest.php`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_PRICE_STARTER and related env vars, Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b92b28c92c832b98b5b3f0aee6805d