### PR TITLE
Fix undefined params in HomeController

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -33,6 +33,9 @@ class HomeController
         $eventSvc = new EventService($pdo, $cfgSvc);
         $settingsSvc = new SettingsService($pdo);
 
+        /** @var array<string, string> $params */
+        $params = $request->getQueryParams();
+
         $catalogParam = (string)($params['katalog'] ?? '');
         if ($catalogParam === '') {
             $catalogParam = (string)($_SESSION['catalog_slug'] ?? '');


### PR DESCRIPTION
## Summary
- ensure HomeController reads request query parameters before use

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `vendor/bin/phpcs -n -p --standard=PSR12 src/Controller/HomeController.php`
- `composer test` *(fails: Missing STRIPE environment variables, phpunit error 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6038362c832b974d26318228888a