### PR TITLE
Regenerate session ID on login

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -72,6 +72,10 @@ class LoginController
         }
 
         if ($valid) {
+            if (!session_regenerate_id(true)) {
+                error_log('Failed to regenerate session ID');
+            }
+
             $_SESSION['user'] = [
                 'id' => $record['id'],
                 'username' => $record['username'],


### PR DESCRIPTION
## Summary
- regenerate session ID when administrator logs in and log failures

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and related env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5c4ea4a4832ba73d820e1febfb73