### PR TITLE
Skip session cookie domain for non-dotted hosts

### DIFF
--- a/src/Application/Middleware/SessionMiddleware.php
+++ b/src/Application/Middleware/SessionMiddleware.php
@@ -34,16 +34,21 @@ class SessionMiddleware implements Middleware
                 $domain = $host;
             }
 
-            if ($domain !== '') {
-                $secure = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
-                session_set_cookie_params([
-                    'domain' => '.' . ltrim($domain, '.'),
-                    'path' => '/',
-                    'secure' => $secure,
-                    'httponly' => true,
-                    'samesite' => 'Lax',
-                ]);
+            $secure = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
+            $params = [
+                'path' => '/',
+                'secure' => $secure,
+                'httponly' => true,
+                'samesite' => 'Lax',
+            ];
+            if (
+                $domain !== '' &&
+                str_contains($domain, '.') &&
+                filter_var($domain, FILTER_VALIDATE_IP) === false
+            ) {
+                $params['domain'] = '.' . ltrim($domain, '.');
             }
+            session_set_cookie_params($params);
 
             session_start();
         }

--- a/tests/SessionMiddlewareTest.php
+++ b/tests/SessionMiddlewareTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Application\Middleware\SessionMiddleware;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request as SlimRequest;
+use Slim\Psr7\Response;
+use Slim\Psr7\Uri;
+
+class SessionMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_unset();
+            session_destroy();
+        }
+        session_set_cookie_params(['domain' => '']);
+        unset($_ENV['MAIN_DOMAIN']);
+        putenv('MAIN_DOMAIN');
+    }
+
+    protected function tearDown(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_unset();
+            session_destroy();
+        }
+        session_set_cookie_params(['domain' => '']);
+        parent::tearDown();
+    }
+
+    private function createRequest(string $host): Request
+    {
+        $uri = new Uri('http', $host, 80, '/');
+        $headers = new Headers();
+        $stream = (new StreamFactory())->createStream();
+        return new SlimRequest('GET', $uri, $headers, [], [], $stream);
+    }
+
+    private function handle(Request $request): void
+    {
+        $handler = new class implements RequestHandlerInterface {
+            public function handle(Request $request): Response
+            {
+                return new Response();
+            }
+        };
+        $middleware = new SessionMiddleware();
+        $middleware->process($request, $handler);
+    }
+
+    public function testSkipsDomainForIpAddress(): void
+    {
+        $request = $this->createRequest('127.0.0.1');
+        $this->handle($request);
+        $params = session_get_cookie_params();
+        $this->assertSame('', $params['domain']);
+    }
+
+    public function testSkipsDomainForLocalhost(): void
+    {
+        $request = $this->createRequest('localhost');
+        $this->handle($request);
+        $params = session_get_cookie_params();
+        $this->assertSame('', $params['domain']);
+    }
+
+    public function testUsesHostDomainWhenEnvEmpty(): void
+    {
+        $request = $this->createRequest('example.com');
+        $this->handle($request);
+        $params = session_get_cookie_params();
+        $this->assertSame('.example.com', $params['domain']);
+    }
+}


### PR DESCRIPTION
## Summary
- Only set session cookie domain for dotted, non-IP hosts
- Cover cookie domain edge cases with unit tests

## Testing
- `./vendor/bin/phpunit tests/SessionMiddlewareTest.php`
- `composer test` *(fails: Missing STRIPE_* env vars, multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bb79c47be8832bb3cd32d84e79094a