### PR TITLE
Align sticker text rendering

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -975,10 +975,10 @@ document.addEventListener('DOMContentLoaded', function () {
     ctx.fillStyle = catalogStickerTextColor?.value || '#000';
     ctx.textBaseline = 'top';
     const linesData = [];
-    if (stickerEventTitle) linesData.push({ font: 'bold 12px sans-serif', size: 12, text: stickerEventTitle });
-    if (stickerEventDesc) linesData.push({ font: 'normal 10px sans-serif', size: 10, text: stickerEventDesc });
-    if (stickerCatalogName) linesData.push({ font: 'bold 11px sans-serif', size: 11, text: stickerCatalogName });
-    if (catalogStickerDesc?.checked && stickerCatalogDesc) linesData.push({ font: 'normal 10px sans-serif', size: 10, text: stickerCatalogDesc });
+    if (stickerEventTitle) linesData.push({ font: 'bold 12px Arial', size: 12, text: stickerEventTitle });
+    if (stickerEventDesc) linesData.push({ font: '10px Arial', size: 10, text: stickerEventDesc });
+    if (stickerCatalogName) linesData.push({ font: 'bold 11px Arial', size: 11, text: stickerCatalogName });
+    if (catalogStickerDesc?.checked && stickerCatalogDesc) linesData.push({ font: '10px Arial', size: 10, text: stickerCatalogDesc });
     let curY = descY;
     const renderedLines = [];
     outer: for (const ln of linesData) {


### PR DESCRIPTION
## Summary
- Use Arial fonts with matching line heights for sticker preview
- Sync PDF sticker generation font metrics and wrapping with canvas algorithm

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3bf59ce0832ba85b2345c669e171