### PR TITLE
feat: suggest random team name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
             "node tests/test_login_free_catalog.js",
             "node tests/test_catalog_smoke.js",
             "node tests/test_catalog_autostart_path.js",
-            "node tests/test_shuffle_questions.js"
+            "node tests/test_shuffle_questions.js",
+            "node tests/test_team_name_suggestion.js"
         ]
     }
 }

--- a/public/js/quiz.js
+++ b/public/js/quiz.js
@@ -64,6 +64,14 @@ const currentEventUid = (window.quizConfig || {}).event_uid || '';
 const basePath = window.basePath || '';
 const withBase = path => basePath + path;
 
+let nameSuggestion;
+function getNameSuggestion(){
+  if(!nameSuggestion){
+    nameSuggestion = generateUserName();
+  }
+  return nameSuggestion;
+}
+
 function formatPuzzleTime(ts){
   const d = new Date(ts * 1000);
   const pad = n => n.toString().padStart(2, '0');
@@ -133,12 +141,18 @@ async function promptTeamName(){
       return;
     }
 
+    const suggestion = getNameSuggestion();
     title.textContent = 'Teamname eingeben';
+    const sugg = document.createElement('span');
+    sugg.className = 'uk-text-muted';
+    sugg.textContent = ` (Vorschlag: ${suggestion})`;
+    title.appendChild(sugg);
     const input = document.createElement('input');
     input.id = 'team-name-input';
     input.className = 'uk-input';
     input.type = 'text';
     input.placeholder = 'Teamname';
+    input.value = suggestion;
     const btn = document.createElement('button');
     btn.id = 'team-name-submit';
     btn.className = 'uk-button uk-button-primary uk-width-1-1 uk-margin-top';
@@ -1213,11 +1227,17 @@ async function runQuiz(questions, skipIntro){
       function showManualInput(){
         const container = document.getElementById('qr-reader');
         container.textContent = '';
+        const suggestion = getNameSuggestion();
+        const hint = document.createElement('div');
+        hint.className = 'uk-text-center uk-margin-small-bottom';
+        hint.textContent = `Vorschlag: ${suggestion}`;
+        container.appendChild(hint);
         const input = document.createElement('input');
         input.id = 'manual-team-name';
         input.className = 'uk-input';
         input.type = 'text';
         input.placeholder = 'Teamname eingeben';
+        input.value = suggestion;
         const submit = document.createElement('button');
         submit.id = 'manual-team-submit';
         submit.className = 'uk-button uk-button-primary uk-width-1-1 uk-margin-top';

--- a/tests/test_team_name_suggestion.js
+++ b/tests/test_team_name_suggestion.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const code = fs.readFileSync('public/js/quiz.js', 'utf8');
+
+if (!/let nameSuggestion;/.test(code)) {
+  throw new Error('nameSuggestion variable missing');
+}
+if (!/function getNameSuggestion\(\)\{[\s\S]*?generateUserName\(\)/.test(code)) {
+  throw new Error('getNameSuggestion function missing');
+}
+if (!/const suggestion = getNameSuggestion\(\);\s*title.textContent = 'Teamname eingeben';[\s\S]*?input.value = suggestion;/.test(code)) {
+  throw new Error('promptTeamName suggestion handling missing');
+}
+if (!/function showManualInput\(\)[\s\S]*?const suggestion = getNameSuggestion\(\);[\s\S]*?input.value = suggestion;/.test(code)) {
+  throw new Error('showManualInput suggestion handling missing');
+}
+
+console.log('ok');


### PR DESCRIPTION
## Summary
- suggest a random team name when none is stored
- reuse the suggestion across manual input flows
- cover team name suggestion with tests

## Testing
- `node tests/test_team_name_suggestion.js`
- `node tests/test_random_name_prompt.js`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3a641e34832b81d772a867dcfacb