### PR TITLE
Handle session catalog fetch errors

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -189,11 +189,19 @@ async function handleSelection(opt, autostart = false) {
   const puzzleInfo = document.getElementById('puzzle-info');
   if (puzzleInfo) puzzleInfo.textContent = '';
 
-  fetch('/session/catalog', {
-    method: 'POST',
-    body: JSON.stringify({ slug: opt.value }),
-    headers: { 'Content-Type': 'application/json' }
-  });
+  try {
+    const resp = await fetch('/session/catalog', {
+      method: 'POST',
+      body: JSON.stringify({ slug: opt.value }),
+      headers: { 'Content-Type': 'application/json' }
+    });
+    if (!resp.ok) {
+      UIkit?.notification?.({ message: 'Session-Update fehlgeschlagen.', status: 'danger' });
+      console.error('session/catalog response not ok:', resp.status, resp.statusText);
+    }
+  } catch (e) {
+    console.error('session/catalog request failed', e);
+  }
 
   // Katalogdaten laden
   const file = opt.dataset.file;


### PR DESCRIPTION
## Summary
- await the `/session/catalog` fetch and handle failure with UIkit notification and console logging

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Errors: 31, Failures: 20)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4e249868832bad3e6edf91ae0180