### PR TITLE
Refactor event handling to avoid global state

### DIFF
--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\CatalogService;
-use App\Service\ConfigService;
 use App\Domain\Roles;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -16,15 +15,13 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 class CatalogController
 {
     private CatalogService $service;
-    private ConfigService $config;
 
     /**
      * Inject catalog service dependency.
      */
-    public function __construct(CatalogService $service, ConfigService $config)
+    public function __construct(CatalogService $service)
     {
         $this->service = $service;
-        $this->config = $config;
     }
 
     /**
@@ -48,7 +45,6 @@ class CatalogController
         $accept = strtolower($request->getHeaderLine('Accept'));
         $params = $request->getQueryParams();
         $event = (string) ($params['event'] ?? '');
-        $this->config->setActiveEventUid($event);
 
         if ($accept === '' || strpos($accept, 'application/json') === false) {
             $slug = $this->service->slugByFile($file) ?? pathinfo($file, PATHINFO_FILENAME);

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -38,7 +38,9 @@ class HomeController
         $uid = $evParam !== '' && !preg_match('/^[0-9a-fA-F]{32}$/', $evParam)
             ? $eventSvc->uidBySlug($evParam) ?? ''
             : $evParam;
-        $cfgSvc->setActiveEventUid($uid);
+        if ($uid !== '') {
+            $cfgSvc->ensureConfigForEvent($uid);
+        }
 
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
@@ -85,7 +87,7 @@ class HomeController
             $cfg = ConfigService::removePuzzleInfo($cfg);
         }
 
-        $catalogService = new CatalogService($pdo, $cfgSvc);
+        $catalogService = new CatalogService($pdo, $cfgSvc, null, '', $uid);
 
         $catalogsJson = $catalogService->read('catalogs.json');
         $catalogs = [];

--- a/tests/Controller/CatalogControllerLimitTest.php
+++ b/tests/Controller/CatalogControllerLimitTest.php
@@ -24,7 +24,7 @@ class CatalogControllerLimitTest extends TestCase
         $cfg->setActiveEventUid('e1');
         $tenantSvc = new TenantService($pdo);
         $service = new CatalogService($pdo, $cfg, $tenantSvc, 'sub1');
-        $controller = new CatalogController($service, $cfg);
+        $controller = new CatalogController($service);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 
@@ -71,7 +71,7 @@ class CatalogControllerLimitTest extends TestCase
         $tenantSvc = new TenantService($pdo);
         $service = new CatalogService($pdo, $cfg, $tenantSvc, 'sub1');
         $service->createCatalog('test.json');
-        $controller = new CatalogController($service, $cfg);
+        $controller = new CatalogController($service);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -53,7 +53,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service, $cfg);
+        $controller = new CatalogController($service);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
         $request = $this->createRequest('GET', '/kataloge/missing.json', ['HTTP_ACCEPT' => 'application/json']);
@@ -103,7 +103,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service, $cfg);
+        $controller = new CatalogController($service);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 
@@ -157,7 +157,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service, $cfg);
+        $controller = new CatalogController($service);
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 
@@ -231,7 +231,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service, $cfg);
+        $controller = new CatalogController($service);
         session_start();
         $_SESSION["user"] = ["id" => 1, "role" => "catalog-editor"];
 
@@ -310,7 +310,7 @@ class CatalogControllerTest extends TestCase
         );
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
-        $controller = new CatalogController($service, $cfg);
+        $controller = new CatalogController($service);
         session_start();
         $_SESSION["user"] = ["id" => 1, "role" => "catalog-editor"];
 
@@ -370,7 +370,7 @@ class CatalogControllerTest extends TestCase
             SQL
         );
         $cfg = new ConfigService($pdo);
-        $controller = new CatalogController(new CatalogService($pdo, $cfg), $cfg);
+        $controller = new CatalogController(new CatalogService($pdo, $cfg));
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
 


### PR DESCRIPTION
## Summary
- Avoid mutating global active event in `HomeController`
- Pass event UID directly into `CatalogService` and dependent routes
- Simplify `CatalogController` to use explicit event IDs

## Testing
- `composer test` *(fails: Slim Application Error; Missing STRIPE_* env vars)*
- `./vendor/bin/phpunit` *(fails: multiple test failures and errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b933cb6818832baa2948277a85fcd8