### PR TITLE
Handle anonymous events without login or name entry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
             "node tests/test_results_rankings.js",
             "node tests/test_random_name_prompt.js",
             "node tests/test_onboarding_plan.js",
-            "node tests/test_onboarding_flow.js"
+            "node tests/test_onboarding_flow.js",
+            "node tests/test_login_free_catalog.js"
         ]
     }
 }

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -356,7 +356,7 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       return;
     }
     const params = new URLSearchParams(window.location.search);
-    if(cfg.competitionMode && !params.get('katalog')){
+    if(cfg.competitionMode && (cfg.QRUser || cfg.randomNames) && !params.get('katalog')){
       const p = document.createElement('p');
       p.textContent = 'Bitte QR-Code verwenden, um einen Fragenkatalog zu starten.';
       p.className = 'uk-text-center';
@@ -801,8 +801,13 @@ window.filterCameraOrientations = window.filterCameraOrientations || function(ca
       }
     }else{
       if(!getStored('quizUser')){
-        setStored('quizUser', generateUserName());
-        sessionStorage.removeItem('quizSolved');
+        if(cfg.randomNames){
+          await promptTeamName();
+          sessionStorage.removeItem('quizSolved');
+        }else{
+          setStored('quizUser', generateUserName());
+          sessionStorage.removeItem('quizSolved');
+        }
       }
       updateUserName();
       proceed();

--- a/tests/test_login_free_catalog.js
+++ b/tests/test_login_free_catalog.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const code = fs.readFileSync('public/js/catalog.js', 'utf8');
+
+if (!/if\(cfg\.competitionMode && \(cfg\.QRUser \|\| cfg\.randomNames\) && !params\.get\('katalog'\)\)/.test(code)) {
+  throw new Error('competition mode condition missing');
+}
+
+if (!/if\(!getStored\('quizUser'\)\)\{[\s\S]*?if\(cfg\.randomNames\)\{[\s\S]*?await promptTeamName\(\);[\s\S]*?sessionStorage\.removeItem\('quizSolved'\);[\s\S]*?\}else\{[\s\S]*?generateUserName\(\);[\s\S]*?sessionStorage\.removeItem\('quizSolved'\);[\s\S]*?\}/.test(code)) {
+  throw new Error('conditional random name assignment missing');
+}
+
+console.log('ok');


### PR DESCRIPTION
## Summary
- Show full catalog selection without requiring QR codes when login and name entry are disabled
- Prompt for a name only when allowed; otherwise assign a random name automatically
- Add regression test for catalog access without login

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY; Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68b9778553ac832b92f9e955f7c7dd26