### PR TITLE
Handle catalog sticker preview scaling

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -164,6 +164,12 @@ body.uk-padding {
   height: 44px;
 }
 
+#catalogStickerPreview canvas {
+  max-width: none;
+  position: relative;
+  display: block;
+}
+
 /* Ensure dropdown menus appear above table rows */
 .uk-dropdown {
   z-index: 1200;


### PR DESCRIPTION
## Summary
- Account for canvas display scale when positioning sticker text and QR elements
- Pass scale ratio into drag and resize helpers
- Disable UIkit canvas scaling so preview bounds align with canvas size

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2c8de15c832bae6c8395e6e64a8e