### PR TITLE
Prefix catalog fetch paths

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -179,7 +179,8 @@ async function handleSelection(opt, autostart = false) {
   try {
     if (file) {
       const base = window.basePath || '';
-      const res = await fetch(base + file, { headers: jsonHeaders });
+      const path = file.startsWith('/kataloge/') ? file : 'kataloge/' + file;
+      const res = await fetch(base + path, { headers: jsonHeaders });
       const data = await res.json();
       window.quizQuestions = data;
       await startQuizOnce(data || window.quizQuestions || [], false);

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -44,7 +44,7 @@
               value="{{ key }}"
               data-slug="{{ cat.slug|e }}"
               data-sort-order="{{ cat.sort_order ?? cat.id }}"
-              data-file="{{ cat.file }}"
+              data-file="/kataloge/{{ cat.file }}"
               data-letter="{{ cat.raetsel_buchstabe }}"
               data-uid="{{ cat.uid }}"
               data-desc="{{ cat.description ?? cat.beschreibung }}"


### PR DESCRIPTION
## Summary
- Load catalog files from `/kataloge/` path in selection handler
- Include full `/kataloge/` path in catalog selector data attributes

## Testing
- `composer test` *(fails: Tests: 299, Assertions: 634, Errors: 31, Failures: 17, Warnings: 5)*

------
https://chatgpt.com/codex/tasks/task_e_68bae0b9ba8c832bb3f9a59c442d5872