### PR TITLE
Prevent saving unnamed users in admin panel

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2737,6 +2737,10 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function saveUsers(list = userManager?.getData() || []) {
+    if (list.some(u => !u.username?.trim())) {
+      notify('Benutzername darf nicht leer sein', 'warning');
+      return;
+    }
     const payload = list
       .map(u => ({
         id: u.id && !isNaN(u.id) ? parseInt(u.id, 10) : undefined,


### PR DESCRIPTION
## Summary
- warn and abort if user list contains empty usernames before saving

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68bf58c8fd40832b989b2fac0f623c37