### PR TITLE
Allow editing event slug in admin interface

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1602,6 +1602,7 @@ document.addEventListener('DOMContentLoaded', function () {
     return {
       id,
       uid: id,
+      slug: ev.slug || '',
       name: ev.name || '',
       start_date: ev.start_date || new Date().toISOString().slice(0, 16),
       end_date: ev.end_date || new Date().toISOString().slice(0, 16),
@@ -1614,6 +1615,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!eventManager) return;
     const list = eventManager.getData().map(ev => ({
       uid: ev.id,
+      slug: slugify(ev.slug || ev.name || ev.id),
       name: ev.name,
       start_date: ev.start_date,
       end_date: ev.end_date,
@@ -1674,6 +1676,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const labels = eventsListEl.dataset || {};
     const eventColumns = [
       { className: 'row-num' },
+      { key: 'slug', label: labels.labelSlug || 'Slug', className: 'event-slug', editable: true },
       { key: 'name', label: labels.labelName || 'Name', className: 'event-name', editable: true },
       { key: 'start_date', label: labels.labelStart || 'Start', className: 'event-start', editable: true },
       { key: 'end_date', label: labels.labelEnd || 'Ende', className: 'event-end', editable: true },
@@ -1757,6 +1760,7 @@ document.addEventListener('DOMContentLoaded', function () {
       saveSelector: '#eventEditSave',
       cancelSelector: '#eventEditCancel',
       getTitle: key => ({
+        slug: labels.labelSlug || 'Slug',
         name: labels.labelName || 'Name',
         start_date: labels.labelStart || 'Start',
         end_date: labels.labelEnd || 'Ende',

--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -34,11 +34,11 @@ class EventService
      * Retrieve all events ordered by name.
      *
      * @param bool $publishedOnly When true, only published events are returned.
-     * @return list<array{uid:string,name:string,start_date:?string,end_date:?string,description:?string,published:bool}>
+     * @return list<array{uid:string,slug:string,name:string,start_date:?string,end_date:?string,description:?string,published:bool}>
      */
     public function getAll(bool $publishedOnly = false): array
     {
-        $sql = 'SELECT uid,name,start_date,end_date,description,published,sort_order FROM events';
+        $sql = 'SELECT uid,slug,name,start_date,end_date,description,published,sort_order FROM events';
         if ($publishedOnly) {
             $sql .= ' WHERE published = TRUE';
         }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -172,6 +172,7 @@
               <tr>
                 <th class="uk-table-shrink"></th>
                 <th>{{ t('column_number') }}</th>
+                <th>{{ t('column_slug') }}</th>
                 <th>{{ t('column_name') }}</th>
                 <th>{{ t('column_start') }}</th>
                 <th>{{ t('column_end') }}</th>
@@ -181,6 +182,7 @@
             </thead>
             <tbody
               id="eventsList"
+              data-label-slug="{{ t('column_slug') }}"
               data-label-name="{{ t('column_name') }}"
               data-label-start="{{ t('column_start') }}"
               data-label-end="{{ t('column_end') }}"

--- a/tests/Service/EventServiceTest.php
+++ b/tests/Service/EventServiceTest.php
@@ -116,6 +116,17 @@ class EventServiceTest extends TestCase
         $this->assertSame(0, $count);
     }
 
+    public function testSaveAllPersistsSlug(): void
+    {
+        $pdo = $this->createPdo();
+        $svc = new EventService($pdo);
+        $svc->saveAll([
+            ['uid' => 'e1', 'slug' => 's1', 'name' => 'One'],
+        ]);
+        $slug = $pdo->query("SELECT slug FROM events WHERE uid='e1'")->fetchColumn();
+        $this->assertSame('s1', $slug);
+    }
+
     public function testSaveAllRespectsStarterLimit(): void
     {
         $pdo = $this->createPdo();


### PR DESCRIPTION
## Summary
- show and edit event slug in admin events table
- include slug in event service output
- test slug persistence in event service

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0004cedc832b84fc18f347b2fa4f