### PR TITLE
Add text color option for catalog stickers

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -709,6 +709,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const catalogStickerTemplate = document.getElementById('catalogStickerTemplate');
   const catalogStickerDesc = document.getElementById('catalogStickerDesc');
   const catalogStickerQrColor = document.getElementById('catalogStickerQrColor');
+  const catalogStickerTextColor = document.getElementById('catalogStickerTextColor');
   const catalogStickerQrSizePct = document.getElementById('catalogStickerQrSizePct');
   const catalogStickerBg = document.getElementById('catalogStickerBg');
   const catalogStickerGenerate = document.getElementById('catalogStickerGenerate');
@@ -916,7 +917,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const textH = Math.round(descH * scale);
     ctx.fillStyle = catalogStickerQrColor?.value || '#000';
     ctx.fillRect(qrX, qrY, qrSize, qrSize);
-    ctx.fillStyle = '#000';
+    ctx.fillStyle = catalogStickerTextColor?.value || '#000';
     ctx.textBaseline = 'top';
     const linesData = [];
     if (stickerEventTitle) linesData.push({ font: 'bold 12px sans-serif', size: 12, text: stickerEventTitle });
@@ -970,6 +971,7 @@ document.addEventListener('DOMContentLoaded', function () {
   catalogStickerTemplate?.addEventListener('change', drawCatalogStickerPreview);
   catalogStickerDesc?.addEventListener('change', drawCatalogStickerPreview);
   catalogStickerQrColor?.addEventListener('input', drawCatalogStickerPreview);
+  catalogStickerTextColor?.addEventListener('input', drawCatalogStickerPreview);
   catalogStickerQrSizePct?.addEventListener('input', drawCatalogStickerPreview);
   let catalogStickerProgress;
   if (catalogStickerBg) {
@@ -986,6 +988,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const params = new URLSearchParams({
       template: catalogStickerTemplate.value,
       qr_color: catalogStickerQrColor.value.replace(/^#/, ''),
+      text_color: catalogStickerTextColor.value.replace(/^#/, ''),
       qr_size_pct: catalogStickerQrSizePct.value,
       print_desc: catalogStickerDesc.checked ? '1' : '0'
     });

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -153,6 +153,7 @@ return [
     'label_qr_login' => 'QR-Code-Login (Name merken)',
     'label_custom_logo' => 'Eigenes Logo',
     'label_qr_color' => 'QR-Code-Farbe',
+    'label_text_color' => 'Textfarbe',
     'label_qr_bg_color' => 'Hintergrundfarbe',
     'label_qr_size' => 'QR-Größe',
     'label_qr_margin' => 'Rand',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -155,6 +155,7 @@ return [
     'label_qr_remember' => 'Remember scanned login',
     'label_custom_logo' => 'Custom logo',
     'label_qr_color' => 'QR code color',
+    'label_text_color' => 'Text color',
     'label_qr_bg_color' => 'Background color',
     'label_qr_size' => 'QR size',
     'label_qr_margin' => 'Margin',

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -88,6 +88,9 @@ class CatalogStickerController
         $printDesc = filter_var($params['print_desc'] ?? false, FILTER_VALIDATE_BOOLEAN);
         $qrColor = preg_replace('/[^0-9A-Fa-f]/', '', (string)($params['qr_color'] ?? '000000'));
         $qrColor = str_pad(substr($qrColor, 0, 6), 6, '0');
+        $textColor = preg_replace('/[^0-9A-Fa-f]/', '', (string)($params['text_color'] ?? '000000'));
+        $textColor = str_pad(substr($textColor, 0, 6), 6, '0');
+        [$r, $g, $b] = array_map('hexdec', str_split($textColor, 2));
         $qrSizePct = max(10, min(100, (int)($params['qr_size_pct'] ?? 42)));
         $descTop = isset($params['desc_top']) ? (float)$params['desc_top'] : 0.0;
         $descLeft = isset($params['desc_left']) ? (float)$params['desc_left'] : 0.0;
@@ -135,6 +138,7 @@ class CatalogStickerController
         $pdf->SetMargins(0.0, 0.0, 0.0);
         $pdf->SetAutoPageBreak(false);
         $pdf->AddPage();
+        $pdf->SetTextColor($r, $g, $b);
 
         if ($catalogs === []) {
             $pdf->SetFont('Arial', 'B', 16);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -535,6 +535,10 @@
                 <input type="color" id="catalogStickerQrColor" class="uk-input" value="#000000">
               </div>
               <div class="uk-margin">
+                <label for="catalogStickerTextColor">{{ t('label_text_color') }}</label>
+                <input type="color" id="catalogStickerTextColor" class="uk-input" value="#000000">
+              </div>
+              <div class="uk-margin">
                 <label for="catalogStickerQrSizePct">{{ t('label_qr_size_pct') }}</label>
                 <input type="number" id="catalogStickerQrSizePct" class="uk-input" value="42" min="35" max="50">
               </div>


### PR DESCRIPTION
## Summary
- add text color picker to catalog sticker settings
- support new translation key for text color
- apply chosen text color in preview, request and PDF generation

## Testing
- `composer test` *(fails: Failed asserting that 4 is identical to 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bee35c0200832b8ffebb8c9d85ebb2