### PR TITLE
Persist quiz catalog slug and extend tests

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -77,6 +77,8 @@ async function init() {
           const data = JSON.parse(inline.textContent);
           // Optional: Name/Desc/Comment aus data oder Metas setzen
           sessionStorage.setItem('quizCatalogName', id.toUpperCase());
+          sessionStorage.setItem('quizCatalog', id);
+          localStorage.setItem('quizCatalog', id);
           sessionStorage.removeItem('quizCatalogDesc');
           sessionStorage.removeItem('quizCatalogComment');
           if (autostart) {
@@ -92,6 +94,8 @@ async function init() {
 
       // 2) Kein Inline: Zeige zumindest Intro, damit der Button erscheint
       sessionStorage.setItem('quizCatalogName', id.toUpperCase());
+      sessionStorage.setItem('quizCatalog', id);
+      localStorage.setItem('quizCatalog', id);
       sessionStorage.removeItem('quizCatalogDesc');
       sessionStorage.removeItem('quizCatalogComment');
       if (!autostart) {
@@ -172,8 +176,8 @@ async function handleSelection(opt, autostart = false) {
   localStorage.setItem('quizCatalogUid', opt.dataset.uid || '');
   localStorage.setItem('quizCatalogSortOrder', opt.dataset.sortOrder || '');
 
-  sessionStorage.setItem('quizCatalog', opt.dataset.uid || opt.dataset.slug || opt.value);
-  localStorage.setItem('quizCatalog', opt.dataset.uid || opt.dataset.slug || opt.value);
+  sessionStorage.setItem('quizCatalog', opt.value || opt.dataset.slug || '');
+  localStorage.setItem('quizCatalog', opt.value || opt.dataset.slug || '');
 
   // Katalogdaten laden
   const file = opt.dataset.file;

--- a/tests/test_catalog_slug_param.js
+++ b/tests/test_catalog_slug_param.js
@@ -146,6 +146,12 @@ context.global = context;
   if (!button) {
     throw new Error("start button missing");
   }
+  if (sessionStorage.getItem('quizCatalog') !== 'second') {
+    throw new Error('sessionStorage quizCatalog not set');
+  }
+  if (localStorage.getItem('quizCatalog') !== 'second') {
+    throw new Error('localStorage quizCatalog not set');
+  }
   console.log('ok');
 })().catch(err => { console.error(err); process.exit(1); });
 


### PR DESCRIPTION
## Summary
- Store catalog slug in `sessionStorage` and `localStorage` in all catalog selection paths
- Save slug when using direct slug without `<select>`
- Expand catalog tests to cover `quizCatalog` persistence

## Testing
- `node tests/test_catalog_handle_selection.js`
- `node tests/test_catalog_slug_param.js`
- `node tests/test_catalog_slug_no_select.js`
- `composer test` *(fails: Tests: 299, Assertions: 634, Errors: 31, Failures: 17, Warnings: 5, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68bad0cd2e44832bb630c0e249a2e617