### PR TITLE
Show warning when no events

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1878,6 +1878,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const initial = Array.isArray(window.initialEvents)
       ? window.initialEvents.map(d => createEventItem(d))
       : [];
+    const initialEmpty = initial.length === 0;
     if (eventManager) {
       eventManager.render(initial);
       highlightCurrentEvent();
@@ -1900,10 +1901,13 @@ document.addEventListener('DOMContentLoaded', function () {
           highlightCurrentEvent();
         }
         populateEventSelect(list);
+        if (initialEmpty && list.length === 0) {
+          notify('Keine Events gefunden', 'warning');
+        }
       })
       .catch(err => {
         console.error(err);
-        notify('Events konnten nicht geladen werden', 'danger');
+        notify(`HTTP-Fehler: ${err.message}`, 'danger');
       });
   }
 


### PR DESCRIPTION
## Summary
- warn if both initial and fetched events lists are empty
- display HTTP error details when events fetch fails

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbdbc668c832b88fc6fbefe2c5548