### PR TITLE
feat: add catalog sticker preview

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -542,6 +542,7 @@
                 <label for="catalogStickerBg">{{ t('label_sticker_bg') }}</label>
                 <input type="file" id="catalogStickerBg" class="uk-input" accept="image/*">
               </div>
+              <div id="catalogStickerPreview" class="uk-margin"></div>
               <div class="uk-text-right">
                 <button class="uk-button uk-button-primary" type="submit" id="catalogStickerGenerate">{{ t('action_download') }}</button>
                 <button class="uk-button uk-button-default uk-modal-close" type="button">{{ t('action_cancel') }}</button>


### PR DESCRIPTION
## Summary
- add sticker preview container to catalog sticker modal
- render sticker preview canvas with live updates for template and background settings

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* settings)*
- `vendor/bin/phpcs` *(fails: line indented incorrectly)*

------
https://chatgpt.com/codex/tasks/task_e_68bea7d30f48832bbf7843a45956e083