### PR TITLE
Clear session cookie on logout

### DIFF
--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -19,6 +19,22 @@ class LogoutController
     {
         $_SESSION = [];
         session_destroy();
+
+        $domain = $request->getUri()->getHost();
+        $domain = getenv('MAIN_DOMAIN') ?: $domain;
+        $domain = $domain !== '' ? '.' . ltrim($domain, '.') : '';
+        $secure = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
+
+        setcookie(
+            session_name(),
+            '',
+            time() - 3600,
+            '/',
+            $domain,
+            $secure,
+            true
+        );
+
         return $response->withHeader('Location', '/login')->withStatus(302);
     }
 }


### PR DESCRIPTION
## Summary
- Remove lingering session cookie after logout by expiring it with domain and secure flags

## Testing
- `vendor/bin/phpcs src/Controller/LogoutController.php`
- `vendor/bin/phpunit tests/Controller/LogoutControllerTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET, and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4e95a7e0832b870dbfa198a29492