### PR TITLE
Add dynamic restart link in quiz summary

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -1332,7 +1332,9 @@ async function runQuiz(questions, skipIntro){
     div.appendChild(remainingInfo);
     if(!cfg.competitionMode){
       const restart = document.createElement('a');
-      restart.href = '/';
+      const catalogSlug = getStored(STORAGE_KEYS.CATALOG) || '';
+      const restartUrl = `/?event=${encodeURIComponent(currentEventUid)}&katalog=${encodeURIComponent(catalogSlug)}`;
+      restart.href = withBase(restartUrl);
       restart.textContent = 'Neu starten';
       restart.className = 'uk-button uk-button-primary uk-margin-top';
       styleButton(restart);


### PR DESCRIPTION
## Summary
- Use stored catalog and event IDs to build restart link
- Preserve existing restart click handler for clearing state

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be6c481db0832ba6968a25c510a797