### PR TITLE
feat: show event name in admin headings

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -204,7 +204,8 @@
     </li>
     <li class="{{ activeRoute == 'event/settings' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
-        <h2 class="uk-heading-bullet">{{ t('heading_event_settings') }}</h2>
+        {% set eventName = event.name|default('') %}
+        <h2 class="uk-heading-bullet">{{ eventName|e }}{% if eventName %} – {% endif %}{{ t('heading_event_settings') }}</h2>
         <p class="uk-text-meta uk-margin-small">{{ 'Änderungen werden automatisch gespeichert.' }}</p>
         <form id="configForm" class="uk-form-stacked" method="post" action="/config.json">
           <div class="uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small" uk-grid>
@@ -403,7 +404,8 @@
     <li class="{{ activeRoute == 'catalogs' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
         <div>
-          <h2 class="uk-heading-bullet">{{ t('heading_catalogs') }}</h2>
+          {% set eventName = event.name|default('') %}
+          <h2 class="uk-heading-bullet">{{ eventName|e }}{% if eventName %} – {% endif %}{{ t('heading_catalogs') }}</h2>
           {% from 'components/table.twig' import qr_rowcards %}
           <div class="uk-overflow-auto uk-visible@m">
             <table class="uk-table uk-table-divider uk-table-small uk-table-hover uk-table-responsive">
@@ -437,7 +439,8 @@
     </li>
     <li class="{{ activeRoute == 'questions' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
-        <h2 class="uk-heading-bullet">{{ t('heading_questions') }}</h2>
+        {% set eventName = event.name|default('') %}
+        <h2 class="uk-heading-bullet">{{ eventName|e }}{% if eventName %} – {% endif %}{{ t('heading_questions') }}</h2>
         <div class="uk-margin">
           <label class="uk-form-label" for="catalogSelect">{{ t('label_catalog_select') }}
             <span class="uk-margin-small-left help-icon" uk-icon="icon: info" uk-tooltip="title: {{ t('tip_catalog_select') }}; pos: right" aria-label="{{ t('tip_catalog_select') }}" tabindex="0"></span>


### PR DESCRIPTION
## Summary
- include event name in event settings, catalog, and question headings

## Testing
- `composer test` *(fails: Script vendor/bin/phpunit handling the phpunit event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bc26f49334832b8952648030ab5693