### PR TITLE
Fix ghost CTA text color in dark mode

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -543,7 +543,7 @@ body.dark-mode .qr-landing .qr-badge{
   align-items:center;
   justify-content:center;
   border:2px solid var(--landing-btn-fg);
-  color:var(--landing-btn-bg-hover)!important;
+  color:var(--landing-btn-fg)!important;
   background:transparent;
   border-radius:12px;
   font-weight:600;
@@ -555,8 +555,8 @@ body.dark-mode .qr-landing .qr-badge{
 }
 .cta-ghost:hover,
 .cta-ghost:focus{
-  background:var(--landing-btn-bg-hover);
-  color:var(--landing-btn-fg)!important;
+  background:var(--landing-btn-fg);
+  color:var(--landing-btn-bg-hover)!important;
   box-shadow:0 6px 18px rgba(47,129,247,.35);
   text-decoration:none;
 }


### PR DESCRIPTION
## Summary
- Use light foreground color for ghost CTA buttons in dark mode
- Swap text/background colors on hover for consistent contrast

## Testing
- `composer test` *(fails: Tests: 323, Errors: 31, Failures: 104)*

------
https://chatgpt.com/codex/tasks/task_e_68bee90e7a00832b921251b973d60797