### PR TITLE
Open user editor on adding new user

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2762,15 +2762,19 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function addUser() {
     const list = userManager.getData();
+    const id = crypto.randomUUID();
     list.push({
-      id: crypto.randomUUID(),
+      id,
       username: '',
       role: (window.roles && window.roles[0]) || '',
       active: true,
       password: ''
     });
     userManager.render(list);
-    saveUsers(list);
+    const cell = usersListEl?.querySelector(`[data-id="${id}"][data-key="username"]`);
+    if (cell) {
+      openUserEditor(cell);
+    }
   }
 
   if (!document.getElementById('userEditModal')) {


### PR DESCRIPTION
## Summary
- open username editor automatically when adding a user
- defer saving users until modal confirmation

## Testing
- `composer test` *(fails: Tests: 323, Assertions: 534, Errors: 31, Failures: 104, Warnings: 4)*

------
https://chatgpt.com/codex/tasks/task_e_68bf522a9b90832bb5ae0f3ed23b2d26