### PR TITLE
Fix admin subdomain detection for tenant sync

### DIFF
--- a/src/Application/Middleware/DomainMiddleware.php
+++ b/src/Application/Middleware/DomainMiddleware.php
@@ -20,10 +20,10 @@ class DomainMiddleware implements MiddlewareInterface
     public function process(Request $request, RequestHandler $handler): Response
     {
         $host = strtolower($request->getUri()->getHost());
-        $host = (string) preg_replace('/^www\./', '', $host);
+        $host = (string) preg_replace('/^(www|admin)\./', '', $host);
 
         $mainDomain = strtolower((string) getenv('MAIN_DOMAIN'));
-        $mainDomain = (string) preg_replace('/^www\./', '', $mainDomain);
+        $mainDomain = (string) preg_replace('/^(www|admin)\./', '', $mainDomain);
 
         $domainType = 'main';
         if (


### PR DESCRIPTION
## Summary
- treat `admin.` subdomains as main domain in domain middleware
- test admin host routing to main domain

## Testing
- `vendor/bin/phpunit tests/DomainMiddlewareTest.php`
- `python3 tests/test_html_validity.py`
- `node tests/test_competition_mode.js` *(fails: buildSolvedSet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0aca9a40832bad25910ebf38ccc5