### PR TITLE
Add user position ordering

### DIFF
--- a/migrations/20250310_add_position_to_users.sql
+++ b/migrations/20250310_add_position_to_users.sql
@@ -1,0 +1,3 @@
+-- Add position column to users for manual ordering
+ALTER TABLE users ADD COLUMN IF NOT EXISTS position INTEGER NOT NULL DEFAULT 0;
+UPDATE users SET position = id WHERE position = 0;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2742,12 +2742,13 @@ document.addEventListener('DOMContentLoaded', function () {
       return;
     }
     const payload = list
-      .map(u => ({
+      .map((u, index) => ({
         id: u.id && !isNaN(u.id) ? parseInt(u.id, 10) : undefined,
         username: u.username?.trim(),
         role: u.role,
         active: u.active !== false,
-        password: u.password || ''
+        password: u.password || '',
+        position: index
       }))
       .filter(u => u.username);
     apiFetch('/users.json', {

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -118,20 +118,20 @@ class UserService
     }
 
     /**
-     * Retrieve all users ordered by their id.
+     * Retrieve all users ordered by their position.
      *
-     * @return list<array{id:int,username:string,email:?string,role:string,active:bool}>
+     * @return list<array{id:int,username:string,email:?string,role:string,active:bool,position:int}>
      */
     public function getAll(): array
     {
-        $stmt = $this->pdo->query('SELECT id,username,email,role,active FROM users ORDER BY id');
+        $stmt = $this->pdo->query('SELECT id,username,email,role,active,position FROM users ORDER BY position');
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**
      * Replace the entire user list with the provided data.
      *
-     * @param list<array{id?:int,username:string,email?:?string,role:string,password?:string,active?:bool}> $users
+     * @param list<array{id?:int,username:string,email?:?string,role:string,password?:string,active?:bool,position?:int}> $users
      */
     public function saveAll(array $users): void
     {
@@ -141,12 +141,12 @@ class UserService
             $existing[(int) $row['id']] = true;
         }
 
-        $insert = $this->pdo->prepare('INSERT INTO users(username,password,email,role,active) VALUES(?,?,?,?,?)');
-        $update = $this->pdo->prepare('UPDATE users SET username=?,email=?,role=?,active=? WHERE id=?');
+        $insert = $this->pdo->prepare('INSERT INTO users(username,password,email,role,active,position) VALUES(?,?,?,?,?,?)');
+        $update = $this->pdo->prepare('UPDATE users SET username=?,email=?,role=?,active=?,position=? WHERE id=?');
         $updatePass = $this->pdo->prepare('UPDATE users SET password=? WHERE id=?');
         $delete = $this->pdo->prepare('DELETE FROM users WHERE id=?');
 
-        foreach ($users as $u) {
+        foreach ($users as $pos => $u) {
             $id = isset($u['id']) ? (int) $u['id'] : 0;
             $username = strtolower((string) $u['username']);
             $role = (string) $u['role'];
@@ -155,17 +155,18 @@ class UserService
                 $role = Roles::CATALOG_EDITOR;
             }
             $pass = $u['password'] ?? '';
-            $active = isset($u['active']) ? (bool)$u['active'] : true;
+            $active = isset($u['active']) ? (bool) $u['active'] : true;
+            $position = $pos;
 
             if ($id === 0 || !isset($existing[$id])) {
                 if ($pass === '') {
                     $pass = bin2hex(random_bytes(8));
                 }
-                $insert->execute([$username, password_hash($pass, PASSWORD_DEFAULT), $email, $role, $active]);
+                $insert->execute([$username, password_hash($pass, PASSWORD_DEFAULT), $email, $role, $active, $position]);
                 continue;
             }
 
-            $update->execute([$username, $email, $role, $active, $id]);
+            $update->execute([$username, $email, $role, $active, $position, $id]);
             if ($pass !== '') {
                 $updatePass->execute([password_hash($pass, PASSWORD_DEFAULT), $id]);
             }


### PR DESCRIPTION
## Summary
- add migration for `users.position`
- track list order via `UserService::saveAll()` and sort in `getAll()`
- send `position` field when saving users in admin UI

## Testing
- `composer test` *(fails: Failed asserting that 4 is identical to 2)*


------
https://chatgpt.com/codex/tasks/task_e_68bf5cecf7dc832bb0ffdfe325af57f5