### PR TITLE
Align landing page theme toggles with app

### DIFF
--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -66,26 +66,28 @@ document.addEventListener('DOMContentLoaded', () => {
   const accessibilityToggles = document.querySelectorAll('.accessibility-toggle');
   const langButtons = document.querySelectorAll('.lang-option');
 
-  const applyTheme = () => {
-    const dark = getStored(STORAGE_KEYS.DARK_MODE) !== 'false';
-    document.documentElement.dataset.theme = dark ? 'dark' : 'light';
-    setStored(STORAGE_KEYS.QR_THEME, dark ? 'dark' : 'light');
-  };
+  let dark = getStored(STORAGE_KEYS.DARK_MODE) !== 'false';
+  document.body.dataset.theme = dark ? 'dark' : 'light';
+  document.body.classList.toggle('dark-mode', dark);
+  setStored(STORAGE_KEYS.QR_THEME, dark ? 'dark' : 'light');
 
-  const applyContrast = () => {
-    const accessible = getStored(STORAGE_KEYS.BARRIER_FREE) === 'true';
-    setStored(STORAGE_KEYS.QR_CONTRAST, accessible ? 'high' : 'normal');
-  };
-
-  applyTheme();
-  applyContrast();
+  let accessible = getStored(STORAGE_KEYS.BARRIER_FREE) === 'true';
+  document.body.classList.toggle('high-contrast', accessible);
+  setStored(STORAGE_KEYS.QR_CONTRAST, accessible ? 'high' : 'normal');
 
   themeToggles.forEach(btn => btn.addEventListener('click', () => {
-    setTimeout(applyTheme, 0);
+    dark = document.body.dataset.theme !== 'dark';
+    document.body.dataset.theme = dark ? 'dark' : 'light';
+    document.body.classList.toggle('dark-mode', dark);
+    setStored(STORAGE_KEYS.DARK_MODE, dark ? 'true' : 'false');
+    setStored(STORAGE_KEYS.QR_THEME, dark ? 'dark' : 'light');
   }));
 
   accessibilityToggles.forEach(btn => btn.addEventListener('click', () => {
-    setTimeout(applyContrast, 0);
+    accessible = !document.body.classList.contains('high-contrast');
+    document.body.classList.toggle('high-contrast', accessible);
+    setStored(STORAGE_KEYS.BARRIER_FREE, accessible ? 'true' : 'false');
+    setStored(STORAGE_KEYS.QR_CONTRAST, accessible ? 'high' : 'normal');
   }));
 
   langButtons.forEach(btn => btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Ensure landing page toggles update `dark-mode` and `high-contrast` classes just like main app
- Persist theme and accessibility choices in storage and QR settings

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*
- `php -S 127.0.0.1:8000 -t public` & `curl -I 127.0.0.1:8000/landing` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb88950fc832b9bbf89a72161ff70