### PR TITLE
Enable dark mode on license page

### DIFF
--- a/public/Lizenz.html
+++ b/public/Lizenz.html
@@ -8,8 +8,9 @@
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" href="/css/dark.css">
 </head>
-<body class="uk-padding uk-background-muted">
+<body class="uk-padding uk-background-muted" data-theme="dark">
   <h1>Lizenz</h1>
   <p>Donec ullamcorper nulla non metus auctor fringilla.</p>
+  <script src="/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable dark theme on `Lizenz.html`
- load app.js to sync theme with LocalStorage

## Testing
- `composer test` *(fails: DFFFF... failing tests, MAIN_DOMAIN misconfiguration)*
- `node <inline>`

------
https://chatgpt.com/codex/tasks/task_e_68bf3a0b9e14832bb111df5d5cde8371