### PR TITLE
fix: avoid duplicate params declaration in admin.js

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -343,8 +343,8 @@ document.addEventListener('DOMContentLoaded', function () {
   // --------- Konfiguration bearbeiten ---------
   // Ausgangswerte aus der bestehenden Konfiguration
   const cfgInitial = window.quizConfig || {};
-  const params = new URLSearchParams(window.location.search);
-  let currentEventUid = params.get('event') || '';
+  const cfgParams = new URLSearchParams(window.location.search);
+  let currentEventUid = cfgParams.get('event') || '';
   // Verweise auf die Formularfelder
   const cfgFields = {
     logoFile: document.getElementById('cfgLogoFile'),


### PR DESCRIPTION
## Summary
- fix duplicate `params` declaration in `public/js/admin.js`
- rename configuration search parameters to `cfgParams`

## Testing
- `node --check public/js/admin.js`
- `timeout 30 composer test` *(fails: MAIN_DOMAIN misconfiguration / Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd24cd118832bba6b65a22375e94f