### PR TITLE
Improve accessibility of admin event select

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -587,15 +587,6 @@ body.admin-page {
   overflow: hidden;
 }
 
-.admin-page #eventSelectWrap button > span:first-child {
-  display: block;
-  line-height: 1.2;
-  margin-top: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 @media (min-width: 640px) {
   #adminTabs {
     display: flex;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2495,14 +2495,16 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function updateEventSelectDisplay() {
-    if (!eventSelectWrap || !eventSelect) return;
-    const btnSpan = eventSelectWrap.querySelector('button > span:first-child');
-    if (btnSpan) {
-      const sel = eventSelect.options[eventSelect.selectedIndex];
-      btnSpan.textContent = sel ? sel.textContent : '';
-      if (eventOpenBtn) eventOpenBtn.disabled = !sel || !sel.value;
-      if (openInvitesBtn) openInvitesBtn.disabled = !sel || !sel.value;
+    if (!eventSelect) return;
+    const sel = eventSelect.options[eventSelect.selectedIndex];
+    if (eventSelectWrap) {
+      const btnSpan = eventSelectWrap.querySelector('button > span:first-child');
+      if (btnSpan) {
+        btnSpan.textContent = sel ? sel.textContent : '';
+      }
     }
+    if (eventOpenBtn) eventOpenBtn.disabled = !sel || !sel.value;
+    if (openInvitesBtn) openInvitesBtn.disabled = !sel || !sel.value;
     window.dispatchEvent(new Event('resize'));
   }
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -39,12 +39,12 @@
     {% block center %}
       <div class="uk-flex uk-flex-middle">
         <label for="eventSelect" class="uk-form-label uk-margin-small-right">{{ t('label_event_select') }}</label>
-        <div id="eventSelectWrap" class="uk-form-custom uk-flex-1" uk-form-custom="target: > * > span:first-child">
-          <select id="eventSelect" aria-label="{{ t('label_event_select') }}"></select>
-          <button class="uk-button uk-button-default" type="button" tabindex="-1">
-            <span></span>
-            <span uk-icon="icon: chevron-down"></span>
-          </button>
+        <div id="eventSelectWrap" class="uk-flex-1">
+          <select
+            id="eventSelect"
+            class="uk-select"
+            aria-label="{{ t('label_event_select') }}"
+          ></select>
         </div>
         <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left uk-visible@s" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
       </div>


### PR DESCRIPTION
## Summary
- replace `uk-form-custom` event selector with native `<select>` styled by UIkit
- update JS to handle select without custom button and keep buttons in sync
- drop unused CSS for removed custom button

## Testing
- `composer test` *(fails: DFFFF.FFEE.F.FF....EE........F...FFFFF....FEEEEEFFFF...........  63 / 324 ( 19%))*
- `node -e "const {JSDOM}=require('jsdom');const fs=require('fs');const html=fs.readFileSync('templates/admin.twig','utf8');const dom=new JSDOM(html);const select=dom.window.document.getElementById('eventSelect');console.log('tabindex:',select.tabIndex);"`


------
https://chatgpt.com/codex/tasks/task_e_68bf60825810832b8f6a2b3f327d398b