### PR TITLE
Handle errors when changing active event

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1720,9 +1720,19 @@ document.addEventListener('DOMContentLoaded', function () {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ event_uid: uid })
-    }).then(() => {
-      window.location.reload();
-    }).catch(() => {});
+    })
+      .then(resp => {
+        if (!resp.ok) {
+          return resp.text().then(text => {
+            notify(text || 'Fehler beim Wechseln des Events', 'danger');
+          });
+        }
+        window.location.reload();
+      })
+      .catch(err => {
+        console.error(err);
+        notify('Fehler beim Wechseln des Events', 'danger');
+      });
   }
 
   if (eventsListEl) {
@@ -1892,7 +1902,7 @@ document.addEventListener('DOMContentLoaded', function () {
   eventSelect?.addEventListener('change', () => {
     const uid = eventSelect.value;
     const name = eventSelect.options[eventSelect.selectedIndex]?.textContent || '';
-    if (uid && uid !== activeEventUid) {
+    if (uid && uid !== activeEventUid && typeof setActiveEvent === 'function') {
       setActiveEvent(uid, name);
     }
   });


### PR DESCRIPTION
## Summary
- Add error handling for setting the active event to notify on failed requests
- Ensure the event selector only calls `setActiveEvent` if the function is available

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0b4d8434832b81ccc2c23267385a