### PR TITLE
Ensure session middleware runs before language to fix admin login loop

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -66,6 +66,9 @@ $app->add(TwigMiddleware::create($app, $twig));
 $app->add(new UrlMiddleware($twig));
 $app->add(new DomainMiddleware());
 $app->add(new ProxyMiddleware());
+
+(require __DIR__ . '/../src/routes.php')($app, $translator);
+
 $app->add(new SessionMiddleware());
 $errorMiddleware = new \App\Application\Middleware\ErrorMiddleware(
     $app->getCallableResolver(),
@@ -76,5 +79,4 @@ $errorMiddleware = new \App\Application\Middleware\ErrorMiddleware(
     $logger
 );
 $app->add($errorMiddleware);
-(require __DIR__ . '/../src/routes.php')($app, $translator);
 $app->run();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -72,10 +72,13 @@ class TestCase extends PHPUnit_TestCase
         $app->add(TwigMiddleware::create($app, $twig));
         $app->add(new UrlMiddleware($twig));
         $app->add(new \App\Application\Middleware\DomainMiddleware());
-        $app->add(new \App\Application\Middleware\LanguageMiddleware($translator));
         $app->add(new ProxyMiddleware());
-        $app->add(new SessionMiddleware());
 
+        // Register routes
+        $routes = require __DIR__ . '/../src/routes.php';
+        $routes($app, $translator);
+
+        $app->add(new SessionMiddleware());
         // Register error middleware
         $errorMiddleware = new \App\Application\Middleware\ErrorMiddleware(
             $app->getCallableResolver(),
@@ -85,10 +88,6 @@ class TestCase extends PHPUnit_TestCase
             false
         );
         $app->add($errorMiddleware);
-
-        // Register routes
-        $routes = require __DIR__ . '/../src/routes.php';
-        $routes($app, $translator);
 
         return $app;
     }


### PR DESCRIPTION
## Summary
- start session after registering routes so it precedes language middleware
- adjust test bootstrap to match middleware order

## Testing
- `vendor/bin/phpunit tests/Controller/AdminControllerTest.php --filter testRedirectWhenNotLoggedIn`
- `vendor/bin/phpunit` *(fails: Slim Application Error, missing Stripe configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bb60db84c0832b98e8662e5c81205c