### PR TITLE
Avoid default event selection

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -99,6 +99,10 @@ document.addEventListener('DOMContentLoaded', () => {
       if (eventTitle) eventTitle.hidden = false;
       return;
     }
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = eventSelect.dataset.placeholder || '';
+    eventSelect.appendChild(placeholder);
     list.forEach((ev) => {
       const opt = document.createElement('option');
       opt.value = ev.uid;
@@ -108,7 +112,11 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     if (selectWrap) selectWrap.hidden = false;
     if (eventTitle) eventTitle.hidden = true;
-    eventSelect.dispatchEvent(new Event('change'));
+    if (currentEventUid) {
+      eventSelect.dispatchEvent(new Event('change'));
+    } else {
+      eventSelect.value = '';
+    }
   }
 
   if (eventSelect) {
@@ -116,13 +124,13 @@ document.addEventListener('DOMContentLoaded', () => {
       .then((r) => r.json())
       .catch(() => [])
       .then((events) => {
-        currentEventUid = pageEventUid || (events[0]?.uid || '');
+        currentEventUid = pageEventUid;
         const cfgPromise = currentEventUid
           ? csrfFetch(`/events/${encodeURIComponent(currentEventUid)}/config.json`).then((r) => r.json()).catch(() => ({}))
           : Promise.resolve({});
         cfgPromise
           .then((cfg) => {
-            window.quizConfig = cfg;
+            window.quizConfig = currentEventUid ? cfg : {};
             populate(events);
           })
           .catch(() => {


### PR DESCRIPTION
## Summary
- Prevent default event selection on public events page and load config only when an event UID is provided.
- Initialize admin event context solely from URL and disable event-specific UI when no events are available.

## Testing
- `composer test` *(fails: Missing Stripe environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ad95018832b9f87c9c25c6c54a8