### PR TITLE
Handle missing event parameter in public pages

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -72,7 +72,7 @@ function formatPuzzleTime(ts){
 
 async function fetchLatestPuzzleEntry(name, catalog){
   try{
-    const list = await fetch(withBase('/results.json')).then(r => r.json());
+    const list = await fetch(withBase(`/results.json${eventUid ? `?event=${encodeURIComponent(eventUid)}` : ''}`)).then(r => r.json());
     if(Array.isArray(list)){
       return list.slice().reverse().find(e => e.name === name && e.catalog === catalog && e.puzzleTime);
     }
@@ -348,7 +348,7 @@ async function runQuiz(questions, skipIntro){
     if(puzzleSolved && puzzleTs){
       data.puzzleTime = parseInt(puzzleTs, 10) || Math.floor(Date.now()/1000);
     }
-    fetch(withBase('/results'), {
+    fetch(withBase(`/results${eventUid ? `?event=${encodeURIComponent(eventUid)}` : ''}`), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
@@ -1368,7 +1368,7 @@ async function runQuiz(questions, skipIntro){
           const uid = getStored(STORAGE_KEYS.PLAYER_UID);
           if(uid) data.player_uid = uid;
         }
-        fetch(withBase('/results?debug=1'), {
+        fetch(withBase(`/results?debug=1${eventUid ? `&event=${encodeURIComponent(eventUid)}` : ''}`), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const pagination = document.getElementById('resultsPagination');
   const basePath = window.basePath || '';
   const withBase = path => basePath + path;
+  const eventUid = (window.quizConfig || {}).event_uid || '';
 
   const PAGE_SIZE = 10;
   let resultsData = [];
@@ -41,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function rotatePhotoImpl(path, img, link) {
     const cleanPath = path.replace(/\?.*$/, '');
-    return fetch(withBase('/photos/rotate'), {
+    return fetch(withBase(`/photos/rotate${eventUid ? `?event=${encodeURIComponent(eventUid)}` : ''}`), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ path: cleanPath })
@@ -388,8 +389,8 @@ document.addEventListener('DOMContentLoaded', () => {
   function load() {
     Promise.all([
       fetchCatalogMap(),
-      fetch(withBase('/results.json')).then(r => r.json()),
-      fetch(withBase('/question-results.json')).then(r => r.json())
+      fetch(withBase(`/results.json${eventUid ? `?event=${encodeURIComponent(eventUid)}` : ''}`)).then(r => r.json()),
+      fetch(withBase(`/question-results.json${eventUid ? `?event=${encodeURIComponent(eventUid)}` : ''}`)).then(r => r.json())
     ])
       .then(([catMap, rows, qrows]) => {
         rows.forEach(r => {

--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -30,7 +30,8 @@ document.addEventListener('DOMContentLoaded', () => {
   let catalogMap = null;
   function fetchCatalogMap() {
     if (catalogMap) return Promise.resolve(catalogMap);
-    return fetch(withBase('/kataloge/catalogs.json'), { headers: { 'Accept': 'application/json' } })
+    const catUrl = '/kataloge/catalogs.json' + (eventUid ? `?event=${encodeURIComponent(eventUid)}` : '');
+    return fetch(withBase(catUrl), { headers: { 'Accept': 'application/json' } })
       .then(r => r.json())
       .then(list => {
         const map = {};
@@ -59,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function fetchPuzzleTimeFromResults(name){
     try{
-      const list = await fetch(withBase('/results.json')).then(r => r.json());
+      const list = await fetch(withBase(`/results.json${eventUid ? `?event=${encodeURIComponent(eventUid)}` : ''}`)).then(r => r.json());
       if(Array.isArray(list)){
         for(let i=list.length-1; i>=0; i--){
           const e = list[i];
@@ -182,8 +183,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     Promise.all([
       fetchCatalogMap(),
-      fetch(withBase('/results.json')).then(r => r.json()),
-      fetch(withBase('/question-results.json')).then(r => r.json())
+      fetch(withBase(`/results.json${eventUid ? `?event=${encodeURIComponent(eventUid)}` : ''}`)).then(r => r.json()),
+      fetch(withBase(`/question-results.json${eventUid ? `?event=${encodeURIComponent(eventUid)}` : ''}`)).then(r => r.json())
     ])
       .then(([catMap, rows, qrows]) => {
         const filtered = rows.filter(row => row.name === user);
@@ -298,7 +299,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if(uid) data.player_uid = uid;
           }
           let debugTimer = null;
-          fetch(withBase('/results?debug=1'), {
+          fetch(withBase(`/results?debug=1${eventUid ? `&event=${encodeURIComponent(eventUid)}` : ''}`), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
@@ -457,7 +458,7 @@ document.addEventListener('DOMContentLoaded', () => {
       spinner.setAttribute('uk-spinner', '');
       btn.appendChild(spinner);
 
-      fetch(withBase('/photos'), { method: 'POST', body: fd })
+      fetch(withBase(`/photos${eventUid ? `?event=${encodeURIComponent(eventUid)}` : ''}`), { method: 'POST', body: fd })
         .then(async r => {
           if (!r.ok) {
             throw new Error(await r.text());

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -32,20 +32,23 @@ class HelpController
 
         $params = $request->getQueryParams();
         $uid = (string)($params['event'] ?? '');
-        if ($uid !== '') {
-            $cfg = $cfgSvc->getConfigForEvent($uid);
-            $event = $eventSvc->getByUid($uid) ?? $eventSvc->getFirst();
-        } else {
-            $cfg = $cfgSvc->getConfig();
-            $event = null;
-            $evUid = (string)($cfg['event_uid'] ?? '');
-            if ($evUid !== '') {
-                $event = $eventSvc->getByUid($evUid);
+        if ($uid === '') {
+            $event = $eventSvc->getFirst();
+            if ($event === null) {
+                return $response->withHeader('Location', '/events')->withStatus(302);
             }
+            $uid = (string)$event['uid'];
+        } else {
+            $event = $eventSvc->getByUid($uid);
             if ($event === null) {
                 $event = $eventSvc->getFirst();
+                if ($event === null) {
+                    return $response->withHeader('Location', '/events')->withStatus(302);
+                }
+                $uid = (string)$event['uid'];
             }
         }
+        $cfg = $cfgSvc->getConfigForEvent($uid);
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
             $cfg = ConfigService::removePuzzleInfo($cfg);

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -38,9 +38,9 @@ class TeamService
     /**
      * Retrieve the ordered list of teams.
      */
-    public function getAll(): array
+    public function getAll(string $eventUid = ''): array
     {
-        $uid = $this->config->getActiveEventUid();
+        $uid = $eventUid !== '' ? $eventUid : $this->config->getActiveEventUid();
         $sql = 'SELECT name FROM teams';
         $params = [];
         if ($uid !== '') {
@@ -56,9 +56,9 @@ class TeamService
     /**
      * Create a team with the given name if it does not exist yet.
      */
-    public function addIfMissing(string $name): void
+    public function addIfMissing(string $name, string $eventUid = ''): void
     {
-        $uid = $this->config->getActiveEventUid();
+        $uid = $eventUid !== '' ? $eventUid : $this->config->getActiveEventUid();
         $sql = 'SELECT uid FROM teams WHERE name=?';
         $params = [$name];
         if ($uid !== '') {
@@ -92,9 +92,9 @@ class TeamService
     /**
      * @param array<int, string> $teams
      */
-    public function saveAll(array $teams): void
+    public function saveAll(array $teams, string $eventUid = ''): void
     {
-        $uid = $this->config->getActiveEventUid();
+        $uid = $eventUid !== '' ? $eventUid : $this->config->getActiveEventUid();
 
         $teamCount = count($teams);
         if ($this->tenants !== null && $this->subdomain !== '') {

--- a/src/routes.php
+++ b/src/routes.php
@@ -168,12 +168,6 @@ return function (\Slim\App $app, TranslationService $translator) {
         $eventUid = $evParam !== '' && !preg_match('/^[0-9a-fA-F]{32}$/', $evParam)
             ? $eventService->uidBySlug($evParam) ?? ''
             : $evParam;
-        if ($eventUid === '') {
-            $eventUid = (string) ($_SESSION['event_uid'] ?? '');
-        }
-        if ($eventUid !== '') {
-            $_SESSION['event_uid'] = $eventUid;
-        }
         $catalogService = new CatalogService($pdo, $configService, $tenantService, $sub, $eventUid);
         $resultService = new ResultService($pdo, $configService);
         $teamService = new TeamService($pdo, $configService, $tenantService, $sub);

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -13,7 +13,7 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a href="{{ basePath }}/admin" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
+      <a href="{{ basePath }}/admin{{ event.uid is defined ? ('?event=' ~ event.uid) : '' }}" class="uk-icon-button" uk-icon="icon: arrow-left; ratio: 2" title="Zurück" aria-label="Zurück"></a>
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -31,13 +31,13 @@
   <div class="uk-container uk-container-small uk-text-center">
     <h2 class="uk-heading-bullet uk-margin-small-top">Herzlichen Glückwunsch, es wurden alle Kataloge gelöst!</h2>
     {% if config.teamResults is not defined or config.teamResults %}
-    <button id="show-results-btn" class="uk-button uk-button-primary uk-margin-top">Ergebnisse anzeigen</button>
+    <button id="show-results-btn" class="uk-button uk-button-primary uk-margin-top" data-event="{{ event.uid|default('') }}">Ergebnisse anzeigen</button>
     {% endif %}
     {% if config.photoUpload is not defined or config.photoUpload %}
-    <button id="upload-photo-btn" class="uk-button uk-button-primary uk-margin-top">Beweisfoto einreichen</button>
+    <button id="upload-photo-btn" class="uk-button uk-button-primary uk-margin-top" data-event="{{ event.uid|default('') }}">Beweisfoto einreichen</button>
     {% endif %}
     {% if config.puzzleWordEnabled %}
-    <button id="check-puzzle-btn" class="uk-button uk-button-primary uk-margin-top">Rätselwort prüfen</button>
+    <button id="check-puzzle-btn" class="uk-button uk-button-primary uk-margin-top" data-event="{{ event.uid|default('') }}">Rätselwort prüfen</button>
     <p id="puzzle-solved-text" class="uk-margin-top"></p>
     {% endif %}
   </div>


### PR DESCRIPTION
## Summary
- Remove backend-driven event fallback; event links now always resolve to the first available event or the one specified by query
- Pass explicit event identifiers through services and controllers so results and teams stay scoped per event
- Include event parameter in quiz result submissions to keep front-end actions event-aware

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0dbc1e14832b86ec410b3d2f1159