### PR TITLE
Add security middlewares to login route

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -398,7 +398,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/onboarding/checkout/{id}/cancel', [SubscriptionController::class, 'cancelOnboardingCheckout']);
     $app->post('/stripe/webhook', StripeWebhookController::class);
     $app->get('/login', [LoginController::class, 'show']);
-    $app->post('/login', [LoginController::class, 'login']);
+    $app->post('/login', [LoginController::class, 'login'])
+        ->add(new RateLimitMiddleware(3, 3600))
+        ->add(new CsrfMiddleware());
     $app->get('/register', [RegisterController::class, 'show']);
     $app->post('/register', [RegisterController::class, 'register']);
     $app->get('/password/reset/request', function (Request $request, Response $response) {

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -34,8 +34,14 @@ class LoginControllerTest extends TestCase
         $this->assertIsArray($record);
 
         $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
         $request = $this->createRequest('POST', '/login')
-            ->withParsedBody(['username' => 'alice', 'password' => 'secret']);
+            ->withParsedBody([
+                'username' => 'alice',
+                'password' => 'secret',
+                'csrf_token' => 'tok',
+            ]);
         $response = $app->handle($request);
         $this->assertSame(302, $response->getStatusCode());
 
@@ -54,8 +60,14 @@ class LoginControllerTest extends TestCase
         $this->assertIsArray($record);
 
         $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
         $request = $this->createRequest('POST', '/login')
-            ->withParsedBody(['username' => 'frank', 'password' => 'secret'])
+            ->withParsedBody([
+                'username' => 'frank',
+                'password' => 'secret',
+                'csrf_token' => 'tok',
+            ])
             ->withHeader('Host', 'localhost');
         $response = $app->handle($request);
         $this->assertSame(302, $response->getStatusCode());
@@ -73,8 +85,14 @@ class LoginControllerTest extends TestCase
         $userService->create('bob', 'secret', 'bob@example.com', Roles::ADMIN);
 
         $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
         $request = $this->createRequest('POST', '/login')
-            ->withParsedBody(['username' => 'bob@example.com', 'password' => 'secret']);
+            ->withParsedBody([
+                'username' => 'bob@example.com',
+                'password' => 'secret',
+                'csrf_token' => 'tok',
+            ]);
         $response = $app->handle($request);
         $this->assertSame(302, $response->getStatusCode());
     }
@@ -86,10 +104,13 @@ class LoginControllerTest extends TestCase
         $userService->create('dave', 'secret', 'dave@example.com', Roles::ADMIN);
 
         $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
         $body = json_encode(['username' => 'dave', 'password' => 'secret']);
         $stream = (new StreamFactory())->createStream((string) $body);
         $request = $this->createRequest('POST', '/login')
             ->withHeader('Content-Type', 'application/json; charset=UTF-8')
+            ->withHeader('X-CSRF-Token', 'tok')
             ->withBody($stream);
 
         $response = $app->handle($request);
@@ -106,8 +127,14 @@ class LoginControllerTest extends TestCase
         $_ENV['BASE_PATH'] = '/base';
 
         $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
         $request = $this->createRequest('POST', '/base/login')
-            ->withParsedBody(['username' => 'erin', 'password' => 'secret']);
+            ->withParsedBody([
+                'username' => 'erin',
+                'password' => 'secret',
+                'csrf_token' => 'tok',
+            ]);
         $response = $app->handle($request);
 
         $this->assertSame(302, $response->getStatusCode());
@@ -120,8 +147,14 @@ class LoginControllerTest extends TestCase
     public function testUnknownUserShowsMessage(): void
     {
         $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
         $request = $this->createRequest('POST', '/login')
-            ->withParsedBody(['username' => 'nobody', 'password' => 'secret']);
+            ->withParsedBody([
+                'username' => 'nobody',
+                'password' => 'secret',
+                'csrf_token' => 'tok',
+            ]);
         $response = $app->handle($request);
         $this->assertSame(401, $response->getStatusCode());
         $this->assertStringContainsString('Benutzer nicht gefunden', (string) $response->getBody());
@@ -134,8 +167,14 @@ class LoginControllerTest extends TestCase
         $userService->create('carol', 'secret', 'carol@example.com', Roles::ADMIN);
 
         $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
         $request = $this->createRequest('POST', '/login')
-            ->withParsedBody(['username' => 'carol', 'password' => 'wrong']);
+            ->withParsedBody([
+                'username' => 'carol',
+                'password' => 'wrong',
+                'csrf_token' => 'tok',
+            ]);
         $response = $app->handle($request);
         $this->assertSame(401, $response->getStatusCode());
         $this->assertStringContainsString('Passwort falsch', (string) $response->getBody());


### PR DESCRIPTION
## Summary
- protect login endpoint with CSRF and rate limiting
- update login tests to include CSRF tokens

## Testing
- `composer test` *(fails: Missing STRIPE_* environment variables and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb598aa9c832b89f46e80b0c80dbb