### PR TITLE
Redirect to selected event without full reload

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1754,7 +1754,9 @@ document.addEventListener('DOMContentLoaded', function () {
             notify(text || 'Fehler beim Wechseln des Events', 'danger');
           });
         }
-        window.location.reload();
+        const url = new URL(window.location);
+        url.searchParams.set('event', uid);
+        window.location.href = url.toString();
       })
       .catch(err => {
         console.error(err);


### PR DESCRIPTION
## Summary
- After changing event, update `?event=<uid>` in URL and navigate there instead of forcing a reload

## Testing
- `composer test` *(fails: Tests: 320, Assertions: 511, Errors: 31, Failures: 117, Warnings: 4)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd9d88b7c832b84bc42372a485d5f