### PR TITLE
Remove catalog dropdown and auto-load catalog

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -35,25 +35,7 @@
       </div>
       <progress id="progress" class="uk-progress" value="0" max="1" aria-label="{{ t('quiz_progress') }}" aria-valuenow="0" uk-scrollspy="cls: uk-animation-fade; delay: 200"></progress>
       <span id="question-announcer" class="uk-hidden-visually" aria-live="polite"></span>
-      <div id="quiz" uk-scrollspy="cls: uk-animation-slide-bottom-small; delay: 300">
-        <select id="catalog-select" class="uk-select">
-          {% for cat in catalogs %}
-            {% set key = cat.slug ?? cat.uid ?? cat.sort_order ?? cat.id %}
-            <option
-              value="{{ key }}"
-              data-slug="{{ cat.slug|e }}"
-              data-sort-order="{{ cat.sort_order ?? cat.id }}"
-              data-file="{{ cat.file }}"
-              data-letter="{{ cat.raetsel_buchstabe }}"
-              data-uid="{{ cat.uid }}"
-              data-desc="{{ cat.description ?? cat.beschreibung }}"
-              data-comment="{{ cat.comment ?? cat.kommentar }}"
-            >
-              {{ cat.name ?? cat.slug ?? cat.uid ?? cat.sort_order ?? cat.id }}
-            </option>
-          {% endfor %}
-        </select>
-      </div>
+      <div id="quiz" uk-scrollspy="cls: uk-animation-slide-bottom-small; delay: 300"></div>
     </div>
   </div>
 {% endblock %}
@@ -63,6 +45,9 @@
   <script src="https://unpkg.com/html5-qrcode@2.3.7/html5-qrcode.min.js" defer></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
+  </script>
+  <script>
+    window.quizCatalogs = {{ catalogs|json_encode|raw }};
   </script>
   <script>
     function enforceProfile() {

--- a/tests/test_catalog_slug_param.js
+++ b/tests/test_catalog_slug_param.js
@@ -26,57 +26,14 @@ class Element {
   addEventListener() {}
 }
 
-class SelectElement extends Element {
-  constructor() {
-    super('select');
-    this.options = [];
-    this.value = '';
-  }
-  appendChild(child) {
-    if (child.tagName === 'OPTION') {
-      this.options.push(child);
-    }
-    return super.appendChild(child);
-  }
-  addEventListener() {}
-  get selectedOptions() {
-    return this.options.filter(o => o.value === this.value);
-  }
-}
-
-class OptionElement extends Element {
-  constructor(value, text) {
-    super('option');
-    this.value = value;
-    this.textContent = text;
-  }
-}
-
 const header = new Element('div');
 header.id = 'quiz-header';
 const quiz = new Element('div');
 quiz.id = 'quiz';
-const select = new SelectElement();
-select.id = 'catalog-select';
-
-const makeOption = (value, slug, text, comment) => {
-  const opt = new OptionElement(value, text);
-  opt.dataset.slug = slug;
-  opt.dataset.file = slug + '.json';
-  opt.dataset.uid = slug + '-uid';
-  opt.dataset.sortOrder = value;
-  opt.dataset.desc = 'Desc';
-  opt.dataset.comment = comment;
-  return opt;
-};
-
-select.appendChild(makeOption('first', 'first', 'First', 'First comment'));
-select.appendChild(makeOption('second', 'valid', 'Valid', 'Comment'));
 
 const elements = {
   'quiz-header': header,
-  quiz,
-  'catalog-select': select
+  quiz
 };
 
 let initFn = null;
@@ -106,6 +63,26 @@ const localStorage = storage();
 const window = {
   location: { search: '?slug=valid' },
   quizConfig: {},
+  quizCatalogs: [
+    {
+      slug: 'first',
+      file: 'first.json',
+      uid: 'first-uid',
+      sort_order: 1,
+      name: 'First',
+      description: 'Desc',
+      comment: 'First comment'
+    },
+    {
+      slug: 'valid',
+      file: 'valid.json',
+      uid: 'valid-uid',
+      sort_order: 2,
+      name: 'Valid',
+      description: 'Desc',
+      comment: 'Comment'
+    }
+  ],
   basePath: '',
   startQuiz: () => {},
   document
@@ -120,7 +97,9 @@ const context = {
   alert: () => {},
   UIkit: {},
   console,
-  URLSearchParams
+  URLSearchParams,
+  promptTeamName: async () => {},
+  generateUserName: () => {}
 };
 context.window.window = context.window; // self-reference
 context.global = context;
@@ -133,9 +112,6 @@ context.global = context;
   initFn();
   await new Promise(r => setTimeout(r, 0));
 
-  if (select.value !== 'second') {
-    throw new Error('selection by slug failed');
-  }
   const comment = quiz.children.find(c => c.tagName === 'P' && c.textContent === 'Comment');
   if (!comment) {
     throw new Error('catalog comment missing');

--- a/tests/test_catalog_smoke.js
+++ b/tests/test_catalog_smoke.js
@@ -32,47 +32,14 @@ class Element {
   }
   addEventListener() {}
 }
-class SelectElement extends Element {
-  constructor() {
-    super('select');
-    this.options = [];
-    this.value = '';
-  }
-  appendChild(child) {
-    if (child.tagName === 'OPTION') {
-      this.options.push(child);
-    }
-    return super.appendChild(child);
-  }
-  addEventListener() {}
-}
-class OptionElement extends Element {
-  constructor(value, text) {
-    super('option');
-    this.value = value;
-    this.textContent = text;
-  }
-}
-
 const header = new Element('div');
 header.id = 'quiz-header';
 const quiz = new Element('div');
 quiz.id = 'quiz';
-const select = new SelectElement();
-select.id = 'catalog-select';
-const opt = new OptionElement('valid', 'Valid');
-opt.dataset.slug = 'valid';
-opt.dataset.file = 'file';
-opt.dataset.uid = 'uid';
-opt.dataset.sortOrder = '1';
-opt.dataset.desc = 'Desc';
-opt.dataset.comment = 'Comment';
-select.appendChild(opt);
 
 const elements = {
   'quiz-header': header,
-  'quiz': quiz,
-  'catalog-select': select
+  'quiz': quiz
 };
 
 const document = {
@@ -99,6 +66,17 @@ const localStorage = storage();
 const window = {
   location: { search: '?slug=valid' },
   quizConfig: {},
+  quizCatalogs: [
+    {
+      slug: 'valid',
+      file: 'file',
+      uid: 'uid',
+      sort_order: 1,
+      name: 'Valid',
+      description: 'Desc',
+      comment: 'Comment'
+    }
+  ],
   basePath: '',
   startQuiz: () => {},
   document
@@ -113,7 +91,9 @@ const context = {
   alert: () => {},
   UIkit: {},
   console,
-  URLSearchParams
+  URLSearchParams,
+  promptTeamName: async () => {},
+  generateUserName: () => {}
 };
 context.window.window = context.window; // self-reference
 context.global = context;


### PR DESCRIPTION
## Summary
- drop catalog select element in index template and expose catalog list globally
- load catalogs directly based on URL params and ensure user login in catalog.js
- update catalog tests to work without dropdown

## Testing
- `node tests/test_login_free_catalog.js`
- `node tests/test_catalog_slug_param.js`
- `node tests/test_catalog_smoke.js`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `vendor/bin/phpunit` *(fails: missing Stripe environment variables)*
- `node tests/test_competition_mode.js` *(fails: buildSolvedSet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba18e52098832bb040bde16ba8c699