### PR TITLE
feat: warn if no events present

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1878,6 +1878,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const initial = Array.isArray(window.initialEvents)
       ? window.initialEvents.map(d => createEventItem(d))
       : [];
+    const initialEmpty = initial.length === 0;
     if (eventManager) {
       eventManager.render(initial);
       highlightCurrentEvent();
@@ -1900,10 +1901,13 @@ document.addEventListener('DOMContentLoaded', function () {
           highlightCurrentEvent();
         }
         populateEventSelect(list);
+        if (initialEmpty && list.length === 0) {
+          notify('Keine Events gefunden', 'warning');
+        }
       })
       .catch(err => {
         console.error(err);
-        notify('Events konnten nicht geladen werden', 'danger');
+        notify(err.message || 'HTTP-Fehler', 'warning');
       });
   }
 


### PR DESCRIPTION
## Summary
- show warning when both initial and fetched events are empty
- surface HTTP fetch errors via notify

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, Missing STRIPE_* env)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbcc03664832b8a5df2d871b656c6