### PR TITLE
fix: align admin action wrappers to right

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -738,7 +738,7 @@ document.addEventListener('DOMContentLoaded', function () {
       className: 'uk-table-shrink',
       render: item => {
         const wrapper = document.createElement('div');
-        wrapper.className = 'uk-flex uk-flex-middle uk-flex-between';
+        wrapper.className = 'uk-flex uk-flex-middle uk-flex-right';
 
         const delBtn = document.createElement('button');
         delBtn.className = 'uk-icon-button qr-action uk-text-danger';
@@ -752,7 +752,7 @@ document.addEventListener('DOMContentLoaded', function () {
       },
       renderCard: item => {
         const wrapper = document.createElement('div');
-        wrapper.className = 'uk-flex uk-flex-middle uk-flex-between qr-action';
+        wrapper.className = 'uk-flex uk-flex-middle uk-flex-right qr-action';
 
         const delBtn = document.createElement('button');
         delBtn.className = 'uk-icon-button qr-action uk-text-danger';
@@ -1854,7 +1854,7 @@ document.addEventListener('DOMContentLoaded', function () {
         className: 'uk-table-shrink',
         render: ev => {
           const wrapper = document.createElement('div');
-          wrapper.className = 'uk-flex uk-flex-middle uk-flex-between';
+          wrapper.className = 'uk-flex uk-flex-middle uk-flex-right';
 
           const delBtn = document.createElement('button');
           delBtn.className = 'uk-icon-button qr-action uk-text-danger';
@@ -1868,7 +1868,7 @@ document.addEventListener('DOMContentLoaded', function () {
         },
         renderCard: ev => {
           const wrapper = document.createElement('div');
-          wrapper.className = 'uk-flex uk-flex-middle uk-flex-between qr-action';
+          wrapper.className = 'uk-flex uk-flex-middle uk-flex-right qr-action';
 
           const delBtn = document.createElement('button');
           delBtn.className = 'uk-icon-button qr-action uk-text-danger';
@@ -2067,7 +2067,7 @@ document.addEventListener('DOMContentLoaded', function () {
         className: 'uk-table-shrink',
         render: item => {
           const wrapper = document.createElement('div');
-          wrapper.className = 'uk-flex uk-flex-middle uk-flex-between';
+          wrapper.className = 'uk-flex uk-flex-middle uk-flex-right';
 
           const pdfBtn = document.createElement('button');
           pdfBtn.className = 'uk-icon-button qr-action';


### PR DESCRIPTION
## Summary
- replace `uk-flex-between` with `uk-flex-right` for action wrappers in admin JS so buttons align to the right

## Testing
- `npm run build` *(fails: Could not read package.json)*
- `composer test` *(fails: Tests: 321, Assertions: 513, Errors: 31, Failures: 117)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf43a28a0832b897da9fcd53a6e31