### PR TITLE
Add CSRF token to profile page

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -342,11 +342,14 @@ return function (\Slim\App $app, TranslationService $translator) {
         $params = $request->getQueryParams();
         $return = (string)($params['return'] ?? '');
         $eventUid = (string)($config['event_uid'] ?? '');
+        $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
+        $_SESSION['csrf_token'] = $csrf;
 
         return $view->render($response, 'profile.twig', [
-            'config'   => $config,
-            'return'   => $return,
-            'eventUid' => $eventUid,
+            'config'     => $config,
+            'return'     => $return,
+            'eventUid'   => $eventUid,
+            'csrf_token' => $csrf,
         ]);
     });
     $app->get('/landing', function (Request $request, Response $response) {

--- a/templates/profile.twig
+++ b/templates/profile.twig
@@ -3,9 +3,11 @@
 {% block title %}{{ t('title_profile') }}{% endblock %}
 
 {% block head %}
+  <meta name="csrf-token" content="{{ csrf_token }}">
   <link rel="stylesheet" href="{{ basePath }}/css/main.css">
   <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+  <script>window.csrfToken = '{{ csrf_token|e('js') }}';</script>
 {% endblock %}
 
 {% block body_class %}uk-padding{% endblock %}


### PR DESCRIPTION
## Summary
- embed CSRF token in profile page head and expose to client scripts
- generate and pass CSRF token in `/profile` route

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and missing Stripe keys)*

------
https://chatgpt.com/codex/tasks/task_e_68bf46c31d60832bb9d9728cd3a180a0