### PR TITLE
Add catalog sticker PDF report

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -694,6 +694,13 @@ document.addEventListener('DOMContentLoaded', function () {
     window.print();
   });
 
+  const catalogStickerPdfBtn = document.getElementById('catalogStickerPdfBtn');
+  catalogStickerPdfBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    const url = '/admin/reports/catalog-stickers.pdf?rows=2&cols=2&margin=8&lang=de';
+    window.open(withBase(url), '_blank');
+  });
+
   const openInvitesBtn = document.getElementById('openInvitesBtn');
   if (openInvitesBtn) openInvitesBtn.disabled = !currentEventUid;
   openInvitesBtn?.addEventListener('click', function (e) {

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -183,6 +183,7 @@ return [
     'placeholder_invite_text' => 'Text eingeben...',
     'action_open_invitations' => 'Einladungen öffnen',
     'action_print_summary' => 'Übersicht Drucken',
+    'action_catalog_stickers_pdf' => 'Katalog-Sticker (PDF)',
     'action_design_qrcodes' => 'QR-Codes gestalten',
     'column_username' => 'Benutzername',
     'column_role' => 'Rolle',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -185,6 +185,7 @@ return [
     'placeholder_invite_text' => 'Enter text...',
     'action_open_invitations' => 'Open invitations',
     'action_print_summary' => 'Print summary',
+    'action_catalog_stickers_pdf' => 'Catalog stickers (PDF)',
     'action_design_qrcodes' => 'Design QR codes',
     'column_username' => 'Username',
     'column_role' => 'Role',

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\CatalogService;
+use App\Service\ConfigService;
+use App\Service\EventService;
+use App\Service\QrCodeService;
+use FPDF;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Throwable;
+
+class CatalogStickerController
+{
+    private ConfigService $config;
+    private EventService $events;
+    private CatalogService $catalogs;
+    private QrCodeService $qr;
+
+    public function __construct(
+        ConfigService $config,
+        EventService $events,
+        CatalogService $catalogs,
+        QrCodeService $qr
+    ) {
+        $this->config = $config;
+        $this->events = $events;
+        $this->catalogs = $catalogs;
+        $this->qr = $qr;
+    }
+
+    public function pdf(Request $request, Response $response): Response
+    {
+        $params = $request->getQueryParams();
+        $rows = max(1, (int)($params['rows'] ?? 2));
+        $cols = max(1, (int)($params['cols'] ?? 2));
+        $margin = max(0.0, (float)($params['margin'] ?? 8));
+        $uid = (string)($params['event_uid'] ?? ($params['event'] ?? ''));
+        if ($uid === '') {
+            $uid = $this->config->getActiveEventUid();
+        }
+
+        $cfg = $uid !== '' ? $this->config->getConfigForEvent($uid) : $this->config->getConfig();
+        $event = $uid !== '' ? $this->events->getByUid($uid) : null;
+        $eventTitle = (string)($event['name'] ?? '');
+        $eventDesc = (string)($event['description'] ?? '');
+
+        $catsJson = $this->catalogs->read('catalogs.json');
+        $catalogs = $catsJson ? json_decode($catsJson, true) : [];
+        if (!is_array($catalogs)) {
+            $catalogs = [];
+        }
+
+        $pdf = new FPDF('P', 'mm', 'A4');
+        $pdf->SetMargins($margin, $margin, $margin);
+        $pdf->SetAutoPageBreak(false);
+        $pdf->AddPage();
+
+        if ($catalogs === []) {
+            $pdf->SetFont('Arial', 'B', 16);
+            $pdf->Cell(0, 10, $this->sanitizePdfText('Keine Kataloge'), 0, 1, 'C');
+            $out = $pdf->Output('S');
+            $response->getBody()->write($out);
+            return $response
+                ->withHeader('Content-Type', 'application/pdf')
+                ->withHeader('Content-Disposition', 'inline; filename="catalog-stickers.pdf"');
+        }
+
+        $pageW = $pdf->GetPageWidth();
+        $pageH = $pdf->GetPageHeight();
+        $gutter = 6.0;
+        $cardW = ($pageW - 2 * $margin - ($cols - 1) * $gutter) / $cols;
+        $cardH = ($pageH - 2 * $margin - ($rows - 1) * $gutter) / $rows;
+        $pad = 4.0;
+        $qrSize = $cardW * 0.4;
+
+        $count = 0;
+        foreach ($catalogs as $cat) {
+            if ($count > 0 && $count % ($rows * $cols) === 0) {
+                $pdf->AddPage();
+            }
+            $pos = $count % ($rows * $cols);
+            $row = intdiv($pos, $cols);
+            $col = $pos % $cols;
+            $x = $margin + $col * ($cardW + $gutter);
+            $y = $margin + $row * ($cardH + $gutter);
+
+            $pdf->SetDrawColor(221, 221, 221);
+            $pdf->SetLineWidth(0.3);
+            $pdf->Rect($x, $y, $cardW, $cardH);
+
+            $innerX = $x + $pad;
+            $innerY = $y + $pad;
+            $textW = $cardW - 2 * $pad - $qrSize - $pad;
+            $pdf->SetXY($innerX, $innerY);
+
+            if ($eventTitle !== '') {
+                $pdf->SetFont('Arial', 'B', 14);
+                $pdf->MultiCell($textW, 6, $this->sanitizePdfText($eventTitle));
+            }
+            if ($eventDesc !== '') {
+                $pdf->SetFont('Arial', '', 10);
+                $pdf->MultiCell($textW, 5, $this->sanitizePdfText($eventDesc));
+            }
+
+            $pdf->SetFont('Arial', 'B', 12);
+            $pdf->MultiCell($textW, 5, $this->sanitizePdfText((string)($cat['name'] ?? '')));
+            $desc = (string)($cat['description'] ?? '');
+            if ($desc !== '') {
+                $pdf->SetFont('Arial', '', 10);
+                $pdf->MultiCell($textW, 5, $this->sanitizePdfText($desc));
+            }
+
+            $link = $uid !== ''
+                ? '/?event=' . $uid . '&katalog=' . ($cat['slug'] ?? '')
+                : '/?katalog=' . ($cat['slug'] ?? '');
+            $q = ['t' => $link, 'format' => 'png'];
+            $qrX = $x + $cardW - $pad - $qrSize;
+            $qrY = $y + ($cardH - $qrSize) / 2;
+            try {
+                $qr = $this->qr->generateCatalog($q, $cfg);
+                $tmp = tempnam(sys_get_temp_dir(), 'qr') . '.png';
+                file_put_contents($tmp, $qr['body']);
+                $pdf->Image($tmp, $qrX, $qrY, $qrSize, $qrSize, 'PNG');
+                unlink($tmp);
+            } catch (Throwable $e) {
+                $pdf->Rect($qrX, $qrY, $qrSize, $qrSize);
+            }
+
+            $count++;
+        }
+
+        $out = $pdf->Output('S');
+        $response->getBody()->write($out);
+        return $response
+            ->withHeader('Content-Type', 'application/pdf')
+            ->withHeader('Content-Disposition', 'inline; filename="catalog-stickers.pdf"');
+    }
+
+    private function sanitizePdfText(string $text): string
+    {
+        $converted = @iconv('UTF-8', 'CP1252//TRANSLIT', $text);
+        if ($converted === false) {
+            return preg_replace('/[^\x00-\x7F]/', '?', $text);
+        }
+        return $converted;
+    }
+}
+

--- a/src/routes.php
+++ b/src/routes.php
@@ -79,6 +79,7 @@ use App\Controller\StripeWebhookController;
 use App\Controller\SubscriptionController;
 use App\Controller\AdminSubscriptionCheckoutController;
 use App\Controller\InvitationController;
+use App\Controller\CatalogStickerController;
 use Slim\Views\Twig;
 use GuzzleHttp\Client;
 use Psr\Log\NullLogger;
@@ -134,6 +135,7 @@ require_once __DIR__ . '/Controller/StripeWebhookController.php';
 require_once __DIR__ . '/Controller/SubscriptionController.php';
 require_once __DIR__ . '/Controller/AdminSubscriptionCheckoutController.php';
 require_once __DIR__ . '/Controller/InvitationController.php';
+require_once __DIR__ . '/Controller/CatalogStickerController.php';
 
 use App\Infrastructure\Migrations\Migrator;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -245,6 +247,12 @@ return function (\Slim\App $app, TranslationService $translator) {
             ->withAttribute('logoController', new LogoController($configService))
             ->withAttribute('qrLogoController', new QrLogoController($configService))
             ->withAttribute('summaryController', new SummaryController($configService, $eventService))
+            ->withAttribute('catalogStickerController', new CatalogStickerController(
+                $configService,
+                $eventService,
+                $catalogService,
+                new QrCodeService()
+            ))
             ->withAttribute('importController', $importController = new ImportController(
                 $catalogService,
                 $configService,
@@ -1106,6 +1114,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->get('/invites.pdf', function (Request $request, Response $response) {
         return $request->getAttribute('qrController')->pdfAll($request, $response);
     })->add(new RoleAuthMiddleware('admin'));
+    $app->get('/admin/reports/catalog-stickers.pdf', function (Request $request, Response $response) {
+        return $request->getAttribute('catalogStickerController')->pdf($request, $response);
+    })->add(new RoleAuthMiddleware(...Roles::ALL));
     $app->get('/{file:logo(?:-[\w-]+)?\.png}', function (Request $request, Response $response) {
         return $request->getAttribute('logoController')->get($request->withAttribute('ext', 'png'), $response);
     });

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -504,6 +504,9 @@
         </div>
 
         <h3 class="uk-heading-bullet">{{ t('heading_catalogs') }}</h3>
+        <button id="catalogStickerPdfBtn" class="uk-button uk-button-default uk-margin-small-bottom">
+          {{ t('action_catalog_stickers_pdf') }}
+        </button>
         <div class="card-grid" uk-grid id="summaryCatalogs">
           {% for c in catalogs %}
           <div class="uk-width-1-1 uk-width-1-2@s">


### PR DESCRIPTION
## Summary
- add admin button to export catalog stickers as PDF
- implement CatalogStickerController for generating A4 sticker sheets with QR codes
- expose `/admin/reports/catalog-stickers.pdf` route and supporting translations

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration)*


------
https://chatgpt.com/codex/tasks/task_e_68bdfbf81718832bbe0dbdd71fa4ddd3