### PR TITLE
Handle undefined domainType in tenant loader

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2493,7 +2493,7 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   function loadTenants(status = tenantStatusFilter?.value || '', query = tenantSearchInput?.value || '') {
-    if (!tenantTableBody || window.domainType !== 'main') return;
+    if (!tenantTableBody || (typeof window.domainType !== 'undefined' && window.domainType !== 'main')) return;
     const params = new URLSearchParams();
     if (status) params.set('status', status);
     if (query) params.set('query', query);


### PR DESCRIPTION
## Summary
- Avoid premature return in tenant loader when `domainType` isn't set

## Testing
- `composer test` *(fails: Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf6ef99fc832bbbc295fae67e2238