### PR TITLE
Use valid UIkit icons for evaluation links

### DIFF
--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -31,8 +31,8 @@
     header: t('menu_evaluation'),
     items: [
       { href: basePath ~ '/admin/summary', icon: 'table', text: t('tab_summary') },
-      { href: basePath ~ '/admin/results', icon: 'checklist', text: t('tab_results') },
-      { href: basePath ~ '/admin/statistics', icon: 'chart-bar', text: t('tab_statistics') },
+      { href: basePath ~ '/admin/results', icon: 'list', text: t('tab_results') },
+      { href: basePath ~ '/admin/statistics', icon: 'signal', text: t('tab_statistics') },
     ]
   },
   {


### PR DESCRIPTION
## Summary
- fix evaluation nav icons to use existing UIkit `list` and `signal` icons

## Testing
- `vendor/bin/phpunit` *(fails: MAIN_DOMAIN misconfiguration; missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf94aaf28832b9e45d1f3330613be