### PR TITLE
Ensure quiz starts only once

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1526,6 +1526,6 @@ function startQuiz(qs, skipIntro){
 }
 
 window.startQuiz = startQuiz;
-if(window.quizQuestions){
+if (window.quizQuestions && window.quizConfig?.autoStart) {
   startQuiz(window.quizQuestions, false);
 }


### PR DESCRIPTION
## Summary
- gate quiz autostart behind `quizConfig.autoStart`
- load quiz script and start quiz once via shared helper

## Testing
- `node tests/test_catalog_autostart_path.js`
- `node tests/test_catalog_smoke.js`
- `composer test` *(fails: hangs after phpunit start)*

------
https://chatgpt.com/codex/tasks/task_e_68babf6d737c832ba0246ffd01e3a6d0