### PR TITLE
Fix dark mode background handling

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -51,6 +51,17 @@ body[data-theme="dark"].uk-background-default {
   background-color: #000 !important;
   color: #f5f5f5;
 }
+
+body[data-theme="dark"].admin-page {
+  background: #000 !important;
+}
+
+body[data-theme="dark"].admin-page .uk-section,
+body[data-theme="dark"].admin-page .uk-container,
+body[data-theme="dark"].admin-page .uk-grid,
+body[data-theme="dark"].admin-page .uk-grid > * {
+  background: transparent !important;
+}
 body .uk-progress {
   background-color: #333;
   color: var(--accent-color, #1e87f0);

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,5 +1,5 @@
 html, body {
-  height: 100%;
+  min-height: 100%;
   margin: 0;
 }
 
@@ -9,7 +9,12 @@ html {
 body {
   min-height: 100vh;
   overflow-x: hidden;
-  background-color: var(--primary-color, #ffffff);
+  background-color: var(--color-bg, #ffffff);
+}
+
+.uk-offcanvas-content {
+  min-height: 100vh;
+  background: var(--color-bg, #ffffff);
 }
 
 .uk-button-primary {


### PR DESCRIPTION
## Summary
- Ensure full-height layout and theme-based backgrounds
- Black admin area containers for dark theme

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration; missing STRIPE_* keys)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfeeb1a0c832bba5e641935928384