### PR TITLE
feat: show all events in admin view

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1646,11 +1646,6 @@ document.addEventListener('DOMContentLoaded', function () {
   const eventOpenBtn = document.getElementById('eventOpenBtn');
   const eventDependentSections = document.querySelectorAll('[data-event-dependent]');
   const langSelect = document.getElementById('langSelect');
-  const EVENTS_PER_PAGE = Number.MAX_SAFE_INTEGER;
-  const eventPaginationEl = document.createElement('ul');
-  eventPaginationEl.id = 'eventsPagination';
-  eventPaginationEl.className = 'uk-pagination uk-flex-center';
-  eventAddBtn?.parentElement?.before(eventPaginationEl);
   let eventManager;
   let eventEditor;
 
@@ -1857,7 +1852,6 @@ document.addEventListener('DOMContentLoaded', function () {
         saveEvents();
       }
     });
-    eventManager.bindPagination(eventPaginationEl, EVENTS_PER_PAGE);
   }
 
   function removeEvent(id) {
@@ -1911,9 +1905,6 @@ document.addEventListener('DOMContentLoaded', function () {
     const list = eventManager.getData();
     const item = createEventItem();
     list.push(item);
-    if (eventManager.pagination) {
-      eventManager.pagination.page = Math.max(1, Math.ceil(list.length / EVENTS_PER_PAGE));
-    }
     eventManager.render(list);
     highlightCurrentEvent();
     saveEvents();


### PR DESCRIPTION
## Summary
- remove events pagination from admin UI so all events are visible

## Testing
- `node tests/test_competition_mode.js`
- `python3 tests/test_html_validity.py`
- `vendor/bin/phpunit` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68bd50da8490832b815704bdea46dc62