### PR TITLE
Scope results and teams to active events

### DIFF
--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -50,11 +50,20 @@ class ResultController
         $this->events = $events;
     }
 
+    private function setEventFromRequest(Request $request): void
+    {
+        $params = $request->getQueryParams();
+        if (isset($params['event_uid'])) {
+            $this->config->setActiveEventUid((string) $params['event_uid']);
+        }
+    }
+
     /**
      * Return all stored results as JSON.
      */
     public function get(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $content = json_encode($this->service->getAll(), JSON_PRETTY_PRINT);
         $response->getBody()->write($content);
         return $response->withHeader('Content-Type', 'application/json');
@@ -65,6 +74,7 @@ class ResultController
      */
     public function getQuestions(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $content = json_encode($this->service->getQuestionResults(), JSON_PRETTY_PRINT);
         $response->getBody()->write($content);
         return $response->withHeader('Content-Type', 'application/json');
@@ -75,6 +85,7 @@ class ResultController
      */
     public function download(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $data = $this->service->getAll();
         $rows = array_map([$this, 'mapResultRow'], $data);
         array_unshift($rows, ['Name', 'Versuch', 'Katalog', 'Richtige', 'Gesamt', 'Zeit', 'Rätselwort', 'Beweisfoto']);
@@ -95,6 +106,7 @@ class ResultController
      */
     public function post(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $data = json_decode((string) $request->getBody(), true);
         $result = ['success' => false];
         if (is_array($data)) {
@@ -144,6 +156,7 @@ class ResultController
      */
     public function page(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $view = Twig::fromRequest($request);
         $results = $this->service->getAll();
 
@@ -208,6 +221,7 @@ class ResultController
      */
     public function pdf(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $results = $this->service->getAll();
         $questionResults = $this->service->getQuestionResults();
         $allResults = $results;

--- a/src/Controller/TeamController.php
+++ b/src/Controller/TeamController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\TeamService;
+use App\Service\ConfigService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -14,13 +15,23 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 class TeamController
 {
     private TeamService $service;
+    private ConfigService $config;
 
     /**
      * Inject team service dependency.
      */
-    public function __construct(TeamService $service)
+    public function __construct(TeamService $service, ConfigService $config)
     {
         $this->service = $service;
+        $this->config = $config;
+    }
+
+    private function setEventFromRequest(Request $request): void
+    {
+        $params = $request->getQueryParams();
+        if (isset($params['event_uid'])) {
+            $this->config->setActiveEventUid((string) $params['event_uid']);
+        }
     }
 
     /**
@@ -28,6 +39,7 @@ class TeamController
      */
     public function get(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $data = $this->service->getAll();
         $response->getBody()->write(json_encode($data));
         return $response->withHeader('Content-Type', 'application/json');
@@ -38,6 +50,7 @@ class TeamController
      */
     public function post(Request $request, Response $response): Response
     {
+        $this->setEventFromRequest($request);
         $body = (string) $request->getBody();
         $data = json_decode($body, true);
         if (!is_array($data)) {

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -32,6 +32,9 @@ class ResultService
     public function getAll(): array
     {
         $event = $this->config->getActiveEventUid();
+        if ($event === '') {
+            return [];
+        }
         $sql = <<<'SQL'
             SELECT r.name, r.catalog, r.attempt, r.correct, r.total, r.time,
                 r.puzzleTime AS "puzzleTime", r.photo,
@@ -42,16 +45,11 @@ class ResultService
                 OR CAST(c.sort_order AS TEXT) = r.catalog
                 OR c.slug = r.catalog
             ) AND (c.event_uid = r.event_uid OR c.event_uid IS NULL)
-
+            WHERE r.event_uid=?
+            ORDER BY r.id
         SQL;
-        $params = [];
-        if ($event !== '') {
-            $sql .= 'WHERE r.event_uid=? ';
-            $params[] = $event;
-        }
-        $sql .= 'ORDER BY r.id';
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($params);
+        $stmt->execute([$event]);
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($rows as &$row) {
             foreach (["options","answers","terms","items"] as $k) {
@@ -71,6 +69,9 @@ class ResultService
     public function getQuestionResults(): array
     {
         $event = $this->config->getActiveEventUid();
+        if ($event === '') {
+            return [];
+        }
         $sql = <<<'SQL'
             SELECT qr.name, qr.catalog, qr.question_id, qr.attempt, qr.correct,
                 qr.answer_text, qr.photo, qr.consent,
@@ -83,16 +84,11 @@ class ResultService
                 OR CAST(c.sort_order AS TEXT) = qr.catalog
                 OR c.slug = qr.catalog
             ) AND (c.event_uid = qr.event_uid OR c.event_uid IS NULL)
-
+            WHERE qr.event_uid=?
+            ORDER BY qr.id
         SQL;
-        $params = [];
-        if ($event !== '') {
-            $sql .= 'WHERE qr.event_uid=? ';
-            $params[] = $event;
-        }
-        $sql .= 'ORDER BY qr.id';
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($params);
+        $stmt->execute([$event]);
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($rows as &$row) {
             foreach (["options", "answers", "terms", "items"] as $k) {
@@ -114,16 +110,13 @@ class ResultService
     public function getQuestionRows(): array
     {
         $uid = $this->config->getActiveEventUid();
-        $sql = 'SELECT name,catalog,question_id,attempt,correct,answer_text,photo,consent'
-            . ',event_uid FROM question_results';
-        $params = [];
-        if ($uid !== '') {
-            $sql .= ' WHERE event_uid=?';
-            $params[] = $uid;
+        if ($uid === '') {
+            return [];
         }
-        $sql .= ' ORDER BY id';
+        $sql = 'SELECT name,catalog,question_id,attempt,correct,answer_text,photo,consent,event_uid '
+            . 'FROM question_results WHERE event_uid=? ORDER BY id';
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($params);
+        $stmt->execute([$uid]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -41,15 +41,12 @@ class TeamService
     public function getAll(): array
     {
         $uid = $this->config->getActiveEventUid();
-        $sql = 'SELECT name FROM teams';
-        $params = [];
-        if ($uid !== '') {
-            $sql .= ' WHERE event_uid=?';
-            $params[] = $uid;
+        if ($uid === '') {
+            return [];
         }
-        $sql .= ' ORDER BY sort_order';
+        $sql = 'SELECT name FROM teams WHERE event_uid=? ORDER BY sort_order';
         $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($params);
+        $stmt->execute([$uid]);
         return array_map(fn($r) => $r['name'], $stmt->fetchAll(PDO::FETCH_ASSOC));
     }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -206,7 +206,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 __DIR__ . '/../data/photos',
                 $eventService
             ))
-            ->withAttribute('teamController', new TeamController($teamService))
+            ->withAttribute('teamController', new TeamController($teamService, $configService))
             ->withAttribute('eventController', new EventController($eventService))
             ->withAttribute('eventConfigController', new EventConfigController($eventService, $configService))
             ->withAttribute(

--- a/tests/Controller/TeamControllerTest.php
+++ b/tests/Controller/TeamControllerTest.php
@@ -24,7 +24,7 @@ class TeamControllerTest extends TestCase
         $cfg->setActiveEventUid('e1');
         $tenantSvc = new TenantService($pdo);
         $service = new TeamService($pdo, $cfg, $tenantSvc, 'sub1');
-        $controller = new TeamController($service);
+        $controller = new TeamController($service, $cfg);
 
         $callableResolver = new \Slim\CallableResolver();
         $responseFactory = new \Slim\Psr7\Factory\ResponseFactory();

--- a/tests/Service/TeamServiceTest.php
+++ b/tests/Service/TeamServiceTest.php
@@ -44,6 +44,19 @@ class TeamServiceTest extends TestCase
         $this->assertNull($row['event_uid']);
     }
 
+    public function testGetAllWithoutActiveEventReturnsEmpty(): void
+    {
+        $pdo = $this->createDatabase();
+        $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event1')");
+        $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e2','e2','Event2')");
+        $pdo->exec("INSERT INTO teams(uid,event_uid,sort_order,name) VALUES('t1','e1',1,'T1')");
+        $pdo->exec("INSERT INTO teams(uid,event_uid,sort_order,name) VALUES('t2','e2',2,'T2')");
+        $cfg = new ConfigService($pdo);
+        $cfg->setActiveEventUid('');
+        $svc = new TeamService($pdo, $cfg);
+        $this->assertSame([], $svc->getAll());
+    }
+
     public function testSaveAllRespectsTeamLimit(): void
     {
         $pdo = $this->createDatabase();


### PR DESCRIPTION
## Summary
- Require an active event for team listing and result queries
- Let controllers set the active event from incoming requests
- Cover missing event context with regression tests

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d925738832b9e20aa13516fdaa2