### PR TITLE
Refine catalog sticker resize handle

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -890,7 +890,20 @@ body.admin-page {
 
 #stickerTextResize,
 #stickerQrHandle {
+  width: 20px;
+  height: 20px;
+  background: #1e87f0;
+  opacity: 0.7;
+  border-radius: 2px;
   z-index: 1001;
+}
+
+#stickerTextResize {
+  cursor: se-resize;
+}
+
+#stickerQrHandle {
+  cursor: move;
 }
 
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -856,29 +856,7 @@ document.addEventListener('DOMContentLoaded', function () {
     let startY = 0;
     let startW = 0;
     let startH = 0;
-    const style = {
-      width: '20px',
-      height: '20px',
-      background: 'rgba(255,255,255,0.8)',
-      border: '2px solid #1e87f0',
-      cursor: 'nwse-resize',
-      position: 'absolute',
-      right: '-10px',
-      bottom: '-10px',
-      zIndex: '10',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      touchAction: 'none'
-    };
-    Object.assign(handle.style, style);
-    handle.innerHTML = '<span uk-icon="move"></span>';
-    handle.setAttribute('uk-tooltip', 'title: Resize');
-    if (window.UIkit) {
-      window.UIkit.icon(handle.firstElementChild);
-      window.UIkit.tooltip(handle);
-    }
-    if (handle.firstElementChild) handle.firstElementChild.style.pointerEvents = 'none';
+    handle.style.touchAction = 'none';
     const start = e => {
       resizing = true;
       const point = e.touches ? e.touches[0] : e;
@@ -1027,10 +1005,8 @@ document.addEventListener('DOMContentLoaded', function () {
       stickerTextBox.style.height = `${scaledTextH}px`;
     }
     if (stickerTextResize) {
-      stickerTextResize.style.left = `${scaledDescX}px`;
-      stickerTextResize.style.top = `${scaledDescY}px`;
-      stickerTextResize.style.width = `${scaledTextW}px`;
-      stickerTextResize.style.height = `${scaledTextH}px`;
+      stickerTextResize.style.left = `${scaledDescX + scaledTextW - 10}px`;
+      stickerTextResize.style.top = `${scaledDescY + scaledTextH - 10}px`;
     }
     if (stickerQrHandle) {
       stickerQrHandle.style.left = `${scaledQrX}px`;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -547,12 +547,11 @@
                 <input type="file" id="catalogStickerBg" class="uk-input" accept="image/*">
               </div>
               <div id="catalogStickerPreview" class="uk-margin uk-position-relative">
-                <div id="stickerTextBox" class="uk-position-absolute">
-                  <div id="stickerTextResize" class="uk-position-absolute" style="width:20px;height:20px;"></div>
-                </div>
+                <div id="stickerTextBox" class="uk-position-absolute"></div>
+                <div id="stickerTextResize" class="uk-position-absolute" uk-tooltip="title: Größe ändern; pos: bottom" aria-label="Größe ändern"></div>
                 <input type="hidden" id="stickerDescTop" name="stickerDescTop" value="">
                 <input type="hidden" id="stickerDescLeft" name="stickerDescLeft" value="">
-                <div id="stickerQrHandle" class="uk-position-absolute" style="width:20px;height:20px;"></div>
+                <div id="stickerQrHandle" class="uk-position-absolute" uk-tooltip="title: Verschieben; pos: bottom" aria-label="Verschieben"></div>
                 <input type="hidden" id="stickerQrTop" name="stickerQrTop" value="">
                 <input type="hidden" id="stickerQrLeft" name="stickerQrLeft" value="">
               </div>


### PR DESCRIPTION
## Summary
- position sticker text resize handle at bottom-right corner without stretching
- style sticker drag/resize handles via CSS with fixed 20x20px and tooltips
- simplify resizable helper to avoid inline styling

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE keys)*

------
https://chatgpt.com/codex/tasks/task_e_68bf352c83f8832ba8231ac6d22edf93