### PR TITLE
refactor: centralize quiz intro

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -81,11 +81,7 @@ async function init() {
           localStorage.setItem('quizCatalog', id);
           sessionStorage.removeItem('quizCatalogDesc');
           sessionStorage.removeItem('quizCatalogComment');
-          if (autostart) {
-            await startQuizOnce(data || [], false);
-          } else {
-            showCatalogIntro(data);
-          }
+          await startQuizOnce(data || [], false);
           return;
         } catch (e) {
           console.warn('Inline-Daten ungültig für slug=', id, e);
@@ -99,7 +95,7 @@ async function init() {
       sessionStorage.removeItem('quizCatalogDesc');
       sessionStorage.removeItem('quizCatalogComment');
       if (!autostart) {
-        showCatalogIntro([]); // Button sichtbar; quiz.js wird bei Klick nachgeladen
+        await startQuizOnce([], false);
       }
       UIkit?.notification?.({ message: 'Katalog nicht gefunden (slug: ' + id + ').', status: 'warning' });
       return;
@@ -187,76 +183,15 @@ async function handleSelection(opt, autostart = false) {
       const res = await fetch(base + file, { headers: jsonHeaders });
       const data = await res.json();
       window.quizQuestions = data;
-      if (autostart) {
-        await startQuizOnce(data || window.quizQuestions || [], false);
-      } else {
-        showCatalogIntro(data);
-      }
+      await startQuizOnce(data || window.quizQuestions || [], false);
       return;
     }
   } catch (e) {
     console.error('Katalogdatei konnte nicht geladen werden', e);
   }
   if (!autostart) {
-    showCatalogIntro([]);
+    await startQuizOnce([], false);
   }
-}
-
-function showCatalogIntro(qs) {
-  const header = document.getElementById('quiz-header');
-  if (header) {
-    const title = sessionStorage.getItem('quizCatalogName') || '';
-    const desc = sessionStorage.getItem('quizCatalogDesc') || '';
-    const comment = sessionStorage.getItem('quizCatalogComment');
-
-    let h1 = header.querySelector('h1');
-    if (!h1) {
-      h1 = document.createElement('h1');
-      header.appendChild(h1);
-    }
-    h1.textContent = title;
-
-    let sub = header.querySelector('p[data-role="subheader"]');
-    if (!sub) {
-      sub = document.createElement('p');
-      sub.dataset.role = 'subheader';
-      header.appendChild(sub);
-    }
-    sub.textContent = desc;
-
-    let cBlock = header.querySelector('div[data-role="catalog-comment-block"]');
-    if (comment) {
-      if (!cBlock) {
-        cBlock = document.createElement('div');
-        cBlock.dataset.role = 'catalog-comment-block';
-        header.appendChild(cBlock);
-      }
-      cBlock.textContent = comment;
-    } else if (cBlock) {
-      cBlock.remove();
-    }
-  }
-
-  const quiz = document.getElementById('quiz');
-  if (!quiz) {
-    return;
-  }
-
-  quiz.innerHTML = '';
-
-  const comment = sessionStorage.getItem('quizCatalogComment');
-  if (comment) {
-    const p = document.createElement('p');
-    p.textContent = comment;
-    quiz.appendChild(p);
-  }
-
-  const button = document.createElement('button');
-  button.textContent = "Los geht's!";
-  button.addEventListener('click', () => {
-    startQuizOnce(qs || window.quizQuestions || [], false);
-  });
-  quiz.appendChild(button);
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -225,10 +225,33 @@ async function runQuiz(questions, skipIntro){
   // Farben werden über CSS-Variablen gesetzt
 
   const headerEl = document.getElementById('quiz-header');
-
-  if(skipIntro && headerEl){
-    headerEl.textContent = '';
-    headerEl.classList.add('uk-hidden');
+  if(headerEl){
+    const name = sessionStorage.getItem('quizCatalogName') || '';
+    const desc = sessionStorage.getItem('quizCatalogDesc') || '';
+    const comment = sessionStorage.getItem('quizCatalogComment');
+    headerEl.innerHTML = '';
+    if(skipIntro){
+      headerEl.classList.add('uk-hidden');
+    }else{
+      if(name){
+        const h1 = document.createElement('h1');
+        h1.textContent = name;
+        headerEl.appendChild(h1);
+      }
+      if(desc){
+        const sub = document.createElement('p');
+        sub.dataset.role = 'subheader';
+        sub.textContent = desc;
+        headerEl.appendChild(sub);
+      }
+      if(comment){
+        const cBlock = document.createElement('div');
+        cBlock.dataset.role = 'catalog-comment-block';
+        cBlock.textContent = comment;
+        headerEl.appendChild(cBlock);
+      }
+      headerEl.classList.remove('uk-hidden');
+    }
   }
 
   elements.forEach((el, i) => {
@@ -1085,6 +1108,25 @@ async function runQuiz(questions, skipIntro){
     div.setAttribute('uk-scrollspy', 'cls: uk-animation-slide-bottom-small; target: > *; delay: 100');
     const stats = document.createElement('div');
     stats.className = 'uk-margin';
+
+    const title = sessionStorage.getItem('quizCatalogName') || '';
+    const desc = sessionStorage.getItem('quizCatalogDesc') || '';
+    const comment = sessionStorage.getItem('quizCatalogComment');
+    if(title){
+      const h2 = document.createElement('h2');
+      h2.textContent = title;
+      div.appendChild(h2);
+    }
+    if(desc){
+      const p = document.createElement('p');
+      p.textContent = desc;
+      div.appendChild(p);
+    }
+    if(comment){
+      const c = document.createElement('div');
+      c.textContent = comment;
+      div.appendChild(c);
+    }
 
     if(cfg.QRUser && !getStored('quizUser')){
       const scanBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- remove duplicate catalog intro in favor of direct quiz start
- show catalog metadata on start screen and quiz header

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars and Slim Application Error)*

------
https://chatgpt.com/codex/tasks/task_e_68bad4d39ec8832b9118c8c81ee7a9b8