### PR TITLE
Initialize catalog script on DOM load

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -95,3 +95,8 @@ function init() {
     handleSelection(opt);
   });
 }
+
+document.addEventListener('DOMContentLoaded', init);
+if (document.readyState !== 'loading') {
+  init();
+}


### PR DESCRIPTION
## Summary
- initialize catalog script when DOM content is loaded
- trigger `init()` immediately if the document is already ready

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY ... script returned error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2567850c832b8a47391fdc7f8808