### PR TITLE
Validate MAIN_DOMAIN and return descriptive response

### DIFF
--- a/tests/DomainMiddlewareTest.php
+++ b/tests/DomainMiddlewareTest.php
@@ -72,7 +72,7 @@ class DomainMiddlewareTest extends TestCase
         }
     }
 
-    public function testMissingMainDomainDefaultsToMain(): void
+    public function testMissingMainDomainReturnsError(): void
     {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN');
@@ -80,19 +80,64 @@ class DomainMiddlewareTest extends TestCase
         $middleware = new DomainMiddleware();
         $factory = new ServerRequestFactory();
         $request = $factory->createServerRequest('GET', 'https://foo.test/');
+        $request = $request->withHeader('Accept', 'application/json');
 
         $handler = new class implements RequestHandlerInterface {
-            public ?Request $request = null;
+            public bool $handled = false;
 
             public function handle(Request $request): ResponseInterface
             {
-                $this->request = $request;
+                $this->handled = true;
                 return new Response();
             }
         };
 
-        $middleware->process($request, $handler);
-        $this->assertSame('main', $handler->request->getAttribute('domainType'));
+        $response = $middleware->process($request, $handler);
+
+        $this->assertFalse($handler->handled);
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+        $this->assertSame(
+            json_encode(['error' => 'Invalid main domain configuration.']),
+            (string) $response->getBody()
+        );
+
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+
+    public function testInvalidMainDomainReturnsError(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main-domain.tld');
+
+        $middleware = new DomainMiddleware();
+        $factory = new ServerRequestFactory();
+        $request = $factory->createServerRequest('GET', 'https://wrong.tld/');
+        $request = $request->withHeader('Accept', 'application/json');
+
+        $handler = new class implements RequestHandlerInterface {
+            public bool $handled = false;
+
+            public function handle(Request $request): ResponseInterface
+            {
+                $this->handled = true;
+                return new Response();
+            }
+        };
+
+        $response = $middleware->process($request, $handler);
+
+        $this->assertFalse($handler->handled);
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+        $this->assertSame(
+            json_encode(['error' => 'Invalid main domain configuration.']),
+            (string) $response->getBody()
+        );
 
         if ($old === false) {
             putenv('MAIN_DOMAIN');


### PR DESCRIPTION
## Summary
- warn and return JSON/HTML error when MAIN_DOMAIN is missing or mismatched
- cover invalid MAIN_DOMAIN cases with unit tests

## Testing
- `vendor/bin/phpunit tests/DomainMiddlewareTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcc3f8f070832b9fd6e81fdb7f5eb8