### PR TITLE
Fix tenant search path mapping for main schema

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -153,7 +153,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $stmt = $base->prepare('SELECT subdomain FROM tenants WHERE subdomain = ?');
         $stmt->execute([$sub]);
         $schema = $stmt->fetchColumn();
-        $schema = $schema === false ? 'public' : (string) $schema;
+        $schema = $schema === false || $schema === 'main' ? 'public' : (string) $schema;
 
         $pdo = Database::connectWithSchema($schema);
         Migrator::migrate($pdo, __DIR__ . '/../migrations');


### PR DESCRIPTION
## Summary
- ensure main tenant uses public search path

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*
- `vendor/bin/phpcs src/routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc01ae5608832babd13e1be586fb04