### PR TITLE
Persist event UID in session

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -167,6 +167,9 @@ return function (\Slim\App $app, TranslationService $translator) {
         if ($eventUid === '') {
             $eventUid = (string) ($_SESSION['event_uid'] ?? '');
         }
+        if ($eventUid !== '') {
+            $_SESSION['event_uid'] = $eventUid;
+        }
         $catalogService = new CatalogService($pdo, $configService, $tenantService, $sub, $eventUid);
         $resultService = new ResultService($pdo, $configService);
         $teamService = new TeamService($pdo, $configService, $tenantService, $sub);


### PR DESCRIPTION
## Summary
- ensure event UID is stored in session after slug resolution

## Testing
- `composer test` (fails: tests report errors and failures)

------
https://chatgpt.com/codex/tasks/task_e_68bae432171c832b9d8f843c1c208278