### PR TITLE
Add path-based slug fallback for catalog autostart

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
             "node tests/test_onboarding_plan.js",
             "node tests/test_onboarding_flow.js",
             "node tests/test_login_free_catalog.js",
-            "node tests/test_catalog_smoke.js"
+            "node tests/test_catalog_smoke.js",
+            "node tests/test_catalog_autostart_path.js"
         ]
     }
 }

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -10,13 +10,20 @@ async function init() {
 
   // URL-Parameter lesen (unterstützt mehrere Varianten)
   const params = new URLSearchParams(window.location.search);
-  const id = (
+  let id = (
     params.get('slug') ||
     params.get('katalog') ||
     params.get('catalog') ||
     params.get('k') ||
     ''
   ).toLowerCase();
+  if (!id) {
+    const segments = window.location.pathname.split('/').filter(Boolean);
+    const last = segments.pop();
+    if (last) {
+      id = decodeURIComponent(last).toLowerCase();
+    }
+  }
   const autoParam = params.get('autostart') ||
                     params.get('auto') ||
                     params.get('start') ||

--- a/tests/test_catalog_autostart_path.js
+++ b/tests/test_catalog_autostart_path.js
@@ -1,0 +1,112 @@
+const fs = require('fs');
+const vm = require('vm');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.dataset = {};
+    this.style = {};
+    this.textContent = '';
+  }
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+  querySelector() { return null; }
+  addEventListener() {}
+}
+class SelectElement extends Element {
+  constructor() {
+    super('select');
+    this.options = [];
+    this.value = '';
+    this.selectedOptions = [];
+  }
+  appendChild(child) {
+    if (child.tagName === 'OPTION') {
+      this.options.push(child);
+    }
+    return super.appendChild(child);
+  }
+}
+class OptionElement extends Element {
+  constructor(value, text) {
+    super('option');
+    this.value = value;
+    this.textContent = text;
+  }
+}
+
+const quiz = new Element('div');
+quiz.id = 'quiz';
+const select = new SelectElement();
+select.id = 'catalog-select';
+const opt = new OptionElement('valid', 'Valid');
+opt.dataset.slug = 'valid';
+opt.dataset.file = 'file';
+select.options.push(opt);
+select.selectedOptions = [opt];
+
+const elements = { quiz, 'catalog-select': select };
+
+const document = {
+  readyState: 'complete',
+  getElementById: id => elements[id] || null,
+  querySelector: () => null,
+  createElement: tag => new Element(tag),
+  addEventListener: () => {},
+  head: new Element('head')
+};
+
+const storage = () => {
+  const data = {};
+  return {
+    getItem: k => (k in data ? data[k] : null),
+    setItem: (k, v) => { data[k] = String(v); },
+    removeItem: k => { delete data[k]; }
+  };
+};
+
+const sessionStorage = storage();
+const localStorage = storage();
+let started = false;
+
+const window = {
+  location: { search: '?autostart=1', pathname: '/catalog/valid' },
+  quizConfig: {},
+  basePath: '',
+  startQuiz: () => { started = true; },
+  document
+};
+
+const context = {
+  window,
+  document,
+  sessionStorage,
+  localStorage,
+  fetch: async () => ({ json: async () => [] }),
+  alert: () => {},
+  UIkit: {},
+  console,
+  URLSearchParams,
+  jsonHeaders: { Accept: 'application/json' }
+};
+context.window.window = context.window;
+context.global = context;
+
+(async () => {
+  vm.runInNewContext(fs.readFileSync('public/js/catalog.js', 'utf8'), context);
+  await new Promise(r => setTimeout(r, 0));
+  if (select.value !== 'valid') {
+    throw new Error('slug not pre-selected');
+  }
+  if (!started) {
+    throw new Error('autostart did not run');
+  }
+  const hasButton = quiz.children.some(c => c.tagName === 'BUTTON');
+  if (hasButton) {
+    throw new Error('intro button should not be rendered');
+  }
+  console.log('ok');
+})().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- Derive catalog slug from URL path segment when no slug query param is present
- Add regression test to ensure path-based autostart skips intro
- Include new test in composer scripts

## Testing
- `python3 tests/test_html_validity.py`
- `node tests/test_catalog_autostart_path.js`
- `node tests/test_competition_mode.js` *(fails: buildSolvedSet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba32570944832b956e3291ce6e64d0