### PR TITLE
feat(catalog): show intro on initial load

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -219,6 +219,12 @@ const withBase = p => basePath + p;
         // Trigger selection manually so setComment() and showCatalogIntro() run
         handleSelection(opt);
       }
+    } else {
+      const opt = select.selectedOptions[0];
+      if (opt) {
+        // Run on initial load so showCatalogIntro() displays the catalog intro
+        handleSelection(opt);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- load catalog intro automatically on catalog start page

## Testing
- `scripts/run_tests.sh` *(fails: missing STRIPE keys, various test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0b211858832ba0d45cfe15725752