### PR TITLE
feat: add event selection label

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -167,6 +167,7 @@ return [
     'label_team_restrict' => 'Nur Teams/Personen aus der Liste dürfen teilnehmen.',
     'label_plan' => 'Abo',
     'label_events' => 'Veranstaltungen',
+    'label_event_select' => 'Veranstaltung wählen',
     'label_catalogs' => 'Kataloge',
     'label_questions' => 'Fragen',
     'word_of' => 'von',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -169,6 +169,7 @@ return [
     'label_team_restrict' => 'Only listed teams may join',
     'label_plan' => 'Plan',
     'label_events' => 'Events',
+    'label_event_select' => 'Select event',
     'label_catalogs' => 'Catalogs',
     'label_questions' => 'Questions',
     'word_of' => 'of',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -38,8 +38,9 @@
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
+        <label for="eventSelect" class="uk-form-label uk-margin-small-right">{{ t('label_event_select') }}</label>
         <div id="eventSelectWrap" class="uk-form-custom uk-flex-1" uk-form-custom="target: > * > span:first-child">
-          <select id="eventSelect" aria-label="{{ t('label_events') }}"></select>
+          <select id="eventSelect" aria-label="{{ t('label_event_select') }}"></select>
           <button class="uk-button uk-button-default" type="button" tabindex="-1">
             <span></span>
             <span uk-icon="icon: chevron-down"></span>


### PR DESCRIPTION
## Summary
- add explicit label for event selector in admin topbar
- provide German and English translations for the label

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration; missing STRIPE_SECRET_KEY; missing STRIPE_PUBLISHABLE_KEY; Missing STRIPE_PRICE_STARTER; Missing STRIPE_PRICE_STANDARD; Missing STRIPE_PRICE_PROFESSIONAL; Missing STRIPE_PRICING_TABLE_ID; Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5c71c188832ba5ad8e2afbc91017