### PR TITLE
Load storage before app on help page

### DIFF
--- a/templates/help.twig
+++ b/templates/help.twig
@@ -27,6 +27,7 @@
 
 {% block scripts %}
   <script src="{{ basePath }}/js/custom-icons.js"></script>
+  <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};


### PR DESCRIPTION
## Summary
- Ensure storage.js is loaded before app.js on the help page so saved UI preferences are available

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfac5dfdc832b870cd8ff0b456750