### PR TITLE
Require explicit event for result and team queries

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -86,6 +86,7 @@ class AdminController
         $sub       = '';
 
         $configSvc = new ConfigService($pdo);
+        $configSvc->setActiveEventUid((string) ($event['uid'] ?? ''));
         if (in_array($section, ['results', 'catalogs', 'questions', 'summary'], true)) {
             $catalogSvc   = new CatalogService($pdo, $configSvc);
             $catalogsJson = $catalogSvc->read('catalogs.json');

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -50,11 +50,19 @@ class ResultController
         $this->events = $events;
     }
 
+    private function setEventFromRequest(Request $request): void
+    {
+        $params = $request->getQueryParams();
+        $uid = (string) ($params['event'] ?? '');
+        $this->config->setActiveEventUid($uid);
+    }
+
     /**
      * Return all stored results as JSON.
      */
     public function get(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $content = json_encode($this->service->getAll(), JSON_PRETTY_PRINT);
         $response->getBody()->write($content);
         return $response->withHeader('Content-Type', 'application/json');
@@ -65,6 +73,7 @@ class ResultController
      */
     public function getQuestions(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $content = json_encode($this->service->getQuestionResults(), JSON_PRETTY_PRINT);
         $response->getBody()->write($content);
         return $response->withHeader('Content-Type', 'application/json');
@@ -75,6 +84,7 @@ class ResultController
      */
     public function download(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $data = $this->service->getAll();
         $rows = array_map([$this, 'mapResultRow'], $data);
         array_unshift($rows, ['Name', 'Versuch', 'Katalog', 'Richtige', 'Gesamt', 'Zeit', 'Rätselwort', 'Beweisfoto']);
@@ -95,6 +105,7 @@ class ResultController
      */
     public function post(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $data = json_decode((string) $request->getBody(), true);
         $result = ['success' => false];
         if (is_array($data)) {

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -41,15 +41,12 @@ class TeamService
     public function getAll(): array
     {
         $uid = $this->config->getActiveEventUid();
-        $sql = 'SELECT name FROM teams';
-        $params = [];
-        if ($uid !== '') {
-            $sql .= ' WHERE event_uid=?';
-            $params[] = $uid;
+        if ($uid === '') {
+            return [];
         }
-        $sql .= ' ORDER BY sort_order';
+        $sql = 'SELECT name FROM teams WHERE event_uid=? ORDER BY sort_order';
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($params);
+        $stmt->execute([$uid]);
         return array_map(fn($r) => $r['name'], $stmt->fetchAll(PDO::FETCH_ASSOC));
     }
 

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -404,4 +404,36 @@ class ResultServiceTest extends TestCase
         $this->assertSame('/photo/img.jpg', $row['photo']);
         $this->assertSame('ev1', $row['event_uid']);
     }
+
+    public function testGetAllWithoutEventReturnsEmpty(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE results(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                catalog TEXT NOT NULL,
+                attempt INTEGER NOT NULL,
+                correct INTEGER NOT NULL,
+                total INTEGER NOT NULL,
+                time INTEGER NOT NULL,
+                puzzleTime INTEGER,
+                photo TEXT,
+                event_uid TEXT
+            );
+            SQL
+        );
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
+        );
+        $pdo->exec('CREATE TABLE config(event_uid TEXT);');
+        $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time,event_uid) VALUES('T','c',1,0,0,0,'e1')");
+        $cfg = new ConfigService($pdo);
+        $svc = new ResultService($pdo, $cfg);
+        $this->assertSame([], $svc->getAll());
+    }
 }

--- a/tests/Service/TeamServiceTest.php
+++ b/tests/Service/TeamServiceTest.php
@@ -106,4 +106,14 @@ class TeamServiceTest extends TestCase
         $this->expectExceptionMessage('max-teams-exceeded');
         $svc->saveAll(['A', 'B', 'C', 'D', 'E', 'F', 'G']);
     }
+
+    public function testGetAllWithoutEventReturnsEmpty(): void
+    {
+        $pdo = $this->createDatabase();
+        $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event1')");
+        $pdo->exec("INSERT INTO teams(uid,event_uid,sort_order,name) VALUES('t1','e1',1,'Team1')");
+        $cfg = new ConfigService($pdo);
+        $svc = new TeamService($pdo, $cfg);
+        $this->assertSame([], $svc->getAll());
+    }
 }


### PR DESCRIPTION
## Summary
- prevent cross-event data by returning empty result sets when no active event is selected for team or result queries
- require controllers to set active event UID from request before accessing results or teams
- add regression tests ensuring queries without event yield no data

## Testing
- `./vendor/bin/phpunit` *(fails: Tests: 307, Assertions: 647, Errors: 30, Failures: 18, Warnings: 5, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1)*


------
https://chatgpt.com/codex/tasks/task_e_68bc2b1ad5f8832b89aebcd05f43e083