### PR TITLE
Normalize reorder ID comparison

### DIFF
--- a/public/js/table-manager.js
+++ b/public/js/table-manager.js
@@ -35,7 +35,8 @@ export default class TableManager {
 
   #handleReorder() {
     const ids = Array.from(this.tbody.children).map(r => r.dataset.id);
-    this.data = ids.map(id => this.data.find(d => d.id === id)).filter(Boolean);
+    const dataMap = new Map(this.data.map(d => [String(d.id), d]));
+    this.data = ids.map(id => dataMap.get(String(id))).filter(Boolean);
     if (typeof this.onReorder === 'function') {
       this.onReorder();
     }


### PR DESCRIPTION
## Summary
- standardize ID comparison when reordering table rows
- keep original data objects when applying reordered IDs

## Testing
- `composer test` *(fails: Tests: 323, Assertions: 534, Errors: 31, Failures: 104, Warnings: 4, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf573bf3ac832b9931bc742200255a