### PR TITLE
Add Accept header for catalog and demo quiz JSON fetches

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -25,6 +25,8 @@ async function init() {
                     autoParam !== '0' &&
                     autoParam.toLowerCase() !== 'false';
 
+  const jsonHeaders = { Accept: 'application/json' };
+
   // Select suchen (ID oder data-role)
   const select = document.getElementById('catalog-select') ||
                  document.querySelector('[data-role="catalog-select"]');
@@ -149,7 +151,7 @@ async function handleSelection(opt, autostart = false) {
   try {
     if (file) {
       const base = window.basePath || '';
-      const res = await fetch(base + file, { headers: { 'Accept': 'application/json' } });
+      const res = await fetch(base + file, { headers: jsonHeaders });
       const data = await res.json();
       window.quizQuestions = data;
       if (autostart) {

--- a/templates/vuequiz/index.html
+++ b/templates/vuequiz/index.html
@@ -48,8 +48,10 @@ createApp({
     const answered = ref(false);
     const userAnswers = reactive({});
 
+    const jsonHeaders = { Accept: 'application/json' };
+
     onMounted(async () => {
-      const res = await fetch('questions.json', { headers: { 'Accept': 'application/json' } });
+      const res = await fetch('questions.json', { headers: jsonHeaders });
       questions.value = await res.json();
       loading.value = false;
     });


### PR DESCRIPTION
## Summary
- ensure catalog question fetch requests `Accept: application/json`
- have Vue demo quiz request questions with JSON accept header

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f40e4b8832bb2ca9568e4fd3724