### PR TITLE
Refactor user actions in admin list

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2862,13 +2862,48 @@ document.addEventListener('DOMContentLoaded', function () {
       {
         className: 'uk-table-shrink',
         render: item => {
-          const btn = document.createElement('button');
-          btn.type = 'button';
-          btn.className = 'uk-icon-button qr-action';
-          btn.setAttribute('uk-icon', 'key');
-          btn.setAttribute('aria-label', window.transUserPass || 'Passwort setzen');
-          btn.addEventListener('click', () => openPassModal(item.id));
-          return btn;
+          const wrapper = document.createElement('div');
+          wrapper.className = 'uk-flex uk-flex-middle uk-flex-right';
+
+          const passBtn = document.createElement('button');
+          passBtn.type = 'button';
+          passBtn.className = 'uk-icon-button qr-action';
+          passBtn.setAttribute('uk-icon', 'key');
+          passBtn.setAttribute('aria-label', window.transUserPass || 'Passwort setzen');
+          passBtn.setAttribute('uk-tooltip', 'title: ' + (window.transUserPass || 'Passwort setzen') + '; pos: left');
+          passBtn.addEventListener('click', () => openPassModal(item.id));
+          wrapper.appendChild(passBtn);
+
+          const delBtn = document.createElement('button');
+          delBtn.type = 'button';
+          delBtn.className = 'uk-icon-button qr-action uk-text-danger uk-margin-small-left';
+          delBtn.setAttribute('uk-icon', 'trash');
+          delBtn.setAttribute('aria-label', window.transDelete || 'Löschen');
+          delBtn.setAttribute('uk-tooltip', 'title: ' + (window.transDelete || 'Löschen') + '; pos: left');
+          delBtn.addEventListener('click', () => removeUser(item.id));
+          wrapper.appendChild(delBtn);
+
+          return wrapper;
+        },
+        renderCard: item => {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'uk-flex uk-flex-middle qr-action';
+
+          const passBtn = document.createElement('button');
+          passBtn.className = 'uk-icon-button qr-action';
+          passBtn.setAttribute('uk-icon', 'key');
+          passBtn.setAttribute('aria-label', window.transUserPass || 'Passwort setzen');
+          passBtn.addEventListener('click', () => openPassModal(item.id));
+          wrapper.appendChild(passBtn);
+
+          const delBtn = document.createElement('button');
+          delBtn.className = 'uk-icon-button qr-action uk-text-danger uk-margin-small-left';
+          delBtn.setAttribute('uk-icon', 'trash');
+          delBtn.setAttribute('aria-label', window.transDelete || 'Löschen');
+          delBtn.addEventListener('click', () => removeUser(item.id));
+          wrapper.appendChild(delBtn);
+
+          return wrapper;
         }
       }
     ];
@@ -2878,7 +2913,6 @@ document.addEventListener('DOMContentLoaded', function () {
       sortable: true,
       mobileCards: { container: usersCardsEl },
       onEdit: cell => openUserEditor(cell),
-      onDelete: id => removeUser(id),
       onReorder: () => saveUsers()
     });
     userManager.setColumnLoading('username', true);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -955,7 +955,6 @@
                 <th data-key="username">{{ t('column_username') }}</th>
                 <th data-key="role">{{ t('column_role') }}</th>
                 <th data-key="active" class="uk-table-shrink">{{ t('column_active') }}</th>
-                <th class="uk-table-shrink"><span uk-icon="icon: key" uk-tooltip="title: {{ t('tip_user_pass') }}; pos: top"></span></th>
                 <th class="uk-table-shrink uk-text-right">{{ t('column_actions') }}</th>
               </tr>
             </thead>


### PR DESCRIPTION
## Summary
- Remove dedicated password column from admin user table
- Render password and delete controls together in a single action column
- Trigger deletion directly from action column instead of TableManager's auto column

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and Stripe keys missing, multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bf524112d8832bb17028e50cfcecfc