### PR TITLE
Move admin summary to event menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,12 +556,13 @@ Für den Versand der E-Mails müssen `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `SMT
 ### Administrationsoberfläche
 Unter `/admin` stehen folgende Tabs zur Verfügung:
 1. **Veranstaltung konfigurieren** – Einstellungen wie Logo, Farben und Texte.
-2. **Kataloge** – Fragenkataloge erstellen und verwalten.
-3. **Fragen anpassen** – Fragen eines Katalogs hinzufügen, bearbeiten oder löschen.
-4. **Teams/Personen** – Teilnehmerlisten pflegen, optional als Login-Beschränkung.
-5. **Ergebnisse** – Spielstände einsehen und herunterladen.
-6. **Statistik** – Einzelne Antworten analysieren und nach Teams filtern.
-7. **Administration** – Benutzer und Backups verwalten.
+2. **Übersicht** – Ergebnisse tabellarisch einsehen.
+3. **Kataloge** – Fragenkataloge erstellen und verwalten.
+4. **Fragen anpassen** – Fragen eines Katalogs hinzufügen, bearbeiten oder löschen.
+5. **Teams/Personen** – Teilnehmerlisten pflegen, optional als Login-Beschränkung.
+6. **Ergebnisse** – Spielstände einsehen und herunterladen.
+7. **Statistik** – Einzelne Antworten analysieren und nach Teams filtern.
+8. **Administration** – Benutzer und Backups verwalten.
 
 ### Fragenkataloge
 `data/kataloge/catalogs.json` listet verfügbare Kataloge mit `slug`, Name und optionaler QR-Code-Adresse. Die Reihenfolge wird durch das Feld `sort_order` bestimmt. Jede Frage speichert die zugehörige `catalog_uid`. Jeder Eintrag kann zusätzlich ein Feld `raetsel_buchstabe` enthalten, das den Buchstaben für das Rätselwort festlegt. Die API bietet hierzu folgende Endpunkte:

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -6,14 +6,14 @@ Die Administrationsoberfläche erreichen Sie über `/admin/dashboard` (kurz `/ad
   * **Startseite** – `/admin/dashboard`
   * **Events** – `/admin/events`
   * **Event-Konfiguration** – `/admin/event/settings`
+  * **Übersicht** – `/admin/summary`
 * **Inhalte**
-* **Kataloge** – `/admin/catalogs`
+  * **Kataloge** – `/admin/catalogs`
   * **Fragen bearbeiten** – `/admin/questions`
   * **Seiten** – `/admin/pages` (nur Administratoren)
 * **Teams**
   * **Teams/Personen** – `/admin/teams`
 * **Auswertung**
-  * **Übersicht** – `/admin/summary`
   * **Ergebnisse** – `/admin/results`
   * **Statistik** – `/admin/statistics`
 * **Konto**

--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -11,6 +11,7 @@
     items: [
       { href: basePath ~ '/admin/events', icon: 'calendar', text: t('tab_events') },
       { href: basePath ~ '/admin/event/settings', icon: 'cog', text: t('tab_event_settings') },
+      { href: basePath ~ '/admin/summary', icon: 'table', text: t('tab_summary') },
     ]
   },
   {
@@ -30,7 +31,6 @@
   {
     header: t('menu_evaluation'),
     items: [
-      { href: basePath ~ '/admin/summary', icon: 'table', text: t('tab_summary') },
       { href: basePath ~ '/admin/results', icon: 'list', text: t('tab_results') },
       { href: basePath ~ '/admin/statistics', icon: 'signal', text: t('tab_statistics') },
     ]


### PR DESCRIPTION
## Summary
- place Summary link with other event settings in admin nav
- document Summary under Event in admin guide and README

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4732fec8832bae70a0987b818efc