### PR TITLE
Add option to include catalog description on stickers

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -702,7 +702,7 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   const catalogStickerForm = document.getElementById('catalogStickerForm');
   const catalogStickerTemplate = document.getElementById('catalogStickerTemplate');
-  const catalogStickerLines = document.getElementById('catalogStickerLines');
+  const catalogStickerDesc = document.getElementById('catalogStickerDesc');
   const catalogStickerQrColor = document.getElementById('catalogStickerQrColor');
   const catalogStickerQrSizePct = document.getElementById('catalogStickerQrSizePct');
   const catalogStickerBg = document.getElementById('catalogStickerBg');
@@ -710,9 +710,9 @@ document.addEventListener('DOMContentLoaded', function () {
     e.preventDefault();
     const params = new URLSearchParams({
       template: catalogStickerTemplate.value,
-      lines: catalogStickerLines.value,
       qr_color: catalogStickerQrColor.value.replace(/^#/, ''),
-      qr_size_pct: catalogStickerQrSizePct.value
+      qr_size_pct: catalogStickerQrSizePct.value,
+      print_desc: catalogStickerDesc.checked ? '1' : '0'
     });
     if (currentEventUid) params.set('event_uid', currentEventUid);
     const url = '/admin/reports/catalog-stickers.pdf?' + params.toString();

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -186,7 +186,7 @@ return [
     'action_catalog_stickers_pdf' => 'Katalog-Sticker (PDF)',
     'heading_catalog_sticker_settings' => 'Sticker-Einstellungen',
     'label_template' => 'Vorlage',
-    'label_lines' => 'Zeilen',
+    'label_print_catalog_desc' => 'Katalogbeschreibung drucken',
     'label_qr_size_pct' => 'QR-Größe (%)',
     'label_sticker_bg' => 'Sticker-Hintergrund',
     'action_design_qrcodes' => 'QR-Codes gestalten',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -188,7 +188,7 @@ return [
     'action_catalog_stickers_pdf' => 'Catalog stickers (PDF)',
     'heading_catalog_sticker_settings' => 'Sticker settings',
     'label_template' => 'Template',
-    'label_lines' => 'Lines',
+    'label_print_catalog_desc' => 'Print catalog description',
     'label_qr_size_pct' => 'QR size (%)',
     'label_sticker_bg' => 'Sticker background',
     'action_design_qrcodes' => 'Design QR codes',

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -85,8 +85,7 @@ class CatalogStickerController
         }
         $tpl = self::LABEL_TEMPLATES[$template];
 
-        $lines = (int)($params['lines'] ?? 3);
-        $lines = $lines === 4 ? 4 : 3;
+        $printDesc = filter_var($params['print_desc'] ?? false, FILTER_VALIDATE_BOOLEAN);
         $qrColor = preg_replace('/[^0-9A-Fa-f]/', '', (string)($params['qr_color'] ?? '000000'));
         $qrColor = str_pad(substr($qrColor, 0, 6), 6, '0');
         $qrSizePct = max(10, min(100, (int)($params['qr_size_pct'] ?? 42)));
@@ -165,10 +164,9 @@ class CatalogStickerController
             }
             $linesData[] = ['Arial', 'B', 11, (string)($cat['name'] ?? '')];
             $desc = (string)($cat['description'] ?? '');
-            if ($lines === 4 && $desc !== '') {
+            if ($printDesc && $desc !== '') {
                 $linesData[] = ['Arial', '', 10, $desc];
             }
-            $linesData = array_slice($linesData, 0, $lines);
 
             foreach ($linesData as $data) {
                 [$fam, $style, $size, $text] = $data;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -520,11 +520,7 @@
                 </select>
               </div>
               <div class="uk-margin">
-                <label for="catalogStickerLines">{{ t('label_lines') }}</label>
-                <select id="catalogStickerLines" class="uk-select">
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                </select>
+                <label><input type="checkbox" id="catalogStickerDesc" class="uk-checkbox"> {{ t('label_print_catalog_desc') }}</label>
               </div>
               <div class="uk-margin">
                 <label for="catalogStickerQrColor">{{ t('label_qr_color') }}</label>


### PR DESCRIPTION
## Summary
- Replace sticker line selector with checkbox to print catalog descriptions
- Add translations for new print catalog description option
- Update controller and JS to handle description printing

## Testing
- `composer phpunit` *(fails: MAIN_DOMAIN misconfiguration; Missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68be94fb29a8832ba374f3735da6bca2