### PR TITLE
Add sticker background upload and PDF rendering

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -705,6 +705,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const catalogStickerLines = document.getElementById('catalogStickerLines');
   const catalogStickerQrColor = document.getElementById('catalogStickerQrColor');
   const catalogStickerQrSizePct = document.getElementById('catalogStickerQrSizePct');
+  const catalogStickerBg = document.getElementById('catalogStickerBg');
   catalogStickerForm?.addEventListener('submit', e => {
     e.preventDefault();
     const params = new URLSearchParams({
@@ -717,6 +718,20 @@ document.addEventListener('DOMContentLoaded', function () {
     const url = '/admin/reports/catalog-stickers.pdf?' + params.toString();
     window.open(withBase(url), '_blank');
     if (catalogStickerModal) catalogStickerModal.hide();
+  });
+
+  catalogStickerBg?.addEventListener('change', () => {
+    const file = catalogStickerBg.files && catalogStickerBg.files[0];
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    const url = '/admin/sticker-background' + (currentEventUid ? `?event_uid=${encodeURIComponent(currentEventUid)}` : '');
+    apiFetch(url, { method: 'POST', body: fd })
+      .then(res => {
+        if (!res.ok) throw new Error('upload failed');
+        notify(window.transImageReady || 'Image bereit', 'success');
+      })
+      .catch(() => notify('Fehler beim Hochladen', 'danger'));
   });
 
   const openInvitesBtn = document.getElementById('openInvitesBtn');

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -188,6 +188,7 @@ return [
     'label_template' => 'Vorlage',
     'label_lines' => 'Zeilen',
     'label_qr_size_pct' => 'QR-Größe (%)',
+    'label_sticker_bg' => 'Sticker-Hintergrund',
     'action_design_qrcodes' => 'QR-Codes gestalten',
     'column_username' => 'Benutzername',
     'column_role' => 'Rolle',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -190,6 +190,7 @@ return [
     'label_template' => 'Template',
     'label_lines' => 'Lines',
     'label_qr_size_pct' => 'QR size (%)',
+    'label_sticker_bg' => 'Sticker background',
     'action_design_qrcodes' => 'Design QR codes',
     'column_username' => 'Username',
     'column_role' => 'Role',

--- a/src/routes.php
+++ b/src/routes.php
@@ -1114,6 +1114,10 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('catalogStickerController')->pdf($request, $response);
     })->add(new RoleAuthMiddleware(...Roles::ALL));
 
+    $app->post('/admin/sticker-background', function (Request $request, Response $response) {
+        return $request->getAttribute('catalogStickerController')->uploadBackground($request, $response);
+    })->add(new RoleAuthMiddleware(...Roles::ALL));
+
     $app->get('/admin/{path:.*}', function (Request $request, Response $response) {
         $base = \Slim\Routing\RouteContext::fromRequest($request)->getBasePath();
         return $response->withHeader('Location', $base . '/admin/dashboard')->withStatus(302);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -534,6 +534,10 @@
                 <label for="catalogStickerQrSizePct">{{ t('label_qr_size_pct') }}</label>
                 <input type="number" id="catalogStickerQrSizePct" class="uk-input" value="42" min="35" max="50">
               </div>
+              <div class="uk-margin">
+                <label for="catalogStickerBg">{{ t('label_sticker_bg') }}</label>
+                <input type="file" id="catalogStickerBg" class="uk-input" accept="image/*">
+              </div>
               <div class="uk-text-right">
                 <button class="uk-button uk-button-primary" type="submit" id="catalogStickerGenerate">{{ t('action_download') }}</button>
                 <button class="uk-button uk-button-default uk-modal-close" type="button">{{ t('action_cancel') }}</button>


### PR DESCRIPTION
## Summary
- Allow admins to upload a sticker background image from the dashboard
- Store uploaded background image and render it behind each sticker in PDF exports
- Wire up new `/admin/sticker-background` endpoint and translations

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml src/Controller/CatalogStickerController.php src/routes.php`
- `composer test` *(fails: Failed asserting that 4 is identical to 2)*

------
https://chatgpt.com/codex/tasks/task_e_68be81eefb98832b8a6552d0a0b3177f