### PR TITLE
refactor: rename active event uid variable

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const eventSelect = document.getElementById('eventSelect');
   const eventOpenBtn = document.getElementById('eventOpenBtn');
   const eventTitle = document.getElementById('eventTitle');
-  let activeEventUid = '';
+  let currentEventUid = '';
   const params = new URLSearchParams(window.location.search);
   const pageEventUid = params.get('event') || '';
 
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const opt = document.createElement('option');
       opt.value = ev.uid;
       opt.textContent = ev.name;
-      if (ev.uid === activeEventUid) opt.selected = true;
+      if (ev.uid === currentEventUid) opt.selected = true;
       eventSelect.appendChild(opt);
     });
     if (selectWrap) selectWrap.hidden = false;
@@ -116,9 +116,9 @@ document.addEventListener('DOMContentLoaded', () => {
       .then((r) => r.json())
       .catch(() => [])
       .then((events) => {
-        activeEventUid = pageEventUid || (events[0]?.uid || '');
-        const cfgPromise = activeEventUid
-          ? csrfFetch(`/events/${encodeURIComponent(activeEventUid)}/config.json`).then((r) => r.json()).catch(() => ({}))
+        currentEventUid = pageEventUid || (events[0]?.uid || '');
+        const cfgPromise = currentEventUid
+          ? csrfFetch(`/events/${encodeURIComponent(currentEventUid)}/config.json`).then((r) => r.json()).catch(() => ({}))
           : Promise.resolve({});
         cfgPromise
           .then((cfg) => {
@@ -135,7 +135,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   eventSelect?.addEventListener('change', () => {
     const uid = eventSelect.value;
-    if (uid && uid !== activeEventUid) {
+    if (uid && uid !== currentEventUid) {
       location.search = '?event=' + uid;
     }
   });

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -2,7 +2,7 @@
 // Profile page logic for handling player names
 
 let nameInput;
-let eventUid;
+let currentEventUid;
 
 const notify = (msg, status = 'primary') => {
   if (typeof UIkit !== 'undefined' && UIkit.notification) {
@@ -43,7 +43,7 @@ function saveName(e) {
   fetch('/api/players', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ event_uid: eventUid, player_name: name, player_uid: uid })
+    body: JSON.stringify({ event_uid: currentEventUid, player_name: name, player_uid: uid })
   }).catch(() => {});
   postSession('player', { name })
     .then(() => notify('Name gespeichert', 'success'))
@@ -63,7 +63,7 @@ function deleteName(e) {
 document.addEventListener('DOMContentLoaded', () => {
   nameInput = document.getElementById('playerName');
   const cfg = window.quizConfig || {};
-  eventUid = cfg.event_uid || '';
+  currentEventUid = cfg.event_uid || '';
   const params = new URLSearchParams(location.search);
   const uidParam = params.get('uid') || params.get('player_uid');
   if (uidParam) {
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const storedName = getStored(STORAGE_KEYS.PLAYER_NAME);
   nameInput.value = storedName || generateRandomName();
   if (!storedName && uidParam && cfg.collectPlayerUid) {
-    fetch(`/api/players?event_uid=${encodeURIComponent(eventUid)}&player_uid=${encodeURIComponent(uidParam)}`)
+    fetch(`/api/players?event_uid=${encodeURIComponent(currentEventUid)}&player_uid=${encodeURIComponent(uidParam)}`)
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (data && data.player_name) {

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -59,7 +59,7 @@
   };
 })();
 
-const eventUid = (window.quizConfig || {}).event_uid || '';
+const currentEventUid = (window.quizConfig || {}).event_uid || '';
 
 const basePath = window.basePath || '';
 const withBase = path => basePath + path;
@@ -338,7 +338,7 @@ async function runQuiz(questions, skipIntro){
     }
       const catalog = getStored(STORAGE_KEYS.CATALOG) || 'unknown';
       const wrong = results.map((r,i)=> r ? null : i+1).filter(v=>v!==null);
-      const data = { name: user, catalog, correct: score, total: questionCount, wrong, answers, event_uid: eventUid };
+      const data = { name: user, catalog, correct: score, total: questionCount, wrong, answers, event_uid: currentEventUid };
       if(cfg.collectPlayerUid){
         const uid = getStored(STORAGE_KEYS.PLAYER_UID);
         if(uid) data.player_uid = uid;

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -36,8 +36,8 @@
   ]);
 
   function mapKey(key){
-    const uid = (window.quizConfig || {}).event_uid || '';
-    return eventScoped.has(key) ? `${key}:${uid}` : key;
+    const currentEventUid = (window.quizConfig || {}).event_uid || '';
+    return eventScoped.has(key) ? `${key}:${currentEventUid}` : key;
   }
 
   function readStorage(key){
@@ -88,8 +88,8 @@
 
   /*
    * Standardized storage keys:
-   * - qr_player_name:<eventUid>  – Spielername
-   * - qr_player_uid:<eventUid>   – Spieler-UID
+   * - qr_player_name:<currentEventUid>  – Spielername
+   * - qr_player_uid:<currentEventUid>   – Spieler-UID
    * - quizCatalog                – Aktueller Katalog-Slug
    * - quizCatalogName            – Katalognamen
    * - quizCatalogDesc            – Katalogbeschreibung


### PR DESCRIPTION
## Summary
- rename activeEventUid to currentEventUid across quiz scripts
- update related comments to use currentEventUid

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4d5a37dc832bb486eade5e7f9079