### PR TITLE
Prevent form submit when saving profile name

### DIFF
--- a/templates/profile.twig
+++ b/templates/profile.twig
@@ -24,7 +24,7 @@
             </div>
           </div>
           <div class="uk-margin">
-            <button id="save-name" class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom">{{ t('action_save_player') }}</button>
+            <button id="save-name" type="button" class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom">{{ t('action_save_player') }}</button>
             <button id="delete-name" class="uk-button uk-width-1-1" type="button">{{ t('action_delete_player') }}</button>
           </div>
           <p class="uk-text-meta">{{ t('text_player_name_hint') }}</p>


### PR DESCRIPTION
## Summary
- avoid unintended form submission by setting the save-name button to `type="button"`

## Testing
- `composer test` *(fails: Missing STRIPE_* vars, several PHPUnit errors)*
- manual: verified clicking save-name with JS disabled no longer triggers navigation

------
https://chatgpt.com/codex/tasks/task_e_68ba077c21cc832ba7c87dbab8a6689c