### PR TITLE
Load storage before admin app

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1205,6 +1205,7 @@
   <script src="{{ basePath }}/js/dashboard.js"></script>
   <script type="module" src="{{ basePath }}/js/admin.js"></script>
   <script src="{{ basePath }}/js/subscription.js"></script>
+  <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/results.js"></script>
   <script src="{{ basePath }}/js/stats.js"></script>


### PR DESCRIPTION
## Summary
- load storage.js before app.js in admin template so toggle logic can access stored data

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bc45ee38f4832b9b5e2fab1f080506