### PR TITLE
Fix catalog slug duplication by reusing existing UID

### DIFF
--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -268,6 +268,25 @@ class CatalogServiceTest extends TestCase
         );
     }
 
+    public function testDuplicateSlugUsesExistingUid(): void
+    {
+        $pdo = $this->createPdo();
+        $cfg = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfg);
+        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES('u1',1,'test','t.json','Old')");
+
+        $service->write('catalogs.json', [[
+            'sort_order' => 2,
+            'slug' => 'test',
+            'file' => 't.json',
+            'name' => 'New',
+        ]]);
+
+        $row = $pdo->query("SELECT uid, name FROM catalogs WHERE slug='test'")->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('u1', $row['uid']);
+        $this->assertSame('New', $row['name']);
+    }
+
     public function testReorderCatalogs(): void
     {
         $pdo = $this->createPdo();


### PR DESCRIPTION
## Summary
- reuse existing catalog UID when writing a slug to avoid duplicate key violations
- add regression test to ensure duplicate slugs use same UID

## Testing
- `vendor/bin/phpunit tests/Service/CatalogServiceTest.php`
- `vendor/bin/phpstan analyse` *(fails: Found 3 errors)*
- `vendor/bin/phpcs src/Service/CatalogService.php tests/Service/CatalogServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9732c41b4832bbc9a9013359ab571