### PR TITLE
Handle missing event UID in selectors

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1644,6 +1644,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const eventSelect = document.getElementById('eventSelect');
   const eventSelectWrap = document.getElementById('eventSelectWrap');
   const eventOpenBtn = document.getElementById('eventOpenBtn');
+  const eventDependentSections = document.querySelectorAll('[data-event-dependent]');
   const langSelect = document.getElementById('langSelect');
   const EVENTS_PER_PAGE = 50;
   const eventPaginationEl = document.createElement('ul');
@@ -1695,8 +1696,10 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!Array.isArray(list) || list.length === 0) {
       currentEventUid = '';
       cfgInitial.event_uid = '';
+      window.quizConfig = {};
       if (eventSelectWrap) eventSelectWrap.hidden = true;
       if (eventOpenBtn) eventOpenBtn.disabled = true;
+      eventDependentSections.forEach(sec => { sec.hidden = true; });
       return;
     }
     const placeholder = document.createElement('option');
@@ -1712,11 +1715,18 @@ document.addEventListener('DOMContentLoaded', function () {
       }
       eventSelect.appendChild(opt);
     });
+    const hasCurrent = list.some(ev => ev.uid === currentEventUid);
+    if (!hasCurrent) {
+      currentEventUid = '';
+      cfgInitial.event_uid = '';
+      window.quizConfig = {};
+    }
     if (currentEventUid) {
       eventSelect.value = currentEventUid;
     } else {
       eventSelect.value = '';
     }
+    eventDependentSections.forEach(sec => { sec.hidden = !currentEventUid; });
     if (eventSelectWrap) eventSelectWrap.hidden = false;
     if (eventOpenBtn) eventOpenBtn.disabled = !currentEventUid;
     updateEventSelectDisplay();
@@ -2825,7 +2835,9 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!events.some(e => e.uid === currentEventUid)) {
         currentEventUid = '';
         cfgInitial.event_uid = '';
+        window.quizConfig = {};
       }
+      eventDependentSections.forEach(sec => { sec.hidden = !currentEventUid; });
       const ev = events.find(e => e.uid === currentEventUid) || {};
       nameEl.textContent = ev.name || '';
       if (descEl) descEl.textContent = ev.description || '';

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -95,6 +95,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!eventSelect) return;
     eventSelect.innerHTML = '';
     if (!Array.isArray(list) || list.length === 0) {
+      currentEventUid = '';
+      window.quizConfig = {};
       if (selectWrap) selectWrap.hidden = true;
       if (eventTitle) eventTitle.hidden = false;
       return;
@@ -110,9 +112,15 @@ document.addEventListener('DOMContentLoaded', () => {
       if (ev.uid === currentEventUid) opt.selected = true;
       eventSelect.appendChild(opt);
     });
+    const hasCurrent = list.some((ev) => ev.uid === currentEventUid);
+    if (!hasCurrent) {
+      currentEventUid = '';
+      window.quizConfig = {};
+    }
     if (selectWrap) selectWrap.hidden = false;
     if (eventTitle) eventTitle.hidden = true;
     if (currentEventUid) {
+      eventSelect.value = currentEventUid;
       eventSelect.dispatchEvent(new Event('change'));
     } else {
       eventSelect.value = '';


### PR DESCRIPTION
## Summary
- Show event select only when events exist, keep quiz config empty if no valid UID
- On admin pages, clear invalid event UID, reset config, and hide event-dependent sections

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68bcac428b04832bbff345d7fb464451