### PR TITLE
Persist selected quiz catalog identifier

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -172,6 +172,9 @@ async function handleSelection(opt, autostart = false) {
   localStorage.setItem('quizCatalogUid', opt.dataset.uid || '');
   localStorage.setItem('quizCatalogSortOrder', opt.dataset.sortOrder || '');
 
+  sessionStorage.setItem('quizCatalog', opt.dataset.uid || opt.dataset.slug || opt.value);
+  localStorage.setItem('quizCatalog', opt.dataset.uid || opt.dataset.slug || opt.value);
+
   // Katalogdaten laden
   const file = opt.dataset.file;
   try {


### PR DESCRIPTION
## Summary
- Save selected quiz catalog UID/slug into sessionStorage and localStorage
- Ensure summary submission uses existing `quizCatalog` key

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bacfbe1900832b896966639401d182