### PR TITLE
Load storage.js before app.js on landing page

### DIFF
--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -173,6 +173,7 @@
 {% endblock %}
 
 {% block scripts %}
+  <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/landing.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Ensure storage.js loads before app.js on the marketing landing page so dark/contrast toggles work again

## Testing
- `composer test` *(fails: command hung; aborted)*
- `php -S 127.0.0.1:8080 -t public & curl -I http://127.0.0.1:8080/landing` *(hangs; no response)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb8881ee4832b860c26106188f1a5