### PR TITLE
Ensure dark theme applies background to body

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -41,10 +41,12 @@ body .uk-card h3,
 body .uk-card p {
   color: #f5f5f5;
 }
+body[data-theme="dark"],
 body[data-theme="dark"] .wrapper,
 body[data-theme="dark"] .content,
 body[data-theme="dark"] .uk-background-muted,
-body[data-theme="dark"] .uk-background-default {
+body[data-theme="dark"] .uk-background-default,
+body[data-theme="dark"].uk-background-muted {
   background-color: #000 !important;
   color: #f5f5f5;
 }


### PR DESCRIPTION
## Summary
- include body element in dark-theme selectors so background color covers page
- handle body with `uk-background-muted` when dark theme is active

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and missing STRIPE_* keys)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf386df30832bbada71542b938913