### PR TITLE
Fix catalog json headers scope

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -1,3 +1,5 @@
+const jsonHeaders = { Accept: 'application/json' };
+
 async function init() {
   // Container sicherstellen
   let quizContainer = document.getElementById('quiz');
@@ -31,8 +33,6 @@ async function init() {
   const autostart = autoParam !== null &&
                     autoParam !== '0' &&
                     autoParam.toLowerCase() !== 'false';
-
-  const jsonHeaders = { Accept: 'application/json' };
 
   // Select suchen (ID oder data-role)
   const select = document.getElementById('catalog-select') ||


### PR DESCRIPTION
## Summary
- expose `jsonHeaders` globally so `handleSelection` can use it
- remove duplicate definition from `init`

## Testing
- `node tests/test_catalog_slug_param.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba81d0a398832b8c1b4489c8187255