### PR TITLE
Ensure catalog question fetch sends credentials

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -126,7 +126,13 @@ async function handleSelection(opt) {
   try {
     if (file) {
       const base = window.basePath || '';
-      const res = await fetch(base + file);
+      const res = await fetch(base + file, {
+        credentials: 'same-origin',
+        headers: { 'Accept': 'application/json' }
+      });
+      if (!res.ok) {
+        throw new Error('HTTP ' + res.status);
+      }
       const data = await res.json();
       window.quizQuestions = data;
       showCatalogIntro(data);

--- a/templates/vuequiz/index.html
+++ b/templates/vuequiz/index.html
@@ -49,7 +49,7 @@ createApp({
     const userAnswers = reactive({});
 
     onMounted(async () => {
-      const res = await fetch('questions.json');
+      const res = await fetch('questions.json', { headers: { 'Accept': 'application/json' } });
       questions.value = await res.json();
       loading.value = false;
     });


### PR DESCRIPTION
## Summary
- ensure catalog question fetch sends credentials and validates HTTP status to avoid empty quizzes

## Testing
- `composer test` *(fails: vendor/bin/phpunit not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `node tests/test_catalog_smoke.js` *(logs HTTP undefined but exits with ok)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2a8ad5f8832b94e17d1dd09dbe24