### PR TITLE
Handle redirects with base path

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -11,6 +11,7 @@ use App\Service\VersionService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
+use Slim\Routing\RouteContext;
 use PDO;
 
 /**
@@ -84,7 +85,8 @@ class LoginController
             $sessionService = new SessionService($pdo);
             $sessionService->persistSession((int) $record['id'], session_id());
             $target = $record['role'] === 'admin' ? '/admin' : '/';
-            return $response->withHeader('Location', $target)->withStatus(302);
+            $basePath = RouteContext::fromRequest($request)->getBasePath();
+            return $response->withHeader('Location', $basePath . $target)->withStatus(302);
         }
 
         $view = Twig::fromRequest($request);

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Routing\RouteContext;
 
 /**
  * Logs out the current user session.
@@ -35,6 +36,7 @@ class LogoutController
             true
         );
 
-        return $response->withHeader('Location', '/login')->withStatus(302);
+        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        return $response->withHeader('Location', $basePath . '/login')->withStatus(302);
     }
 }

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -96,6 +96,27 @@ class LoginControllerTest extends TestCase
         $this->assertSame(302, $response->getStatusCode());
     }
 
+    public function testLoginRedirectRespectsBasePath(): void
+    {
+        $pdo = $this->getDatabase();
+        $userService = new UserService($pdo);
+        $userService->create('erin', 'secret', 'erin@example.com', Roles::ADMIN);
+
+        putenv('BASE_PATH=/base');
+        $_ENV['BASE_PATH'] = '/base';
+
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('POST', '/base/login')
+            ->withParsedBody(['username' => 'erin', 'password' => 'secret']);
+        $response = $app->handle($request);
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/base/admin', $response->getHeaderLine('Location'));
+
+        putenv('BASE_PATH');
+        unset($_ENV['BASE_PATH']);
+    }
+
     public function testUnknownUserShowsMessage(): void
     {
         $app = $this->getAppInstance();

--- a/tests/Controller/LogoutControllerTest.php
+++ b/tests/Controller/LogoutControllerTest.php
@@ -19,4 +19,22 @@ class LogoutControllerTest extends TestCase
         $this->assertEquals('/login', $response->getHeaderLine('Location'));
         session_destroy();
     }
+
+    public function testLogoutRedirectRespectsBasePath(): void
+    {
+        putenv('BASE_PATH=/base');
+        $_ENV['BASE_PATH'] = '/base';
+
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $request = $this->createRequest('GET', '/base/logout');
+        $response = $app->handle($request);
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('/base/login', $response->getHeaderLine('Location'));
+        session_destroy();
+
+        putenv('BASE_PATH');
+        unset($_ENV['BASE_PATH']);
+    }
 }


### PR DESCRIPTION
## Summary
- Prefix login and logout redirects with Slim base path
- Cover login and logout redirects with base path aware tests

## Testing
- `composer phpunit` *(fails: Missing STRIPE_SECRET_KEY etc., errors remain)*
- `vendor/bin/phpunit tests/Controller/LoginControllerTest.php tests/Controller/LogoutControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68bcaf8a9990832b9febf463aa230e33