### PR TITLE
Add user position ordering and persistence

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -165,7 +165,8 @@ CREATE TABLE IF NOT EXISTS users (
     username TEXT UNIQUE NOT NULL,
     password TEXT NOT NULL,
     email TEXT UNIQUE,
-    role user_role NOT NULL DEFAULT 'catalog-editor'
+    role user_role NOT NULL DEFAULT 'catalog-editor',
+    position INTEGER NOT NULL DEFAULT 0
 );
 
 -- Tenant definitions

--- a/migrations/20240910_base_schema.sql
+++ b/migrations/20240910_base_schema.sql
@@ -174,7 +174,8 @@ CREATE TABLE IF NOT EXISTS users (
     password TEXT NOT NULL,
     email TEXT UNIQUE,
     active BOOLEAN NOT NULL DEFAULT TRUE,
-    role user_role NOT NULL DEFAULT 'catalog-editor'
+    role user_role NOT NULL DEFAULT 'catalog-editor',
+    position INTEGER NOT NULL DEFAULT 0
 );
 
 -- Sessions for logged-in users

--- a/migrations/20250310_add_position_to_users.sql
+++ b/migrations/20250310_add_position_to_users.sql
@@ -1,0 +1,3 @@
+-- Add position column to users for manual ordering
+ALTER TABLE users ADD COLUMN IF NOT EXISTS position INTEGER NOT NULL DEFAULT 0;
+UPDATE users SET position = id WHERE position = 0;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2742,12 +2742,13 @@ document.addEventListener('DOMContentLoaded', function () {
       return;
     }
     const payload = list
-      .map(u => ({
+      .map((u, idx) => ({
         id: u.id && !isNaN(u.id) ? parseInt(u.id, 10) : undefined,
         username: u.username?.trim(),
         role: u.role,
         active: u.active !== false,
-        password: u.password || ''
+        password: u.password || '',
+        position: idx
       }))
       .filter(u => u.username);
     apiFetch('/users.json', {

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -179,7 +179,8 @@ CREATE TABLE IF NOT EXISTS users (
     password TEXT NOT NULL,
     email TEXT UNIQUE,
     active BOOLEAN NOT NULL DEFAULT TRUE,
-    role TEXT NOT NULL DEFAULT 'catalog-editor'
+    role TEXT NOT NULL DEFAULT 'catalog-editor',
+    position INTEGER NOT NULL DEFAULT 0
 );
 
 -- User sessions

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -118,20 +118,20 @@ class UserService
     }
 
     /**
-     * Retrieve all users ordered by their id.
+     * Retrieve all users ordered by their position.
      *
-     * @return list<array{id:int,username:string,email:?string,role:string,active:bool}>
+     * @return list<array{id:int,username:string,email:?string,role:string,active:bool,position:int}>
      */
     public function getAll(): array
     {
-        $stmt = $this->pdo->query('SELECT id,username,email,role,active FROM users ORDER BY id');
+        $stmt = $this->pdo->query('SELECT id,username,email,role,active,position FROM users ORDER BY position');
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**
      * Replace the entire user list with the provided data.
      *
-     * @param list<array{id?:int,username:string,email?:?string,role:string,password?:string,active?:bool}> $users
+     * @param list<array{id?:int,username:string,email?:?string,role:string,password?:string,active?:bool,position?:int}> $users
      */
     public function saveAll(array $users): void
     {
@@ -141,12 +141,12 @@ class UserService
             $existing[(int) $row['id']] = true;
         }
 
-        $insert = $this->pdo->prepare('INSERT INTO users(username,password,email,role,active) VALUES(?,?,?,?,?)');
-        $update = $this->pdo->prepare('UPDATE users SET username=?,email=?,role=?,active=? WHERE id=?');
+        $insert = $this->pdo->prepare('INSERT INTO users(username,password,email,role,active,position) VALUES(?,?,?,?,?,?)');
+        $update = $this->pdo->prepare('UPDATE users SET username=?,email=?,role=?,active=?,position=? WHERE id=?');
         $updatePass = $this->pdo->prepare('UPDATE users SET password=? WHERE id=?');
         $delete = $this->pdo->prepare('DELETE FROM users WHERE id=?');
 
-        foreach ($users as $u) {
+        foreach ($users as $idx => $u) {
             $id = isset($u['id']) ? (int) $u['id'] : 0;
             $username = strtolower((string) $u['username']);
             $role = (string) $u['role'];
@@ -156,16 +156,17 @@ class UserService
             }
             $pass = $u['password'] ?? '';
             $active = isset($u['active']) ? (bool)$u['active'] : true;
+            $position = $idx;
 
             if ($id === 0 || !isset($existing[$id])) {
                 if ($pass === '') {
                     $pass = bin2hex(random_bytes(8));
                 }
-                $insert->execute([$username, password_hash($pass, PASSWORD_DEFAULT), $email, $role, $active]);
+                $insert->execute([$username, password_hash($pass, PASSWORD_DEFAULT), $email, $role, $active, $position]);
                 continue;
             }
 
-            $update->execute([$username, $email, $role, $active, $id]);
+            $update->execute([$username, $email, $role, $active, $position, $id]);
             if ($pass !== '') {
                 $updatePass->execute([password_hash($pass, PASSWORD_DEFAULT), $id]);
             }


### PR DESCRIPTION
## Summary
- add `position` column to `users` and initialize from existing ids
- order users by `position` and persist array order in bulk saves
- include `position` when admin UI posts user data

## Testing
- `composer test` *(fails: Tests: 324, Assertions: 536, Errors: 31, Failures: 104)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6047c058832b83c6ba5d6b4a4a20