### PR TITLE
Display event header below topbar on index page

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -171,11 +171,6 @@ body .uk-icon-button:not(.uk-button-primary) {
   background-color: rgba(255, 255, 255, 0.1);
   border: 1px solid #444;
 }
-body .event-header-bar {
-  background-color: #1e1e1e;
-  border-color: #444;
-}
-
 body .modern-info-card {
   border-color: #444;
 }
@@ -484,11 +479,6 @@ body[data-theme="dark"] .topbar {
   border-color: #444;
   padding-top: env(safe-area-inset-top);
 }
-body[data-theme="dark"] .event-header-bar {
-  background-color: #1e1e1e;
-  border-color: #444;
-}
-
 body[data-theme="dark"] .modern-info-card {
   border-color: #444;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -240,13 +240,6 @@ body.uk-padding {
   justify-content: center;
 }
 
-.event-header-bar {
-  background: #fff;
-  border-bottom: 1px solid var(--qr-border);
-  padding: 0.25rem 0.5rem;
-  line-height: 1.2;
-}
-
 /* Admin sidebar navigation */
 .qr-sidebar { min-height: calc(100vh - 56px); }
 .qr-sidebar-card { height: 100%; overflow-y: auto; }

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -22,12 +22,13 @@
     {% block center %}
       <span id="topbar-title" class="uk-navbar-title uk-text-center" data-default-title="{{ event.name|default('Sommerfest 2025') }}">{{ event.name|default('Sommerfest 2025') }}</span>
     {% endblock %}
-    {% block headerbar %}
-      {% if event.description %}
-        <div class="event-header-bar uk-text-center">{{ event.description }}</div>
-      {% endif %}
-    {% endblock %}
   {% endembed %}
+  <div class="uk-container uk-container-large">
+    <h1 class="uk-heading-medium uk-text-center">{{ event.name }}</h1>
+    {% if event.description %}
+      <p class="uk-text-lead uk-text-center">{{ event.description }}</p>
+    {% endif %}
+  </div>
   <div class="uk-container uk-width-1-1 uk-width-1-2@s uk-width-2-3@m">
     <div class="uk-card qr-card uk-card-body uk-box-shadow-large uk-margin" uk-scrollspy="cls: uk-animation-fade">
       <div id="quiz-header" class="uk-text-center uk-margin" uk-scrollspy="cls: uk-animation-scale-up; delay: 100">


### PR DESCRIPTION
## Summary
- Move event description from topbar to main layout
- Remove unused `.event-header-bar` styling

## Testing
- `composer test` *(fails: Missing STRIPE keys)*

------
https://chatgpt.com/codex/tasks/task_e_68be739d89ac832b8f0b5ccd1c470a6b