### PR TITLE
feat: adapt onboarding buttons for dark mode

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -73,7 +73,7 @@
     </div>
 
     <div class="uk-text-center uk-margin-large">
-      <a class="uk-button uk-button-primary uk-button-large" href="{{ basePath }}/onboarding">Event starten</a>
+      <a class="uk-button uk-button-primary uk-button-large onboarding-btn" href="{{ basePath }}/onboarding">Event starten</a>
       <a class="uk-button uk-button-default uk-button-large" href="https://demo.quizrace.app" target="_blank" rel="noopener">Demo ansehen</a>
     </div>
   </div>
@@ -352,7 +352,7 @@
     </script>
 
     <div class="uk-text-center uk-margin-large">
-      <a class="cta-ghost uk-button uk-button-large" href="{{ basePath }}/onboarding">
+      <a class="cta-ghost uk-button uk-button-large onboarding-btn" href="{{ basePath }}/onboarding">
         Idee gefunden – los geht’s
       </a>
     </div>
@@ -379,7 +379,7 @@
             <p class="uk-text-small uk-margin-remove">Sofort sehen, wie es für Teilnehmende aussieht.</p>
           </div>
         </div>
-        <a class="uk-button uk-button-primary uk-margin-medium-top" href="{{ basePath }}/onboarding">Editor testen</a>
+        <a class="uk-button uk-button-primary uk-margin-medium-top onboarding-btn" href="{{ basePath }}/onboarding">Editor testen</a>
       </div>
       <div>
         <div class="uk-card uk-card-quizrace uk-card-body">

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -118,6 +118,12 @@ body.dark-mode {
   color: var(--qr-text);
 }
 
+body.qr-landing[data-theme="dark"] {
+  --landing-btn-bg: var(--qr-bg-soft);
+  --landing-btn-bg-hover: #30363d;
+  --landing-btn-fg: var(--qr-landing-text);
+}
+
 body[data-theme],
 body.qr-landing {
   background: var(--qr-hero-gradient);
@@ -523,12 +529,21 @@ body.dark-mode .qr-landing .qr-badge{
   opacity:.85;
   transform:translateY(-1px);
 }
+
+.qr-landing .onboarding-btn {
+  background: var(--landing-btn-bg);
+  color: var(--landing-btn-fg) !important;
+  border: 1px solid color-mix(in oklab, var(--landing-btn-bg) 80%, transparent);
+}
+.qr-landing .onboarding-btn:hover {
+  background: var(--landing-btn-bg-hover);
+}
 .cta-ghost{
   display:flex;
   align-items:center;
   justify-content:center;
-  border:2px solid var(--qr-blue,#2F81F7);
-  color:var(--qr-blue,#2F81F7)!important;
+  border:2px solid var(--landing-btn-fg);
+  color:var(--landing-btn-bg-hover)!important;
   background:transparent;
   border-radius:12px;
   font-weight:600;
@@ -540,8 +555,8 @@ body.dark-mode .qr-landing .qr-badge{
 }
 .cta-ghost:hover,
 .cta-ghost:focus{
-  background:var(--qr-blue,#2F81F7);
-  color:#fff!important;
+  background:var(--landing-btn-bg-hover);
+  color:var(--landing-btn-fg)!important;
   box-shadow:0 6px 18px rgba(47,129,247,.35);
   text-decoration:none;
 }


### PR DESCRIPTION
## Summary
- add dark-theme variables and onboarding button styles
- apply onboarding button class to all landing onboarding links
- restyle ghost CTA to use landing button theme colors

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68be6f7c772c832baa87dd06987c2bf4