### PR TITLE
refactor: remove redundant null coalesce

### DIFF
--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -58,7 +58,7 @@ class HelpController
             $invite = ConfigService::sanitizeHtml((string)$cfg['inviteText']);
             $invite = str_ireplace('[team]', 'Team´s', $invite);
             if ($event !== null) {
-                $invite = str_ireplace('[event_name]', (string)($event['name'] ?? ''), $invite);
+                $invite = str_ireplace('[event_name]', (string)$event['name'], $invite);
                 $invite = str_ireplace('[event_start]', (string)($event['start_date'] ?? ''), $invite);
                 $invite = str_ireplace('[event_end]', (string)($event['end_date'] ?? ''), $invite);
                 $invite = str_ireplace('[event_description]', (string)($event['description'] ?? ''), $invite);

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -231,7 +231,7 @@ class QrController
                 $team = 'Team';
             }
             $invite = str_ireplace('[team]', $team, $invite);
-            $invite = str_ireplace('[event_name]', (string)($ev['name'] ?? ''), $invite);
+            $invite = str_ireplace('[event_name]', (string)$ev['name'], $invite);
             $invite = str_ireplace('[event_start]', (string)($ev['start_date'] ?? ''), $invite);
             $invite = str_ireplace('[event_end]', (string)($ev['end_date'] ?? ''), $invite);
             $invite = str_ireplace('[event_description]', (string)($ev['description'] ?? ''), $invite);
@@ -335,7 +335,7 @@ class QrController
             if ($invite !== '') {
                 $invite = ConfigService::sanitizeHtml($invite);
                 $invite = str_ireplace('[team]', $team ?: 'Team', $invite);
-                $invite = str_ireplace('[event_name]', (string)($ev['name'] ?? ''), $invite);
+                $invite = str_ireplace('[event_name]', (string)$ev['name'], $invite);
                 $invite = str_ireplace('[event_start]', (string)($ev['start_date'] ?? ''), $invite);
                 $invite = str_ireplace('[event_end]', (string)($ev['end_date'] ?? ''), $invite);
                 $invite = str_ireplace('[event_description]', (string)($ev['description'] ?? ''), $invite);


### PR DESCRIPTION
## Summary
- avoid redundant null coalescing for event name in HelpController
- avoid redundant null coalescing for event name in QrController

## Testing
- `vendor/bin/phpstan analyse --no-progress --memory-limit=512M`
- `vendor/bin/phpcs src/Controller/HelpController.php src/Controller/QrController.php`
- `composer test` *(fails: Missing STRIPE env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68b9739732f8832b8bc05875cafa0577