### PR TITLE
Nest sticker text resize handle within sticker text box

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -715,6 +715,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const catalogStickerPreview = document.getElementById('catalogStickerPreview');
   const stickerTextBox = document.getElementById('stickerTextBox');
   const stickerTextResize = document.getElementById('stickerTextResize');
+  if (stickerTextResize) stickerTextResize.style.zIndex = '10';
   const stickerQrHandle = document.getElementById('stickerQrHandle');
   const descTopInput = document.getElementById('descTop');
   const descLeftInput = document.getElementById('descLeft');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -543,8 +543,9 @@
                 <input type="file" id="catalogStickerBg" class="uk-input" accept="image/*">
               </div>
               <div id="catalogStickerPreview" class="uk-margin uk-position-relative">
-                <div id="stickerTextBox" class="uk-position-absolute"></div>
-                <div id="stickerTextResize" class="uk-position-absolute"></div>
+                <div id="stickerTextBox" class="uk-position-absolute">
+                  <div id="stickerTextResize" class="uk-position-absolute"></div>
+                </div>
                 <input type="hidden" id="descTop" name="descTop" value="">
                 <input type="hidden" id="descLeft" name="descLeft" value="">
                 <input type="hidden" id="descWidth" name="descWidth" value="">


### PR DESCRIPTION
## Summary
- move sticker text resize handle inside text box so absolute positioning is relative to the box
- boost resize handle z-index to keep it visible

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration / missing STRIPE_* environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68bee20e834c832b8fbd9b0fcd423cad