### PR TITLE
Trigger catalog selection on slug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
             "node tests/test_random_name_prompt.js",
             "node tests/test_onboarding_plan.js",
             "node tests/test_onboarding_flow.js",
-            "node tests/test_login_free_catalog.js"
+            "node tests/test_login_free_catalog.js",
+            "node tests/test_catalog_smoke.js"
         ]
     }
 }

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -216,6 +216,7 @@ const withBase = p => basePath + p;
       });
       if (opt) {
         select.value = opt.value;
+        // Trigger selection manually so setComment() and showCatalogIntro() run
         handleSelection(opt);
       }
     }

--- a/tests/test_catalog_smoke.js
+++ b/tests/test_catalog_smoke.js
@@ -1,0 +1,134 @@
+const fs = require('fs');
+const vm = require('vm');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.dataset = {};
+    this.className = '';
+    this.classList = {
+      add: () => {},
+      remove: () => {}
+    };
+    this.style = {};
+    this.textContent = '';
+  }
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+  querySelector(sel) {
+    if (sel === 'h1') {
+      return this.children.find(c => c.tagName === 'H1') || null;
+    }
+    if (sel === 'p[data-role="subheader"]') {
+      return this.children.find(c => c.tagName === 'P' && c.dataset.role === 'subheader') || null;
+    }
+    if (sel === 'div[data-role="catalog-comment-block"]') {
+      return this.children.find(c => c.tagName === 'DIV' && c.dataset.role === 'catalog-comment-block') || null;
+    }
+    return null;
+  }
+  addEventListener() {}
+}
+class SelectElement extends Element {
+  constructor() {
+    super('select');
+    this.options = [];
+    this.value = '';
+  }
+  appendChild(child) {
+    if (child.tagName === 'OPTION') {
+      this.options.push(child);
+    }
+    return super.appendChild(child);
+  }
+  addEventListener() {}
+}
+class OptionElement extends Element {
+  constructor(value, text) {
+    super('option');
+    this.value = value;
+    this.textContent = text;
+  }
+}
+
+const header = new Element('div');
+header.id = 'quiz-header';
+const quiz = new Element('div');
+quiz.id = 'quiz';
+const select = new SelectElement();
+select.id = 'catalog-select';
+const opt = new OptionElement('valid', 'Valid');
+opt.dataset.slug = 'valid';
+opt.dataset.file = 'file';
+opt.dataset.uid = 'uid';
+opt.dataset.sortOrder = '1';
+opt.dataset.desc = 'Desc';
+opt.dataset.comment = 'Comment';
+select.appendChild(opt);
+
+const elements = {
+  'quiz-header': header,
+  'quiz': quiz,
+  'catalog-select': select
+};
+
+const document = {
+  readyState: 'complete',
+  getElementById: id => elements[id] || null,
+  querySelector: () => null,
+  createElement: tag => new Element(tag),
+  addEventListener: () => {},
+  head: new Element('head')
+};
+
+const storage = () => {
+  const data = {};
+  return {
+    getItem: k => (k in data ? data[k] : null),
+    setItem: (k, v) => { data[k] = String(v); },
+    removeItem: k => { delete data[k]; }
+  };
+};
+
+const sessionStorage = storage();
+const localStorage = storage();
+
+const window = {
+  location: { search: '?slug=valid' },
+  quizConfig: {},
+  basePath: '',
+  startQuiz: () => {},
+  document
+};
+
+const context = {
+  window,
+  document,
+  sessionStorage,
+  localStorage,
+  fetch: async () => ({ json: async () => [] }),
+  alert: () => {},
+  UIkit: {},
+  console,
+  URLSearchParams
+};
+context.window.window = context.window; // self-reference
+context.global = context;
+
+(async () => {
+  vm.runInNewContext(fs.readFileSync('public/js/catalog.js', 'utf8'), context);
+  await new Promise(r => setTimeout(r, 0));
+
+  const commentBlock = header.querySelector('div[data-role="catalog-comment-block"]');
+  if (!commentBlock || commentBlock.textContent !== 'Comment') {
+    throw new Error('comment not rendered');
+  }
+  const button = quiz.children.find(c => c.tagName === 'BUTTON');
+  if (!button) {
+    throw new Error('start button missing');
+  }
+  console.log('ok');
+})().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- Ensure catalog selection runs on initial load when URL slug matches
- Add smoke test confirming catalog comment and start button render

## Testing
- `composer test` *(fails: vendor/bin/phpunit not found)*
- `node tests/test_catalog_smoke.js`
- `node tests/test_login_free_catalog.js` *(fails: competition mode condition missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eb818994832bad8e07d53232360b