### PR TITLE
Wrap user password inputs in form

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2137,7 +2137,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const userPassModal = window.UIkit ? UIkit.modal('#userPassModal') : null;
   const userPassInput = document.getElementById('userPassInput');
   const userPassRepeat = document.getElementById('userPassRepeat');
-  const userPassSave = document.getElementById('userPassSave');
+  const userPassForm = document.getElementById('userPassForm');
   let currentUserRow = null;
 
   function collectUsers() {
@@ -2263,7 +2263,8 @@ document.addEventListener('DOMContentLoaded', function () {
     saveUsers();
   });
 
-  userPassSave?.addEventListener('click', () => {
+  userPassForm?.addEventListener('submit', e => {
+    e.preventDefault();
     if (!userPassInput || !userPassRepeat || !currentUserRow) return;
     const p1 = userPassInput.value;
     const p2 = userPassRepeat.value;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -874,12 +874,14 @@
         <div id="userPassModal" uk-modal>
           <div class="uk-modal-dialog uk-modal-body">
             <h2 class="uk-modal-title">Passwort setzen</h2>
-            <div class="uk-margin"><input id="userPassInput" class="uk-input" type="password" placeholder="Passwort"></div>
-            <div class="uk-margin"><input id="userPassRepeat" class="uk-input" type="password" placeholder="Wiederholen"></div>
-            <div class="uk-flex uk-flex-right uk-margin-top">
-              <button id="userPassSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="button" aria-label="{{ t('action_save') }}"></button>
-              <button class="uk-button uk-button-default uk-modal-close" type="button">{{ t('action_cancel') }}</button>
-            </div>
+            <form id="userPassForm">
+              <div class="uk-margin"><input id="userPassInput" class="uk-input" type="password" placeholder="Passwort"></div>
+              <div class="uk-margin"><input id="userPassRepeat" class="uk-input" type="password" placeholder="Wiederholen"></div>
+              <div class="uk-flex uk-flex-right uk-margin-top">
+                <button id="userPassSave" class="uk-icon-button uk-button-primary" uk-icon="check" type="submit" aria-label="{{ t('action_save') }}"></button>
+                <button class="uk-button uk-button-default uk-modal-close" type="button">{{ t('action_cancel') }}</button>
+              </div>
+            </form>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- wrap user password inputs in a form within admin modal
- handle password form submission via JavaScript

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration; PHPUnit tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bddfbd3410832baffd423f28e87e31