### PR TITLE
Add customizable catalog sticker preview

### DIFF
--- a/src/Controller/AdminCatalogController.php
+++ b/src/Controller/AdminCatalogController.php
@@ -46,4 +46,21 @@ class AdminCatalogController
         $response->getBody()->write((string) json_encode($payload));
         return $response->withHeader('Content-Type', 'application/json');
     }
+
+    /**
+     * Return the first catalog (name and description only).
+     */
+    public function sample(Request $request, Response $response): Response
+    {
+        $items = $this->service->fetchPagedCatalogs(0, 1, 'asc');
+        $first = $items[0] ?? null;
+        $payload = $first === null
+            ? null
+            : [
+                'name' => $first['name'] ?? '',
+                'description' => $first['description'] ?? '',
+            ];
+        $response->getBody()->write((string) json_encode($payload));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
 }

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -91,6 +91,8 @@ class CatalogStickerController
         $qrSizePct = max(10, min(100, (int)($params['qr_size_pct'] ?? 42)));
         $descTop = isset($params['desc_top']) ? (float)$params['desc_top'] : 0.0;
         $descLeft = isset($params['desc_left']) ? (float)$params['desc_left'] : 0.0;
+        $descWidth = isset($params['desc_width']) ? (float)$params['desc_width'] : null;
+        $descHeight = isset($params['desc_height']) ? (float)$params['desc_height'] : null;
         $qrTop = isset($params['qr_top']) ? (float)$params['qr_top'] : null;
         $qrLeft = isset($params['qr_left']) ? (float)$params['qr_left'] : null;
 
@@ -118,6 +120,8 @@ class CatalogStickerController
         $descLeft = max(0.0, min($innerMaxW, $descLeft));
         $innerW = $innerMaxW - $descLeft;
         $innerH = $innerMaxH - $descTop;
+        $descWidth = $descWidth !== null ? max(0.0, min($innerW, $descWidth)) : $innerW * 0.6;
+        $descHeight = $descHeight !== null ? max(0.0, min($innerH, $descHeight)) : $innerH - 6.0;
         $qrSize = min($innerW * $qrSizePct / 100.0, $innerH * 0.55);
         $qrPad = 2.0;
         $qrLeft = $qrLeft !== null
@@ -168,8 +172,8 @@ class CatalogStickerController
             $baseY = $y + $tpl['padding'];
             $innerX = $baseX + $descLeft;
             $innerY = $baseY + $descTop;
-            $textW = $innerW * 0.6;
-            $maxTextH = $innerH - 6.0;
+            $textW = $descWidth;
+            $maxTextH = $descHeight;
 
             $curY = $innerY;
             $linesData = [];

--- a/src/routes.php
+++ b/src/routes.php
@@ -733,6 +733,10 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = $request->getAttribute('adminCatalogController');
         return $controller->catalogs($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
+    $app->get('/admin/catalogs/sample', function (Request $request, Response $response) {
+        $controller = $request->getAttribute('adminCatalogController');
+        return $controller->sample($request, $response);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
 
     $app->get('/admin/pages/{slug}', function (Request $request, Response $response, array $args) {
         $controller = new PageController();

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -543,9 +543,13 @@
                 <input type="file" id="catalogStickerBg" class="uk-input" accept="image/*">
               </div>
               <div id="catalogStickerPreview" class="uk-margin uk-position-relative">
-                <div id="stickerDescHandle" class="uk-position-absolute"></div>
+                <div id="stickerTextBox" class="uk-position-absolute">
+                  <div id="stickerTextResize" class="uk-position-absolute"></div>
+                </div>
                 <input type="hidden" id="descTop" name="descTop" value="">
                 <input type="hidden" id="descLeft" name="descLeft" value="">
+                <input type="hidden" id="descWidth" name="descWidth" value="">
+                <input type="hidden" id="descHeight" name="descHeight" value="">
                 <div id="stickerQrHandle" class="uk-position-absolute"></div>
                 <input type="hidden" id="qrTop" name="qrTop" value="">
                 <input type="hidden" id="qrLeft" name="qrLeft" value="">


### PR DESCRIPTION
## Summary
- expose first-catalog sample endpoint for admin
- allow dragging and resizing sticker text box with sample catalog and event data
- use provided sticker text dimensions in PDF generation for accurate output

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and missing STRIPE keys)*

------
https://chatgpt.com/codex/tasks/task_e_68beb0cb3698832b9c196be7c98bf641