### PR TITLE
feat: add async catalog loading and intro view setup

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -96,6 +96,115 @@ function init() {
   });
 }
 
+async function handleSelection(opt) {
+  if (!opt) {
+    return;
+  }
+
+  // Metadaten speichern
+  const name = opt.textContent || opt.dataset.name || '';
+  const desc = opt.dataset.desc || '';
+  const comment = opt.dataset.comment || '';
+
+  sessionStorage.setItem('quizCatalogName', name);
+  if (desc) {
+    sessionStorage.setItem('quizCatalogDesc', desc);
+  } else {
+    sessionStorage.removeItem('quizCatalogDesc');
+  }
+  if (comment) {
+    sessionStorage.setItem('quizCatalogComment', comment);
+  } else {
+    sessionStorage.removeItem('quizCatalogComment');
+  }
+
+  localStorage.setItem('quizCatalogUid', opt.dataset.uid || '');
+  localStorage.setItem('quizCatalogSortOrder', opt.dataset.sortOrder || '');
+
+  // Katalogdaten laden
+  const file = opt.dataset.file;
+  try {
+    if (file) {
+      const base = window.basePath || '';
+      const res = await fetch(base + file);
+      const data = await res.json();
+      window.quizQuestions = data;
+      showCatalogIntro(data);
+      return;
+    }
+  } catch (e) {
+    console.error('Katalogdatei konnte nicht geladen werden', e);
+  }
+  showCatalogIntro([]);
+}
+
+function showCatalogIntro(qs) {
+  const header = document.getElementById('quiz-header');
+  if (header) {
+    const title = sessionStorage.getItem('quizCatalogName') || '';
+    const desc = sessionStorage.getItem('quizCatalogDesc') || '';
+    const comment = sessionStorage.getItem('quizCatalogComment');
+
+    let h1 = header.querySelector('h1');
+    if (!h1) {
+      h1 = document.createElement('h1');
+      header.appendChild(h1);
+    }
+    h1.textContent = title;
+
+    let sub = header.querySelector('p[data-role="subheader"]');
+    if (!sub) {
+      sub = document.createElement('p');
+      sub.dataset.role = 'subheader';
+      header.appendChild(sub);
+    }
+    sub.textContent = desc;
+
+    let cBlock = header.querySelector('div[data-role="catalog-comment-block"]');
+    if (comment) {
+      if (!cBlock) {
+        cBlock = document.createElement('div');
+        cBlock.dataset.role = 'catalog-comment-block';
+        header.appendChild(cBlock);
+      }
+      cBlock.textContent = comment;
+    } else if (cBlock) {
+      cBlock.remove();
+    }
+  }
+
+  const quiz = document.getElementById('quiz');
+  if (!quiz) {
+    return;
+  }
+
+  quiz.innerHTML = '';
+
+  const comment = sessionStorage.getItem('quizCatalogComment');
+  if (comment) {
+    const p = document.createElement('p');
+    p.textContent = comment;
+    quiz.appendChild(p);
+  }
+
+  const button = document.createElement('button');
+  button.textContent = "Los geht's!";
+  button.addEventListener('click', async () => {
+    if (typeof window.startQuiz !== 'function') {
+      await new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = (window.basePath || '') + 'js/quiz.js';
+        script.onload = resolve;
+        script.onerror = reject;
+        document.head.appendChild(script);
+      });
+    }
+    const questions = qs || window.quizQuestions || [];
+    window.startQuiz(questions, false);
+  });
+  quiz.appendChild(button);
+}
+
 document.addEventListener('DOMContentLoaded', init);
 if (document.readyState !== 'loading') {
   init();


### PR DESCRIPTION
## Summary
- load catalog data asynchronously and store catalog meta
- render catalog intro with comment and start button
- auto-run init when DOM is ready

## Testing
- `node tests/test_catalog_smoke.js`
- `node tests/test_catalog_slug_param.js`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2797afd4832ba07190a7ad424603