### PR TITLE
Show placeholder when no event is selected

### DIFF
--- a/public/js/results.js
+++ b/public/js/results.js
@@ -385,7 +385,39 @@ document.addEventListener('DOMContentLoaded', () => {
       });
   }
 
+  function renderNoEvent() {
+    if (grid) {
+      grid.innerHTML = '<p>Kein Event ausgewählt</p>';
+    }
+    if (tbody) {
+      tbody.innerHTML = '';
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = 7;
+      td.textContent = 'Kein Event ausgewählt';
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+    }
+    if (wrongBody) {
+      wrongBody.innerHTML = '';
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = 3;
+      td.textContent = 'Kein Event ausgewählt';
+      tr.appendChild(td);
+      wrongBody.appendChild(tr);
+    }
+    if (pagination) {
+      pagination.textContent = '';
+    }
+  }
+
   function load() {
+    const currentEventUid = (window.quizConfig || {}).event_uid || '';
+    if (!currentEventUid) {
+      renderNoEvent();
+      return;
+    }
     Promise.all([
       fetchCatalogMap(),
       fetch(withBase('/results.json')).then(r => r.json()),

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -124,6 +124,21 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  function renderNoEvent() {
+    if (tbody) {
+      tbody.innerHTML = '';
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = 7;
+      td.textContent = 'Kein Event ausgewählt';
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+    }
+    if (filter) {
+      filter.innerHTML = '<option value="">Alle</option>';
+    }
+  }
+
   function updateFilterOptions() {
     if (!filter) return;
     const names = Array.from(new Set(data.map(r => r.name))).sort();
@@ -143,6 +158,12 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function load() {
+    const currentEventUid = (window.quizConfig || {}).event_uid || '';
+    if (!currentEventUid) {
+      data = [];
+      renderNoEvent();
+      return;
+    }
     Promise.all([
       fetchCatalogMap(),
       fetch(withBase('/question-results.json')).then(r => r.json())


### PR DESCRIPTION
## Summary
- Skip results and stats fetches when no event UID is configured
- Render clear "Kein Event ausgewählt" placeholders for missing event context

## Testing
- `node tests/test_results_rankings.js`
- `./vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68bcac43e970832b928d5ffcabf62c46