### PR TITLE
fix: avoid duplicate slug errors when saving catalogs

### DIFF
--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -432,7 +432,7 @@ class CatalogService
             $uids = [];
             $prepared = [];
             foreach ($data as $cat) {
-                if (!isset($cat['uid']) && isset($cat['slug'])) {
+                if (isset($cat['slug'])) {
                     $sql = 'SELECT uid FROM catalogs WHERE slug=?';
                     $params = [$cat['slug']];
                     if ($uid !== '') {

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -354,15 +354,17 @@ class CatalogServiceTest extends TestCase
         $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES('u1',1,'test','t.json','Old')");
 
         $service->write('catalogs.json', [[
+            'uid' => 'u2',
             'sort_order' => 2,
             'slug' => 'test',
             'file' => 't.json',
             'name' => 'New',
         ]]);
 
-        $row = $pdo->query("SELECT uid, name FROM catalogs WHERE slug='test'")->fetch(PDO::FETCH_ASSOC);
-        $this->assertSame('u1', $row['uid']);
-        $this->assertSame('New', $row['name']);
+        $rows = $pdo->query('SELECT uid, name FROM catalogs')->fetchAll(PDO::FETCH_ASSOC);
+        $this->assertCount(1, $rows);
+        $this->assertSame('u1', $rows[0]['uid']);
+        $this->assertSame('New', $rows[0]['name']);
     }
 
     public function testReorderCatalogs(): void


### PR DESCRIPTION
## Summary
- reuse existing catalog UID when saving a slug that already exists
- add regression test for duplicate slug handling

## Testing
- `./vendor/bin/phpunit --filter DuplicateSlugUsesExistingUid tests/Service/CatalogServiceTest.php`
- `./vendor/bin/phpunit` *(fails: process hung after initial output)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1373d7f0832ba03c4f0955dda6ad