### PR TITLE
refactor: centralize session post requests

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -203,16 +203,9 @@ async function handleSelection(opt, autostart = false) {
   if (puzzleInfo) puzzleInfo.textContent = '';
 
   try {
-    const resp = await fetch('/session/catalog', {
-      method: 'POST',
-      body: JSON.stringify({ slug: opt.value }),
-      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.csrfToken }
-    });
-    if (!resp.ok) {
-      UIkit?.notification?.({ message: 'Session-Update fehlgeschlagen.', status: 'danger' });
-      console.error('session/catalog response not ok:', resp.status, resp.statusText);
-    }
+    await postSession('catalog', { slug: opt.value });
   } catch (e) {
+    UIkit?.notification?.({ message: 'Session-Update fehlgeschlagen.', status: 'danger' });
     console.error('session/catalog request failed', e);
   }
 

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -45,11 +45,7 @@ function saveName(e) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ event_uid: eventUid, player_name: name, player_uid: uid })
   }).catch(() => {});
-  fetch('/session/player', {
-    method: 'POST',
-    body: JSON.stringify({ name }),
-    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.csrfToken }
-  })
+  postSession('player', { name })
     .then(() => notify('Name gespeichert', 'success'))
     .catch(() => notify('Fehler beim Speichern', 'danger'));
   if (typeof returnUrl !== 'undefined' && returnUrl) {

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -134,14 +134,7 @@ async function promptTeamName(){
       if(name){
         setStored(STORAGE_KEYS.PLAYER_NAME, name);
         try {
-          const resp = await fetch('/session/player', {
-            method: 'POST',
-            body: JSON.stringify({ name }),
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.csrfToken }
-          });
-          if(!resp.ok){
-            throw new Error('Request failed');
-          }
+          await postSession('player', { name });
           ui.hide();
         } catch (e) {
           if(typeof UIkit !== 'undefined' && UIkit.notification){

--- a/public/js/session.js
+++ b/public/js/session.js
@@ -1,0 +1,29 @@
+(function(){
+  function postSession(path, payload){
+    const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || window.csrfToken || '';
+    const headers = { 'Content-Type': 'application/json' };
+    if(token){
+      headers['X-CSRF-Token'] = token;
+    }
+    return fetch(`/session/${path}`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers,
+      body: JSON.stringify(payload || {})
+    }).then(async resp => {
+      if(!resp.ok){
+        const text = await resp.text();
+        throw new Error(text || 'Session request failed');
+      }
+      const ct = resp.headers.get('Content-Type') || '';
+      if(ct.includes('application/json')){
+        return resp.json();
+      }
+      return null;
+    }).catch(e => {
+      console.error(`session/${path} request failed`, e);
+      throw e;
+    });
+  }
+  globalThis.postSession = postSession;
+})();

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -72,6 +72,7 @@
     window.sessionPlayerName = {{ player_name|json_encode|raw }};
   </script>
   <script src="{{ basePath }}/js/storage.js"></script>
+  <script src="{{ basePath }}/js/session.js"></script>
   <script>
     function enforceProfile() {
       const cfg = window.quizConfig || {};

--- a/templates/profile.twig
+++ b/templates/profile.twig
@@ -41,6 +41,7 @@
   </script>
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/storage.js"></script>
+  <script src="{{ basePath }}/js/session.js"></script>
   <script src="{{ basePath }}/js/profile.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add postSession helper with CSRF support and error handling
- refactor quiz, profile and catalog scripts to use postSession
- include session helper script in relevant templates

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5c3fe4a0832b810db9b6e2c18f54