### PR TITLE
Fix quiz question fetch by requesting JSON

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -126,7 +126,7 @@ async function handleSelection(opt) {
   try {
     if (file) {
       const base = window.basePath || '';
-      const res = await fetch(base + file);
+      const res = await fetch(base + file, { headers: { 'Accept': 'application/json' } });
       const data = await res.json();
       window.quizQuestions = data;
       showCatalogIntro(data);

--- a/templates/vuequiz/index.html
+++ b/templates/vuequiz/index.html
@@ -49,7 +49,7 @@ createApp({
     const userAnswers = reactive({});
 
     onMounted(async () => {
-      const res = await fetch('questions.json');
+      const res = await fetch('questions.json', { headers: { 'Accept': 'application/json' } });
       questions.value = await res.json();
       loading.value = false;
     });


### PR DESCRIPTION
## Summary
- Ensure catalog question fetch requests JSON responses
- Request JSON when loading demo Vue quiz questions

## Testing
- `composer test` *(fails: vendor/bin/phpunit not found)*
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2a8ad5f8832b94e17d1dd09dbe24