### PR TITLE
Event-Header außerhalb der Topbar und mobil verkleinert

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -205,12 +205,6 @@ body.uk-padding {
   flex-shrink: 0;
 }
 
-#topbar-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .uk-icon-button {
   border-radius: 6px;
   border: 1px solid var(--topbar-btn-border, #ddd);

--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -37,10 +37,6 @@ body[data-theme="dark"].high-contrast{
   --topbar-focus-ring: rgba(140,200,255,0.8);
 }
 
-#topbar-title {
-  color: var(--topbar-text);
-}
-
 /* Buttons in der Topbar */
 .topbar .uk-button,
 .topbar .uk-navbar-nav>li>a{

--- a/templates/event_catalogs.twig
+++ b/templates/event_catalogs.twig
@@ -12,13 +12,9 @@
 {% block body_class %}uk-padding{% endblock %}
 
 {% block body %}
-  {% embed 'topbar.twig' %}
-    {% block center %}
-      <span class="uk-navbar-title uk-text-center">{{ event.name }}</span>
-    {% endblock %}
-  {% endembed %}
+  {% embed 'topbar.twig' %}{% endembed %}
   <div class="uk-container uk-container-large">
-    <h1 class="uk-heading-medium uk-text-center">{{ event.name }}</h1>
+    <h1 class="uk-heading-small uk-heading-medium@m uk-text-center uk-text-light">{{ event.name }}</h1>
     <div class="uk-text-center uk-margin">
       <img class="logo-placeholder"
            src="{% if config.logoPath %}{{ basePath ~ config.logoPath }}{% else %}{{ basePath }}/logo-160.svg{% endif %}"

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -19,12 +19,9 @@
         <button id="teamNameBtn" class="uk-button uk-button-default uk-button-small" type="button" data-placeholder="Teamnamen eingeben">{{ player_name|default('Teamnamen eingeben') }}</button>
       {% endif %}
     {% endblock %}
-    {% block center %}
-      <span id="topbar-title" class="uk-navbar-title uk-text-center" data-default-title="{{ event.name|default('Sommerfest 2025') }}">{{ event.name|default('Sommerfest 2025') }}</span>
-    {% endblock %}
   {% endembed %}
   <div class="uk-container uk-container-large">
-    <h1 class="uk-heading-medium uk-text-center">{{ event.name }}</h1>
+    <h1 class="uk-heading-small uk-heading-medium@m uk-text-center uk-text-light">{{ event.name }}</h1>
     {% if event.description %}
       <p class="uk-text-lead uk-text-center">{{ event.description }}</p>
     {% endif %}


### PR DESCRIPTION
## Zusammenfassung
- Entfernt den Eventnamen aus der Topbar und positioniert ihn als eigenständige Überschrift oberhalb der Eventbeschreibung.
- Entfernt die Topbar-Überschrift auch auf der Katalogübersicht und bereinigt übriggebliebene CSS-Regeln für `#topbar-title`.

## Testing
- `composer test` *(fehlgeschlagen: vendor/bin/phpunit nicht gefunden)*

------
https://chatgpt.com/codex/tasks/task_e_68be7334a838832b945885ff942ca46f