### PR TITLE
Refactor user table into reusable component

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2300,6 +2300,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (u.id) row.dataset.id = u.id;
 
     const handleCell = document.createElement('td');
+    handleCell.className = 'uk-table-shrink';
     const handleSpan = document.createElement('span');
     handleSpan.className = 'uk-sortable-handle uk-icon';
     handleSpan.setAttribute('uk-icon', 'icon: table');
@@ -2321,6 +2322,7 @@ document.addEventListener('DOMContentLoaded', function () {
     activeCell.appendChild(activeCheckbox);
 
     const passCell = document.createElement('td');
+    passCell.className = 'uk-table-shrink';
     const passBtn = document.createElement('button');
     passBtn.className = 'uk-button uk-button-default';
     passBtn.setAttribute('uk-icon', 'icon: key');
@@ -2348,6 +2350,7 @@ document.addEventListener('DOMContentLoaded', function () {
     roleCell.appendChild(roleSelect);
 
     const delCell = document.createElement('td');
+    delCell.className = 'uk-table-shrink';
     const delBtn = document.createElement('button');
     delBtn.className = 'uk-icon-button uk-button-danger';
     delBtn.setAttribute('uk-icon', 'trash');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1,4 +1,5 @@
 {% extends 'layout.twig' %}
+{% import 'components/standard_table.twig' as std_table %}
 
 {% block title %}{{ t('admin_title') }}{% endblock %}
 
@@ -896,20 +897,14 @@
         </div>
 
         <h3 class="uk-heading-bullet">{{ t('heading_users') }}</h3>
-        <div class="uk-overflow-auto">
-          <table class="uk-table uk-table-divider uk-table-small uk-table-hover">
-            <thead>
-              <tr>
-                <th>{{ t('column_username') }}</th>
-                <th>{{ t('column_role') }}</th>
-                <th>Aktiv</th>
-                <th class="uk-table-shrink"><span uk-icon="icon: key" uk-tooltip="title: {{ t('tip_user_pass') }}; pos: top" tabindex="0"></span></th>
-                <th class="uk-table-shrink"></th>
-              </tr>
-            </thead>
-            <tbody id="usersList"></tbody>
-          </table>
-        </div>
+        {{ std_table.render([
+          {label: '', class: 'uk-table-shrink'},
+          {label: t('column_username')},
+          {label: t('column_role')},
+          {label: 'Aktiv'},
+          {label: '<span uk-icon="icon: key" uk-tooltip="title: ' ~ t('tip_user_pass') ~ '; pos: top" tabindex="0"></span>', class: 'uk-table-shrink'},
+          {label: '', class: 'uk-table-shrink'}
+        ], 'usersList') }}
         <div class="uk-margin">
           <button id="userAddBtn" class="uk-icon-button uk-button-default" uk-icon="plus" uk-tooltip="title: {{ t('tip_user_add') }}; pos: right" aria-label="{{ t('tip_user_add') }}"></button>
         </div>

--- a/templates/components/standard_table.twig
+++ b/templates/components/standard_table.twig
@@ -1,0 +1,14 @@
+{% macro render(headings, body_id, body='') %}
+<div class="uk-overflow-auto">
+  <table class="uk-table uk-table-divider uk-table-small uk-table-hover">
+    <thead>
+      <tr>
+        {% for h in headings %}
+          <th{% if h.class %} class="{{ h.class }}"{% endif %}>{{ h.label|raw }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody id="{{ body_id }}">{{ body|raw }}</tbody>
+  </table>
+</div>
+{% endmacro %}


### PR DESCRIPTION
## Summary
- add generic `standard_table` macro for consistent UIkit table markup
- use new macro for admin user management table
- align user-row generation with standardized table structure

## Testing
- `composer test` *(fails: DFFFF.FFEE.F.FF....EE........F...FFFFF....FEEEEEFFFF...........  63 / 323 ( 19%))*

------
https://chatgpt.com/codex/tasks/task_e_68be81a9aa94832bae058e469f188269