### PR TITLE
feat: combine team actions into single column

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2006,23 +2006,47 @@ document.addEventListener('DOMContentLoaded', function () {
     const teamColumns = [
       { key: 'name', label: 'Name', className: 'team-name', editable: true },
       {
-        className: 'uk-table-shrink',
+        className: 'uk-table-shrink uk-flex uk-flex-middle uk-flex-between',
         render: item => {
-          const btn = document.createElement('button');
-          btn.className = 'uk-icon-button qr-action';
-          btn.setAttribute('uk-icon', 'file-text');
-          btn.setAttribute('aria-label', window.transTeamPdf || 'PDF');
-          btn.setAttribute('uk-tooltip', 'title: ' + (window.transTeamPdf || 'PDF') + '; pos: left');
-          btn.addEventListener('click', () => openTeamPdf(item.name));
-          return btn;
+          const frag = document.createDocumentFragment();
+
+          const pdfBtn = document.createElement('button');
+          pdfBtn.className = 'uk-icon-button qr-action';
+          pdfBtn.setAttribute('uk-icon', 'file-text');
+          pdfBtn.setAttribute('aria-label', window.transTeamPdf || 'PDF');
+          pdfBtn.setAttribute('uk-tooltip', 'title: ' + (window.transTeamPdf || 'PDF') + '; pos: left');
+          pdfBtn.addEventListener('click', () => openTeamPdf(item.name));
+          frag.appendChild(pdfBtn);
+
+          const delBtn = document.createElement('button');
+          delBtn.className = 'uk-icon-button qr-action uk-text-danger';
+          delBtn.setAttribute('uk-icon', 'trash');
+          delBtn.setAttribute('aria-label', window.transDelete || 'Löschen');
+          delBtn.setAttribute('uk-tooltip', 'title: ' + (window.transDelete || 'Löschen') + '; pos: left');
+          delBtn.addEventListener('click', () => removeTeam(item.id));
+          frag.appendChild(delBtn);
+
+          return frag;
         },
         renderCard: item => {
-          const btn = document.createElement('button');
-          btn.className = 'uk-icon-button qr-action';
-          btn.setAttribute('uk-icon', 'file-text');
-          btn.setAttribute('aria-label', window.transTeamPdf || 'PDF');
-          btn.addEventListener('click', () => openTeamPdf(item.name));
-          return btn;
+          const wrapper = document.createElement('div');
+          wrapper.className = 'uk-flex uk-flex-middle uk-flex-between qr-action';
+
+          const pdfBtn = document.createElement('button');
+          pdfBtn.className = 'uk-icon-button qr-action';
+          pdfBtn.setAttribute('uk-icon', 'file-text');
+          pdfBtn.setAttribute('aria-label', window.transTeamPdf || 'PDF');
+          pdfBtn.addEventListener('click', () => openTeamPdf(item.name));
+
+          const delBtn = document.createElement('button');
+          delBtn.className = 'uk-icon-button qr-action uk-text-danger';
+          delBtn.setAttribute('uk-icon', 'trash');
+          delBtn.setAttribute('aria-label', window.transDelete || 'Löschen');
+          delBtn.addEventListener('click', () => removeTeam(item.id));
+
+          wrapper.appendChild(pdfBtn);
+          wrapper.appendChild(delBtn);
+          return wrapper;
         }
       }
     ];
@@ -2035,7 +2059,6 @@ document.addEventListener('DOMContentLoaded', function () {
         teamEditError.hidden = true;
         teamEditor.open(cell);
       },
-      onDelete: removeTeam,
       onReorder: () => reorderTeams(teamManager.getData())
     });
     teamEditor = createCellEditor(teamManager, {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -472,13 +472,12 @@
               <tr>
                 <th class="uk-table-shrink"></th>
                 <th data-key="name">{{ t('column_name') }}</th>
-                <th class="uk-table-shrink" data-key="actions">{{ t('column_actions') }}</th>
+                <th class="uk-table-shrink">{{ t('column_actions') }}</th>
               </tr>
             </thead>
             <tbody
               id="teamsList"
               data-label-name="{{ t('column_name') }}"
-              data-label-actions="{{ t('column_actions') }}"
             ></tbody>
           </table>
         </div>
@@ -1203,6 +1202,7 @@
     window.transEventSettingsHelp = '{{ t('text_event_settings_help')|e('js') }}';
     window.transTeamPdf = '{{ t('tip_team_pdf') }}';
     window.transActions = '{{ t('column_actions') }}';
+    window.transDelete = '{{ t('action_delete') }}';
     window.stripeDashboard = '{{ stripe_sandbox ? 'https://dashboard.stripe.com/test' : 'https://dashboard.stripe.com' }}';
     window.initialEvents = {{ events|json_encode|raw }};
   </script>


### PR DESCRIPTION
## Summary
- consolidate team PDF and delete controls into one actions column
- remove TableManager delete option to keep table header aligned
- expose translation for delete action

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration; Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68bde2470090832baf2d2ae63b43a97f