### PR TITLE
Add test for catalog slug parameter matching

### DIFF
--- a/tests/test_catalog_slug_param.js
+++ b/tests/test_catalog_slug_param.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const code = fs.readFileSync('public/js/catalog.js', 'utf8');
+
+if (!/params\.get\(['\"]slug['\"]\)/.test(code)) {
+  throw new Error('slug param handling missing');
+}
+
+if (!/dataset\.slug/.test(code)) {
+  throw new Error('dataset.slug match missing');
+}
+
+if (!/return\s+value\s*===\s*id\s*\|\|\s*slug\s*===\s*id/.test(code)) {
+  throw new Error('slug comparison logic missing');
+}
+
+console.log('ok');


### PR DESCRIPTION
## Summary
- add Node-based test ensuring catalog slug query parameter is matched against dataset slug entries

## Testing
- `node tests/test_catalog_slug_param.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ea01aac8832baf9ef9ed4e573567