### PR TITLE
Respect base path in auth redirects

### DIFF
--- a/src/Application/Middleware/AdminAuthMiddleware.php
+++ b/src/Application/Middleware/AdminAuthMiddleware.php
@@ -25,7 +25,10 @@ class AdminAuthMiddleware implements MiddlewareInterface
             $accept = $request->getHeaderLine('Accept');
             $xhr = $request->getHeaderLine('X-Requested-With');
             $path = $request->getUri()->getPath();
-            $isApi = str_starts_with($path, '/api/') || str_contains($accept, 'application/json') || $xhr === 'fetch';
+            $base = $request->getUri()->getBasePath();
+            $isApi = str_starts_with($path, $base . '/api/')
+                || str_contains($accept, 'application/json')
+                || $xhr === 'fetch';
 
             if ($isApi) {
                 $response = new SlimResponse(401);
@@ -35,7 +38,7 @@ class AdminAuthMiddleware implements MiddlewareInterface
             }
 
             $response = new SlimResponse();
-            return $response->withHeader('Location', '/login')->withStatus(302);
+            return $response->withHeader('Location', $base . '/login')->withStatus(302);
         }
 
         return $handler->handle($request);

--- a/src/Application/Middleware/LanguageMiddleware.php
+++ b/src/Application/Middleware/LanguageMiddleware.php
@@ -32,13 +32,15 @@ class LanguageMiddleware implements MiddlewareInterface
         $request = $request
             ->withAttribute('lang', $this->translator->getLocale())
             ->withAttribute('translator', $this->translator);
+        $path = $request->getUri()->getPath();
+        $base = $request->getUri()->getBasePath();
         if (
             $first &&
             empty($_SESSION['user']) &&
-            str_starts_with($request->getUri()->getPath(), '/admin/dashboard')
+            str_starts_with($path, $base . '/admin/dashboard')
         ) {
             return (new SlimResponse())
-                ->withHeader('Location', '/admin/dashboard')
+                ->withHeader('Location', $base . '/admin/dashboard')
                 ->withStatus(302);
         }
         return $handler->handle($request);

--- a/src/Application/Middleware/RoleAuthMiddleware.php
+++ b/src/Application/Middleware/RoleAuthMiddleware.php
@@ -35,7 +35,10 @@ class RoleAuthMiddleware implements MiddlewareInterface
             $accept = $request->getHeaderLine('Accept');
             $xhr = $request->getHeaderLine('X-Requested-With');
             $path = $request->getUri()->getPath();
-            $isApi = str_starts_with($path, '/api/') || str_contains($accept, 'application/json') || $xhr === 'fetch';
+            $base = $request->getUri()->getBasePath();
+            $isApi = str_starts_with($path, $base . '/api/')
+                || str_contains($accept, 'application/json')
+                || $xhr === 'fetch';
 
             if ($isApi) {
                 $response = new SlimResponse(401);
@@ -46,7 +49,7 @@ class RoleAuthMiddleware implements MiddlewareInterface
 
             $response = new SlimResponse();
 
-            return $response->withHeader('Location', '/login')->withStatus(302);
+            return $response->withHeader('Location', $base . '/login')->withStatus(302);
         }
 
         return $handler->handle($request);

--- a/src/Application/Security/AuthorizationMiddleware.php
+++ b/src/Application/Security/AuthorizationMiddleware.php
@@ -30,7 +30,8 @@ class AuthorizationMiddleware implements MiddlewareInterface
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== $this->requiredRole) {
             $response = new SlimResponse();
-            return $response->withHeader('Location', '/login')->withStatus(302);
+            $base = $request->getUri()->getBasePath();
+            return $response->withHeader('Location', $base . '/login')->withStatus(302);
         }
         return $handler->handle($request);
     }


### PR DESCRIPTION
## Summary
- use request base path for auth redirect in admin and role middleware
- consider base path in authorization and language middlewares
- handle API path detection with base path

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*
- `vendor/bin/phpcs src/Application/Middleware/AdminAuthMiddleware.php src/Application/Middleware/RoleAuthMiddleware.php src/Application/Security/AuthorizationMiddleware.php src/Application/Middleware/LanguageMiddleware.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb7c8d15ec832b98735a542f52ce5e