### PR TITLE
Add draggable handles for catalog sticker layout

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -542,7 +542,14 @@
                 <label for="catalogStickerBg">{{ t('label_sticker_bg') }}</label>
                 <input type="file" id="catalogStickerBg" class="uk-input" accept="image/*">
               </div>
-              <div id="catalogStickerPreview" class="uk-margin"></div>
+              <div id="catalogStickerPreview" class="uk-margin uk-position-relative">
+                <div id="stickerDescHandle" class="uk-position-absolute"></div>
+                <input type="hidden" id="descTop" name="descTop" value="">
+                <input type="hidden" id="descLeft" name="descLeft" value="">
+                <div id="stickerQrHandle" class="uk-position-absolute"></div>
+                <input type="hidden" id="qrTop" name="qrTop" value="">
+                <input type="hidden" id="qrLeft" name="qrLeft" value="">
+              </div>
               <div class="uk-text-right">
                 <button class="uk-button uk-button-primary" type="submit" id="catalogStickerGenerate">{{ t('action_download') }}</button>
                 <button class="uk-button uk-button-default uk-modal-close" type="button">{{ t('action_cancel') }}</button>


### PR DESCRIPTION
## Summary
- allow positioning of description and QR code via draggable handles in sticker preview
- store handle coordinates for PDF generation and render them in server

## Testing
- `vendor/bin/phpcs src/Controller/CatalogStickerController.php`
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* variables, PHPUnit tests DFFFF.FFEE)*

------
https://chatgpt.com/codex/tasks/task_e_68beab4d9950832ba1c8bd7b01259f79