### PR TITLE
Add competition mode replay prevention test

### DIFF
--- a/tests/test_competition_prevent_replay.js
+++ b/tests/test_competition_prevent_replay.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.style = {};
+  }
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+}
+
+const storage = () => {
+  const data = {};
+  return {
+    getItem: k => (k in data ? data[k] : null),
+    setItem: (k, v) => { data[k] = String(v); },
+    removeItem: k => { delete data[k]; }
+  };
+};
+
+const sessionStorage = storage();
+const localStorage = storage();
+
+const body = new Element('body');
+
+const document = {
+  readyState: 'loading',
+  getElementById: () => null,
+  querySelector: sel => (sel === 'main' ? body : null),
+  createElement: tag => new Element(tag),
+  addEventListener: () => {},
+  body
+};
+
+let warnings = 0;
+const UIkit = { notification: () => { warnings++; } };
+let started = 0;
+
+const window = {
+  document,
+  location: { search: '?slug=slug1' },
+  quizConfig: { competitionMode: true },
+  basePath: '',
+  startQuiz: () => { started++; }
+};
+window.window = window;
+
+const context = {
+  window,
+  document,
+  sessionStorage,
+  localStorage,
+  fetch: async () => ({ ok: true, json: async () => [] }),
+  UIkit,
+  console,
+  URLSearchParams,
+  withBase: p => p
+};
+context.global = context;
+
+(async () => {
+  vm.runInNewContext(fs.readFileSync('public/js/catalog.js', 'utf8'), context);
+  context.buildSolvedSet = async () => new Set(['slug1']);
+  await context.init();
+  assert.strictEqual(warnings, 1);
+  assert.strictEqual(started, 0);
+  console.log('ok');
+})().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- Add test to ensure competition mode blocks replaying a solved catalog and warns the user

## Testing
- `node tests/test_competition_prevent_replay.js`
- `composer test` *(fails: "PHPUnit 10.5.49" with misconfiguration warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5baa8eb4832ba2f07608cf70cba9