### PR TITLE
Warn on MAIN_DOMAIN misconfiguration

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -3024,7 +3024,11 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   function loadTenants(status = tenantStatusFilter?.value || '', query = tenantSearchInput?.value || '') {
-    if (!tenantTableBody || (typeof window.domainType !== 'undefined' && window.domainType !== 'main')) return;
+    if (!tenantTableBody) return;
+    if (typeof window.domainType !== 'undefined' && window.domainType !== 'main') {
+      notify('MAIN_DOMAIN falsch konfiguriert – Mandantenliste nicht geladen', 'warning');
+      return;
+    }
     const params = new URLSearchParams();
     if (status) params.set('status', status);
     if (query) params.set('query', query);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1069,6 +1069,13 @@
         {{ qr_rowcards('tenantCards', false, 'uk-hidden@s', 'div') }}
       </div>
     </li>
+    {% else %}
+    <li class="{{ activeRoute == 'tenants' ? 'uk-active' }}">
+      <div class="uk-container uk-container-large">
+        <h2 class="uk-heading-bullet">{{ t('heading_tenants') }}</h2>
+        <div class="uk-alert-warning" uk-alert>MAIN_DOMAIN falsch konfiguriert – Mandantenliste nicht geladen</div>
+      </div>
+    </li>
     {% endif %}
     {% endif %}
     {% if activeRoute == 'profile' %}


### PR DESCRIPTION
## Summary
- add warning notification when tenants list is requested on non-main domains
- show static hint in admin tenants tab if MAIN_DOMAIN is misconfigured

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and missing Stripe configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68beee97b1a0832b95daf7403a555c7a