### PR TITLE
Use quizUser key for player name storage

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -91,7 +91,7 @@ function insertSoftHyphens(text){
 
 async function promptTeamName(){
   return new Promise(resolve => {
-    const existing = getStored(STORAGE_KEYS.PLAYER_NAME);
+    const existing = getStored('quizUser');
     const modal = document.createElement('div');
     modal.setAttribute('uk-modal', '');
     modal.setAttribute('aria-modal', 'true');
@@ -132,7 +132,7 @@ async function promptTeamName(){
     btn.addEventListener('click', async () => {
       const name = (input.value || '').trim();
       if(name){
-        setStored(STORAGE_KEYS.PLAYER_NAME, name);
+        setStored('quizUser', name);
         try {
           await postSession('player', { name });
           ui.hide();
@@ -214,7 +214,7 @@ async function runQuiz(questions, skipIntro){
     if(v != null) setStored(k, v);
   });
 
-  if(!getStored(STORAGE_KEYS.PLAYER_NAME) && !cfg.QRRestrict && !cfg.QRUser){
+  if(!getStored('quizUser') && !cfg.QRRestrict && !cfg.QRUser){
     if(cfg.randomNames){
       await promptTeamName();
     }
@@ -1276,7 +1276,7 @@ async function runQuiz(questions, skipIntro){
         alert('Nur Registrierung per QR-Code erlaubt');
         return;
       }
-      if(!getStored(STORAGE_KEYS.PLAYER_NAME)){
+      if(!getStored('quizUser')){
         if(cfg.randomNames){
           await promptTeamName();
         }

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -1,6 +1,6 @@
 (function(){
   const STORAGE_KEYS = {
-    PLAYER_NAME: 'qr_player_name',
+    PLAYER_NAME: 'quizUser',
     PLAYER_UID: 'qr_player_uid',
     CATALOG: 'quizCatalog',
     CATALOG_NAME: 'quizCatalogName',
@@ -88,7 +88,7 @@
 
   /*
    * Standardized storage keys:
-   * - qr_player_name:<currentEventUid>  – Spielername
+   * - quizUser:<currentEventUid>  – Spielername
    * - qr_player_uid:<currentEventUid>   – Spieler-UID
    * - quizCatalog                – Aktueller Katalog-Slug
    * - quizCatalogName            – Katalognamen

--- a/tests/test_profile_flow.js
+++ b/tests/test_profile_flow.js
@@ -68,6 +68,8 @@ const ctx2 = {
   self: { crypto: { randomUUID: () => 'uid-123' } },
   returnUrl: '/quiz',
   location: { href: '', search: '' },
+  postSession: () => Promise.resolve(),
+  alert: () => {},
   console,
   document: {
     getElementById(id) {
@@ -88,7 +90,7 @@ vm.runInNewContext(profileCode, ctx2);
 ctx2.nameInput.value = 'Alice';
 (async () => {
   await ctx2.saveHandler?.({ preventDefault() {} });
-  assert.strictEqual(ctx2.localStorage.getItem('qr_player_name:'), 'Alice');
+  assert.strictEqual(ctx2.localStorage.getItem('quizUser:'), 'Alice');
   assert.strictEqual(ctx2.localStorage.getItem('qr_player_uid:'), 'uid-123');
   assert.strictEqual(ctx2.fetchCalls[0].url, '/api/players');
   assert(ctx2.fetchCalls[0].opts.body.includes('Alice'));
@@ -117,6 +119,8 @@ const ctx3 = {
   self: { crypto: { randomUUID: () => 'uid-123' } },
   returnUrl: '/quiz',
   location: { href: '', search: '?uid=uid-123' },
+  postSession: () => Promise.resolve(),
+  alert: () => {},
   console,
   document: {
     getElementById(id) {
@@ -139,7 +143,7 @@ vm.runInNewContext(storageCode, ctx3);
 vm.runInNewContext(profileCode, ctx3);
 (async () => {
   await new Promise(r => setTimeout(r, 0));
-  assert.strictEqual(ctx3.localStorage.getItem('qr_player_name:ev1'), 'Bob');
+  assert.strictEqual(ctx3.localStorage.getItem('quizUser:ev1'), 'Bob');
   assert.strictEqual(ctx3.localStorage.getItem('qr_player_uid:ev1'), 'uid-123');
   assert.strictEqual(ctx3.location.href, '/quiz');
   assert(ctx3.fetchCalls[0].startsWith('/api/players?'));


### PR DESCRIPTION
## Summary
- store player names under `quizUser` key
- reference `quizUser` from start button and initial prompt
- update tests for new key and stub dependencies

## Testing
- `node tests/test_profile_flow.js`
- `node tests/test_random_name_prompt.js`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc3cf2b90832baac89ef18f9351fa