### PR TITLE
Persist catalog selection in session

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -173,6 +173,11 @@ async function handleSelection(opt, autostart = false) {
   setStored(STORAGE_KEYS.CATALOG_SORT, opt.dataset.sortOrder || '');
 
   setStored(STORAGE_KEYS.CATALOG, opt.value || opt.dataset.slug || '');
+  fetch('/session/catalog', {
+    method: 'POST',
+    body: JSON.stringify({ slug: opt.value }),
+    headers: { 'Content-Type': 'application/json' }
+  });
 
   // Katalogdaten laden
   const file = opt.dataset.file;

--- a/src/Application/Middleware/SessionMiddleware.php
+++ b/src/Application/Middleware/SessionMiddleware.php
@@ -28,6 +28,17 @@ class SessionMiddleware implements Middleware
         }
 
         if (session_status() === PHP_SESSION_NONE && !headers_sent()) {
+            $domain = getenv('MAIN_DOMAIN') ?: '';
+            if ($domain !== '') {
+                $secure = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
+                session_set_cookie_params([
+                    'domain' => '.' . ltrim($domain, '.'),
+                    'path' => '/',
+                    'secure' => $secure,
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]);
+            }
             session_start();
         }
 

--- a/src/Controller/CatalogSessionController.php
+++ b/src/Controller/CatalogSessionController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Store the selected catalog slug in the session.
+ */
+class CatalogSessionController
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $data = json_decode((string) $request->getBody(), true);
+        $slug = is_array($data) ? ($data['slug'] ?? '') : '';
+        if (!is_string($slug) || trim($slug) === '') {
+            return $response->withStatus(400);
+        }
+        $_SESSION['catalog_slug'] = $slug;
+        return $response->withStatus(204);
+    }
+}

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -33,8 +33,14 @@ class HomeController
         $eventSvc = new EventService($pdo, $cfgSvc);
         $settingsSvc = new SettingsService($pdo);
 
-        $params = $request->getQueryParams();
+        $catalogParam = (string)($params['katalog'] ?? '');
+        if ($catalogParam === '') {
+            $catalogParam = (string)($_SESSION['catalog_slug'] ?? '');
+        }
         $evParam = (string)($params['event'] ?? '');
+        if ($evParam === '') {
+            $evParam = (string)($_SESSION['event_uid'] ?? '');
+        }
         $isUid = preg_match('/^[0-9a-fA-F]{32}$/', $evParam)
             || preg_match('/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/', $evParam);
         $uid = $evParam !== '' && !$isUid
@@ -70,8 +76,7 @@ class HomeController
                 $ctrl = new HelpController();
                 return $ctrl($request, $response);
             } elseif ($home === 'landing') {
-                $params = $request->getQueryParams();
-                if (($params['katalog'] ?? '') === '') {
+                if ($catalogParam === '') {
                     $domainType = $request->getAttribute('domainType');
                     $host = $request->getUri()->getHost();
                     $mainDomain = getenv('MAIN_DOMAIN') ?: '';
@@ -95,8 +100,7 @@ class HomeController
         }
 
         if (($cfg['competitionMode'] ?? false) === true) {
-            $params = $request->getQueryParams();
-            $slug = $params['katalog'] ?? '';
+            $slug = $catalogParam;
             $allowed = array_map(
                 static fn($c) => $c['uid'] ?? $c['slug'] ?? $c['sort_order'] ?? '',
                 $catalogs

--- a/src/routes.php
+++ b/src/routes.php
@@ -71,6 +71,7 @@ use App\Controller\RegisterController;
 use App\Controller\OnboardingController;
 use App\Controller\OnboardingEmailController;
 use App\Controller\OnboardingSessionController;
+use App\Controller\CatalogSessionController;
 use App\Controller\PlayerSessionController;
 use App\Controller\StripeCheckoutController;
 use App\Controller\StripeSessionController;
@@ -125,6 +126,7 @@ require_once __DIR__ . '/Controller/RegisterController.php';
 require_once __DIR__ . '/Controller/OnboardingController.php';
 require_once __DIR__ . '/Controller/OnboardingEmailController.php';
 require_once __DIR__ . '/Controller/OnboardingSessionController.php';
+require_once __DIR__ . '/Controller/CatalogSessionController.php';
 require_once __DIR__ . '/Controller/PlayerSessionController.php';
 require_once __DIR__ . '/Controller/StripeCheckoutController.php';
 require_once __DIR__ . '/Controller/StripeSessionController.php';
@@ -378,6 +380,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = new OnboardingSessionController();
         return $controller->clear($request, $response);
     })->add(new CsrfMiddleware());
+    $app->post('/session/catalog', CatalogSessionController::class);
     $app->post('/session/player', PlayerSessionController::class);
     $app->get('/onboarding/tenants/{subdomain}', function (Request $request, Response $response, array $args) {
         if ($request->getAttribute('domainType') !== 'main') {


### PR DESCRIPTION
## Summary
- post selected catalog to `/session/catalog` and keep slug in session
- use session event/catalog if query params absent on home page
- make session cookies available across subdomains

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3ecba30c832b8bc50cdde682c95e