### PR TITLE
Embed inline logo placeholder

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -238,7 +238,7 @@
                       src="{% if config.logoPath %}
                             {{ basePath ~ config.logoPath }}
                           {% else %}
-                            https://via.placeholder.com/160x240?text=Logo
+                            data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='160'%20height='240'%3E%3Crect%20width='160'%20height='240'%20fill='%23ccc'/%3E%3Ctext%20x='50%25'%20y='50%25'%20dominant-baseline='middle'%20text-anchor='middle'%20font-size='20'%20fill='%23666'%3ELogo%3C/text%3E%3C/svg%3E
                           {% endif %}"
                       alt="{{ t('label_logo_preview') }}"
                       class="logo-placeholder"


### PR DESCRIPTION
## Summary
- drop committed placeholder image file
- embed SVG data URI as fallback for admin logo preview

## Testing
- `composer test` *(fails: Tests: 320, Assertions: 511, Errors: 31, Failures: 117, Warnings: 4, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bdda256e3c832b9b92e86860ab1f75