### PR TITLE
Remove duplicate catalog info from start screen

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1107,25 +1107,6 @@ async function runQuiz(questions, skipIntro){
     const stats = document.createElement('div');
     stats.className = 'uk-margin';
 
-    const title = getStored(STORAGE_KEYS.CATALOG_NAME) || '';
-    const desc = getStored(STORAGE_KEYS.CATALOG_DESC) || '';
-    const comment = getStored(STORAGE_KEYS.CATALOG_COMMENT);
-    if(title){
-      const h2 = document.createElement('h2');
-      h2.textContent = title;
-      div.appendChild(h2);
-    }
-    if(desc){
-      const p = document.createElement('p');
-      p.textContent = desc;
-      div.appendChild(p);
-    }
-    if(comment){
-      const c = document.createElement('div');
-      c.textContent = comment;
-      div.appendChild(c);
-    }
-
     if(cfg.QRUser && !getStored(STORAGE_KEYS.PLAYER_NAME)){
       const scanBtn = document.createElement('button');
       scanBtn.className = 'uk-button uk-button-primary uk-button-large';


### PR DESCRIPTION
## Summary
- Ensure start screen no longer repeats catalog title, description or comment
- Keep catalog metadata rendering centralized in the header

## Testing
- `npm run build` *(fails: Could not read package.json)*
- `node tests/test_catalog_smoke.js` *(fails: comment not rendered)*
- `node tests/test_catalog_autostart_path.js` *(passes)*
- `node tests/test_catalog_handle_selection.js` *(fails: UI warning triggered)*
- `node tests/test_catalog_slug_no_select.js` *(fails: sessionStorage quizCatalog not set)*
- `node tests/test_catalog_slug_param.js` *(fails: catalog comment missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf5cba73c832bb6a345bd5abc87b2