### PR TITLE
Include event UID in generated QR codes

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2884,6 +2884,7 @@ document.addEventListener('DOMContentLoaded', function () {
         qrImg.dataset.target = link;
         const params = new URLSearchParams();
         params.set('t', link);
+        params.set('event', ev.uid);
         applyDesign(params, 'qrColorEvent');
         qrImg.src = withBase('/qr/event?' + params.toString());
       }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -496,7 +496,7 @@
             <p id="summaryEventDesc">{{ event.description }}</p>
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
-            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr/event?t={{ (baseUrl ? baseUrl ~ '/?event=' ~ event.uid : '?event=' ~ event.uid)|url_encode }}&size=150&margin=40" alt="QR">
+            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr/event?event={{ event.uid }}&t={{ (baseUrl ? baseUrl ~ '/?event=' ~ event.uid : '?event=' ~ event.uid)|url_encode }}&size=150&margin=40" alt="QR">
           </div>
         </div>
 

--- a/templates/admin/event_config.twig
+++ b/templates/admin/event_config.twig
@@ -173,7 +173,7 @@
           <div class="uk-card uk-card-default uk-card-body uk-margin-small-top">
             <h3 class="uk-card-title uk-margin-remove">QR-Links</h3>
             <div class="uk-margin-small-top">
-              <a class="uk-button uk-button-default uk-width-1-1 uk-margin-small-bottom" href="{{ basePath }}/qr/event?t={{ ('?event=' ~ (event.slug|default('demo')))|url_encode }}" target="_blank">Event‑QR</a>
+              <a class="uk-button uk-button-default uk-width-1-1 uk-margin-small-bottom" href="{{ basePath }}/qr/event?event={{ (event.slug|default('demo')) }}&t={{ ('?event=' ~ (event.slug|default('demo')))|url_encode }}" target="_blank">Event‑QR</a>
               <a class="uk-button uk-button-default uk-width-1-1 uk-margin-small-bottom" href="{{ basePath }}/qr/catalog?t={{ ('?event=' ~ (event.slug|default('demo')) ~ '&katalog=' ~ (catalog.slug|default('default')))|url_encode }}" target="_blank">Katalog‑QR</a>
               <a class="uk-button uk-button-default uk-width-1-1" href="{{ basePath }}/qr/team?t={{ (team|default('team-1'))|url_encode }}" target="_blank">Team‑QR</a>
             </div>


### PR DESCRIPTION
## Summary
- Ensure event QR URLs carry the event UID from admin.js
- Append event parameter to admin and event_config templates

## Testing
- `curl -o /tmp/out.png -w "%{http_code}\n" "http://127.0.0.1:8080/qr/event?event=1&t=%3Fevent%3D1" -s -S` *(500 – endpoint reachable, not 400)*
- `vendor/bin/phpunit --stop-on-failure` *(fails: MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd2662784832ba2d04976f45de426