### PR TITLE
Secure catalog question loading via controller endpoint

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -4,6 +4,9 @@ const withBase = p => basePath + p;
 
 (function () {
   const eventUid = (window.quizConfig || {}).event_uid || '';
+  const csrfToken =
+    document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ||
+    window.csrfToken || '';
 
   function setStored(key, value) {
     try {
@@ -88,9 +91,13 @@ const withBase = p => basePath + p;
 
     let loaded = false;
     try {
+      const headers = { Accept: 'application/json' };
+      if (csrfToken) {
+        headers['X-CSRF-Token'] = csrfToken;
+      }
       const res = await fetch(
-        withBase(withEvent('/kataloge/' + file)),
-        { headers: { 'Accept': 'application/json' } }
+        withBase(withEvent('/catalog/questions/' + file)),
+        { headers }
       );
       const data = await res.json();
       window.quizQuestions = data;

--- a/src/routes.php
+++ b/src/routes.php
@@ -828,6 +828,11 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('settingsController')->post($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN));
 
+    $app->get('/catalog/questions/{file}', function (Request $request, Response $response, array $args) {
+        $req = $request->withAttribute('file', $args['file']);
+        return $request->getAttribute('catalogController')->getQuestions($req, $response, $args);
+    });
+
     $app->get('/kataloge/{file}', function (Request $request, Response $response, array $args) {
         $req = $request->withAttribute('file', $args['file']);
         return $request->getAttribute('catalogController')->get($req, $response, $args);

--- a/tests/Controller/CatalogQuestionsControllerTest.php
+++ b/tests/Controller/CatalogQuestionsControllerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Controller\CatalogController;
+use App\Service\CatalogService;
+use App\Service\ConfigService;
+use Tests\TestCase;
+use Slim\Psr7\Response;
+
+class CatalogQuestionsControllerTest extends TestCase
+{
+    public function testGetQuestionsRequiresValidTokenAndWhitelist(): void
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE catalogs(
+                uid TEXT PRIMARY KEY,
+                sort_order INTEGER UNIQUE NOT NULL,
+                slug TEXT UNIQUE NOT NULL,
+                file TEXT NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT,
+                raetsel_buchstabe TEXT,
+                comment TEXT,
+                event_uid TEXT
+            );
+            SQL
+        );
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE questions(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                catalog_uid TEXT NOT NULL,
+                sort_order INTEGER,
+                type TEXT NOT NULL,
+                prompt TEXT NOT NULL,
+                options TEXT,
+                answers TEXT,
+                terms TEXT,
+                items TEXT,
+                cards TEXT,
+                right_label TEXT,
+                left_label TEXT,
+                UNIQUE(catalog_uid, sort_order)
+            );
+            SQL
+        );
+        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES('u1',1,'station_1','station_1.json','Station 1');");
+        $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u1',1,'text','Frage?');");
+
+        $cfg = new ConfigService($pdo);
+        $service = new CatalogService($pdo, $cfg);
+        $controller = new CatalogController($service);
+
+        session_start();
+        $_SESSION['csrf_token'] = 'token';
+        $_SESSION['catalog_files'] = ['station_1.json'];
+
+        $req = $this->createRequest('GET', '/catalog/questions/station_1.json', [
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_X_CSRF_TOKEN' => 'token',
+        ]);
+        $res = $controller->getQuestions($req, new Response(), ['file' => 'station_1.json']);
+        $this->assertSame(200, $res->getStatusCode());
+        $data = json_decode((string) $res->getBody(), true);
+        $this->assertIsArray($data);
+        $this->assertSame('Frage?', $data[0]['prompt'] ?? null);
+
+        $req = $this->createRequest('GET', '/catalog/questions/station_1.json', [
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+        $res = $controller->getQuestions($req, new Response(), ['file' => 'station_1.json']);
+        $this->assertSame(403, $res->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary
- add `CatalogController::getQuestions` to serve catalog data only for sessions with matching CSRF token and allowed files
- expose new `/catalog/questions/{file}` route
- update client `catalog.js` to use new endpoint with CSRF header
- cover catalog question endpoint with tests

## Testing
- `vendor/bin/phpunit tests/Controller/CatalogQuestionsControllerTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b98391bc30832ba7f8684e59a7fd19