### PR TITLE
Include event UID in results submission

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -338,7 +338,7 @@ async function runQuiz(questions, skipIntro){
     }
       const catalog = getStored(STORAGE_KEYS.CATALOG) || 'unknown';
       const wrong = results.map((r,i)=> r ? null : i+1).filter(v=>v!==null);
-      const data = { name: user, catalog, correct: score, total: questionCount, wrong, answers };
+      const data = { name: user, catalog, correct: score, total: questionCount, wrong, answers, event_uid: eventUid };
       if(cfg.collectPlayerUid){
         const uid = getStored(STORAGE_KEYS.PLAYER_UID);
         if(uid) data.player_uid = uid;


### PR DESCRIPTION
## Summary
- send `event_uid` with quiz results so backend can associate submissions with the current event

## Testing
- `composer test` *(fails: Missing STRIPE env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bc253d0e60832b80c7d21596aa46a8