### PR TITLE
Store player name under legacy and scoped keys

### DIFF
--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -149,6 +149,7 @@ async function promptTeamName(){
       const name = (input.value || '').trim();
       if(name){
         setStored('quizUser', name);
+        setStored(STORAGE_KEYS.PLAYER_NAME, name);
         try {
           await postSession('player', { name });
           ui.hide();

--- a/tests/test_random_name_prompt.js
+++ b/tests/test_random_name_prompt.js
@@ -3,6 +3,9 @@ const vm = require('vm');
 const assert = require('assert');
 
 const quizCode = fs.readFileSync('public/js/quiz.js', 'utf8');
+if (!/setStored\('quizUser', name\);\s*setStored\(STORAGE_KEYS\.PLAYER_NAME, name\);/.test(quizCode)) {
+    throw new Error('Team name not stored under both keys');
+}
 const initMatch = quizCode.match(/if\(!getStored\('quizUser'\) && !cfg\.QRRestrict && !cfg\.QRUser\)\{[\s\S]*?\n\s*\}\n\s*\}/);
 const handlerMatch = quizCode.match(/startBtn.addEventListener\('click', async\(\) => \{([\s\S]*?)\n\s*\}\);/);
 if (!initMatch || !handlerMatch) {


### PR DESCRIPTION
## Summary
- persist team name under both legacy and scoped storage keys
- assert in tests that team name is stored for both keys and profile return skips extra prompt

## Testing
- `node tests/test_random_name_prompt.js`
- `node tests/test_profile_flow.js`
- `composer test` *(fails: many tests failing due to MAIN_DOMAIN misconfiguration and missing Stripe keys)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2a25ac84832bb332c37cf9187657