### PR TITLE
Display full license text on license page

### DIFF
--- a/public/Lizenz.html
+++ b/public/Lizenz.html
@@ -10,7 +10,27 @@
 </head>
 <body class="uk-padding uk-background-muted" data-theme="dark">
   <h1>Lizenz</h1>
-  <p>Donec ullamcorper nulla non metus auctor fringilla.</p>
+  <section lang="de" class="uk-margin-bottom">
+    <h2>Deutsche Lizenzbeschreibung</h2>
+    <p>Proprietäre Lizenz – Sommerfest Quiz</p>
+    <p>Copyright (c) 2025 René Buske</p>
+    <p>Alle Rechte vorbehalten.</p>
+    <p>Die Software „Sommerfest Quiz“ („Software“) ist das alleinige Eigentum von René Buske. Kommerzielle Nutzung der Software ist gestattet. Der Quellcode bleibt vertraulich und darf ohne vorherige schriftliche Genehmigung von René Buske nicht kopiert, verbreitet, verändert oder öffentlich zugänglich gemacht werden.</p>
+    <p>Die Software wird ohne jegliche Gewährleistung bereitgestellt. René Buske haftet nicht für Schäden, die aus der Nutzung der Software entstehen.</p>
+  </section>
+  <h2>License (English)</h2>
+  <pre>Proprietary License - Sommerfest Quiz
+
+Copyright (c) 2025 René Buske
+All rights reserved.
+
+The "Sommerfest Quiz" software ("Software") is the sole property of René Buske.
+Commercial use of the Software is permitted. The source code remains confidential
+and may not be copied, distributed, modified or made publicly accessible without
+prior written permission from René Buske.
+
+The Software is provided "as is" without warranty of any kind. René Buske shall
+not be liable for any damages arising from the use of the Software.</pre>
   <script src="/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show actual proprietary license text instead of placeholder on Lizenz page
- ensure license page uses dark theme and loads app script
- add German license description before English license text

## Testing
- `php -S 127.0.0.1:8000 -t public` & `curl -s http://127.0.0.1:8000/Lizenz.html | head -n 40`
- `timeout 60 composer test` (fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* env vars)


------
https://chatgpt.com/codex/tasks/task_e_68bf4b1c8e64832b908d293cd7c11644