### PR TITLE
feat: highlight catalog cards in dark mode

### DIFF
--- a/templates/event_catalogs.twig
+++ b/templates/event_catalogs.twig
@@ -34,7 +34,7 @@
       {% for cat in catalogs %}
         {% set key = cat.slug ?? cat.uid ?? cat.sort_order ?? cat.id %}
         <div>
-          <div class="uk-card uk-card-default uk-card-hover catalog-card" tabindex="0" data-start-url="{{ basePath }}/?event={{ event.uid }}&katalog={{ key|url_encode }}">
+          <div class="uk-card uk-card-default uk-card-hover catalog-card qr-card" tabindex="0" data-start-url="{{ basePath }}/?event={{ event.uid }}&katalog={{ key|url_encode }}">
             <div class="uk-card-body">
               <h3 class="uk-card-title">{{ cat.name ?? key }}</h3>
               {% if cat.description %}


### PR DESCRIPTION
## Summary
- show dark-mode hover styling on catalog cards by adding `qr-card`

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* keys)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5558bd64832ba2612821ddc95dcf