### PR TITLE
Return user list after saving

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2721,12 +2721,22 @@ document.addEventListener('DOMContentLoaded', function () {
       body: JSON.stringify(list)
     })
       .then(r => {
+        if (r.status === 409) {
+          notify('Benutzername bereits vergeben', 'danger');
+          return Promise.reject();
+        }
         if (!r.ok) throw new Error(r.statusText);
+        return r.json();
+      })
+      .then(data => {
+        renderUsers(data);
         notify('Liste gespeichert', 'success');
       })
       .catch(err => {
-        console.error(err);
-        notify('Fehler beim Speichern', 'danger');
+        if (err) {
+          console.error(err);
+          notify('Fehler beim Speichern', 'danger');
+        }
       });
   }
 


### PR DESCRIPTION
## Summary
- Return JSON list of users from `UserController::post` and report duplicates with HTTP 409
- Refresh admin user table after save and notify on duplicate usernames

## Testing
- `composer test` *(fails: Tests: 323, Assertions: 534, Errors: 31, Failures: 104)*

------
https://chatgpt.com/codex/tasks/task_e_68bf48e38130832babf64ebcc858b0d8