### PR TITLE
feat: add player session endpoint

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -133,6 +133,11 @@ async function promptTeamName(){
       const name = (input.value || '').trim();
       if(name){
         setStored(STORAGE_KEYS.PLAYER_NAME, name);
+        fetch('/session/player', {
+          method: 'POST',
+          body: JSON.stringify({ name }),
+          headers: { 'Content-Type': 'application/json' }
+        });
         ui.hide();
       }
     });

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -88,9 +88,14 @@
    * - darkMode                   – Aktiviertes Dunkelmodus-Flag
    * - barrierFree                – Barrierefrei-Flag
    * - qr-theme                   – Letztes Theme
-   * - qr-contrast                – Letzter Kontrastmodus
-   * - tenantColumns              – Sichtbare Mandantenspalten (JSON)
-   */
+  * - qr-contrast                – Letzter Kontrastmodus
+  * - tenantColumns              – Sichtbare Mandantenspalten (JSON)
+  */
+
+  const sessionName = globalThis.sessionPlayerName;
+  if (typeof sessionName === 'string' && sessionName && !getStored(STORAGE_KEYS.PLAYER_NAME)) {
+    setStored(STORAGE_KEYS.PLAYER_NAME, sessionName);
+  }
 
   globalThis.STORAGE_KEYS = STORAGE_KEYS;
   globalThis.getStored = getStored;

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -113,6 +113,7 @@ class HomeController
             'catalogs' => $catalogs,
             'event' => $event,
             'csrf_token' => $_SESSION['csrf_token'] ?? '',
+            'player_name' => $_SESSION['player_name'] ?? '',
         ]);
     }
 }

--- a/src/Controller/PlayerSessionController.php
+++ b/src/Controller/PlayerSessionController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Store the player name in the session.
+ */
+class PlayerSessionController
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        $name = is_array($data) ? ($data['name'] ?? '') : '';
+        if (!is_string($name) || trim($name) === '') {
+            return $response->withStatus(400);
+        }
+        $_SESSION['player_name'] = $name;
+        return $response->withStatus(204);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -71,6 +71,7 @@ use App\Controller\RegisterController;
 use App\Controller\OnboardingController;
 use App\Controller\OnboardingEmailController;
 use App\Controller\OnboardingSessionController;
+use App\Controller\PlayerSessionController;
 use App\Controller\StripeCheckoutController;
 use App\Controller\StripeSessionController;
 use App\Controller\StripeWebhookController;
@@ -124,6 +125,7 @@ require_once __DIR__ . '/Controller/RegisterController.php';
 require_once __DIR__ . '/Controller/OnboardingController.php';
 require_once __DIR__ . '/Controller/OnboardingEmailController.php';
 require_once __DIR__ . '/Controller/OnboardingSessionController.php';
+require_once __DIR__ . '/Controller/PlayerSessionController.php';
 require_once __DIR__ . '/Controller/StripeCheckoutController.php';
 require_once __DIR__ . '/Controller/StripeSessionController.php';
 require_once __DIR__ . '/Controller/StripeWebhookController.php';
@@ -376,6 +378,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = new OnboardingSessionController();
         return $controller->clear($request, $response);
     })->add(new CsrfMiddleware());
+    $app->post('/session/player', PlayerSessionController::class);
     $app->get('/onboarding/tenants/{subdomain}', function (Request $request, Response $response, array $args) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(404);

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -68,6 +68,9 @@
   <script>
     window.csrfToken = '{{ csrf_token|e('js') }}';
   </script>
+  <script>
+    window.sessionPlayerName = {{ player_name|json_encode|raw }};
+  </script>
   <script src="{{ basePath }}/js/storage.js"></script>
   <script>
     function enforceProfile() {


### PR DESCRIPTION
## Summary
- add controller to store player name in session
- register /session/player route and call from quiz frontend
- sync player name from session to client storage

## Testing
- `composer test` *(fails: missing STRIPE_* env vars and multiple test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68baebf7cc94832bb133d1b0d4aa0960