### PR TITLE
Fix phpstan warnings and remove unused config dependency

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -89,7 +89,7 @@ class AdminController
         }
 
         if ($section === 'results') {
-            $results  = (new ResultService($pdo, $configSvc))->getAll();
+            $results  = (new ResultService($pdo))->getAll();
             $catMap   = [];
             foreach ($catalogs as $c) {
                 $name = $c['name'] ?? '';

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -84,7 +84,7 @@ class ImportController
             $tmp = new self(
                 new CatalogService($pdo, $cfg),
                 $cfg,
-                new ResultService($pdo, $cfg),
+                new ResultService($pdo),
                 new TeamService($pdo, $cfg),
                 new PhotoConsentService($pdo, $cfg),
                 new SummaryPhotoService($pdo, $cfg),

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -194,7 +194,7 @@ class QrController
         if ($tmp !== false) {
             file_put_contents($tmp, $png);
         }
-        $title = (string)($ev['name'] ?? '');
+        $title = (string)$ev['name'];
         $subtitle = (string)($ev['description'] ?? '');
         $logoFile = __DIR__ . '/../../data/' . ltrim((string)($cfg['logoPath'] ?? ''), '/');
 
@@ -287,7 +287,7 @@ class QrController
             $response->getBody()->write('unknown event uid');
             return $response->withStatus(404)->withHeader('Content-Type', 'text/plain');
         }
-        $title = (string)($ev['name'] ?? '');
+        $title = (string)$ev['name'];
         $subtitle = (string)($ev['description'] ?? '');
         $logoPath = __DIR__ . '/../../data/' . ltrim((string)($cfg['logoPath'] ?? ''), '/');
 

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -313,7 +313,7 @@ class ResultController
             if ($event === null) {
                 return $response->withHeader('Location', '/events')->withStatus(302);
             }
-            $uid = (string)($event['uid'] ?? '');
+            $uid = (string)$event['uid'];
         } else {
             $event = $this->events->getByUid($uid);
             if ($event === null) {
@@ -321,11 +321,11 @@ class ResultController
                 if ($event === null) {
                     return $response->withHeader('Location', '/events')->withStatus(302);
                 }
-                $uid = (string)($event['uid'] ?? '');
+                $uid = (string)$event['uid'];
             }
         }
         $cfg = $this->config->getConfigForEvent($uid);
-        $title = (string)($event['name'] ?? '');
+        $title = (string)$event['name'];
         $subtitle = (string)($event['description'] ?? '');
         $logoPath = __DIR__ . '/../../data/' . ltrim((string)($cfg['logoPath'] ?? ''), '/');
 

--- a/src/Controller/SummaryController.php
+++ b/src/Controller/SummaryController.php
@@ -46,7 +46,7 @@ class SummaryController
             if ($event === null) {
                 return $response->withHeader('Location', '/events')->withStatus(302);
             }
-            $uid = (string)($event['uid'] ?? '');
+            $uid = (string)$event['uid'];
             $cfg = $this->config->getConfigForEvent($uid);
         }
         $role = $_SESSION['user']['role'] ?? null;

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -6,7 +6,6 @@ namespace App\Service;
 
 use PDO;
 use PDOException;
-use App\Service\ConfigService;
 
 /**
  * Service for persisting and retrieving quiz results.
@@ -14,15 +13,13 @@ use App\Service\ConfigService;
 class ResultService
 {
     private PDO $pdo;
-    private ConfigService $config;
 
     /**
      * Inject database connection.
      */
-    public function __construct(PDO $pdo, ConfigService $config)
+    public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
-        $this->config = $config;
     }
 
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -175,7 +175,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             $_SESSION['event_uid'] = $eventUid;
         }
         $catalogService = new CatalogService($pdo, $configService, $tenantService, $sub, $eventUid);
-        $resultService = new ResultService($pdo, $configService);
+        $resultService = new ResultService($pdo);
         $teamService = new TeamService($pdo, $configService, $tenantService, $sub);
         $consentService = new PhotoConsentService($pdo, $configService);
         $summaryService = new SummaryPhotoService($pdo, $configService);

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -28,7 +28,7 @@ class ExportControllerTest extends TestCase
         return [
             new CatalogService($pdo, $cfg),
             $cfg,
-            new ResultService($pdo, $cfg),
+            new ResultService($pdo),
             new TeamService($pdo, $cfg),
             new PhotoConsentService($pdo, $cfg),
             new SummaryPhotoService($pdo, $cfg),

--- a/tests/Controller/ExportImportControllerTest.php
+++ b/tests/Controller/ExportImportControllerTest.php
@@ -29,7 +29,7 @@ class ExportImportControllerTest extends TestCase
         return [
             new CatalogService($pdo, $cfg),
             $cfg,
-            new ResultService($pdo, $cfg),
+            new ResultService($pdo),
             new TeamService($pdo, $cfg),
             new PhotoConsentService($pdo, $cfg),
             new SummaryPhotoService($pdo, $cfg),

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -28,7 +28,7 @@ class ImportControllerTest extends TestCase
         return [
             new CatalogService($pdo, $cfg),
             $cfg,
-            new ResultService($pdo, $cfg),
+            new ResultService($pdo),
             new TeamService($pdo, $cfg),
             new PhotoConsentService($pdo, $cfg),
             new SummaryPhotoService($pdo, $cfg),

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -38,7 +38,7 @@ class ResultServiceTest extends TestCase
         );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
 
         $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $this->assertSame(1, $first['attempt']);
@@ -74,7 +74,7 @@ class ResultServiceTest extends TestCase
         );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
 
         $first = $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $this->assertSame(1, $first['attempt']);
@@ -110,7 +110,7 @@ class ResultServiceTest extends TestCase
         );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $ts = time();
@@ -147,7 +147,7 @@ class ResultServiceTest extends TestCase
         );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1', 'puzzleTime' => 123]);
         $res = $service->markPuzzle('TeamA', 'cat1', 456);
@@ -183,7 +183,7 @@ class ResultServiceTest extends TestCase
         );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
         $service->setPhoto('TeamA', 'cat1', '/photo/test.jpg');
@@ -256,7 +256,7 @@ class ResultServiceTest extends TestCase
         $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u1',2,'text','Q2')");
 
         $cfg = new ConfigService($pdo);
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
         $service->add(['name' => 'Team', 'catalog' => 'cat1', 'correct' => 1, 'total' => 2, 'wrong' => [2]]);
 
         $stmt = $pdo->query('SELECT question_id, correct FROM question_results ORDER BY id');
@@ -311,7 +311,7 @@ class ResultServiceTest extends TestCase
             SQL
         );
         $cfg = new ConfigService($pdo);
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
         $service->add([ 'name' => 'Team', 'catalog' => 'cat1', 'correct' => 1, 'total' => 1 ]);
         $service->clear();
         $resCount = (int) $pdo->query('SELECT COUNT(*) FROM results')->fetchColumn();
@@ -391,7 +391,7 @@ class ResultServiceTest extends TestCase
             SQL
         );
         $cfg = new ConfigService($pdo);
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
 
         $service->add(['name' => 'TeamA', 'catalog' => 'cat1']);
 
@@ -433,7 +433,7 @@ class ResultServiceTest extends TestCase
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('ev1');
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
 
         $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time,event_uid) VALUES('Team1','cat',1,0,0,0,'ev1')");
         $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time,event_uid) VALUES('Team2','cat',1,0,0,0,'ev2')");
@@ -491,7 +491,7 @@ class ResultServiceTest extends TestCase
         );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
         $cfg = new ConfigService($pdo);
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
 
         $pdo->exec("INSERT INTO questions(id,catalog_uid,sort_order,type,prompt) VALUES(1,'u1',1,'text','Q1')");
 
@@ -558,7 +558,7 @@ class ResultServiceTest extends TestCase
 
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('');
-        $service = new ResultService($pdo, $cfg);
+        $service = new ResultService($pdo);
 
         $this->assertSame([], $service->getAll());
         $this->assertSame([], $service->getQuestionResults());


### PR DESCRIPTION
## Summary
- remove redundant null coalescing on mandatory event fields
- drop unused ConfigService from ResultService and update usages

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`
- `composer phpunit` *(fails: Missing STRIPE_SECRET_KEY, database constraint violations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb71976d0832bb5e1ce31c6e9c9cb