### PR TITLE
Improve dark-mode contrast for landing page secondary button

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -577,9 +577,9 @@ body.qr-landing:not(.dark-mode) .btn.btn-black.uk-button-secondary{
 .qr-landing .btn.btn-black.uk-button-secondary:hover{ opacity:.85; }
 body.dark-mode .qr-landing .btn.btn-black.uk-button-secondary,
 body[data-theme="dark"] .qr-landing .btn.btn-black.uk-button-secondary{
-  background-color:#0d1117;
+  background-color:#30363d;
   color:var(--qr-landing-text);
-  border:0;
+  border:1px solid var(--qr-border);
 }
 
 .qr-landing .uk-section{ padding-top:72px; padding-bottom:72px; }


### PR DESCRIPTION
## Summary
- add contrasting background and border to secondary button in dark mode

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bee91c4154832bb9b34bc81562df8d