### PR TITLE
Sync player name with session and show notifications

### DIFF
--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -1,8 +1,16 @@
-/* global STORAGE_KEYS, getStored, setStored, clearStored */
+/* global STORAGE_KEYS, getStored, setStored, clearStored, UIkit */
 // Profile page logic for handling player names
 
 let nameInput;
 let eventUid;
+
+const notify = (msg, status = 'primary') => {
+  if (typeof UIkit !== 'undefined' && UIkit.notification) {
+    UIkit.notification({ message: msg, status });
+  } else {
+    alert(msg);
+  }
+};
 
 function generateRandomName() {
   const adjectives = [
@@ -37,6 +45,13 @@ function saveName(e) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ event_uid: eventUid, player_name: name, player_uid: uid })
   }).catch(() => {});
+  fetch('/session/player', {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+    headers: { 'Content-Type': 'application/json' }
+  })
+    .then(() => notify('Name gespeichert', 'success'))
+    .catch(() => notify('Fehler beim Speichern', 'danger'));
   if (typeof returnUrl !== 'undefined' && returnUrl) {
     window.location.href = returnUrl;
   }


### PR DESCRIPTION
## Summary
- Add UIkit-based notifications helper on profile page
- POST player name to `/session/player` when saving profile

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3fbd5e68832b972326368e97ffeb