### PR TITLE
fix: remove admin topbar position override

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -572,7 +572,6 @@ body.admin-page {
 
 .admin-page .topbar .uk-navbar-right {
   order: 2;
-  position: relative;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Summary
- remove conflicting `position: relative` from admin topbar

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb8ebe1a0832b88aa4ff5ac19a24a