### PR TITLE
Fix team and catalog QR links in overview and PDF generation

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -716,7 +716,17 @@ document.addEventListener('DOMContentLoaded', function () {
       e.preventDefault();
       const team = btn.getAttribute('data-team');
       if (team) {
-        let url = '/qr.pdf?t=' + encodeURIComponent(team) + '&rounded=1';
+        let link;
+        if (currentEventUid) {
+          link = window.baseUrl
+            ? window.baseUrl + '/?event=' + currentEventUid + '&t=' + team
+            : withBase('/?event=' + currentEventUid + '&t=' + team);
+        } else {
+          link = window.baseUrl
+            ? window.baseUrl + '/?t=' + team
+            : withBase('/?t=' + team);
+        }
+        let url = '/qr.pdf?t=' + encodeURIComponent(link) + '&rounded=1';
         if (currentEventUid) {
           url += '&event=' + encodeURIComponent(currentEventUid);
         }
@@ -3010,12 +3020,12 @@ document.addEventListener('DOMContentLoaded', function () {
         wrapper.className = 'uk-width-1-1 uk-width-1-2@s';
         const card = document.createElement('div');
         card.className = 'export-card uk-card qr-card uk-card-body';
-        let href = withBase('/?katalog=' + encodeURIComponent(c.slug));
-        if (ev.uid) {
-          href = withBase('/?event=' + encodeURIComponent(ev.uid) + '&katalog=' + encodeURIComponent(c.slug));
-        }
+        const path = ev.uid
+          ? '/?event=' + encodeURIComponent(ev.uid) + '&katalog=' + encodeURIComponent(c.slug)
+          : '/?katalog=' + encodeURIComponent(c.slug);
+        const qrLink = window.baseUrl + path;
         const linkEl = document.createElement('a');
-        linkEl.href = href;
+        linkEl.href = qrLink;
         linkEl.target = '_blank';
         linkEl.textContent = c.name || '';
         const h4 = document.createElement('h4');
@@ -3024,7 +3034,6 @@ document.addEventListener('DOMContentLoaded', function () {
         const p = document.createElement('p');
         p.textContent = c.description || '';
         const img = document.createElement('img');
-        const qrLink = (window.baseUrl ? window.baseUrl + href : href);
         img.dataset.endpoint = '/qr/catalog';
         img.dataset.target = qrLink;
         const cParams = new URLSearchParams();
@@ -3064,9 +3073,19 @@ document.addEventListener('DOMContentLoaded', function () {
         h4.textContent = t;
         const img = document.createElement('img');
         img.dataset.endpoint = '/qr/team';
-        img.dataset.target = t;
+        let link;
+        if (currentEventUid) {
+          link = window.baseUrl
+            ? window.baseUrl + '/?event=' + currentEventUid + '&t=' + t
+            : withBase('/?event=' + currentEventUid + '&t=' + t);
+        } else {
+          link = window.baseUrl
+            ? window.baseUrl + '/?t=' + t
+            : withBase('/?t=' + t);
+        }
+        img.dataset.target = link;
         const tParams = new URLSearchParams();
-        tParams.set('t', t);
+        tParams.set('t', link);
         applyDesign(tParams, 'qrColorTeam');
         img.src = withBase('/qr/team?' + tParams.toString());
         img.alt = 'QR';
@@ -3077,7 +3096,7 @@ document.addEventListener('DOMContentLoaded', function () {
         designBtn.setAttribute('uk-icon', 'icon: paint-bucket');
         designBtn.type = 'button';
         designBtn.addEventListener('click', () => {
-          openQrDesignModal(img, '/qr/team', t, t);
+          openQrDesignModal(img, '/qr/team', link, t);
         });
         card.appendChild(btn);
         card.appendChild(h4);

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -8,6 +8,7 @@ use App\Service\CatalogService;
 use App\Service\ConfigService;
 use App\Service\EventService;
 use App\Service\QrCodeService;
+use App\Service\UrlService;
 use FPDF;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -47,6 +48,8 @@ class CatalogStickerController
         $event = $uid !== '' ? $this->events->getByUid($uid) : null;
         $eventTitle = (string)($event['name'] ?? '');
         $eventDesc = (string)($event['description'] ?? '');
+
+        $baseUrl = UrlService::determineBaseUrl($request);
 
         $catsJson = $this->catalogs->read('catalogs.json');
         $catalogs = $catsJson ? json_decode($catsJson, true) : [];
@@ -114,9 +117,10 @@ class CatalogStickerController
                 $pdf->MultiCell($textW, 5, $this->sanitizePdfText($desc));
             }
 
-            $link = $uid !== ''
+            $path = $uid !== ''
                 ? '/?event=' . $uid . '&katalog=' . ($cat['slug'] ?? '')
                 : '/?katalog=' . ($cat['slug'] ?? '');
+            $link = $baseUrl . $path;
             $q = ['t' => $link, 'format' => 'png'];
             $qrX = $x + $cardW - $pad - $qrSize;
             $qrY = $y + ($cardH - $qrSize) / 2;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -512,9 +512,9 @@
           <div class="uk-width-1-1 uk-width-1-2@s">
             <div class="export-card uk-card qr-card uk-card-body">
               {% if event.uid %}
-                {% set link = baseUrl ? baseUrl ~ '/?event=' ~ event.uid ~ '&katalog=' ~ c.slug : '?event=' ~ event.uid ~ '&katalog=' ~ c.slug %}
+                {% set link = baseUrl ~ '/?event=' ~ event.uid ~ '&katalog=' ~ c.slug %}
               {% else %}
-                {% set link = baseUrl ? baseUrl ~ '/?katalog=' ~ c.slug : '?katalog=' ~ c.slug %}
+                {% set link = baseUrl ~ '/?katalog=' ~ c.slug %}
               {% endif %}
               <h4 class="uk-card-title"><a href="{{ link }}" target="_blank">{{ c.name }}</a></h4>
               <p>{{ c.description }}</p>
@@ -535,7 +535,12 @@
             <div class="export-card uk-card qr-card uk-card-body uk-position-relative">
               <button class="qr-print-btn uk-icon-button uk-position-top-right" data-team="{{ t }}" uk-icon="icon: print" aria-label="QR-Code drucken"></button>
               <h4 class="uk-card-title">{{ t }}</h4>
-              <img class="qr-img" src="{{ basePath }}/qr/team?t={{ t|url_encode }}&size=150&margin=40" alt="Team QR">
+              {% if event.uid %}
+                {% set link = baseUrl ? baseUrl ~ '/?event=' ~ event.uid ~ '&t=' ~ t : '?event=' ~ event.uid ~ '&t=' ~ t %}
+              {% else %}
+                {% set link = baseUrl ? baseUrl ~ '/?t=' ~ t : '?t=' ~ t %}
+              {% endif %}
+              <img class="qr-img" data-endpoint="/qr/team" data-target="{{ link }}" src="{{ basePath }}/qr/team?t={{ link|url_encode }}&size=150&margin=40" alt="Team QR">
             </div>
           </div>
           {% else %}

--- a/templates/admin/event_config.twig
+++ b/templates/admin/event_config.twig
@@ -174,7 +174,7 @@
             <h3 class="uk-card-title uk-margin-remove">QR-Links</h3>
             <div class="uk-margin-small-top">
               <a class="uk-button uk-button-default uk-width-1-1 uk-margin-small-bottom" href="{{ basePath }}/qr/event?event={{ (event.slug|default('demo')) }}&t={{ ('?event=' ~ (event.slug|default('demo')))|url_encode }}" target="_blank">Event‑QR</a>
-              <a class="uk-button uk-button-default uk-width-1-1 uk-margin-small-bottom" href="{{ basePath }}/qr/catalog?t={{ ('?event=' ~ (event.slug|default('demo')) ~ '&katalog=' ~ (catalog.slug|default('default')))|url_encode }}" target="_blank">Katalog‑QR</a>
+              <a class="uk-button uk-button-default uk-width-1-1 uk-margin-small-bottom" href="{{ basePath }}/qr/catalog?t={{ (baseUrl ~ '/?event=' ~ (event.slug|default('demo')) ~ '&katalog=' ~ (catalog.slug|default('default')))|url_encode }}" target="_blank">Katalog‑QR</a>
               <a class="uk-button uk-button-default uk-width-1-1" href="{{ basePath }}/qr/team?t={{ (team|default('team-1'))|url_encode }}" target="_blank">Team‑QR</a>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Build team and catalog QR links with event and base URL on overview and config pages
- Encode full team and catalog URLs when printing invite and catalog sticker PDFs

## Testing
- `composer test` *(fails: 321 tests, 115 failures, 31 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be03bbaeec832b949cdcff2e5d4f32