### PR TITLE
test: cover user position ordering

### DIFF
--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -179,7 +179,8 @@ CREATE TABLE IF NOT EXISTS users (
     password TEXT NOT NULL,
     email TEXT UNIQUE,
     active BOOLEAN NOT NULL DEFAULT TRUE,
-    role TEXT NOT NULL DEFAULT 'catalog-editor'
+    role TEXT NOT NULL DEFAULT 'catalog-editor',
+    position INTEGER NOT NULL DEFAULT 0
 );
 
 -- User sessions

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\UserService;
+use App\Domain\Roles;
+use Tests\TestCase;
+
+class UserServiceTest extends TestCase
+{
+    public function testSaveAllStoresPositionAndReturnsOrdered(): void
+    {
+        $pdo = $this->createDatabase();
+        $svc = new UserService($pdo);
+
+        $svc->saveAll([
+            ['username' => 'alice', 'role' => Roles::ADMIN],
+            ['username' => 'bob', 'role' => Roles::CATALOG_EDITOR],
+            ['username' => 'carol', 'role' => Roles::ANALYST],
+        ]);
+
+        $users = $svc->getAll();
+        $this->assertSame(['alice', 'bob', 'carol'], array_column($users, 'username'));
+        $this->assertSame([0, 1, 2], array_column($users, 'position'));
+
+        $svc->saveAll([
+            ['id' => $users[2]['id'], 'username' => 'carol', 'role' => $users[2]['role'], 'active' => true],
+            ['id' => $users[0]['id'], 'username' => 'alice', 'role' => $users[0]['role'], 'active' => true],
+            ['id' => $users[1]['id'], 'username' => 'bob', 'role' => $users[1]['role'], 'active' => true],
+        ]);
+
+        $users = $svc->getAll();
+        $this->assertSame(['carol', 'alice', 'bob'], array_column($users, 'username'));
+        $this->assertSame([0, 1, 2], array_column($users, 'position'));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for user positions to ensure ordering is preserved on save
- update SQLite schema to include `position` column

## Testing
- `vendor/bin/phpunit tests/Service/UserServiceTest.php`
- `vendor/bin/phpunit` *(fails: MAIN_DOMAIN misconfiguration and other missing env settings)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6225bb70832baf48e77a211cb5f3