### PR TITLE
Allow hyphenated UUID event IDs

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -35,7 +35,9 @@ class HomeController
 
         $params = $request->getQueryParams();
         $evParam = (string)($params['event'] ?? '');
-        $uid = $evParam !== '' && !preg_match('/^[0-9a-fA-F]{32}$/', $evParam)
+        $isUid = preg_match('/^[0-9a-fA-F]{32}$/', $evParam)
+            || preg_match('/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/', $evParam);
+        $uid = $evParam !== '' && !$isUid
             ? $eventSvc->uidBySlug($evParam) ?? ''
             : $evParam;
         if ($uid !== '') {


### PR DESCRIPTION
## Summary
- accept standard hyphenated UUIDs when resolving event IDs

## Testing
- `vendor/bin/phpcs src/Controller/HomeController.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET, createCheckoutSession returned https://example.com/checkout, Database error: fail, Error creating tenant: boom, runSyncProcess failed: boom, Failed to reload nginx: reload failed, Tests: 295, Assertions: 632, Errors: 30, Failures: 10, Warnings: 5, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1.)`

------
https://chatgpt.com/codex/tasks/task_e_68b947f3f470832b87ee5df97b15009c