### PR TITLE
Add event-specific sticker configuration

### DIFF
--- a/migrations/20250307_add_sticker_fields_to_config.sql
+++ b/migrations/20250307_add_sticker_fields_to_config.sql
@@ -1,0 +1,9 @@
+-- Add sticker configuration fields to config table
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerTemplate TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerPrintDesc BOOLEAN;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerQrColor TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerQrSizePct INTEGER;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerDescTop REAL;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerDescLeft REAL;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerQrTop REAL;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerQrLeft REAL;

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -37,6 +37,7 @@ class ConfigService
         'loginRequired',
         'qrLogoPunchout',
         'qrRounded',
+        'stickerPrintDesc',
     ];
 
     /**
@@ -225,6 +226,14 @@ class ConfigService
             'qrColorTeam',
             'qrColorCatalog',
             'qrColorEvent',
+            'stickerTemplate',
+            'stickerPrintDesc',
+            'stickerQrColor',
+            'stickerQrSizePct',
+            'stickerDescTop',
+            'stickerDescLeft',
+            'stickerQrTop',
+            'stickerQrLeft',
         ];
         $existing = array_map('strtolower', $this->getConfigColumns());
         $filtered = array_intersect_key($data, array_flip($keys));
@@ -374,6 +383,14 @@ class ConfigService
             'qrColorTeam',
             'qrColorCatalog',
             'qrColorEvent',
+            'stickerTemplate',
+            'stickerPrintDesc',
+            'stickerQrColor',
+            'stickerQrSizePct',
+            'stickerDescTop',
+            'stickerDescLeft',
+            'stickerQrTop',
+            'stickerQrLeft',
         ];
         $map = [];
         foreach ($keys as $k) {

--- a/src/routes.php
+++ b/src/routes.php
@@ -1118,6 +1118,13 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('catalogStickerController')->pdf($request, $response);
     })->add(new RoleAuthMiddleware(...Roles::ALL));
 
+    $app->get('/admin/sticker-settings', function (Request $request, Response $response) {
+        return $request->getAttribute('catalogStickerController')->getSettings($request, $response);
+    })->add(new RoleAuthMiddleware(...Roles::ALL));
+    $app->post('/admin/sticker-settings', function (Request $request, Response $response) {
+        return $request->getAttribute('catalogStickerController')->saveSettings($request, $response);
+    })->add(new RoleAuthMiddleware(...Roles::ALL));
+
     $app->post('/admin/sticker-background', function (Request $request, Response $response) {
         return $request->getAttribute('catalogStickerController')->uploadBackground($request, $response);
     })->add(new RoleAuthMiddleware(...Roles::ALL));

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -550,11 +550,11 @@
                 <div id="stickerTextBox" class="uk-position-absolute">
                   <div id="stickerTextResize" class="uk-position-absolute"></div>
                 </div>
-                <input type="hidden" id="descTop" name="descTop" value="">
-                <input type="hidden" id="descLeft" name="descLeft" value="">
+                <input type="hidden" id="stickerDescTop" name="stickerDescTop" value="">
+                <input type="hidden" id="stickerDescLeft" name="stickerDescLeft" value="">
                 <div id="stickerQrHandle" class="uk-position-absolute"></div>
-                <input type="hidden" id="qrTop" name="qrTop" value="">
-                <input type="hidden" id="qrLeft" name="qrLeft" value="">
+                <input type="hidden" id="stickerQrTop" name="stickerQrTop" value="">
+                <input type="hidden" id="stickerQrLeft" name="stickerQrLeft" value="">
               </div>
               <div class="uk-grid-small uk-margin" uk-grid>
                 <div class="uk-width-1-2">


### PR DESCRIPTION
## Summary
- add sticker-related fields to config service and database
- expose /admin/sticker-settings API and respect event-specific backgrounds
- persist and load sticker settings in admin interface

## Testing
- `composer test` (errors: missing configuration, 31 errors, 104 failures)


------
https://chatgpt.com/codex/tasks/task_e_68bef0082bdc832bba282d94761d663c