### PR TITLE
Enable drag interactions on sticker text box

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -878,7 +878,7 @@ body.admin-page {
 #stickerTextBox {
   background: transparent;
   border: 1px dashed #1e87f0;
-  pointer-events: none;
+  cursor: move;
 }
 
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -543,7 +543,7 @@
                 <input type="file" id="catalogStickerBg" class="uk-input" accept="image/*">
               </div>
               <div id="catalogStickerPreview" class="uk-margin uk-position-relative">
-                <div id="stickerTextBox" class="uk-position-absolute uk-pointer-events-none"></div>
+                <div id="stickerTextBox" class="uk-position-absolute"></div>
                 <div id="stickerTextResize" class="uk-position-absolute"></div>
                 <input type="hidden" id="descTop" name="descTop" value="">
                 <input type="hidden" id="descLeft" name="descLeft" value="">


### PR DESCRIPTION
## Summary
- remove `uk-pointer-events-none` from sticker text box so it can capture mouse interactions
- restore pointer events and add `cursor: move` style for sticker text box

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68bedb8868c0832bb3af608c37a18c9d