### PR TITLE
Add CSRF protection to session routes

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -206,7 +206,7 @@ async function handleSelection(opt, autostart = false) {
     const resp = await fetch('/session/catalog', {
       method: 'POST',
       body: JSON.stringify({ slug: opt.value }),
-      headers: { 'Content-Type': 'application/json' }
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.csrfToken }
     });
     if (!resp.ok) {
       UIkit?.notification?.({ message: 'Session-Update fehlgeschlagen.', status: 'danger' });

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -48,7 +48,7 @@ function saveName(e) {
   fetch('/session/player', {
     method: 'POST',
     body: JSON.stringify({ name }),
-    headers: { 'Content-Type': 'application/json' }
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.csrfToken }
   })
     .then(() => notify('Name gespeichert', 'success'))
     .catch(() => notify('Fehler beim Speichern', 'danger'));

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -137,7 +137,7 @@ async function promptTeamName(){
           const resp = await fetch('/session/player', {
             method: 'POST',
             body: JSON.stringify({ name }),
-            headers: { 'Content-Type': 'application/json' }
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.csrfToken }
           });
           if(!resp.ok){
             throw new Error('Request failed');

--- a/src/routes.php
+++ b/src/routes.php
@@ -380,8 +380,8 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = new OnboardingSessionController();
         return $controller->clear($request, $response);
     })->add(new CsrfMiddleware());
-    $app->post('/session/catalog', CatalogSessionController::class);
-    $app->post('/session/player', PlayerSessionController::class);
+    $app->post('/session/catalog', CatalogSessionController::class)->add(new CsrfMiddleware());
+    $app->post('/session/player', PlayerSessionController::class)->add(new CsrfMiddleware());
     $app->get('/onboarding/tenants/{subdomain}', function (Request $request, Response $response, array $args) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(404);


### PR DESCRIPTION
## Summary
- protect `/session/catalog` and `/session/player` routes with CSRF middleware
- include `X-CSRF-Token` header in catalog, profile and quiz fetch requests

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*
- `vendor/bin/phpcs src/routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb52dc66fc832ba56f398bd5680e17