### PR TITLE
Await player session fetch and handle failures

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -129,16 +129,32 @@ async function promptTeamName(){
     btn.textContent = 'Weiter';
     dialog.appendChild(input);
     dialog.appendChild(btn);
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', async () => {
       const name = (input.value || '').trim();
       if(name){
         setStored(STORAGE_KEYS.PLAYER_NAME, name);
-        fetch('/session/player', {
-          method: 'POST',
-          body: JSON.stringify({ name }),
-          headers: { 'Content-Type': 'application/json' }
-        });
-        ui.hide();
+        try {
+          const resp = await fetch('/session/player', {
+            method: 'POST',
+            body: JSON.stringify({ name }),
+            headers: { 'Content-Type': 'application/json' }
+          });
+          if(!resp.ok){
+            throw new Error('Request failed');
+          }
+          ui.hide();
+        } catch (e) {
+          if(typeof UIkit !== 'undefined' && UIkit.notification){
+            UIkit.notification({
+              message: 'Teamname konnte nicht gespeichert werden. Bitte erneut versuchen.',
+              status: 'danger',
+              pos: 'top-center',
+              timeout: 3000
+            });
+          } else {
+            alert('Teamname konnte nicht gespeichert werden. Bitte erneut versuchen.');
+          }
+        }
       }
     });
     input.addEventListener('keydown', ev => {


### PR DESCRIPTION
## Summary
- await quiz session player fetch request
- notify the user when saving the team name fails

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bb465ca4c0832b90228bf1b37d3b82