### PR TITLE
Handle team name button in app layer

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -12,9 +12,23 @@ document.addEventListener('DOMContentLoaded', function () {
   const themeIcon = document.getElementById('themeIcon');
   const accessibilityIcon = document.getElementById('accessibilityIcon');
   const helpBtn = document.getElementById('helpBtn');
+  const teamNameBtn = document.getElementById('teamNameBtn');
 
   if (offcanvasToggle && !offcanvasHasItems) {
     offcanvasToggle.hidden = true;
+  }
+
+  if (teamNameBtn) {
+    const placeholder = teamNameBtn.textContent;
+    const update = () => {
+      const name = getStored(STORAGE_KEYS.PLAYER_NAME);
+      teamNameBtn.textContent = name || placeholder;
+    };
+    update();
+    teamNameBtn.addEventListener('click', async () => {
+      await promptTeamName();
+      update();
+    });
   }
 
   const storedTheme = getStored(STORAGE_KEYS.DARK_MODE);

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -92,13 +92,9 @@ function insertSoftHyphens(text){
 function updateTeamNameButton(){
   const btn = document.getElementById('teamNameBtn');
   if(!btn) return;
-  const name = getStored('quizUser');
-  if(name){
-    btn.textContent = name;
-  }
+  const name = getStored(STORAGE_KEYS.PLAYER_NAME);
+  btn.textContent = name || btn.getAttribute('data-placeholder') || 'Teamnamen eingeben';
 }
-
-document.addEventListener('DOMContentLoaded', updateTeamNameButton);
 
 async function promptTeamName(){
   return new Promise(resolve => {

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -16,7 +16,7 @@
   {% embed 'topbar.twig' %}
     {% block left %}
       {% if config.randomNames %}
-        <button id="teamNameBtn" class="uk-button uk-button-default uk-button-small" type="button" onclick="promptTeamName()">Teamnamen eingeben</button>
+        <button id="teamNameBtn" class="uk-button uk-button-default uk-button-small" type="button" data-placeholder="Teamnamen eingeben">{{ player_name|default('Teamnamen eingeben') }}</button>
       {% endif %}
     {% endblock %}
     {% block center %}

--- a/tests/test_random_name_prompt.js
+++ b/tests/test_random_name_prompt.js
@@ -2,14 +2,16 @@ const fs = require('fs');
 const vm = require('vm');
 const assert = require('assert');
 
-const code = fs.readFileSync('public/js/quiz.js', 'utf8');
-if (!/if\(cfg.randomNames\)\s*\{\n\s*const nameBtn/.test(code)) {
-    throw new Error('Team name button not found for randomNames');
-}
-const initMatch = code.match(/if\(!getStored\('quizUser'\) && !cfg\.QRRestrict && !cfg\.QRUser\)\{[\s\S]*?\n\s*\}\n\s*\}/);
-const handlerMatch = code.match(/startBtn.addEventListener\('click', async\(\) => \{([\s\S]*?)\n\s*\}\);/);
+const quizCode = fs.readFileSync('public/js/quiz.js', 'utf8');
+const initMatch = quizCode.match(/if\(!getStored\('quizUser'\) && !cfg\.QRRestrict && !cfg\.QRUser\)\{[\s\S]*?\n\s*\}\n\s*\}/);
+const handlerMatch = quizCode.match(/startBtn.addEventListener\('click', async\(\) => \{([\s\S]*?)\n\s*\}\);/);
 if (!initMatch || !handlerMatch) {
     throw new Error('Required code blocks not found');
+}
+
+const appCode = fs.readFileSync('public/js/app.js', 'utf8');
+if (!/getElementById\('teamNameBtn'\)/.test(appCode)) {
+    throw new Error('teamNameBtn handling missing in app.js');
 }
 
 (async() => {


### PR DESCRIPTION
## Summary
- Render team name button in index template with placeholder
- Update button text and click handler on DOMContentLoaded in app.js
- Adjust quiz helper and tests for new button handling

## Testing
- `node tests/test_random_name_prompt.js`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f14fbb4832bb4cbc43ab251d914