### PR TITLE
Use native UIkit select for event picker

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -584,16 +584,10 @@ body.admin-page {
 .admin-page #eventSelectWrap {
   flex: 1;
   min-width: 150px;
-  overflow: hidden;
 }
 
-.admin-page #eventSelectWrap button > span:first-child {
-  display: block;
-  line-height: 1.2;
-  margin-top: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.admin-page #eventSelectWrap select {
+  width: 100%;
 }
 
 @media (min-width: 640px) {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2495,14 +2495,10 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function updateEventSelectDisplay() {
-    if (!eventSelectWrap || !eventSelect) return;
-    const btnSpan = eventSelectWrap.querySelector('button > span:first-child');
-    if (btnSpan) {
-      const sel = eventSelect.options[eventSelect.selectedIndex];
-      btnSpan.textContent = sel ? sel.textContent : '';
-      if (eventOpenBtn) eventOpenBtn.disabled = !sel || !sel.value;
-      if (openInvitesBtn) openInvitesBtn.disabled = !sel || !sel.value;
-    }
+    if (!eventSelect) return;
+    const sel = eventSelect.options[eventSelect.selectedIndex];
+    if (eventOpenBtn) eventOpenBtn.disabled = !sel || !sel.value;
+    if (openInvitesBtn) openInvitesBtn.disabled = !sel || !sel.value;
     window.dispatchEvent(new Event('resize'));
   }
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -39,12 +39,8 @@
     {% block center %}
       <div class="uk-flex uk-flex-middle">
         <label for="eventSelect" class="uk-form-label uk-margin-small-right">{{ t('label_event_select') }}</label>
-        <div id="eventSelectWrap" class="uk-form-custom uk-flex-1" uk-form-custom="target: > * > span:first-child">
-          <select id="eventSelect" aria-label="{{ t('label_event_select') }}"></select>
-          <button class="uk-button uk-button-default" type="button" tabindex="-1">
-            <span></span>
-            <span uk-icon="icon: chevron-down"></span>
-          </button>
+        <div id="eventSelectWrap" class="uk-flex-1">
+          <select id="eventSelect" class="uk-select" aria-label="{{ t('label_event_select') }}"></select>
         </div>
         <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left uk-visible@s" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
       </div>

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -17,12 +17,8 @@
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
-        <div id="eventSelectWrap" class="uk-form-custom uk-flex-1" uk-form-custom="target: > * > span:first-child">
-          <select id="eventSelect" aria-label="{{ t('label_events') }}"></select>
-          <button class="uk-button uk-button-default" type="button" tabindex="-1">
-            <span></span>
-            <span uk-icon="icon: chevron-down"></span>
-          </button>
+        <div id="eventSelectWrap" class="uk-flex-1">
+          <select id="eventSelect" class="uk-select" aria-label="{{ t('label_events') }}"></select>
         </div>
         <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
       </div>

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -15,13 +15,7 @@
     {% block center %}
       <div class="uk-flex uk-flex-middle">
         <div id="eventSelectWrap" class="uk-flex uk-flex-middle" hidden>
-          <div class="uk-form-custom uk-flex-1" uk-form-custom="target: > * > span:first-child">
-            <select id="eventSelect" aria-label="{{ t('label_events') }}"></select>
-            <button class="uk-button uk-button-default" type="button" tabindex="-1">
-              <span></span>
-              <span uk-icon="icon: chevron-down"></span>
-            </button>
-          </div>
+          <select id="eventSelect" class="uk-select uk-flex-1" aria-label="{{ t('label_events') }}"></select>
           <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
         </div>
         <span id="eventTitle" class="uk-navbar-title uk-text-center">{{ event.name|default('Sommerfest 2025') }}</span>


### PR DESCRIPTION
## Summary
- replace custom event dropdowns with native `<select>` controls
- update admin JS to handle native selects
- simplify event picker styling

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68bf60748154832b8575f11fd16f48e5