### PR TITLE
Hide summary event QR when no event UID

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2887,14 +2887,22 @@ document.addEventListener('DOMContentLoaded', function () {
         if (col) params.set('fg', col.replace('#', ''));
       };
       if (qrImg) {
-        const link = window.baseUrl ? window.baseUrl : withBase('/?event=' + encodeURIComponent(ev.uid || ''));
-        qrImg.dataset.endpoint = '/qr/event';
-        qrImg.dataset.target = link;
-        const params = new URLSearchParams();
-        params.set('t', link);
-        params.set('event', ev.uid);
-        applyDesign(params, 'qrColorEvent');
-        qrImg.src = withBase('/qr/event?' + params.toString());
+        if (ev.uid) {
+          qrImg.hidden = false;
+          const link = window.baseUrl ? window.baseUrl : withBase('/?event=' + encodeURIComponent(ev.uid));
+          qrImg.dataset.endpoint = '/qr/event';
+          qrImg.dataset.target = link;
+          const params = new URLSearchParams();
+          params.set('t', link);
+          params.set('event', ev.uid);
+          applyDesign(params, 'qrColorEvent');
+          qrImg.src = withBase('/qr/event?' + params.toString());
+        } else {
+          qrImg.removeAttribute('src');
+          qrImg.dataset.endpoint = '';
+          qrImg.dataset.target = '';
+          qrImg.hidden = true;
+        }
       }
       catalogsEl.innerHTML = '';
       catalogs.forEach(c => {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -496,7 +496,9 @@
             <p id="summaryEventDesc">{{ event.description }}</p>
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
-            <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr/event?event={{ event.uid }}&t={{ (baseUrl ? baseUrl ~ '/?event=' ~ event.uid : '?event=' ~ event.uid)|url_encode }}&size=150&margin=40" alt="QR">
+            {% if event.uid %}
+              <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr/event?event={{ event.uid }}&t={{ (baseUrl ? baseUrl ~ '/?event=' ~ event.uid : '?event=' ~ event.uid)|url_encode }}&size=150&margin=40" alt="QR">
+            {% endif %}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Render summary event QR only when event UID exists
- Clear and hide summary QR image in admin view if no event is selected

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and Stripe keys missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bddc6b29d8832bae890916c4561616