### PR TITLE
Use storage helpers for persistent settings

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2249,7 +2249,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const tenantColumnDefaults = tenantColumnDefs.map(c => c.key);
   let tenantColumns = [...tenantColumnDefaults];
   try {
-    const stored = JSON.parse(localStorage.getItem('tenantColumns'));
+    const stored = JSON.parse(getStored(STORAGE_KEYS.TENANT_COLUMNS));
     if (Array.isArray(stored)) {
       tenantColumns = tenantColumnDefaults.filter(k => stored.includes(k));
     }
@@ -2292,7 +2292,7 @@ document.addEventListener('DOMContentLoaded', function () {
           .filter(cb => cb.checked)
           .map(cb => cb.dataset.col);
         tenantColumns = tenantColumnDefaults.filter(k => selected.includes(k));
-        try { localStorage.setItem('tenantColumns', JSON.stringify(tenantColumns)); } catch (_) {}
+        try { setStored(STORAGE_KEYS.TENANT_COLUMNS, JSON.stringify(tenantColumns)); } catch (_) {}
         updateTenantColumnVisibility();
         loadTenants(tenantStatusFilter?.value, tenantSearchInput?.value);
         UIkit.modal(modal).hide();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
     offcanvasToggle.hidden = true;
   }
 
-  const storedTheme = localStorage.getItem('darkMode');
+  const storedTheme = getStored(STORAGE_KEYS.DARK_MODE);
   let dark = storedTheme !== 'false';
 
   if (darkStylesheet) {
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', function () {
     themeIcon.innerHTML = dark ? sunSVG : moonSVG;
   }
 
-  let accessible = localStorage.getItem('barrierFree') === 'true';
+  let accessible = getStored(STORAGE_KEYS.BARRIER_FREE) === 'true';
   if (accessible) {
     document.body.classList.add('high-contrast');
   }
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (darkStylesheet) {
           darkStylesheet.toggleAttribute('disabled', !dark);
         }
-        localStorage.setItem('darkMode', dark ? 'true' : 'false');
+        setStored(STORAGE_KEYS.DARK_MODE, dark ? 'true' : 'false');
         if (themeIcon) {
           themeIcon.innerHTML = dark ? sunSVG : moonSVG;
         }
@@ -125,7 +125,7 @@ document.addEventListener('DOMContentLoaded', function () {
       toggle.addEventListener('click', function (event) {
         event.preventDefault();
         accessible = document.body.classList.toggle('high-contrast');
-        localStorage.setItem('barrierFree', accessible ? 'true' : 'false');
+        setStored(STORAGE_KEYS.BARRIER_FREE, accessible ? 'true' : 'false');
         if (accessibilityIcon) {
           accessibilityIcon.innerHTML = accessible ? accessibilityOnSVG : accessibilityOffSVG;
         }

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -67,14 +67,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const langButtons = document.querySelectorAll('.lang-option');
 
   const applyTheme = () => {
-    const dark = localStorage.getItem('darkMode') !== 'false';
+    const dark = getStored(STORAGE_KEYS.DARK_MODE) !== 'false';
     document.documentElement.dataset.theme = dark ? 'dark' : 'light';
-    localStorage.setItem('qr-theme', dark ? 'dark' : 'light');
+    setStored(STORAGE_KEYS.QR_THEME, dark ? 'dark' : 'light');
   };
 
   const applyContrast = () => {
-    const accessible = localStorage.getItem('barrierFree') === 'true';
-    localStorage.setItem('qr-contrast', accessible ? 'high' : 'normal');
+    const accessible = getStored(STORAGE_KEYS.BARRIER_FREE) === 'true';
+    setStored(STORAGE_KEYS.QR_CONTRAST, accessible ? 'high' : 'normal');
   };
 
   applyTheme();

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -12,7 +12,12 @@
     PUZZLE_SOLVED: 'puzzleSolved',
     PUZZLE_TIME: 'puzzleTime',
     QUIZ_SOLVED: 'quizSolved',
-    USED_NAMES: 'usedNames'
+    USED_NAMES: 'usedNames',
+    DARK_MODE: 'darkMode',
+    BARRIER_FREE: 'barrierFree',
+    QR_THEME: 'qr-theme',
+    QR_CONTRAST: 'qr-contrast',
+    TENANT_COLUMNS: 'tenantColumns'
   };
 
   const eventScoped = new Set([STORAGE_KEYS.PLAYER_NAME, STORAGE_KEYS.PLAYER_UID]);
@@ -80,6 +85,11 @@
    * - puzzleTime                 – Zeitstempel des Rätsels
    * - quizSolved                 – Liste gelöster Fragen (JSON)
    * - usedNames                  – Für Zufallsnamen verwendete Namen
+   * - darkMode                   – Aktiviertes Dunkelmodus-Flag
+   * - barrierFree                – Barrierefrei-Flag
+   * - qr-theme                   – Letztes Theme
+   * - qr-contrast                – Letzter Kontrastmodus
+   * - tenantColumns              – Sichtbare Mandantenspalten (JSON)
    */
 
   globalThis.STORAGE_KEYS = STORAGE_KEYS;


### PR DESCRIPTION
## Summary
- replace direct localStorage access in app, landing, and admin scripts with getStored/setStored helpers
- extend STORAGE_KEYS with dark mode, accessibility, theme, contrast, and tenant column keys
- document new storage keys in storage.js

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other Stripe env variables; Script vendor/bin/phpunit returned error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bae62f5bfc832b89297828eb43eae9