### PR TITLE
Validate JSON in login handler

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -52,6 +52,9 @@ class LoginController
         $data = $request->getParsedBody();
         if (str_starts_with($request->getHeaderLine('Content-Type'), 'application/json')) {
             $data = json_decode((string) $request->getBody(), true);
+            if (json_last_error() !== JSON_ERROR_NONE || !is_array($data)) {
+                return $response->withStatus(400);
+            }
         }
 
         $pdo = $request->getAttribute('pdo');


### PR DESCRIPTION
## Summary
- Check decoded JSON payload in `LoginController::login`
- Abort login with `400 Bad Request` when body is invalid or not an array

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb59057e0832b9e4a92d22ab51670