### PR TITLE
Remove sticker preview text and style as frame

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -875,4 +875,10 @@ body.admin-page {
   color: #999;
 }
 
+#stickerTextBox {
+  background: transparent;
+  border: 1px dashed #1e87f0;
+  pointer-events: none;
+}
+
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -726,15 +726,6 @@ document.addEventListener('DOMContentLoaded', function () {
   let stickerEventDesc = '';
   let stickerCatalogName = '';
   let stickerCatalogDesc = '';
-  if (stickerTextBox) {
-    Object.assign(stickerTextBox.style, {
-      border: '1px dashed #1e87f0',
-      color: '#000',
-      padding: '2px',
-      whiteSpace: 'pre-wrap',
-      cursor: 'move'
-    });
-  }
   const catalogStickerBgImg = new Image();
   let catalogStickerBgUrl = '';
   const stickerTemplates = {
@@ -938,7 +929,6 @@ document.addEventListener('DOMContentLoaded', function () {
       stickerTextBox.style.top = `${descY}px`;
       stickerTextBox.style.width = `${textW}px`;
       stickerTextBox.style.height = `${textH}px`;
-      stickerTextBox.textContent = renderedLines.join('\n');
     }
     if (stickerQrHandle) {
       stickerQrHandle.style.left = `${qrX}px`;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -543,9 +543,8 @@
                 <input type="file" id="catalogStickerBg" class="uk-input" accept="image/*">
               </div>
               <div id="catalogStickerPreview" class="uk-margin uk-position-relative">
-                <div id="stickerTextBox" class="uk-position-absolute">
-                  <div id="stickerTextResize" class="uk-position-absolute"></div>
-                </div>
+                <div id="stickerTextBox" class="uk-position-absolute uk-pointer-events-none"></div>
+                <div id="stickerTextResize" class="uk-position-absolute"></div>
                 <input type="hidden" id="descTop" name="descTop" value="">
                 <input type="hidden" id="descLeft" name="descLeft" value="">
                 <input type="hidden" id="descWidth" name="descWidth" value="">


### PR DESCRIPTION
## Summary
- show catalog sticker text box only as a draggable/resizable frame
- keep box styling via CSS with dashed border

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68beb874321c832bb33ef02439c8e192