### PR TITLE
feat: dark mode topbar button background

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -371,6 +371,25 @@ body.dark-mode .qr-landing .qr-topbar{
   border-radius:6px;
 }
 .qr-landing .qr-topbar .uk-navbar-toggle{ color:var(--qr-text)!important; }
+.git-btn{
+  width:40px;height:40px;padding:0;
+  border-radius:6px;
+  border:1px solid var(--topbar-btn-border);
+  color:var(--topbar-text);
+  background:var(--topbar-btn-bg);
+  display:inline-flex;align-items:center;justify-content:center;
+  box-sizing:border-box;cursor:pointer;
+  transition:background .12s,border-color .12s,box-shadow .12s;
+}
+.git-btn:hover{
+  background:var(--topbar-btn-bg-hover);
+  border-color:var(--topbar-btn-border-hover);
+}
+.git-btn:focus{
+  outline:none;
+  box-shadow:0 0 0 3px var(--topbar-focus-ring);
+}
+.git-btn svg{width:24px;height:24px;}
 .qr-landing .qr-topbar #offcanvas-toggle.git-btn{
   width:56px;
   height:56px;

--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -67,6 +67,7 @@ body:not(.dark-mode) .topbar .uk-navbar-nav>li>a{
   border-radius:6px;
   border:1px solid var(--topbar-btn-border);
   color:var(--topbar-text);
+  background:var(--topbar-btn-bg);
   display:inline-flex;align-items:center;justify-content:center;
   box-sizing:border-box;cursor:pointer;
   transition:background .12s,border-color .12s,box-shadow .12s;

--- a/public/css/topbar.landing.css
+++ b/public/css/topbar.landing.css
@@ -9,6 +9,7 @@ body.qr-landing:not([data-theme="dark"]){
   --topbar-text: var(--qr-text);
 }
 body.qr-landing[data-theme="dark"]{
+  --topbar-btn-bg: #1f232a;
   --topbar-btn-border: var(--qr-card-border);
   --topbar-btn-border-hover: color-mix(in oklab,var(--qr-text) 60%, transparent);
   --topbar-btn-bg-hover: color-mix(in oklab,var(--qr-text) 16%, transparent);


### PR DESCRIPTION
## Summary
- apply topbar button background variable in shared styles
- provide landing page dark theme `--topbar-btn-bg`
- add landing stylesheet `.git-btn` rule for dark-mode backgrounds

## Testing
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1f41d91c832bbab822ccbe2de73d