### PR TITLE
test: add handleSelection header test

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -1,3 +1,5 @@
+const jsonHeaders = { Accept: 'application/json' };
+
 async function init() {
   // Container sicherstellen
   let quizContainer = document.getElementById('quiz');
@@ -31,8 +33,6 @@ async function init() {
   const autostart = autoParam !== null &&
                     autoParam !== '0' &&
                     autoParam.toLowerCase() !== 'false';
-
-  const jsonHeaders = { Accept: 'application/json' };
 
   // Select suchen (ID oder data-role)
   const select = document.getElementById('catalog-select') ||

--- a/tests/test_catalog_handle_selection.js
+++ b/tests/test_catalog_handle_selection.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const vm = require('vm');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.dataset = {};
+    this.textContent = '';
+  }
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+}
+
+const storage = () => {
+  const data = {};
+  return {
+    getItem: k => (k in data ? data[k] : null),
+    setItem: (k, v) => { data[k] = String(v); },
+    removeItem: k => { delete data[k]; }
+  };
+};
+
+const sessionStorage = storage();
+const localStorage = storage();
+
+let uiWarnings = 0;
+const UIkit = { notification: () => { uiWarnings++; } };
+
+const fetchCalls = [];
+const fetch = async (url, opts) => {
+  fetchCalls.push({ url, opts });
+  return { json: async () => [] };
+};
+
+const document = {
+  readyState: 'loading',
+  addEventListener: () => {},
+  getElementById: () => null,
+  querySelector: () => null,
+  createElement: tag => new Element(tag),
+  head: new Element('head')
+};
+
+const window = { document, basePath: '', startQuiz: () => {}, quizQuestions: [] };
+
+const context = {
+  window,
+  document,
+  sessionStorage,
+  localStorage,
+  fetch,
+  UIkit,
+  alert: () => {},
+  console,
+  URLSearchParams
+};
+context.window.window = context.window;
+context.global = context;
+
+(async () => {
+  vm.runInNewContext(fs.readFileSync('public/js/catalog.js', 'utf8'), context);
+  // prevent DOM side effects
+  context.showCatalogIntro = () => {};
+
+  const opt = { textContent: 'Test', dataset: { file: 'foo.json', uid: '1', sortOrder: '1' } };
+  await context.handleSelection(opt);
+
+  if (fetchCalls.length !== 1) {
+    throw new Error('fetch not called');
+  }
+  const headers = fetchCalls[0].opts && fetchCalls[0].opts.headers;
+  if (!headers || headers.Accept !== 'application/json') {
+    throw new Error('jsonHeaders missing');
+  }
+  if (uiWarnings !== 0) {
+    throw new Error('UI warning triggered');
+  }
+  console.log('ok');
+})().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- expose `jsonHeaders` globally for catalog loading
- add regression test ensuring `handleSelection` uses JSON headers and triggers no UI warning

## Testing
- `node tests/test_catalog_handle_selection.js`
- `node tests/test_catalog_slug_param.js`
- `node tests/test_catalog_autostart_path.js`
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ba81d78004832bb99a05b0e8896508