### PR TITLE
Normalize catalog keys to strings

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -715,7 +715,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
           const user = (sessionStorage.getItem(key) || '') || (typeof localStorage !== 'undefined' ? localStorage.getItem(key) : '');
           data.forEach(entry => {
             if(entry.name === user){
-              solved.add(entry.catalog);
+              solved.add(String(entry.catalog));
             }
           });
         }
@@ -750,7 +750,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       const solvedNow = await buildSolvedSet(cfg);
       const selected = catalogs.find(c => ((c.slug || c.sort_order || c.id || c.uid || '').toLowerCase()) === id);
       if(selected){
-        const selectedKey = selected.uid ?? selected.slug ?? selected.sort_order ?? selected.id;
+        const selectedKey = String(selected.uid ?? selected.slug ?? selected.sort_order ?? selected.id);
         if(cfg.competitionMode && solvedNow.has(selectedKey)){
           const remaining = catalogs.filter(c => {
             const key = c.uid ?? c.slug ?? c.sort_order ?? c.id;


### PR DESCRIPTION
## Summary
- Store competition results catalog IDs as strings before adding to solved set
- Compare selected catalog keys using string representation to ensure match

## Testing
- `python3 tests/test_json_validity.py`
- `node tests/test_competition_mode.js`
- `node tests/test_results_rankings.js`
- `node tests/test_random_name_prompt.js`
- `node tests/test_onboarding_plan.js`
- `node tests/test_onboarding_flow.js`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68b96a0cae80832bbc2ba3771f5d9cfe