### PR TITLE
Escape return URL for profile and test special characters

### DIFF
--- a/templates/profile.twig
+++ b/templates/profile.twig
@@ -39,7 +39,7 @@
 {% block scripts %}
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
-    const returnUrl = '{{ return }}';
+    const returnUrl = '{{ return|e('js') }}';
   </script>
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/storage.js"></script>


### PR DESCRIPTION
## Summary
- Escape `return` parameter in `templates/profile.twig` for safe JavaScript usage
- Add regression test covering return URLs containing `&` and `=`

## Testing
- `node tests/test_profile_flow.js`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68bf48c1ca18832ba8ca70cd8f55b88c