### PR TITLE
Support slug lookup in catalog

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -207,9 +207,13 @@ const withBase = p => basePath + p;
     });
 
     const params = new URLSearchParams(window.location.search);
-    const id = (params.get('katalog') || '').toLowerCase();
+    const id = (params.get('slug') || params.get('katalog') || '').toLowerCase();
     if (id) {
-      const opt = Array.from(select.options).find(o => (o.value || '').toLowerCase() === id);
+      const opt = Array.from(select.options).find(o => {
+        const value = (o.value || '').toLowerCase();
+        const slug = (o.dataset.slug || '').toLowerCase();
+        return value === id || slug === id;
+      });
       if (opt) {
         select.value = opt.value;
         handleSelection(opt);


### PR DESCRIPTION
## Summary
- allow selecting catalog via `slug` query param
- match catalog options by value or slug attribute

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars, 31 errors, 17 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e3aab678832bba224d0f0475c568