### PR TITLE
Ignore flip questions in scoring and logs

### DIFF
--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -186,7 +186,7 @@ class ResultService
         if ($uid === false) {
             return;
         }
-        $qStmt = $this->pdo->prepare('SELECT id FROM questions WHERE catalog_uid=? ORDER BY sort_order');
+        $qStmt = $this->pdo->prepare("SELECT id FROM questions WHERE catalog_uid=? AND type<>'flip' ORDER BY sort_order");
         $qStmt->execute([$uid]);
         $ids = $qStmt->fetchAll(PDO::FETCH_COLUMN);
         if (!$ids) {


### PR DESCRIPTION
## Summary
- Exclude `flip` questions from quiz scoring and progress display
- Prevent flip cards from altering result arrays
- Record only scorable questions in `ResultService` logging

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and missing STRIPE keys)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3fe0baf4832bbca66bc874221c64