### PR TITLE
Fix German start button text

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -274,7 +274,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
     }
     const btn = document.createElement('button');
     btn.className = 'uk-button uk-button-primary uk-button-large uk-align-right';
-    btn.textContent = 'Los geht es!';
+    btn.textContent = 'Los geht\'s!';
     const cfg = window.quizConfig || {};
     if(cfg.colors && cfg.colors.accent){
       btn.style.backgroundColor = cfg.colors.accent;
@@ -682,7 +682,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       if(!cfg.competitionMode || hasCatalog){
         const btn = document.createElement('button');
         btn.className = 'uk-button uk-button-primary uk-align-right';
-        btn.textContent = 'Los geht es!';
+        btn.textContent = 'Los geht\'s!';
         if(cfg.colors && cfg.colors.accent){
           btn.style.backgroundColor = cfg.colors.accent;
           btn.style.borderColor = cfg.colors.accent;

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1237,7 +1237,7 @@ async function runQuiz(questions, skipIntro){
 
     const startBtn = document.createElement('button');
     startBtn.className = 'uk-button uk-button-primary uk-button-large uk-align-right';
-    startBtn.textContent = 'Los geht es!';
+    startBtn.textContent = 'Los geht\'s!';
     styleButton(startBtn);
     // Zeigt bisherige Ergebnisse als kleine Slideshow an
     stats.textContent = 'Noch keine Ergebnisse vorhanden.';


### PR DESCRIPTION
## Summary
- Correct German start button phrasing to "Los geht's!" in catalog and quiz modules
- Checked translations; no additional language updates needed

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b941eb3bf4832b8698c34dfc4e0c32