### PR TITLE
Use stored active event when query parameter missing

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -51,8 +51,13 @@ class AdminController
         $version = $versionSvc->getCurrentVersion();
 
         $params = $request->getQueryParams();
-        $uid    = (string) ($params['event'] ?? '');
-        $cfgSvc->setActiveEventUid($uid);
+        if (array_key_exists('event', $params)) {
+            $uid = (string) $params['event'];
+            $cfgSvc->setActiveEventUid($uid);
+        } else {
+            $uid = (string) ($cfgSvc->getActiveEventUid() ?? '');
+        }
+
         if ($uid === '') {
             $cfg   = [];
             $event = null;


### PR DESCRIPTION
## Summary
- avoid clearing active event when no event parameter is provided
- fallback to the stored active event UID for configuration and event lookup

## Testing
- `vendor/bin/phpcs src/Controller/AdminController.php`
- `vendor/bin/phpunit` *(fails: MAIN_DOMAIN misconfiguration, missing Stripe environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bdda006e9c832bbaa5b15ebf1e4532