### PR TITLE
fix: preserve player name on restart

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1321,7 +1321,7 @@ async function runQuiz(questions, skipIntro){
       restart.className = 'uk-button uk-button-primary uk-margin-top';
       styleButton(restart);
         restart.addEventListener('click', () => {
-          clearStored(STORAGE_KEYS.PLAYER_NAME);
+          // keep player name across restarts but allow new quiz attempts
           clearStored(STORAGE_KEYS.QUIZ_SOLVED);
           const topbar = document.getElementById('topbar-title');
           if(topbar){


### PR DESCRIPTION
## Summary
- avoid resetting the player name when clicking "Neu starten"

## Testing
- `composer test` *(fails: phpunit tests not completing; missing STRIPE_* env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68be156afba4832b9c2c9061876bed01