### PR TITLE
feat: enable autosave for event configuration

### DIFF
--- a/public/js/event-config.js
+++ b/public/js/event-config.js
@@ -48,8 +48,6 @@
   const optQrLogin = document.getElementById('QRUser');
   const logoInput = document.getElementById('logo');
   const logoPreview = document.getElementById('logoPreview');
-  const saveBtn = document.getElementById('saveConfig');
-  const saveHeaderBtn = document.getElementById('saveConfigHeader');
   const publishBtn = document.querySelector('.event-config-sidebar .uk-button-primary');
 
   function applyRules(shouldQueue) {
@@ -116,8 +114,6 @@
     puzzleWordEnabled?.addEventListener('change', applyRules);
     competitionMode?.addEventListener('change', queueAutosave);
     optQrLogin?.addEventListener('change', queueAutosave);
-    saveBtn?.addEventListener('click', (e) => { e.preventDefault(); save(); });
-    saveHeaderBtn?.addEventListener('click', (e) => { e.preventDefault(); save(); });
     publishBtn?.addEventListener('click', (e) => { e.preventDefault(); save(); });
     document.querySelectorAll('input, textarea, select').forEach((el) => {
       el.addEventListener('input', queueAutosave);

--- a/templates/admin/event_config.twig
+++ b/templates/admin/event_config.twig
@@ -17,10 +17,10 @@
         <div>
           <h1 class="uk-heading-bullet uk-margin-remove">Event konfigurieren</h1>
           <div class="uk-text-meta">ID: {{ event.uid|default('—') }} · letzte Änderung: {{ event.updated_at|default('—') }}</div>
+          <div class="uk-text-meta">Änderungen werden automatisch gespeichert.</div>
         </div>
-        <div class="uk-button-group">
+        <div>
           <a class="uk-button uk-button-default" href="{{ basePath }}/?event={{ event.slug|default('demo') }}" target="_blank">Vorschau</a>
-          <button id="saveConfigHeader" class="uk-button uk-button-primary">Speichern</button>
         </div>
       </div>
     </div>
@@ -177,9 +177,6 @@
               <a class="uk-button uk-button-default uk-width-1-1 uk-margin-small-bottom" href="{{ basePath }}/qr/catalog?t={{ ('?event=' ~ (event.slug|default('demo')) ~ '&katalog=' ~ (catalog.slug|default('default')))|url_encode }}" target="_blank">Katalog‑QR</a>
               <a class="uk-button uk-button-default uk-width-1-1" href="{{ basePath }}/qr/team?t={{ (team|default('team-1'))|url_encode }}" target="_blank">Team‑QR</a>
             </div>
-          </div>
-          <div class="uk-margin-top">
-            <button id="saveConfig" class="uk-button uk-button-primary uk-width-1-1">Speichern</button>
           </div>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- remove save buttons from event configuration page
- autosave event settings on every change

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY... Tests: 295, Assertions: 632, Errors: 30, Failures: 10)*

------
https://chatgpt.com/codex/tasks/task_e_68b96b57cbb8832b89296e2e5e94e49a