### PR TITLE
refactor: remove config fallback for empty event

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -50,14 +50,14 @@ class AdminController
         $version = $versionSvc->getCurrentVersion();
 
         $params = $request->getQueryParams();
-        $uid = (string) ($params['event'] ?? '');
-        $cfgSvc->setActiveEventUid($uid);
-        if ($uid !== '') {
-            $cfg = $cfgSvc->getConfigForEvent($uid);
-            $event = $eventSvc->getByUid($uid) ?? $eventSvc->getFirst();
-        } else {
-            $cfg = [];
+        $uid    = (string) ($params['event'] ?? '');
+        if ($uid === '') {
+            $cfg   = [];
             $event = null;
+        } else {
+            $cfgSvc->setActiveEventUid($uid);
+            $cfg   = $cfgSvc->getConfigForEvent($uid);
+            $event = $eventSvc->getByUid($uid);
         }
         $context = \Slim\Routing\RouteContext::fromRequest($request);
         $route   = $context->getRoute();

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -109,12 +109,11 @@ class ConfigService
 
         $stmt = $this->pdo->prepare('SELECT * FROM config WHERE event_uid = ? LIMIT 1');
         $stmt->execute([$uid]);
-        $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
-        if ($row !== null) {
-            return $this->normalizeKeys($row);
-        }
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        return [];
+        return $row !== false && $row !== null
+            ? $this->normalizeKeys($row)
+            : [];
     }
 
     /**
@@ -318,14 +317,15 @@ class ConfigService
         if ($this->activeEvent !== null) {
             return $this->activeEvent;
         }
+
         $stmt = $this->pdo->query('SELECT event_uid FROM active_event LIMIT 1');
         $uid = $stmt->fetchColumn();
+
         if ($uid === false || $uid === null || $uid === '') {
-            $this->activeEvent = '';
-            return $this->activeEvent;
+            return $this->activeEvent = '';
         }
-        $this->activeEvent = (string) $uid;
-        return $this->activeEvent;
+
+        return $this->activeEvent = (string) $uid;
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid fetching config when no active event is set
- prevent admin dashboard from loading config and event when event UID missing

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY...)*

------
https://chatgpt.com/codex/tasks/task_e_68bcac8c4eb0832bb1a6d0d5a60e8c5e