### PR TITLE
refactor: rely on SessionMiddleware

### DIFF
--- a/src/Application/Middleware/LanguageMiddleware.php
+++ b/src/Application/Middleware/LanguageMiddleware.php
@@ -24,9 +24,6 @@ class LanguageMiddleware implements MiddlewareInterface
 
     public function process(Request $request, RequestHandler $handler): Response
     {
-        if (session_status() === PHP_SESSION_NONE && !headers_sent()) {
-            session_start();
-        }
         $first = empty($_SESSION['lang']);
         $params = $request->getQueryParams();
         $locale = (string)($params['lang'] ?? ($_SESSION['lang'] ?? $this->defaultLocale));

--- a/src/Application/Security/AuthorizationMiddleware.php
+++ b/src/Application/Security/AuthorizationMiddleware.php
@@ -27,9 +27,6 @@ class AuthorizationMiddleware implements MiddlewareInterface
         if ($this->requiredRole === '') {
             return $handler->handle($request);
         }
-        if (session_status() === PHP_SESSION_NONE && !headers_sent()) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== $this->requiredRole) {
             $response = new SlimResponse();

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -35,9 +35,6 @@ class AdminController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
         $_SESSION['csrf_token'] = $csrf;
         $role = $_SESSION['user']['role'] ?? null;

--- a/src/Controller/AdminLogsController.php
+++ b/src/Controller/AdminLogsController.php
@@ -20,9 +20,6 @@ class AdminLogsController
         $stripeLog = LogService::tail('stripe');
         $slimLog = LogService::tailDocker('slim-1');
         $view = Twig::fromRequest($request);
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? '';
         return $view->render($response, 'admin/logs.twig', [
             'appLog' => $appLog,

--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -21,9 +21,6 @@ class AdminSubscriptionCheckoutController
     {
         $logger = LogService::create('stripe');
         try {
-            if (session_status() === PHP_SESSION_NONE) {
-                session_start();
-            }
             $sessionToken = $_SESSION['csrf_token'] ?? '';
             $headerToken = $request->getHeaderLine('X-CSRF-Token');
             if ($sessionToken === '' || $headerToken !== $sessionToken) {

--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -29,9 +29,6 @@ class CatalogController
      */
     private function hasRole(string ...$roles): bool
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         return $role !== null && in_array($role, $roles, true);
     }
@@ -72,10 +69,6 @@ class CatalogController
      */
     public function getQuestions(Request $request, Response $response, array $args): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
-
         $headerToken = $request->getHeaderLine('X-CSRF-Token');
         $sessionToken = (string) ($_SESSION['csrf_token'] ?? '');
         if ($sessionToken === '' || $headerToken === '' || !hash_equals($sessionToken, $headerToken)) {

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -33,9 +33,6 @@ class ConfigController
     public function get(Request $request, Response $response): Response
     {
         $cfg = $this->service->getConfig();
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
             $cfg = ConfigService::removePuzzleInfo($cfg);
@@ -56,9 +53,6 @@ class ConfigController
     {
         $uid = (string) ($args['uid'] ?? '');
         $cfg = $this->service->getConfigForEvent($uid);
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
             $cfg = ConfigService::removePuzzleInfo($cfg);
@@ -77,9 +71,6 @@ class ConfigController
      */
     public function post(Request $request, Response $response): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== Roles::ADMIN && $role !== Roles::EVENT_MANAGER) {
             return $response->withStatus(403);

--- a/src/Controller/EventListController.php
+++ b/src/Controller/EventListController.php
@@ -26,9 +26,6 @@ class EventListController
         }
         $eventSvc = new EventService($pdo);
         $cfgSvc = new ConfigService($pdo);
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         $events = $eventSvc->getAll();
         $cfg = $cfgSvc->getConfig();

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -46,9 +46,6 @@ class HelpController
                 $event = $eventSvc->getFirst();
             }
         }
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
             $cfg = ConfigService::removePuzzleInfo($cfg);

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -17,9 +17,6 @@ class LogoutController
      */
     public function __invoke(Request $request, Response $response): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $_SESSION = [];
         session_destroy();
         return $response->withHeader('Location', '/login')->withStatus(302);

--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -45,9 +45,6 @@ class OnboardingController
             $record = $service->getByUsername($serviceUser);
             if ($record !== null && (bool)$record['active']) {
                 if (password_verify($servicePass, (string)$record['password'])) {
-                    if (session_status() === PHP_SESSION_NONE) {
-                        session_start();
-                    }
                     $_SESSION['user'] = [
                         'id' => $record['id'],
                         'username' => $record['username'],
@@ -55,10 +52,6 @@ class OnboardingController
                     ];
                 }
             }
-        }
-
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
         }
 
         $loggedIn = isset($_SESSION['user']);

--- a/src/Controller/OnboardingEmailController.php
+++ b/src/Controller/OnboardingEmailController.php
@@ -37,9 +37,6 @@ class OnboardingEmailController
             return $response->withStatus(400);
         }
 
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $_SESSION['onboarding']['email'] = $email;
 
         $token = $this->service->createToken($email);
@@ -76,9 +73,6 @@ class OnboardingEmailController
             return $response->withStatus(400);
         }
 
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $_SESSION['onboarding']['email'] = $email;
         $_SESSION['onboarding']['verified'] = true;
 

--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -169,9 +169,6 @@ class PasswordResetController
         if ($next !== '' && str_starts_with($next, '/')) {
             $user = $this->users->getById($userId);
             if ($user !== null) {
-                if (session_status() === PHP_SESSION_NONE) {
-                    session_start();
-                }
                 $_SESSION['user'] = [
                     'id' => $user['id'],
                     'username' => $user['username'],

--- a/src/Controller/SettingsController.php
+++ b/src/Controller/SettingsController.php
@@ -30,9 +30,6 @@ class SettingsController
 
     public function post(Request $request, Response $response): Response
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== Roles::ADMIN) {
             return $response->withStatus(403);


### PR DESCRIPTION
## Summary
- remove ad-hoc session_start checks in controllers and middlewares
- depend on SessionMiddleware for session lifecycle management

## Testing
- `vendor/bin/phpcs`
- `composer test` *(fails: Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bae3f95148832bbeb02aef54a597d4