### PR TITLE
Add robots.txt and ensure static delivery

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /
+Allow: /$
+Allow: /landing$

--- a/public/router.php
+++ b/public/router.php
@@ -22,7 +22,24 @@ if (str_contains($decoded, '..') || str_contains($decoded, '\\')) {
 
 $publicDir = realpath(__DIR__);
 $path = realpath($publicDir . $decoded);
-$allowedExt = ['css', 'js', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'ico', 'html', 'json', 'map', 'webp', 'woff', 'woff2', 'ttf'];
+$allowedExt = [
+    'css',
+    'js',
+    'png',
+    'jpg',
+    'jpeg',
+    'gif',
+    'svg',
+    'ico',
+    'html',
+    'json',
+    'txt',
+    'map',
+    'webp',
+    'woff',
+    'woff2',
+    'ttf',
+];
 
 if (
     $path !== false
@@ -40,6 +57,7 @@ if (
         'js' => 'application/javascript; charset=UTF-8',
         'json' => 'application/json; charset=UTF-8',
         'html' => 'text/html; charset=UTF-8',
+        'txt' => 'text/plain; charset=UTF-8',
         'svg' => 'image/svg+xml',
         'png' => 'image/png',
         'jpg' => 'image/jpeg',

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -55,7 +55,7 @@ class AdminController
             $uid = (string) $params['event'];
             $cfgSvc->setActiveEventUid($uid);
         } else {
-            $uid = (string) ($cfgSvc->getActiveEventUid() ?? '');
+            $uid = (string) $cfgSvc->getActiveEventUid();
         }
 
         if ($uid === '') {

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -36,5 +36,4 @@ class EventController
         $this->service->saveAll($data);
         return $response->withStatus(204);
     }
-
 }

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class RobotsTxtTest extends TestCase
+{
+    public function testRouterServesRobotsTxt(): void
+    {
+        $originalBase = getenv('BASE_PATH');
+        $originalUri = $_SERVER['REQUEST_URI'] ?? null;
+        $originalMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+
+        putenv('BASE_PATH=/base');
+        $_SERVER['REQUEST_URI'] = '/base/robots.txt';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        ob_start();
+        $result = include __DIR__ . '/../public/router.php';
+        $content = ob_get_clean();
+
+        $this->assertTrue($result);
+        $this->assertStringContainsString('User-agent: *', $content);
+
+        if ($originalBase === false) {
+            putenv('BASE_PATH');
+        } else {
+            putenv('BASE_PATH=' . $originalBase);
+        }
+
+        if ($originalUri === null) {
+            unset($_SERVER['REQUEST_URI']);
+        } else {
+            $_SERVER['REQUEST_URI'] = $originalUri;
+        }
+
+        if ($originalMethod === null) {
+            unset($_SERVER['REQUEST_METHOD']);
+        } else {
+            $_SERVER['REQUEST_METHOD'] = $originalMethod;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add robots.txt disallowing all paths except landing and root
- allow router to serve .txt files and return correct MIME type
- cover robots.txt via new unit test
- tidy controller code to satisfy static analysis

## Testing
- `vendor/bin/phpcs -s public/router.php tests/RobotsTxtTest.php src/Controller/AdminController.php src/Controller/EventController.php`
- `vendor/bin/phpstan analyse src/`
- `vendor/bin/phpunit` *(fails: MAIN_DOMAIN misconfiguration)*
- `vendor/bin/phpunit tests/RobotsTxtTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdef1d4e1c832b99fc0c323c45a73b