### PR TITLE
feat: preload events on admin page

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1873,6 +1873,14 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   if (eventManager || eventSelect) {
+    const initial = Array.isArray(window.initialEvents)
+      ? window.initialEvents.map(d => createEventItem(d))
+      : [];
+    if (eventManager) {
+      eventManager.render(initial);
+      highlightCurrentEvent();
+    }
+    populateEventSelect(initial);
     apiFetch('/events.json', { headers: { 'Accept': 'application/json' } })
       .then(r => {
         if (!r.ok) {

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -44,6 +44,7 @@ class AdminController
         }
         $cfgSvc = new ConfigService($pdo);
         $eventSvc = new EventService($pdo);
+        $events = $eventSvc->getAll();
         $settingsSvc = new SettingsService($pdo);
         $settings = $settingsSvc->getAll();
         $versionSvc = new VersionService();
@@ -186,6 +187,7 @@ class AdminController
               'catalogs' => $catalogs,
               'teams' => $teams,
               'users' => $users,
+              'events' => $events,
               'roles' => Roles::ALL,
               'baseUrl' => $baseUrl,
               'main_domain' => $mainDomain,

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1202,6 +1202,7 @@
     window.transTeamPdf = '{{ t('tip_team_pdf') }}';
     window.transActions = '{{ t('column_actions') }}';
     window.stripeDashboard = '{{ stripe_sandbox ? 'https://dashboard.stripe.com/test' : 'https://dashboard.stripe.com' }}';
+    window.initialEvents = {{ events|json_encode|raw }};
   </script>
   <script src="{{ basePath }}/js/dashboard.js"></script>
   <script type="module" src="{{ basePath }}/js/admin.js"></script>

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -122,6 +122,24 @@ class AdminControllerTest extends TestCase
         unlink($db);
     }
 
+    public function testEventsEmbeddedOnPage(): void
+    {
+        $db = $this->setupDb();
+        $pdo = new PDO('sqlite:' . $db);
+        Migrator::migrate($pdo, __DIR__ . '/../../migrations');
+        $pdo->exec("INSERT INTO events(uid, slug, name, start_date, end_date, description, published, sort_order) VALUES('e1','test','Test Event','2025-01-01 00:00:00','2025-01-01 01:00:00','',1,0)");
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $request = $this->createRequest('GET', '/admin/events');
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('Test Event', $body);
+        session_destroy();
+        unlink($db);
+    }
+
     /**
      * Ensure stripe customer id is stored when loading subscription page on main domain.
      *


### PR DESCRIPTION
## Summary
- preload events in AdminController and expose to client
- initialize admin UI with preloaded events before fetching
- embed events data in admin template and add regression test

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE secrets)*

------
https://chatgpt.com/codex/tasks/task_e_68bd43aa6834832b8b4b43e8c23d54c5