### PR TITLE
Add search to admin event selector

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -596,6 +596,10 @@ body.admin-page {
   white-space: nowrap;
 }
 
+.admin-page #eventSearchInput {
+  width: 120px;
+}
+
 @media (min-width: 640px) {
   #adminTabs {
     display: flex;
@@ -617,6 +621,9 @@ body.admin-page {
   .admin-page #eventSelectWrap {
     flex: 0;
     min-width: 220px;
+  }
+  .admin-page #eventSearchInput {
+    width: 180px;
   }
 }
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2178,6 +2178,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const eventAddBtn = document.getElementById('eventAddBtn');
   const eventSelect = document.getElementById('eventSelect');
   const eventSelectWrap = document.getElementById('eventSelectWrap');
+  const eventSearchInput = document.getElementById('eventSearchInput');
   const eventOpenBtn = document.getElementById('eventOpenBtn');
   const eventDependentSections = document.querySelectorAll('[data-event-dependent]');
   const langSelect = document.getElementById('langSelect');
@@ -2255,6 +2256,11 @@ document.addEventListener('DOMContentLoaded', function () {
     if (eventSelectWrap) eventSelectWrap.hidden = false;
     if (eventOpenBtn) eventOpenBtn.disabled = !currentEventUid;
     if (openInvitesBtn) openInvitesBtn.disabled = !currentEventUid;
+    if (eventSearchInput) {
+      eventSearchInput.hidden = !(Array.isArray(list) && list.length > 0);
+      eventSearchInput.value = '';
+      eventSearchInput.dispatchEvent(new Event('input'));
+    }
     updateEventSelectDisplay();
   }
 
@@ -2512,6 +2518,16 @@ document.addEventListener('DOMContentLoaded', function () {
     if (uid && uid !== currentEventUid && typeof setCurrentEvent === 'function') {
       setCurrentEvent(uid, name);
     }
+  });
+
+  eventSearchInput?.addEventListener('input', () => {
+    const term = eventSearchInput.value.toLowerCase();
+    Array.from(eventSelect?.options || []).forEach(opt => {
+      if (!opt.value) return;
+      const match = opt.textContent.toLowerCase().includes(term);
+      opt.style.display = match ? '' : 'none';
+    });
+    updateEventSelectDisplay();
   });
 
   eventOpenBtn?.addEventListener('click', () => {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -46,6 +46,7 @@
             <span uk-icon="icon: chevron-down"></span>
           </button>
         </div>
+        <input id="eventSearchInput" class="uk-input uk-form-small uk-width-small uk-margin-small-left" type="search" placeholder="Suchen" hidden>
         <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left uk-visible@s" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
       </div>
     {% endblock %}


### PR DESCRIPTION
## Summary
- Add event search input and filtering logic to admin dashboard
- Style and layout adjustments for new search field in top bar

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, MAIN_DOMAIN misconfiguration, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf60881b14832b87085386d9941c84