### PR TITLE
feat: centralize storage utilities

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -1,3 +1,5 @@
+/* global UIkit, STORAGE_KEYS, setStored, clearStored */
+
 const jsonHeaders = { Accept: 'application/json' };
 
 let quizScriptPromise;
@@ -76,11 +78,10 @@ async function init() {
         try {
           const data = JSON.parse(inline.textContent);
           // Optional: Name/Desc/Comment aus data oder Metas setzen
-          sessionStorage.setItem('quizCatalogName', id.toUpperCase());
-          sessionStorage.setItem('quizCatalog', id);
-          localStorage.setItem('quizCatalog', id);
-          sessionStorage.removeItem('quizCatalogDesc');
-          sessionStorage.removeItem('quizCatalogComment');
+          setStored(STORAGE_KEYS.CATALOG_NAME, id.toUpperCase());
+          setStored(STORAGE_KEYS.CATALOG, id);
+          clearStored(STORAGE_KEYS.CATALOG_DESC);
+          clearStored(STORAGE_KEYS.CATALOG_COMMENT);
           await startQuizOnce(data || [], false);
           return;
         } catch (e) {
@@ -89,11 +90,10 @@ async function init() {
       }
 
       // 2) Kein Inline: Zeige zumindest Intro, damit der Button erscheint
-      sessionStorage.setItem('quizCatalogName', id.toUpperCase());
-      sessionStorage.setItem('quizCatalog', id);
-      localStorage.setItem('quizCatalog', id);
-      sessionStorage.removeItem('quizCatalogDesc');
-      sessionStorage.removeItem('quizCatalogComment');
+      setStored(STORAGE_KEYS.CATALOG_NAME, id.toUpperCase());
+      setStored(STORAGE_KEYS.CATALOG, id);
+      clearStored(STORAGE_KEYS.CATALOG_DESC);
+      clearStored(STORAGE_KEYS.CATALOG_COMMENT);
       if (!autostart) {
         await startQuizOnce([], false);
       }
@@ -157,23 +157,22 @@ async function handleSelection(opt, autostart = false) {
   const desc = opt.dataset.desc || '';
   const comment = opt.dataset.comment || '';
 
-  sessionStorage.setItem('quizCatalogName', name);
+  setStored(STORAGE_KEYS.CATALOG_NAME, name);
   if (desc) {
-    sessionStorage.setItem('quizCatalogDesc', desc);
+    setStored(STORAGE_KEYS.CATALOG_DESC, desc);
   } else {
-    sessionStorage.removeItem('quizCatalogDesc');
+    clearStored(STORAGE_KEYS.CATALOG_DESC);
   }
   if (comment) {
-    sessionStorage.setItem('quizCatalogComment', comment);
+    setStored(STORAGE_KEYS.CATALOG_COMMENT, comment);
   } else {
-    sessionStorage.removeItem('quizCatalogComment');
+    clearStored(STORAGE_KEYS.CATALOG_COMMENT);
   }
 
-  localStorage.setItem('quizCatalogUid', opt.dataset.uid || '');
-  localStorage.setItem('quizCatalogSortOrder', opt.dataset.sortOrder || '');
+  setStored(STORAGE_KEYS.CATALOG_UID, opt.dataset.uid || '');
+  setStored(STORAGE_KEYS.CATALOG_SORT, opt.dataset.sortOrder || '');
 
-  sessionStorage.setItem('quizCatalog', opt.value || opt.dataset.slug || '');
-  localStorage.setItem('quizCatalog', opt.value || opt.dataset.slug || '');
+  setStored(STORAGE_KEYS.CATALOG, opt.value || opt.dataset.slug || '');
 
   // Katalogdaten laden
   const file = opt.dataset.file;

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -1,8 +1,7 @@
+/* global STORAGE_KEYS, getStored, setStored, clearStored */
 // Profile page logic for handling player names
 
 let nameInput;
-let nameKey;
-let uidKey;
 let eventUid;
 
 function generateRandomName() {
@@ -24,14 +23,14 @@ function saveName(e) {
   e?.preventDefault();
   const name = nameInput.value.trim();
   if (name) {
-    localStorage.setItem(nameKey, name);
+    setStored(STORAGE_KEYS.PLAYER_NAME, name);
   } else {
-    localStorage.removeItem(nameKey);
+    clearStored(STORAGE_KEYS.PLAYER_NAME);
   }
-  let uid = localStorage.getItem(uidKey);
+  let uid = getStored(STORAGE_KEYS.PLAYER_UID);
   if (!uid) {
     uid = self.crypto?.randomUUID ? self.crypto.randomUUID() : Math.random().toString(36).slice(2);
-    localStorage.setItem(uidKey, uid);
+    setStored(STORAGE_KEYS.PLAYER_UID, uid);
   }
   fetch('/api/players', {
     method: 'POST',
@@ -45,8 +44,8 @@ function saveName(e) {
 
 function deleteName(e) {
   e?.preventDefault();
-  localStorage.removeItem(nameKey);
-  localStorage.removeItem(uidKey);
+  clearStored(STORAGE_KEYS.PLAYER_NAME);
+  clearStored(STORAGE_KEYS.PLAYER_UID);
   nameInput.value = generateRandomName();
 }
 
@@ -54,14 +53,12 @@ document.addEventListener('DOMContentLoaded', () => {
   nameInput = document.getElementById('playerName');
   const cfg = window.quizConfig || {};
   eventUid = cfg.event_uid || '';
-  nameKey = `qr_player_name:${eventUid}`;
-  uidKey = `qr_player_uid:${eventUid}`;
   const params = new URLSearchParams(location.search);
   const uidParam = params.get('uid') || params.get('player_uid');
   if (uidParam) {
-    localStorage.setItem(uidKey, uidParam);
+    setStored(STORAGE_KEYS.PLAYER_UID, uidParam);
   }
-  const storedName = localStorage.getItem(nameKey);
+  const storedName = getStored(STORAGE_KEYS.PLAYER_NAME);
   nameInput.value = storedName || generateRandomName();
   if (!storedName && uidParam && cfg.collectPlayerUid) {
     fetch(`/api/players?event_uid=${encodeURIComponent(eventUid)}&player_uid=${encodeURIComponent(uidParam)}`)

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -1,0 +1,73 @@
+(function(){
+  const eventUid = (window.quizConfig || {}).event_uid || '';
+
+  const STORAGE_KEYS = {
+    PLAYER_NAME: 'qr_player_name',
+    PLAYER_UID: 'qr_player_uid',
+    CATALOG: 'quizCatalog',
+    CATALOG_NAME: 'quizCatalogName',
+    CATALOG_DESC: 'quizCatalogDesc',
+    CATALOG_COMMENT: 'quizCatalogComment',
+    CATALOG_UID: 'quizCatalogUid',
+    CATALOG_SORT: 'quizCatalogSortOrder',
+    LETTER: 'quizLetter',
+    PUZZLE_SOLVED: 'puzzleSolved',
+    PUZZLE_TIME: 'puzzleTime',
+    QUIZ_SOLVED: 'quizSolved',
+    USED_NAMES: 'usedNames'
+  };
+
+  const eventScoped = new Set([STORAGE_KEYS.PLAYER_NAME, STORAGE_KEYS.PLAYER_UID]);
+
+  function mapKey(key){
+    return eventScoped.has(key) ? `${key}:${eventUid}` : key;
+  }
+
+  function getStored(key){
+    key = mapKey(key);
+    try{
+      return (typeof sessionStorage !== 'undefined' && sessionStorage.getItem(key)) ||
+             (typeof localStorage !== 'undefined' && localStorage.getItem(key));
+    }catch(e){
+      return null;
+    }
+  }
+
+  function setStored(key, value){
+    key = mapKey(key);
+    try{
+      if(typeof sessionStorage !== 'undefined') sessionStorage.setItem(key, value);
+      if(typeof localStorage !== 'undefined') localStorage.setItem(key, value);
+    }catch(e){ /* empty */ }
+  }
+
+  function clearStored(key){
+    key = mapKey(key);
+    try{
+      if(typeof sessionStorage !== 'undefined') sessionStorage.removeItem(key);
+      if(typeof localStorage !== 'undefined') localStorage.removeItem(key);
+    }catch(e){ /* empty */ }
+  }
+
+  /*
+   * Standardized storage keys:
+   * - qr_player_name:<eventUid>  – Spielername
+   * - qr_player_uid:<eventUid>   – Spieler-UID
+   * - quizCatalog                – Aktueller Katalog-Slug
+   * - quizCatalogName            – Katalognamen
+   * - quizCatalogDesc            – Katalogbeschreibung
+   * - quizCatalogComment         – Zusätzlicher Kommentar
+   * - quizCatalogUid             – Katalog-UID
+   * - quizCatalogSortOrder       – Sortierreihenfolge
+   * - quizLetter                 – Buchstabe für Rätselwort
+   * - puzzleSolved               – Flag, ob Rätsel gelöst
+   * - puzzleTime                 – Zeitstempel des Rätsels
+   * - quizSolved                 – Liste gelöster Fragen (JSON)
+   * - usedNames                  – Für Zufallsnamen verwendete Namen
+   */
+
+  globalThis.STORAGE_KEYS = STORAGE_KEYS;
+  globalThis.getStored = getStored;
+  globalThis.setStored = setStored;
+  globalThis.clearStored = clearStored;
+})();

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -68,15 +68,14 @@
   <script>
     window.csrfToken = '{{ csrf_token|e('js') }}';
   </script>
+  <script src="{{ basePath }}/js/storage.js"></script>
   <script>
     function enforceProfile() {
       const cfg = window.quizConfig || {};
       if (!cfg.randomNames || cfg.QRUser || cfg.QRRestrict) {
         return;
       }
-      const eventUid = cfg.event_uid || '';
-      const nameKey = `qr_player_name:${eventUid}`;
-      if (!localStorage.getItem(nameKey)) {
+      if (!getStored(STORAGE_KEYS.PLAYER_NAME)) {
         const params = new URLSearchParams(location.search);
         const uidParam = params.get('uid') || params.get('player_uid');
         let url = '/profile?return=' + encodeURIComponent(location.href);

--- a/templates/profile.twig
+++ b/templates/profile.twig
@@ -40,6 +40,7 @@
     const returnUrl = '{{ return }}';
   </script>
   <script src="{{ basePath }}/js/app.js"></script>
+  <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/profile.js"></script>
 {% endblock %}
 

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -50,5 +50,6 @@
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
   </script>
+  <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/summary.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add shared storage helpers with event-aware keys
- replace direct storage access in quiz, summary, catalog and profile scripts
- load new helper in related templates

## Testing
- `node tests/test_profile_flow.js`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68badc1e6404832b8c939f85514a7f5b