### PR TITLE
Handle missing event UID without admin selection

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -291,22 +291,25 @@ class ResultController
 
         $params = $request->getQueryParams();
         $uid = (string)($params['event'] ?? '');
-        if ($uid !== '') {
-            $cfg = $this->config->getConfigForEvent($uid);
-            $event = $this->events->getByUid($uid) ?? $this->events->getFirst() ?? ['name' => '', 'description' => ''];
-        } else {
-            $cfg = $this->config->getConfig();
-            $evUid = $this->config->getActiveEventUid();
-            $event = null;
-            if ($evUid !== '') {
-                $event = $this->events->getByUid($evUid);
-            }
+        if ($uid === '') {
+            $event = $this->events->getFirst();
             if ($event === null) {
-                $event = $this->events->getFirst() ?? ['name' => '', 'description' => ''];
+                return $response->withHeader('Location', '/events')->withStatus(302);
+            }
+            $uid = (string)($event['uid'] ?? '');
+        } else {
+            $event = $this->events->getByUid($uid);
+            if ($event === null) {
+                $event = $this->events->getFirst();
+                if ($event === null) {
+                    return $response->withHeader('Location', '/events')->withStatus(302);
+                }
+                $uid = (string)($event['uid'] ?? '');
             }
         }
-        $title = (string)$event['name'];
-        $subtitle = (string)$event['description'];
+        $cfg = $this->config->getConfigForEvent($uid);
+        $title = (string)($event['name'] ?? '');
+        $subtitle = (string)($event['description'] ?? '');
         $logoPath = __DIR__ . '/../../data/' . ltrim((string)($cfg['logoPath'] ?? ''), '/');
 
         $pdf = new Pdf($title, $subtitle, $logoPath);

--- a/src/Controller/SummaryController.php
+++ b/src/Controller/SummaryController.php
@@ -38,16 +38,16 @@ class SummaryController
         if ($uid !== '') {
             $cfg = $this->config->getConfigForEvent($uid);
             $event = $this->events->getByUid($uid) ?? $this->events->getFirst();
-        } else {
-            $cfg = $this->config->getConfig();
-            $event = null;
-            $evUid = (string)($cfg['event_uid'] ?? '');
-            if ($evUid !== '') {
-                $event = $this->events->getByUid($evUid);
-            }
             if ($event === null) {
-                $event = $this->events->getFirst();
+                return $response->withHeader('Location', '/events')->withStatus(302);
             }
+        } else {
+            $event = $this->events->getFirst();
+            if ($event === null) {
+                return $response->withHeader('Location', '/events')->withStatus(302);
+            }
+            $uid = (string)($event['uid'] ?? '');
+            $cfg = $this->config->getConfigForEvent($uid);
         }
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {


### PR DESCRIPTION
## Summary
- Avoid using active event config when no event is specified by using the first available event instead
- Redirect to event list if no event exists
- Ensure results PDF uses config for a chosen event rather than the active admin selection

## Testing
- `vendor/bin/phpcs src/Controller/SummaryController.php src/Controller/ResultController.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2cb57188832ba43a9027e8e6fec6