### PR TITLE
Remove redundant session initialization

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -44,9 +44,6 @@ class HomeController
             $cfgSvc->ensureConfigForEvent($uid);
         }
 
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($uid !== '') {
             $cfg = $cfgSvc->getConfigForEvent($uid);

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -72,9 +72,6 @@ class LoginController
         }
 
         if ($valid) {
-            if (session_status() === PHP_SESSION_NONE) {
-                session_start();
-            }
             $_SESSION['user'] = [
                 'id' => $record['id'],
                 'username' => $record['username'],

--- a/src/Controller/Marketing/LandingController.php
+++ b/src/Controller/Marketing/LandingController.php
@@ -26,9 +26,6 @@ class LandingController
         $basePath = RouteContext::fromRequest($request)->getBasePath();
         $html = str_replace('{{ basePath }}', $basePath, $html);
 
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
         $_SESSION['csrf_token'] = $csrf;
         $html = str_replace('{{ csrf_token }}', $csrf, $html);

--- a/src/Controller/OnboardingSessionController.php
+++ b/src/Controller/OnboardingSessionController.php
@@ -17,9 +17,6 @@ class OnboardingSessionController
      */
     public function get(Request $request, Response $response): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $data = $_SESSION['onboarding'] ?? [];
         $payload = json_encode($data, JSON_THROW_ON_ERROR);
         $response->getBody()->write($payload);
@@ -31,9 +28,6 @@ class OnboardingSessionController
      */
     public function store(Request $request, Response $response): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data)) {
             return $response->withStatus(400);
@@ -48,9 +42,6 @@ class OnboardingSessionController
      */
     public function clear(Request $request, Response $response): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         unset($_SESSION['onboarding']);
         return $response->withStatus(204);
     }

--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -56,9 +56,6 @@ class PasswordController
             return $response->withStatus(400);
         }
 
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $id = $_SESSION['user']['id'] ?? null;
         if ($id === null) {
             return $response->withStatus(403);

--- a/src/Controller/SummaryController.php
+++ b/src/Controller/SummaryController.php
@@ -49,9 +49,6 @@ class SummaryController
                 $event = $this->events->getFirst();
             }
         }
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
             $cfg = ConfigService::removePuzzleInfo($cfg);

--- a/src/routes.php
+++ b/src/routes.php
@@ -165,10 +165,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             ? $eventService->uidBySlug($evParam) ?? ''
             : $evParam;
         if ($eventUid === '') {
-            if (session_status() === PHP_SESSION_NONE) {
-                session_start();
-            }
-            $eventUid = (string)($_SESSION['event_uid'] ?? '');
+            $eventUid = (string) ($_SESSION['event_uid'] ?? '');
         }
         $catalogService = new CatalogService($pdo, $configService, $tenantService, $sub, $eventUid);
         $resultService = new ResultService($pdo, $configService);
@@ -323,9 +320,6 @@ return function (\Slim\App $app, TranslationService $translator) {
         }
         $configService = new ConfigService($pdo);
         $config = $configService->getConfig();
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
             $config = ConfigService::removePuzzleInfo($config);


### PR DESCRIPTION
## Summary
- remove manual session_start guards from controllers and route definitions
- rely on SessionMiddleware for session initialization and directly access $_SESSION

## Testing
- `composer phpunit` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bad8aa4910832bb1143b1e0be8e58e