### PR TITLE
Remove placeholder results message

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1261,7 +1261,6 @@ async function runQuiz(questions, skipIntro){
     startBtn.textContent = 'Los geht\'s!';
     styleButton(startBtn);
     // Zeigt bisherige Ergebnisse als kleine Slideshow an
-    stats.textContent = 'Noch keine Ergebnisse vorhanden.';
 
     if(cfg.randomNames){
       const nameBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- remove default 'Noch keine Ergebnisse vorhanden.' notice from quiz start screen

## Testing
- `composer test` *(fails: Failed asserting that 4 is identical to 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bddcee2f28832b827b02b4f99d3415