### PR TITLE
Load storage script before app

### DIFF
--- a/templates/login.twig
+++ b/templates/login.twig
@@ -67,5 +67,6 @@
 
 {% block scripts %}
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure storage.js loads before app.js in login template so storage helpers are available

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb40adf378832b9afb3787a1372c83