### PR TITLE
Disable dark stylesheet by default on help page

### DIFF
--- a/templates/help.twig
+++ b/templates/help.twig
@@ -4,7 +4,7 @@
 
 {% block head %}
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css" disabled>
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- disable dark CSS by default on help page so dark mode activates only after user toggle

## Testing
- `node - <<'NODE' ...`
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfacdb784832ba9cfd4e77e228f0e