### PR TITLE
feat(storage): scope puzzle and catalog data

### DIFF
--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -20,7 +20,20 @@
     TENANT_COLUMNS: 'tenantColumns'
   };
 
-  const eventScoped = new Set([STORAGE_KEYS.PLAYER_NAME, STORAGE_KEYS.PLAYER_UID]);
+  const eventScoped = new Set([
+    STORAGE_KEYS.PLAYER_NAME,
+    STORAGE_KEYS.PLAYER_UID,
+    STORAGE_KEYS.CATALOG,
+    STORAGE_KEYS.CATALOG_NAME,
+    STORAGE_KEYS.CATALOG_DESC,
+    STORAGE_KEYS.CATALOG_COMMENT,
+    STORAGE_KEYS.CATALOG_UID,
+    STORAGE_KEYS.CATALOG_SORT,
+    STORAGE_KEYS.LETTER,
+    STORAGE_KEYS.PUZZLE_SOLVED,
+    STORAGE_KEYS.PUZZLE_TIME,
+    STORAGE_KEYS.QUIZ_SOLVED
+  ]);
 
   function mapKey(key){
     const uid = (window.quizConfig || {}).event_uid || '';
@@ -42,11 +55,14 @@
     try{
       let val = readStorage(mapped);
       if(val === null && eventScoped.has(key)){
-        const legacy = `${key}:`;
-        val = readStorage(legacy);
-        if(val !== null){
-          setStored(key, val);
-          try{ removeStorage(legacy); }catch(e){ /* empty */ }
+        const legacies = [`${key}:`, key];
+        for(const legacy of legacies){
+          val = readStorage(legacy);
+          if(val !== null){
+            setStored(key, val);
+            try{ removeStorage(legacy); }catch(e){ /* empty */ }
+            break;
+          }
         }
       }
       return val;


### PR DESCRIPTION
## Summary
- scope puzzle progress, catalog info, and quiz results per event
- migrate legacy unscoped storage keys to new event-specific variants

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bb42621260832b90a688e9b76afd4e