### PR TITLE
Skip config fallback when no active event

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -56,15 +56,8 @@ class AdminController
             $cfg = $cfgSvc->getConfigForEvent($uid);
             $event = $eventSvc->getByUid($uid) ?? $eventSvc->getFirst();
         } else {
-            $cfg = $cfgSvc->getConfig();
+            $cfg = [];
             $event = null;
-            $evUid = (string)($cfg['event_uid'] ?? '');
-            if ($evUid !== '') {
-                $event = $eventSvc->getByUid($evUid);
-            }
-            if ($event === null) {
-                $event = $eventSvc->getFirst();
-            }
         }
         $context = \Slim\Routing\RouteContext::fromRequest($request);
         $route   = $context->getRoute();

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -103,16 +103,13 @@ class ConfigService
     public function getConfig(): array
     {
         $uid = $this->getActiveEventUid();
-        $row = null;
-        if ($uid !== '') {
-            $stmt = $this->pdo->prepare('SELECT * FROM config WHERE event_uid = ? LIMIT 1');
-            $stmt->execute([$uid]);
-            $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+        if ($uid === '') {
+            return [];
         }
-        if ($row === null) {
-            $stmt = $this->pdo->query('SELECT * FROM config LIMIT 1');
-            $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
-        }
+
+        $stmt = $this->pdo->prepare('SELECT * FROM config WHERE event_uid = ? LIMIT 1');
+        $stmt->execute([$uid]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
         if ($row !== null) {
             return $this->normalizeKeys($row);
         }
@@ -324,10 +321,10 @@ class ConfigService
         $stmt = $this->pdo->query('SELECT event_uid FROM active_event LIMIT 1');
         $uid = $stmt->fetchColumn();
         if ($uid === false || $uid === null || $uid === '') {
-            $stmt = $this->pdo->query('SELECT event_uid FROM config LIMIT 1');
-            $uid = $stmt->fetchColumn();
+            $this->activeEvent = '';
+            return $this->activeEvent;
         }
-        $this->activeEvent = $uid !== false && $uid !== null ? (string)$uid : '';
+        $this->activeEvent = (string) $uid;
         return $this->activeEvent;
     }
 

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -33,7 +33,7 @@ class ConfigControllerTest extends TestCase
         $_SESSION['user'] = ['id' => 1, 'role' => 'event-manager'];
 
         $request = $this->createRequest('POST', '/config.json');
-        $request = $request->withParsedBody(['pageTitle' => 'Demo']);
+        $request = $request->withParsedBody(['event_uid' => 'ev1', 'pageTitle' => 'Demo']);
         $postResponse = $controller->post($request, new Response());
         $this->assertEquals(204, $postResponse->getStatusCode());
 
@@ -74,7 +74,11 @@ class ConfigControllerTest extends TestCase
         $_SESSION['user'] = ['id' => 1, 'role' => 'event-manager'];
 
         $request = $this->createRequest('POST', '/config.json');
-        $request = $request->withParsedBody(['pageTitle' => 'Demo', 'backgroundColor' => 'blue']);
+        $request = $request->withParsedBody([
+            'event_uid' => 'ev1',
+            'pageTitle' => 'Demo',
+            'backgroundColor' => 'blue',
+        ]);
         $response = $controller->post($request, new Response());
         $this->assertEquals(400, $response->getStatusCode());
         session_destroy();

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -40,7 +40,7 @@ class ConfigServiceTest extends TestCase
             SQL
         );
         $service = new ConfigService($pdo);
-        $data = ['pageTitle' => 'Demo', 'QRUser' => false, 'QRRemember' => true];
+        $data = ['event_uid' => 'ev1', 'pageTitle' => 'Demo', 'QRUser' => false, 'QRRemember' => true];
 
         $service->saveConfig($data);
         $json = $service->getJson();
@@ -49,6 +49,24 @@ class ConfigServiceTest extends TestCase
         $this->assertSame('Demo', $cfg['pageTitle']);
         $this->assertFalse($cfg['QRUser']);
         $this->assertTrue($cfg['QRRemember']);
+    }
+
+    public function testGetConfigReturnsEmptyWithoutActiveEvent(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            <<<'SQL'
+            CREATE TABLE config(
+                pageTitle TEXT,
+                event_uid TEXT
+            );
+            SQL
+        );
+        $service = new ConfigService($pdo);
+        $pdo->exec("INSERT INTO config(pageTitle,event_uid) VALUES('Demo','ev1')");
+
+        $this->assertSame([], $service->getConfig());
     }
 
     public function testGetJsonReturnsNullIfEmpty(): void


### PR DESCRIPTION
## Summary
- Stop `ConfigService` from querying global config when no active event is set and return an empty config instead
- Simplify `AdminController` to bypass config/event lookup when no event UID is provided
- Adjust and extend tests for the new configuration behaviour

## Testing
- `vendor/bin/phpunit` *(fails: 29 errors, 31 failures)*
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other env vars)*
- `node tests/test_competition_mode.js` *(fails: buildSolvedSet not found)*
- `python3 tests/test_json_validity.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc56bdb0f8832bb181ca4fd124e763