### PR TITLE
Handle tenant import errors in sync endpoint

### DIFF
--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -113,9 +113,18 @@ class TenantController
      */
     public function sync(Request $request, Response $response): Response
     {
-        $count = $this->service->importMissing();
-        $response->getBody()->write(json_encode(['imported' => $count]));
-        return $response->withHeader('Content-Type', 'application/json');
+        try {
+            $count = $this->service->importMissing();
+            $response->getBody()->write(json_encode(['imported' => $count]));
+            return $response->withHeader('Content-Type', 'application/json');
+        } catch (\Throwable $e) {
+            $msg = 'Error importing tenants: ' . $e->getMessage();
+            error_log($msg);
+            $response->getBody()->write(json_encode(['error' => $e->getMessage()]));
+            return $response
+                ->withStatus(500)
+                ->withHeader('Content-Type', 'application/json');
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Wrap tenant import with try/catch and log errors
- Return JSON error response with HTTP 500 on failure

## Testing
- `composer test` *(fails: Tests: 294, Assertions: 629, Errors: 30, Failures: 10, Warnings: 5, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b92b595ddc832ba01915fd37938c64