### PR TITLE
feat: enhance event catalogs layout

### DIFF
--- a/templates/event_catalogs.twig
+++ b/templates/event_catalogs.twig
@@ -5,7 +5,7 @@
 {% block head %}
   <meta name="csrf-token" content="{{ csrf_token }}">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
-  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css" disabled>
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
 {% endblock %}
 
@@ -18,10 +18,22 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-large">
+    <div class="uk-text-center uk-margin">
+      <img class="logo-placeholder"
+           src="{% if config.logoPath %}{{ basePath ~ config.logoPath }}{% else %}{{ basePath }}/logo-160.svg{% endif %}"
+           {% if not config.logoPath %}
+           srcset="{{ basePath }}/logo-160.svg 160w, {{ basePath }}/logo-320.svg 320w"
+           sizes="(max-width: 600px) 160px, 320px"
+           {% endif %}
+           alt="Logo" width="160" height="240" loading="lazy">
+    </div>
     {% if event.description %}
       <p class="uk-text-lead uk-text-center">{{ event.description }}</p>
     {% endif %}
-    <div class="uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid>
+    {% if event.comment %}
+      <div class="uk-text-center uk-margin">{{ event.comment|raw }}</div>
+    {% endif %}
+    <div class="uk-child-width-1-1 uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-small" uk-grid uk-height-match="target: > div > .uk-card">
       {% for cat in catalogs %}
         {% set key = cat.slug ?? cat.uid ?? cat.sort_order ?? cat.id %}
         <div>
@@ -41,5 +53,6 @@
 
 {% block scripts %}
   <script src="{{ basePath }}/js/custom-icons.js" defer></script>
+  <script src="{{ basePath }}/js/app.js" defer></script>
   <script src="{{ basePath }}/js/catalog-grid.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable theme options for dark, light, and high contrast modes
- ensure catalog cards share equal height
- show event logo and comment on catalog list

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration; missing Stripe keys)*

------
https://chatgpt.com/codex/tasks/task_e_68be1f3a4a0c832bbabbb054699fee55