### PR TITLE
Handle catalog param case-insensitively

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -745,10 +745,10 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     applyConfig();
     const catalogs = await loadCatalogList();
     const params = new URLSearchParams(window.location.search);
-    const id = params.get('katalog');
+    const id = (params.get('katalog') || '').toLowerCase();
     const proceed = async () => {
       const solvedNow = await buildSolvedSet(cfg);
-      const selected = catalogs.find(c => (c.slug || c.sort_order || c.id || c.uid) === id);
+      const selected = catalogs.find(c => ((c.slug || c.sort_order || c.id || c.uid || '').toLowerCase()) === id);
       if(selected){
         const selectedKey = selected.uid ?? selected.slug ?? selected.sort_order ?? selected.id;
         if(cfg.competitionMode && solvedNow.has(selectedKey)){


### PR DESCRIPTION
## Summary
- normalize the `katalog` query parameter and catalog identifiers to lowercase before comparison

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b941be2c7c832b824c036848bcdea1