### PR TITLE
Persist additional sticker settings

### DIFF
--- a/migrations/20250309_add_sticker_extra_fields.sql
+++ b/migrations/20250309_add_sticker_extra_fields.sql
@@ -1,0 +1,5 @@
+-- Add missing sticker configuration fields
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerTextColor TEXT;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerDescWidth REAL;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerDescHeight REAL;
+ALTER TABLE config ADD COLUMN IF NOT EXISTS stickerBgPath TEXT;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -779,6 +779,13 @@ document.addEventListener('DOMContentLoaded', function () {
       if (catalogStickerSubheaderSize) catalogStickerSubheaderSize.value = data.stickerSubheaderFontSize != null ? data.stickerSubheaderFontSize : 10;
       if (catalogStickerCatalogSize) catalogStickerCatalogSize.value = data.stickerCatalogFontSize != null ? data.stickerCatalogFontSize : 11;
       if (catalogStickerDescSize) catalogStickerDescSize.value = data.stickerDescFontSize != null ? data.stickerDescFontSize : 10;
+      if (catalogStickerTextColor) catalogStickerTextColor.value = '#' + (data.stickerTextColor || '000000').replace(/^#/, '');
+      if (descWidthInput) descWidthInput.value = data.stickerDescWidth != null ? data.stickerDescWidth : '';
+      if (descHeightInput) descHeightInput.value = data.stickerDescHeight != null ? data.stickerDescHeight : '';
+      if (data.stickerBgPath) {
+        catalogStickerBgUrl = withBase(data.stickerBgPath);
+        catalogStickerBgImg.src = catalogStickerBgUrl;
+      }
     } catch (e) { /* ignore */ }
     drawCatalogStickerPreview();
   }
@@ -798,7 +805,11 @@ document.addEventListener('DOMContentLoaded', function () {
       stickerHeaderFontSize: parseInt(catalogStickerHeaderSize?.value || '12', 10),
       stickerSubheaderFontSize: parseInt(catalogStickerSubheaderSize?.value || '10', 10),
       stickerCatalogFontSize: parseInt(catalogStickerCatalogSize?.value || '11', 10),
-      stickerDescFontSize: parseInt(catalogStickerDescSize?.value || '10', 10)
+      stickerDescFontSize: parseInt(catalogStickerDescSize?.value || '10', 10),
+      stickerTextColor: (catalogStickerTextColor?.value || '#000000').replace(/^#/, ''),
+      stickerDescWidth: parseFloat(descWidthInput?.value || '0'),
+      stickerDescHeight: parseFloat(descHeightInput?.value || '0'),
+      stickerBgPath: catalogStickerBgUrl.replace(withBase(''), '').split('?')[0] || ''
     };
     try {
       await apiFetch('/admin/sticker-settings', {
@@ -1040,11 +1051,13 @@ document.addEventListener('DOMContentLoaded', function () {
     const val = parseFloat(descWidthInput.value) * scale * stickerScaleRatio;
     if (stickerTextBox) stickerTextBox.style.width = `${Math.max(10, val)}px`;
     drawCatalogStickerPreview();
+    saveStickerSettings();
   });
   descHeightInput?.addEventListener('input', () => {
     const val = parseFloat(descHeightInput.value) * scale * stickerScaleRatio;
     if (stickerTextBox) stickerTextBox.style.height = `${Math.max(10, val)}px`;
     drawCatalogStickerPreview();
+    saveStickerSettings();
   });
   makeDraggable(stickerQrHandle, qrTopInput, qrLeftInput, false, () => stickerScaleRatio);
   catalogStickerBgImg.onload = () => drawCatalogStickerPreview();
@@ -1057,7 +1070,7 @@ document.addEventListener('DOMContentLoaded', function () {
   catalogStickerTemplate?.addEventListener('change', () => { drawCatalogStickerPreview(); saveStickerSettings(); });
   catalogStickerDesc?.addEventListener('change', () => { drawCatalogStickerPreview(); saveStickerSettings(); });
   catalogStickerQrColor?.addEventListener('input', () => { drawCatalogStickerPreview(); saveStickerSettings(); });
-  catalogStickerTextColor?.addEventListener('input', drawCatalogStickerPreview);
+  catalogStickerTextColor?.addEventListener('input', () => { drawCatalogStickerPreview(); saveStickerSettings(); });
   catalogStickerQrSizePct?.addEventListener('input', () => { drawCatalogStickerPreview(); saveStickerSettings(); });
   catalogStickerHeaderSize?.addEventListener('input', () => { drawCatalogStickerPreview(); saveStickerSettings(); });
   catalogStickerSubheaderSize?.addEventListener('input', () => { drawCatalogStickerPreview(); saveStickerSettings(); });
@@ -1137,6 +1150,12 @@ document.addEventListener('DOMContentLoaded', function () {
       const text = (xhr.responseText || '').trim();
       if (xhr.status >= 200 && xhr.status < 300) {
         notify(window.transImageReady || 'Image bereit', 'success');
+        const path = currentEventUid
+          ? `/data/events/${encodeURIComponent(currentEventUid)}/sticker-bg.png?${Date.now()}`
+          : `/data/uploads/sticker-bg.png?${Date.now()}`;
+        catalogStickerBgUrl = withBase(path);
+        catalogStickerBgImg.src = catalogStickerBgUrl;
+        saveStickerSettings();
         if (catalogStickerGenerate) catalogStickerGenerate.disabled = false;
       } else {
         const errorMap = {

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -94,6 +94,10 @@ class CatalogStickerController
             'stickerSubheaderFontSize' => $cfg['stickerSubheaderFontSize'] ?? 10,
             'stickerCatalogFontSize' => $cfg['stickerCatalogFontSize'] ?? 11,
             'stickerDescFontSize' => $cfg['stickerDescFontSize'] ?? 10,
+            'stickerTextColor' => $cfg['stickerTextColor'] ?? '000000',
+            'stickerDescWidth' => $cfg['stickerDescWidth'] ?? null,
+            'stickerDescHeight' => $cfg['stickerDescHeight'] ?? null,
+            'stickerBgPath' => $cfg['stickerBgPath'] ?? null,
         ];
         $response->getBody()->write(json_encode($data));
         return $response->withHeader('Content-Type', 'application/json');
@@ -126,6 +130,10 @@ class CatalogStickerController
             'stickerSubheaderFontSize' => (int)($data['stickerSubheaderFontSize'] ?? 10),
             'stickerCatalogFontSize' => (int)($data['stickerCatalogFontSize'] ?? 11),
             'stickerDescFontSize' => (int)($data['stickerDescFontSize'] ?? 10),
+            'stickerTextColor' => preg_replace('/[^0-9A-Fa-f]/', '', (string)($data['stickerTextColor'] ?? '000000')),
+            'stickerDescWidth' => isset($data['stickerDescWidth']) ? (float)$data['stickerDescWidth'] : null,
+            'stickerDescHeight' => isset($data['stickerDescHeight']) ? (float)$data['stickerDescHeight'] : null,
+            'stickerBgPath' => (string)($data['stickerBgPath'] ?? ''),
         ];
         $this->config->saveConfig($save);
         return $response->withStatus(204);
@@ -155,7 +163,11 @@ class CatalogStickerController
             (string)($params['qr_color'] ?? ($cfg['stickerQrColor'] ?? '000000'))
         );
         $qrColor = str_pad(substr($qrColor, 0, 6), 6, '0');
-        $textColor = preg_replace('/[^0-9A-Fa-f]/', '', (string)($params['text_color'] ?? '000000'));
+        $textColor = preg_replace(
+            '/[^0-9A-Fa-f]/',
+            '',
+            (string)($params['text_color'] ?? ($cfg['stickerTextColor'] ?? '000000'))
+        );
         $textColor = str_pad(substr($textColor, 0, 6), 6, '0');
         [$r, $g, $b] = array_map('hexdec', str_split($textColor, 2));
         $qrSizePct = isset($params['qr_size_pct'])
@@ -168,8 +180,12 @@ class CatalogStickerController
         $descLeft = isset($params['desc_left'])
             ? (float)$params['desc_left']
             : (float)($cfg['stickerDescLeft'] ?? 0.0);
-        $descWidth = isset($params['desc_width']) ? (float)$params['desc_width'] : null;
-        $descHeight = isset($params['desc_height']) ? (float)$params['desc_height'] : null;
+        $descWidth = isset($params['desc_width'])
+            ? (float)$params['desc_width']
+            : (isset($cfg['stickerDescWidth']) ? (float)$cfg['stickerDescWidth'] : null);
+        $descHeight = isset($params['desc_height'])
+            ? (float)$params['desc_height']
+            : (isset($cfg['stickerDescHeight']) ? (float)$cfg['stickerDescHeight'] : null);
         $qrTop = isset($params['qr_top'])
             ? (float)$params['qr_top']
             : (isset($cfg['stickerQrTop']) ? (float)$cfg['stickerQrTop'] : null);

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -238,6 +238,10 @@ class ConfigService
             'stickerSubheaderFontSize',
             'stickerCatalogFontSize',
             'stickerDescFontSize',
+            'stickerTextColor',
+            'stickerDescWidth',
+            'stickerDescHeight',
+            'stickerBgPath',
         ];
         $existing = array_map('strtolower', $this->getConfigColumns());
         $filtered = array_intersect_key($data, array_flip($keys));
@@ -395,6 +399,10 @@ class ConfigService
             'stickerDescLeft',
             'stickerQrTop',
             'stickerQrLeft',
+            'stickerTextColor',
+            'stickerDescWidth',
+            'stickerDescHeight',
+            'stickerBgPath',
         ];
         $map = [];
         foreach ($keys as $k) {


### PR DESCRIPTION
## Summary
- persist text color, description size and background path for catalog stickers
- expose these settings via API and PDF generation
- allow storing new sticker fields in config

## Testing
- `composer test` *(fails: command killed after hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68bf54729410832b93bd5d9371574623