### PR TITLE
Ensure admin views respect selected event

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -51,11 +51,11 @@ class AdminController
 
         $params = $request->getQueryParams();
         $uid    = (string) ($params['event'] ?? '');
+        $cfgSvc->setActiveEventUid($uid);
         if ($uid === '') {
             $cfg   = [];
             $event = null;
         } else {
-            $cfgSvc->setActiveEventUid($uid);
             $cfg   = $cfgSvc->getConfigForEvent($uid);
             $event = $eventSvc->getByUid($uid);
         }
@@ -80,16 +80,19 @@ class AdminController
         $sub       = '';
 
         $configSvc = new ConfigService($pdo);
-        if (in_array($section, ['results', 'catalogs', 'questions', 'summary'], true)) {
-            $catalogSvc   = new CatalogService($pdo, $configSvc);
+        if (
+            $uid !== ''
+            && in_array($section, ['results', 'catalogs', 'questions', 'summary'], true)
+        ) {
+            $catalogSvc   = new CatalogService($pdo, $configSvc, null, '', $uid);
             $catalogsJson = $catalogSvc->read('catalogs.json');
             if ($catalogsJson !== null) {
                 $catalogs = json_decode($catalogsJson, true) ?? [];
             }
         }
 
-        if ($section === 'results') {
-            $results  = (new ResultService($pdo))->getAll();
+        if ($section === 'results' && $uid !== '') {
+            $results  = (new ResultService($pdo))->getAll($uid);
             $catMap   = [];
             foreach ($catalogs as $c) {
                 $name = $c['name'] ?? '';


### PR DESCRIPTION
## Summary
- Clear active event on dashboard load and filter catalog/result data by selected event

## Testing
- `vendor/bin/phpcs src/Controller/AdminController.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY and other configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3d1a4b5c832ba8e1afcf02678ba4