### PR TITLE
Auto-start catalog when only option is available

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -201,13 +201,16 @@ const withBase = p => basePath + p;
     const select = document.getElementById('catalog-select');
     if (!select) return;
 
+    const params = new URLSearchParams(window.location.search);
+    const id = (params.get('slug') || params.get('katalog') || '').toLowerCase();
+
+    if (select.options.length === 1 && !id) handleSelection(select.options[0]);
+
     select.addEventListener('change', () => {
       const opt = select.selectedOptions[0];
       handleSelection(opt);
     });
 
-    const params = new URLSearchParams(window.location.search);
-    const id = (params.get('slug') || params.get('katalog') || '').toLowerCase();
     if (id) {
       const opt = Array.from(select.options).find(o => {
         const value = (o.value || '').toLowerCase();


### PR DESCRIPTION
## Summary
- Auto-run catalog selection when only one option is available and no slug specified

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68ba06f44b80832b8f8d45eddb3f2e61