### PR TITLE
Ensure admin uses selected event for results/teams

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -50,7 +50,8 @@ class AdminController
         $version = $versionSvc->getCurrentVersion();
 
         $params = $request->getQueryParams();
-        $uid = (string)($params['event'] ?? '');
+        $uid = (string) ($params['event'] ?? '');
+        $cfgSvc->setActiveEventUid($uid);
         if ($uid !== '') {
             $cfg = $cfgSvc->getConfigForEvent($uid);
             $event = $eventSvc->getByUid($uid) ?? $eventSvc->getFirst();


### PR DESCRIPTION
## Summary
- set active event UID from query parameters before loading results or teams

## Testing
- `php /tmp/test_event.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Stripe config)*


------
https://chatgpt.com/codex/tasks/task_e_68bc2ad8b35c832ba679054164aef4db