### PR TITLE
Add catalog not found hint

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -774,7 +774,22 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
           selected.comment || selected.kommentar || ''
         );
       }else{
+        const container = document.getElementById('quiz');
+        let hint;
+        if(container){
+          hint = document.createElement('p');
+          hint.className = 'uk-text-center';
+          hint.textContent = 'Katalog nicht gefunden. ';
+          const link = document.createElement('a');
+          link.href = '/';
+          link.textContent = 'Zur Startseite';
+          hint.appendChild(link);
+          container.appendChild(hint);
+        }
         showSelection(catalogs, solvedNow);
+        if(container && hint){
+          container.insertAdjacentElement('afterbegin', hint);
+        }
       }
     };
     if(cfg.QRUser || cfg.QRRestrict){


### PR DESCRIPTION
## Summary
- Warn when a requested catalog slug is invalid and guide users back to the start page.

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other configuration, multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b941d97a18832ba67b380e63850baf