### PR TITLE
Ensure CSRF token when loading catalogs

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -97,7 +97,7 @@ const withBase = p => basePath + p;
       }
       const res = await fetch(
         withBase(withEvent('/catalog/questions/' + file)),
-        { headers }
+        { headers, credentials: 'same-origin' }
       );
       const data = await res.json();
       window.quizQuestions = data;

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -115,6 +115,7 @@ class HomeController
             'config' => $cfg,
             'catalogs' => $catalogs,
             'event' => $event,
+            'csrf_token' => $_SESSION['csrf_token'] ?? '',
         ]);
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -300,7 +300,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $response;
     });
 
-    $app->get('/', HomeController::class);
+    $app->get('/', HomeController::class)->add(new CsrfMiddleware());
     $app->get('/favicon.ico', function (Request $request, Response $response) {
         $iconPath = __DIR__ . '/../public/favicon.svg';
         if (file_exists($iconPath)) {

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -3,6 +3,7 @@
 {% block title %}{{ config.pageTitle|default('Modernes Quiz mit UIkit') }}{% endblock %}
 
 {% block head %}
+  <meta name="csrf-token" content="{{ csrf_token }}">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
   <link rel="stylesheet" href="{{ basePath }}/css/dark.css" disabled>
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
@@ -63,6 +64,9 @@
   <script src="https://unpkg.com/html5-qrcode@2.3.7/html5-qrcode.min.js" defer></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
+  </script>
+  <script>
+    window.csrfToken = '{{ csrf_token|e('js') }}';
   </script>
   <script>
     function enforceProfile() {


### PR DESCRIPTION
## Summary
- Generate CSRF token on start page and expose it for scripts
- Attach CSRF middleware to home route
- Send credentials when fetching catalog questions

## Testing
- `node tests/test_catalog_smoke.js`
- `node tests/test_catalog_slug_param.js`
- `composer test` *(fails: Tests: 298, Assertions: 632, Errors: 31, Failures: 17, Warnings: 5, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0cbab970832bb279dc3a3b8a8942