### PR TITLE
Redirect event selection via query string

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -136,9 +136,7 @@ document.addEventListener('DOMContentLoaded', () => {
   eventSelect?.addEventListener('change', () => {
     const uid = eventSelect.value;
     if (uid && uid !== activeEventUid) {
-      const url = new URL(window.location.href);
-      url.searchParams.set('event', uid);
-      window.location.href = url.toString();
+      location.search = '?event=' + uid;
     }
   });
 


### PR DESCRIPTION
## Summary
- Simplify event dropdown change handling to redirect with `location.search` instead of rebuilding URLs

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4be8eb28832bb51dabd63a747dbd