### PR TITLE
Propagate event ID in QR design flows

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2622,6 +2622,9 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!currentQrEndpoint) return;
     const params = new URLSearchParams();
     params.set('t', currentQrTarget);
+    if (currentQrEndpoint === '/qr/event' && currentEventUid) {
+      params.set('event', currentEventUid);
+    }
     const label = qrLabelInput?.value || '';
     const lines = label.split(/\n/, 2).map(s => s.trim());
     if (qrLogoPath) {
@@ -2771,6 +2774,9 @@ document.addEventListener('DOMContentLoaded', function () {
         }
         const params = new URLSearchParams();
         params.set('t', target);
+        if (endpoint === '/qr/event' && currentEventUid) {
+          params.set('event', currentEventUid);
+        }
         if (qrLogoPath) {
           params.set('logo_path', qrLogoPath);
         } else {


### PR DESCRIPTION
## Summary
- Ensure QR design preview includes both `event` and `t` parameters for event QR codes
- Add event ID when applying QR design globally so server receives event context

## Testing
- `composer install --no-progress`
- `composer test` *(fails: Tests: 320, Assertions: 511, Errors: 31, Failures: 117, Warnings: 4)*

------
https://chatgpt.com/codex/tasks/task_e_68bdda1d8708832b9590b362962e0260