### PR TITLE
Expose catalog sticker description size controls

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -807,9 +807,20 @@ document.addEventListener('DOMContentLoaded', function () {
       cursor: 'nwse-resize',
       position: 'absolute',
       right: '-6px',
-      bottom: '-6px'
+      bottom: '-6px',
+      zIndex: '10',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center'
     };
     Object.assign(handle.style, style);
+    handle.innerHTML = '<span uk-icon="move"></span>';
+    handle.setAttribute('uk-tooltip', 'title: Resize');
+    if (window.UIkit) {
+      window.UIkit.icon(handle.firstElementChild);
+      window.UIkit.tooltip(handle);
+    }
+    if (handle.firstElementChild) handle.firstElementChild.style.pointerEvents = 'none';
     handle.onpointerdown = e => {
       resizing = true;
       startX = e.clientX;
@@ -937,6 +948,17 @@ document.addEventListener('DOMContentLoaded', function () {
   }
   makeDraggable(stickerTextBox, descTopInput, descLeftInput, true);
   makeResizable(stickerTextResize, descWidthInput, descHeightInput, stickerTextBox);
+  const scale = 4;
+  descWidthInput?.addEventListener('input', () => {
+    const val = parseFloat(descWidthInput.value) * scale;
+    if (stickerTextBox) stickerTextBox.style.width = `${Math.max(10, val)}px`;
+    drawCatalogStickerPreview();
+  });
+  descHeightInput?.addEventListener('input', () => {
+    const val = parseFloat(descHeightInput.value) * scale;
+    if (stickerTextBox) stickerTextBox.style.height = `${Math.max(10, val)}px`;
+    drawCatalogStickerPreview();
+  });
   makeDraggable(stickerQrHandle, qrTopInput, qrLeftInput);
   catalogStickerBgImg.onload = () => drawCatalogStickerPreview();
   if (catalogStickerModal && window.UIkit && UIkit.util) {

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -191,6 +191,8 @@ return [
     'label_print_catalog_desc' => 'Katalogbeschreibung drucken',
     'label_qr_size_pct' => 'QR-Größe (%)',
     'label_sticker_bg' => 'Sticker-Hintergrund',
+    'label_desc_width' => 'Breite der Beschreibung (mm)',
+    'label_desc_height' => 'Höhe der Beschreibung (mm)',
     'action_design_qrcodes' => 'QR-Codes gestalten',
     'column_username' => 'Benutzername',
     'column_role' => 'Rolle',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -193,6 +193,8 @@ return [
     'label_print_catalog_desc' => 'Print catalog description',
     'label_qr_size_pct' => 'QR size (%)',
     'label_sticker_bg' => 'Sticker background',
+    'label_desc_width' => 'Description width (mm)',
+    'label_desc_height' => 'Description height (mm)',
     'action_design_qrcodes' => 'Design QR codes',
     'column_username' => 'Username',
     'column_role' => 'Role',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -547,11 +547,19 @@
                 <div id="stickerTextResize" class="uk-position-absolute"></div>
                 <input type="hidden" id="descTop" name="descTop" value="">
                 <input type="hidden" id="descLeft" name="descLeft" value="">
-                <input type="hidden" id="descWidth" name="descWidth" value="">
-                <input type="hidden" id="descHeight" name="descHeight" value="">
                 <div id="stickerQrHandle" class="uk-position-absolute"></div>
                 <input type="hidden" id="qrTop" name="qrTop" value="">
                 <input type="hidden" id="qrLeft" name="qrLeft" value="">
+              </div>
+              <div class="uk-grid-small uk-margin" uk-grid>
+                <div class="uk-width-1-2">
+                  <label for="descWidth">{{ t('label_desc_width') }}</label>
+                  <input type="number" id="descWidth" name="descWidth" class="uk-input" step="0.1">
+                </div>
+                <div class="uk-width-1-2">
+                  <label for="descHeight">{{ t('label_desc_height') }}</label>
+                  <input type="number" id="descHeight" name="descHeight" class="uk-input" step="0.1">
+                </div>
               </div>
               <div class="uk-text-right">
                 <button class="uk-button uk-button-primary" type="submit" id="catalogStickerGenerate">{{ t('action_download') }}</button>


### PR DESCRIPTION
## Summary
- show and sync description width/height inputs beneath sticker preview
- add icon, tooltip, and higher z-index for resizable handle
- add translation strings for description size labels

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_SECRET_KEY, multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68beba6ab6c0832bac46f135d3f2dc3c