### PR TITLE
chore: improve event select accessibility

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -38,12 +38,8 @@
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
-        <div id="eventSelectWrap" class="uk-form-custom uk-flex-1" uk-form-custom="target: > * > span:first-child">
-          <select id="eventSelect" aria-label="{{ t('label_events') }}"></select>
-          <button class="uk-button uk-button-default" type="button" tabindex="-1">
-            <span></span>
-            <span uk-icon="icon: chevron-down"></span>
-          </button>
+        <div id="eventSelectWrap" class="uk-flex-1">
+          <select id="eventSelect" class="uk-select" aria-label="{{ t('label_events') }}"></select>
         </div>
         <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left uk-visible@s" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
       </div>


### PR DESCRIPTION
## Summary
- replace custom event select wrapper with native `select`
- remove tabindex to keep event chooser keyboard focusable

## Testing
- `composer test` *(fails: Tests: 323, Assertions: 534, Errors: 31, Failures: 104, Warnings: 4)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5cb56c20832b995f7e1347358916