### PR TITLE
Update admin nav icons

### DIFF
--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -16,9 +16,9 @@
   {
     header: t('menu_content'),
     items: [
-      { href: basePath ~ '/admin/catalogs', icon: 'file-text', text: t('tab_catalogs') },
+      { href: basePath ~ '/admin/catalogs', icon: 'database', text: t('tab_catalogs') },
       { href: basePath ~ '/admin/questions', icon: 'question', text: t('tab_questions') },
-      { href: basePath ~ '/admin/pages', icon: 'file-text', text: t('tab_pages'), admin: true },
+      { href: basePath ~ '/admin/pages', icon: 'file-edit', text: t('tab_pages'), admin: true },
     ]
   },
   {
@@ -39,7 +39,7 @@
     header: t('menu_account'),
     items: [
       { href: basePath ~ '/admin/profile', icon: 'user', text: t('tab_profile'), noEvent: true },
-      { href: basePath ~ '/admin/subscription', icon: 'file-text', text: t('tab_subscription'), noEvent: true },
+      { href: basePath ~ '/admin/subscription', icon: 'credit-card', text: t('tab_subscription'), noEvent: true },
     ]
   },
   {
@@ -47,7 +47,7 @@
     admin: true,
     items: [
       { href: basePath ~ '/admin/management', icon: 'cog', text: t('tab_management'), noEvent: true },
-      { href: basePath ~ '/admin/logs', icon: 'file-text', text: t('tab_logs'), noEvent: true },
+      { href: basePath ~ '/admin/logs', icon: 'history', text: t('tab_logs'), noEvent: true },
       { href: basePath ~ '/admin/tenants', icon: 'users', text: t('tab_tenants'), domain: 'main', noEvent: true },
     ]
   },


### PR DESCRIPTION
## Summary
- swap outdated admin navigation icons for database, file-edit, credit-card, and history icons
- verify new icons exist in bundled UIkit icon set

## Testing
- `composer test` *(fails: Failed to reload nginx: reload failed; Script vendor/bin/phpunit handling the phpunit event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf2f98e98832b88c5bd500e9ae3da