### PR TITLE
feat: inline role editing

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -964,6 +964,13 @@
           </table>
         </div>
         {{ qr_rowcards('usersCards') }}
+        <template id="userRoleSelect">
+          <select class="uk-select">
+            {% for role in roles %}
+              <option value="{{ role }}">{{ role }}</option>
+            {% endfor %}
+          </select>
+        </template>
         <div class="uk-margin">
           <button id="userAddBtn" class="uk-icon-button uk-button-default" uk-icon="plus" uk-tooltip="title: {{ t('tip_user_add') }}; pos: right" aria-label="{{ t('tip_user_add') }}"></button>
         </div>


### PR DESCRIPTION
## Summary
- render role options as select template
- enable inline role updates without modal

## Testing
- `composer test` *(fails: Tests\Service\TenantServiceTest::testImportMissingSyncsTenantsDirectory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf625d90d8832b8b21c9daa04af3d8