### PR TITLE
Include CSRF token in login form

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -37,10 +37,14 @@ class LoginController
         if ($version === false || $version === '') {
             $version = (new VersionService())->getCurrentVersion();
         }
+        $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
+        $_SESSION['csrf_token'] = $csrf;
+
         return $view->render($response, 'login.twig', [
             'registration_allowed' => $allowed,
             'reset_success' => $resetSuccess,
             'version' => $version,
+            'csrf_token' => $csrf,
         ]);
     }
 

--- a/templates/login.twig
+++ b/templates/login.twig
@@ -33,6 +33,7 @@
           </div>
           {% endif %}
           <form method="post" action="{{ basePath }}/login">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <div class="uk-margin">
               <div class="uk-inline uk-width-1-1">
                 <span class="uk-form-icon" uk-icon="icon: user"></span>

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -25,6 +25,18 @@ class LoginControllerTest extends TestCase
         unset($_ENV['APP_VERSION']);
     }
 
+    public function testLoginPageGeneratesCsrfToken(): void
+    {
+        $app = $this->getAppInstance();
+        $response = $app->handle($this->createRequest('GET', '/login'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertNotEmpty($_SESSION['csrf_token']);
+        $this->assertStringContainsString(
+            '<input type="hidden" name="csrf_token"',
+            (string) $response->getBody()
+        );
+    }
+
     public function testLoginPersistsSession(): void
     {
         $pdo = $this->getDatabase();


### PR DESCRIPTION
## Summary
- pass CSRF token to login template
- add hidden CSRF token field to login form
- ensure login page generates CSRF token via test

## Testing
- `composer test` *(fails: Tests: 319, Assertions: 514, Errors: 29, Failures: 116)*

------
https://chatgpt.com/codex/tasks/task_e_68bd38a4fe68832badbaeb737f4b43b1