### PR TITLE
feat: make tenants directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,10 @@ standardmäßig `https://` vorangestellt.
 
 ## Multi-Tenant Setup
 
-Mehrere Subdomains lassen sich als eigene Mandanten betreiben. Ein neuer
-Mandant wird mit `scripts/create_tenant.sh` angelegt:
+Mehrere Subdomains lassen sich als eigene Mandanten betreiben. Das Verzeichnis
+für die Compose-Dateien der Mandanten lässt sich über die Variable
+`TENANTS_DIR` steuern (Standard: `tenants/`). Ein neuer Mandant wird mit
+`scripts/create_tenant.sh` angelegt:
 
 ```bash
 scripts/create_tenant.sh foo
@@ -320,10 +322,11 @@ Haupt-Stack dieses Netzwerk erstellt oder verwaltet. Den Namen kannst du
 über die Umgebungsvariable `NETWORK` im Skript anpassen.
 
 Das Skript `scripts/onboard_tenant.sh` steht weiterhin zur Verfügung, um
-einen Container manuell zu starten oder neu aufzusetzen. Es schreibt unter
-`tenants/<slug>/` eine eigene `docker-compose.yml`, legt dort ein
-persistentes `data/`-Verzeichnis an und bindet es im Container unter
-`/var/www/data` ein. So bleiben hochgeladene Logos oder Fotos auch bei
+einen Container manuell zu starten oder neu aufzusetzen. Es legt im durch
+`TENANTS_DIR` festgelegten Verzeichnis (`Standard: tenants/`) den Ordner
+`<slug>/` an, erstellt dort eine eigene `docker-compose.yml` und ein
+persistentes `data/`-Verzeichnis, das im Container unter `/var/www/data`
+eingebunden wird. So bleiben hochgeladene Logos oder Fotos auch bei
 Upgrades erhalten. Zusätzlich fordert das Skript das SSL-Zertifikat an.
 Welches Docker-Image dabei verwendet wird, lässt sich über die Variable `APP_IMAGE` in der `.env` steuern.
 Dieses Tag sollte dem lokal gebauten Slim-Image entsprechen (`docker build -t <tag> .`),
@@ -348,7 +351,8 @@ alternativ direkt auf dem Host aus, wenn Docker im Container nicht
 verfügbar ist.
 
 Zum Entfernen einer isolierten Instanz nutzt du `scripts/offboard_tenant.sh`.
-Das Skript stoppt den Container und löscht das Verzeichnis `tenants/<slug>/`:
+Das Skript stoppt den Container und löscht das Verzeichnis
+`${TENANTS_DIR}/<slug>/`:
 
 ```bash
 scripts/offboard_tenant.sh foo

--- a/config/settings.php
+++ b/config/settings.php
@@ -34,5 +34,6 @@ $settings['postgres_pass'] = getenv('POSTGRES_PASSWORD')
 $settings['main_domain'] = getenv('MAIN_DOMAIN') ?: ($settings['main_domain'] ?? null);
 $settings['service_user'] = getenv('SERVICE_USER') ?: ($settings['service_user'] ?? null);
 $settings['service_pass'] = getenv('SERVICE_PASS') ?: ($settings['service_pass'] ?? null);
+$settings['tenants_dir'] = getenv('TENANTS_DIR') ?: (dirname(__DIR__) . '/tenants');
 
 return $settings;

--- a/sample.env
+++ b/sample.env
@@ -14,6 +14,7 @@ APP_IMAGE=sommerfest-quiz:latest # Docker-Image für Tenant-Container
 # das vom Onboarding-Skript verwendet wird
 SLIM_VIRTUAL_HOST=example.com # Hostname des Quiz-Containers
 NETWORK=webproxy                # Docker-Netzwerk des Reverse Proxy
+TENANTS_DIR=tenants             # Verzeichnis für Tenant-Compose-Dateien
 
 # Let's Encrypt
 LETSENCRYPT_EMAIL=admin@example.com # Kontaktadresse für Zertifikate

--- a/scripts/offboard_tenant.sh
+++ b/scripts/offboard_tenant.sh
@@ -2,13 +2,16 @@
 # Stop and remove a tenant container and clean up resources
 set -e
 
+SCRIPT_DIR="$(dirname "$0")"
+
 if [ "$#" -lt 1 ]; then
   echo "Usage: $0 <tenant-slug>" >&2
   exit 1
 fi
 
 SLUG=$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
-TENANT_DIR="$(dirname "$0")/../tenants/$SLUG"
+TENANTS_DIR="${TENANTS_DIR:-$SCRIPT_DIR/../tenants}"
+TENANT_DIR="$TENANTS_DIR/$SLUG"
 COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
 
 # detect docker compose command

--- a/scripts/onboard_tenant.sh
+++ b/scripts/onboard_tenant.sh
@@ -24,7 +24,8 @@ if [ "$#" -lt 1 ]; then
 fi
 
 SLUG=$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
-TENANT_DIR="$(dirname "$0")/../tenants/$SLUG"
+TENANTS_DIR="${TENANTS_DIR:-$SCRIPT_DIR/../tenants}"
+TENANT_DIR="$TENANTS_DIR/$SLUG"
 DATA_DIR="$TENANT_DIR/data"
 COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
 DOMAIN_SUFFIX="${MAIN_DOMAIN:-$DOMAIN}"

--- a/scripts/renew_ssl.sh
+++ b/scripts/renew_ssl.sh
@@ -2,6 +2,8 @@
 # Force renew SSL certificate for a tenant or the main system via acme-companion
 set -e
 
+SCRIPT_DIR="$(dirname "$0")"
+
 if [ "$#" -lt 1 ]; then
   echo "Usage: $0 <tenant-slug>|--main" >&2
   exit 1
@@ -20,11 +22,12 @@ fi
 
 if [ "$1" = "--main" ] || [ "$1" = "--system" ]; then
   SLUG="main"
-  COMPOSE_FILE="$(dirname "$0")/../docker-compose.yml"
+  COMPOSE_FILE="$SCRIPT_DIR/../docker-compose.yml"
   SERVICE="slim"
 else
   SLUG="$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')"
-  TENANT_DIR="$(dirname "$0")/../tenants/$SLUG"
+  TENANTS_DIR="${TENANTS_DIR:-$SCRIPT_DIR/../tenants}"
+  TENANT_DIR="$TENANTS_DIR/$SLUG"
   COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
   SERVICE="slim"
 

--- a/scripts/restart_tenant.sh
+++ b/scripts/restart_tenant.sh
@@ -2,6 +2,8 @@
 # Restart tenant or main container
 set -e
 
+SCRIPT_DIR="$(dirname "$0")"
+
 if [ "$#" -lt 1 ]; then
   echo "Usage: $0 <tenant-slug>|--main" >&2
   exit 1
@@ -18,11 +20,12 @@ fi
 
 if [ "$1" = "--main" ] || [ "$1" = "--system" ]; then
   SLUG="main"
-  COMPOSE_FILE="$(dirname "$0")/../docker-compose.yml"
+  COMPOSE_FILE="$SCRIPT_DIR/../docker-compose.yml"
   SERVICE="slim"
 else
   SLUG="$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')"
-  TENANT_DIR="$(dirname "$0")/../tenants/$SLUG"
+  TENANTS_DIR="${TENANTS_DIR:-$SCRIPT_DIR/../tenants}"
+  TENANT_DIR="$TENANTS_DIR/$SLUG"
   COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
   SERVICE="app"
 fi

--- a/scripts/upgrade_tenant.sh
+++ b/scripts/upgrade_tenant.sh
@@ -31,6 +31,8 @@ done
 
 [ -z "$ARG" ] && usage
 
+SCRIPT_DIR="$(dirname "$0")"
+
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   DOCKER_COMPOSE="docker compose"
 elif command -v docker-compose >/dev/null 2>&1; then
@@ -44,11 +46,12 @@ SLUG_SANITIZED="$(echo "$ARG" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-
 
 if [ "$ARG" = "--main" ] || [ "$ARG" = "--system" ] || [ "$SLUG_SANITIZED" = "main" ]; then
   SLUG="main"
-  COMPOSE_FILE="$(dirname "$0")/../docker-compose.yml"
+  COMPOSE_FILE="$SCRIPT_DIR/../docker-compose.yml"
   SERVICE="slim"
 else
   SLUG="$SLUG_SANITIZED"
-  TENANT_DIR="$(dirname "$0")/../tenants/$SLUG"
+  TENANTS_DIR="${TENANTS_DIR:-$SCRIPT_DIR/../tenants}"
+  TENANT_DIR="$TENANTS_DIR/$SLUG"
   COMPOSE_FILE="$TENANT_DIR/docker-compose.yml"
   SERVICE="app"
 fi

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -18,6 +18,7 @@ class TenantService
     private PDO $pdo;
     private string $migrationsDir;
     private ?NginxService $nginxService;
+    private string $tenantsDir;
 
     private const RESERVED_SUBDOMAINS = [
         'public',
@@ -36,11 +37,16 @@ class TenantService
         'kz',
     ];
 
-    public function __construct(?PDO $pdo = null, ?string $migrationsDir = null, ?NginxService $nginxService = null)
-    {
+    public function __construct(
+        ?PDO $pdo = null,
+        ?string $migrationsDir = null,
+        ?NginxService $nginxService = null,
+        ?string $tenantsDir = null
+    ) {
         $this->pdo = $pdo ?? Database::connectFromEnv();
         $this->migrationsDir = $migrationsDir ?? dirname(__DIR__, 2) . '/migrations';
         $this->nginxService = $nginxService;
+        $this->tenantsDir = $tenantsDir ?? (getenv('TENANTS_DIR') ?: dirname(__DIR__, 2) . '/tenants');
     }
 
     /**
@@ -644,7 +650,7 @@ class TenantService
             $count++;
         }
 
-        $tenantsDir = dirname(__DIR__, 2) . '/tenants';
+        $tenantsDir = $this->tenantsDir;
         if (is_dir($tenantsDir)) {
             foreach (scandir($tenantsDir) as $dir) {
                 if ($dir === '.' || $dir === '..') {


### PR DESCRIPTION
## Summary
- add `TENANTS_DIR` configuration
- let `TenantService::importMissing()` read tenants directory from config
- respect `TENANTS_DIR` in management scripts and docs

## Testing
- `STRIPE_SECRET_KEY=1 STRIPE_PUBLISHABLE_KEY=1 STRIPE_PRICE_STARTER=1 STRIPE_PRICE_STANDARD=1 STRIPE_PRICE_PROFESSIONAL=1 STRIPE_PRICING_TABLE_ID=1 STRIPE_WEBHOOK_SECRET=1 composer test` *(fails: Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b92b671fa4832b911c67c7afcb8e7b