### PR TITLE
Normalize admin route path

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -3120,8 +3120,8 @@ document.addEventListener('DOMContentLoaded', function () {
   // Page editors are handled in trumbowyg-pages.js
 
   loadBackups();
-  const path = window.location.pathname.replace(basePath + '/admin/', '');
-  const currentRoute = path === '' ? 'dashboard' : path.replace(/^\/?/, '');
+  const path = window.location.pathname.replace(basePath + '/admin', '');
+  const currentRoute = path.replace(/^\/|\/$/g, '') || 'dashboard';
   if (currentRoute === 'tenants') {
     syncTenants();
   }


### PR DESCRIPTION
## Summary
- Trim leading and trailing slashes from admin path before determining current route
- Ensure tenant synchronization runs when visiting `/admin/tenants/`

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2e342c64832ba6ef0b14c5a55b50