### PR TITLE
Fix base path retrieval in middleware

### DIFF
--- a/src/Application/Middleware/AdminAuthMiddleware.php
+++ b/src/Application/Middleware/AdminAuthMiddleware.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Slim\Psr7\Response as SlimResponse;
+use Slim\Routing\RouteContext;
 
 /**
  * Middleware ensuring the user has the administrator role.
@@ -25,7 +26,7 @@ class AdminAuthMiddleware implements MiddlewareInterface
             $accept = $request->getHeaderLine('Accept');
             $xhr = $request->getHeaderLine('X-Requested-With');
             $path = $request->getUri()->getPath();
-            $base = $request->getUri()->getBasePath();
+            $base = RouteContext::fromRequest($request)->getBasePath();
             $isApi = str_starts_with($path, $base . '/api/')
                 || str_contains($accept, 'application/json')
                 || $xhr === 'fetch';

--- a/src/Application/Middleware/LanguageMiddleware.php
+++ b/src/Application/Middleware/LanguageMiddleware.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Slim\Psr7\Response as SlimResponse;
+use Slim\Routing\RouteContext;
 
 class LanguageMiddleware implements MiddlewareInterface
 {
@@ -33,7 +34,7 @@ class LanguageMiddleware implements MiddlewareInterface
             ->withAttribute('lang', $this->translator->getLocale())
             ->withAttribute('translator', $this->translator);
         $path = $request->getUri()->getPath();
-        $base = $request->getUri()->getBasePath();
+        $base = RouteContext::fromRequest($request)->getBasePath();
         if (
             $first &&
             empty($_SESSION['user']) &&

--- a/src/Application/Middleware/RoleAuthMiddleware.php
+++ b/src/Application/Middleware/RoleAuthMiddleware.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Slim\Psr7\Response as SlimResponse;
+use Slim\Routing\RouteContext;
 
 /**
  * Middleware ensuring the user has one of the allowed roles.
@@ -35,7 +36,7 @@ class RoleAuthMiddleware implements MiddlewareInterface
             $accept = $request->getHeaderLine('Accept');
             $xhr = $request->getHeaderLine('X-Requested-With');
             $path = $request->getUri()->getPath();
-            $base = $request->getUri()->getBasePath();
+            $base = RouteContext::fromRequest($request)->getBasePath();
             $isApi = str_starts_with($path, $base . '/api/')
                 || str_contains($accept, 'application/json')
                 || $xhr === 'fetch';

--- a/src/Application/Security/AuthorizationMiddleware.php
+++ b/src/Application/Security/AuthorizationMiddleware.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Slim\Psr7\Response as SlimResponse;
+use Slim\Routing\RouteContext;
 
 /**
  * Middleware ensuring a user has a specific role.
@@ -30,7 +31,7 @@ class AuthorizationMiddleware implements MiddlewareInterface
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== $this->requiredRole) {
             $response = new SlimResponse();
-            $base = $request->getUri()->getBasePath();
+            $base = RouteContext::fromRequest($request)->getBasePath();
             return $response->withHeader('Location', $base . '/login')->withStatus(302);
         }
         return $handler->handle($request);


### PR DESCRIPTION
## Summary
- use `RouteContext` to determine base path instead of calling the missing `getBasePath()` on `Slim\Psr7\Uri`
- apply fix across authorization and language middleware

## Testing
- `composer test` *(fails: Slim Application Error)*
- `vendor/bin/phpcs src/Application/Middleware/LanguageMiddleware.php src/Application/Middleware/AdminAuthMiddleware.php src/Application/Middleware/RoleAuthMiddleware.php src/Application/Security/AuthorizationMiddleware.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb7f24c154832ba6f2250cf8e31b92