### PR TITLE
chore: seed admin user

### DIFF
--- a/migrations/20250305_seed_admin_user.sql
+++ b/migrations/20250305_seed_admin_user.sql
@@ -1,0 +1,14 @@
+-- Ensure the default admin user exists
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+DO $$
+DECLARE
+    new_pass TEXT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM users WHERE username = 'admin') THEN
+        new_pass := encode(gen_random_bytes(16), 'hex');
+        INSERT INTO users (username, password, role, active)
+        VALUES ('admin', crypt(new_pass, gen_salt('bf')), 'admin', TRUE);
+        RAISE NOTICE 'Created admin user with password: %', new_pass;
+    END IF;
+END $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- seed default admin user with random password if missing

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET, Failed asserting that 303 matches expected 204, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bb708a38e0832bb4798b603835edf1