### PR TITLE
test: ensure login redirect on main domain

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -89,11 +89,10 @@ class LoginController
             $sessionService->persistSession((int) $record['id'], session_id());
             $host = (string) ($_SERVER['HTTP_HOST'] ?? '');
             $mainDomain = (string) getenv('MAIN_DOMAIN');
+            // Redirect to the configured main domain if the login request
+            // was sent to a different host.
             if ($mainDomain !== '' && strcasecmp($host, $mainDomain) !== 0) {
-                $scheme = $request->getUri()->getScheme();
-                if ($scheme === '') {
-                    $scheme = 'https';
-                }
+                $scheme = $request->getUri()->getScheme() ?: 'https';
                 return $response
                     ->withHeader('Location', $scheme . '://' . $mainDomain . '/admin')
                     ->withStatus(302);

--- a/tests/Integration/LoginRedirectMainDomainTest.php
+++ b/tests/Integration/LoginRedirectMainDomainTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use App\Service\UserService;
+use App\Domain\Roles;
+use Tests\TestCase;
+
+final class LoginRedirectMainDomainTest extends TestCase
+{
+    public function testLoginRedirectsToMainDomainOnWrongHost(): void
+    {
+        $pdo = $this->getDatabase();
+        $userService = new UserService($pdo);
+        $userService->create('heidi', 'secret', 'heidi@example.com', Roles::ADMIN);
+
+        putenv('MAIN_DOMAIN=main.test');
+        $_ENV['MAIN_DOMAIN'] = 'main.test';
+
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['csrf_token'] = 'tok';
+        $_SERVER['HTTP_HOST'] = 'tenant.main.test';
+        $request = $this->createRequest('POST', '/login', ['HTTP_HOST' => 'tenant.main.test'])
+            ->withParsedBody([
+                'username' => 'heidi',
+                'password' => 'secret',
+                'csrf_token' => 'tok',
+            ]);
+        $request = $request->withUri(
+            $request->getUri()->withHost('tenant.main.test')->withScheme('https')
+        );
+        $response = $app->handle($request);
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('https://main.test/admin', $response->getHeaderLine('Location'));
+
+        putenv('MAIN_DOMAIN');
+        unset($_ENV['MAIN_DOMAIN'], $_SERVER['HTTP_HOST']);
+    }
+}


### PR DESCRIPTION
## Summary
- Redirect users to the configured main domain after successful login if the request host differs
- Add integration test verifying main-domain redirect on login from a foreign host

## Testing
- `vendor/bin/phpunit tests/Integration/LoginRedirectMainDomainTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcc94fca40832b9cfe3bb8316ccc89