### PR TITLE
Handle MAIN_DOMAIN misconfiguration with message

### DIFF
--- a/src/Application/Middleware/DomainMiddleware.php
+++ b/src/Application/Middleware/DomainMiddleware.php
@@ -35,8 +35,6 @@ class DomainMiddleware implements MiddlewareInterface
             $domainType = 'tenant';
         }
 
-        $request = $request->withAttribute('domainType', $domainType);
-
         if (
             $mainDomain === ''
             || ($domainType === 'main' && $host !== $mainDomain)
@@ -56,18 +54,20 @@ class DomainMiddleware implements MiddlewareInterface
                 || str_contains($accept, 'application/json')
                 || $xhr === 'fetch';
 
-            $resp = new SlimResponse(403);
+            $response = new SlimResponse(403);
 
             if ($isApi) {
-                $resp->getBody()->write(json_encode(['error' => $message]));
+                $response->getBody()->write(json_encode(['error' => $message]));
 
-                return $resp->withHeader('Content-Type', 'application/json');
+                return $response->withHeader('Content-Type', 'application/json');
             }
 
-            $resp->getBody()->write($message);
+            $response->getBody()->write($message);
 
-            return $resp->withHeader('Content-Type', 'text/html');
+            return $response->withHeader('Content-Type', 'text/html');
         }
+
+        $request = $request->withAttribute('domainType', $domainType);
 
         return $handler->handle($request);
     }


### PR DESCRIPTION
## Summary
- return descriptive JSON or HTML payload when MAIN_DOMAIN is missing or mismatched
- add unit test ensuring HTML responses on misconfigured MAIN_DOMAIN

## Testing
- `MAIN_DOMAIN=example.com vendor/bin/phpunit tests/DomainMiddlewareTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68bcc94beafc832b8237bb6fed5760a6