### PR TITLE
Attach event ID to catalog requests

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -156,10 +156,17 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       }
     }
   }
+  function withEvent(url){
+    const sep = url.includes('?') ? '&' : '?';
+    return url + sep + 'event=' + encodeURIComponent(eventUid);
+  }
+
   async function loadCatalogList(){
     try{
-      const url = '/kataloge/catalogs.json' + (eventUid ? '?event=' + encodeURIComponent(eventUid) : '');
-      const res = await fetch(withBase(url), { headers: { 'Accept': 'application/json' } });
+      const res = await fetch(
+        withBase(withEvent('/kataloge/catalogs.json')),
+        { headers: { 'Accept': 'application/json' } }
+      );
       if(res.ok){
         return await res.json();
       }
@@ -216,7 +223,10 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       if(!eventUid){
         console.warn('eventUid not set when loading questions');
       }
-      const res = await fetch(withBase('/kataloge/' + file + '?event=' + encodeURIComponent(eventUid)), { headers: { 'Accept': 'application/json' } });
+      const res = await fetch(
+        withBase(withEvent('/kataloge/' + file)),
+        { headers: { 'Accept': 'application/json' } }
+      );
       const data = await res.json();
       window.quizQuestions = data;
       loaded = true;

--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -48,6 +48,7 @@ class CatalogController
         $accept = strtolower($request->getHeaderLine('Accept'));
         $params = $request->getQueryParams();
         $event = (string) ($params['event'] ?? '');
+        $this->config->setActiveEventUid($event);
 
         if ($accept === '' || strpos($accept, 'application/json') === false) {
             $slug = $this->service->slugByFile($file) ?? pathinfo($file, PATHINFO_FILENAME);
@@ -61,11 +62,6 @@ class CatalogController
                 ->withHeader('Location', $location)
                 ->withStatus(302);
         }
-
-        if ($event !== '') {
-            $this->config->setActiveEventUid($event);
-        }
-
         $content = $this->service->read($file);
         if ($content === null) {
             return $response->withStatus(404);

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -32,19 +32,18 @@ class HomeController
         $cfgSvc = new ConfigService($pdo);
         $eventSvc = new EventService($pdo, $cfgSvc);
         $settingsSvc = new SettingsService($pdo);
+
+        $params = $request->getQueryParams();
+        $evParam = (string)($params['event'] ?? '');
+        $uid = $evParam !== '' && !preg_match('/^[0-9a-fA-F]{32}$/', $evParam)
+            ? $eventSvc->uidBySlug($evParam) ?? ''
+            : $evParam;
+        $cfgSvc->setActiveEventUid($uid);
+
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
         }
         $role = $_SESSION['user']['role'] ?? null;
-
-        $params = $request->getQueryParams();
-        $evParam = (string)($params['event'] ?? '');
-        if ($evParam !== '' && !preg_match('/^[0-9a-fA-F]{32}$/', $evParam)) {
-            $uid = $eventSvc->uidBySlug($evParam) ?? '';
-        } else {
-            $uid = $evParam;
-        }
-        $cfgSvc->setActiveEventUid($uid);
         if ($uid !== '') {
             $cfg = $cfgSvc->getConfigForEvent($uid);
             $event = $eventSvc->getByUid($uid) ?? $eventSvc->getFirst();


### PR DESCRIPTION
## Summary
- always append event UID to catalog list and question fetches in the quiz frontend
- propagate event query parameter in CatalogController by setting active event before reading catalog
- parse event from query in HomeController and set active event immediately for shared ConfigService

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b9328c44dc832b880cf9e5d265dc8a