### PR TITLE
Rename primary-color field to buttonColor

### DIFF
--- a/templates/admin/event_config.twig
+++ b/templates/admin/event_config.twig
@@ -59,9 +59,9 @@
                 <div class="uk-text-meta">Optionales Logo für das Event.</div>
               </div>
               <div class="uk-margin">
-                <label class="uk-form-label" for="primary-color">Primärfarbe</label>
+                <label class="uk-form-label" for="buttonColor">Primärfarbe</label>
                 <div class="uk-form-controls">
-                  <input class="uk-input" id="primary-color" name="primary-color" type="color">
+                  <input class="uk-input" id="buttonColor" name="buttonColor" type="color" value="{{ config.buttonColor|default('#1e87f0') }}">
                 </div>
                 <div class="uk-text-meta">Steuert Buttons und Highlights.</div>
               </div>


### PR DESCRIPTION
## Summary
- rename event config color field to `buttonColor`

## Testing
- `php /tmp/dbtest.php`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY, Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b92a85706c832ba87224409ea70ed4