### PR TITLE
Fix logo preview label semantics

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -231,7 +231,7 @@
             </div>
             <div>
               <div class="uk-margin">
-                <label class="uk-form-label" for="cfgLogoPreview">{{ t('label_logo_preview') }}</label>
+                <div class="uk-form-label">{{ t('label_logo_preview') }}</div>
                 <div class="uk-form-controls">
                   <div class="logo-frame uk-margin-small-top">
                     <img


### PR DESCRIPTION
## Summary
- replace `<label>` referencing non-form element with a neutral container

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE keys)*

------
https://chatgpt.com/codex/tasks/task_e_68bdef4eaa44832bb3badb27d340973e