### PR TITLE
Replace custom event selector and centralize button toggling

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -586,10 +586,6 @@ body.admin-page {
   min-width: 150px;
 }
 
-.admin-page #eventSelectWrap select {
-  width: 100%;
-}
-
 .admin-page #eventSearchInput {
   width: 120px;
 }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1175,7 +1175,6 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   const openInvitesBtn = document.getElementById('openInvitesBtn');
-  if (openInvitesBtn) openInvitesBtn.disabled = !currentEventUid;
   openInvitesBtn?.addEventListener('click', function (e) {
     e.preventDefault();
     if (currentEventUid) {
@@ -2252,10 +2251,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     eventSelect.value = currentEventUid || '';
+    eventSelect.dispatchEvent(new Event('change'));
     eventDependentSections.forEach(sec => { sec.hidden = !currentEventUid; });
     if (eventSelectWrap) eventSelectWrap.hidden = false;
-    if (eventOpenBtn) eventOpenBtn.disabled = !currentEventUid;
-    if (openInvitesBtn) openInvitesBtn.disabled = !currentEventUid;
     if (eventSearchInput) {
       eventSearchInput.hidden = !(Array.isArray(list) && list.length > 0);
       eventSearchInput.value = '';
@@ -2493,6 +2491,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const opt = Array.from(eventSelect.options).find(o => o.value === uid);
       if (opt) {
         eventSelect.value = opt.value;
+        eventSelect.dispatchEvent(new Event('change'));
       }
     }
     updateEventSelectDisplay();
@@ -2502,9 +2501,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function updateEventSelectDisplay() {
     if (!eventSelect) return;
-    const sel = eventSelect.options[eventSelect.selectedIndex];
-    if (eventOpenBtn) eventOpenBtn.disabled = !sel || !sel.value;
-    if (openInvitesBtn) openInvitesBtn.disabled = !sel || !sel.value;
     window.dispatchEvent(new Event('resize'));
   }
 

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -88,9 +88,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const eventOpenBtn = document.getElementById('eventOpenBtn');
   const eventTitle = document.getElementById('eventTitle');
   const eventNotice = document.getElementById('eventNotice');
+  const eventButtons = document.querySelectorAll('[data-event-btn]');
+  const isAdminPage = document.body?.classList.contains('admin-page');
   let currentEventUid = '';
   const params = new URLSearchParams(window.location.search);
   const pageEventUid = params.get('event') || '';
+
+  const updateEventButtons = (uid) => {
+    eventButtons.forEach((btn) => {
+      btn.disabled = !uid;
+    });
+  };
 
   function populate(list) {
     if (!eventSelect) return;
@@ -104,6 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
         eventNotice.textContent = eventNotice.dataset.empty || 'Keine Veranstaltungen vorhanden';
         eventNotice.hidden = false;
       }
+      updateEventButtons('');
       return;
     }
     const placeholder = document.createElement('option');
@@ -126,9 +135,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (eventTitle) eventTitle.hidden = true;
     if (currentEventUid) {
       if (eventNotice) eventNotice.hidden = true;
+      updateEventButtons(currentEventUid);
       eventSelect.dispatchEvent(new Event('change'));
     } else {
       eventSelect.value = '';
+      updateEventButtons('');
       if (eventNotice) {
         eventNotice.textContent = eventNotice.dataset.required || '';
         eventNotice.hidden = false;
@@ -136,7 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  if (eventSelect) {
+  if (eventSelect && !isAdminPage) {
     const initialOptionCount = eventSelect.options.length;
     const warnIfEmpty = (list) => {
       if (initialOptionCount === 0 && (!Array.isArray(list) || list.length === 0)) {
@@ -171,11 +182,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const msg = eventNotice?.dataset.error || 'Veranstaltungen konnten nicht geladen werden';
         notify(msg, 'danger');
       });
+  } else if (eventSelect) {
+    updateEventButtons(eventSelect.value);
   }
 
   eventSelect?.addEventListener('change', () => {
     const uid = eventSelect.value;
-    if (uid && uid !== currentEventUid) {
+    updateEventButtons(uid);
+    if (!isAdminPage && uid && uid !== currentEventUid) {
       location.search = '?event=' + uid;
     }
   });

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -43,7 +43,7 @@
           <select id="eventSelect" class="uk-select" aria-label="{{ t('label_event_select') }}"></select>
         </div>
         <input id="eventSearchInput" class="uk-input uk-form-small uk-width-small uk-margin-small-left" type="search" placeholder="Suchen" hidden>
-        <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left uk-visible@s" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
+        <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left uk-visible@s" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom" data-event-btn disabled></button>
       </div>
     {% endblock %}
     {% block right %}{% endblock %}
@@ -639,7 +639,7 @@
           </div>
           <div class="uk-width-1-1 uk-width-expand@m">
             <div class="uk-flex uk-flex-wrap uk-flex-right@m">
-              <button id="openInvitesBtn" class="uk-button uk-button-default uk-margin-small-bottom uk-margin-small-right" uk-tooltip="title: {{ t('tip_invitations_open') }}; pos: right">{{ t('action_open_invitations') }}</button>
+              <button id="openInvitesBtn" class="uk-button uk-button-default uk-margin-small-bottom uk-margin-small-right" uk-tooltip="title: {{ t('tip_invitations_open') }}; pos: right" data-event-btn disabled>{{ t('action_open_invitations') }}</button>
               <button id="summaryPrintBtn" class="uk-button uk-button-default uk-margin-small-bottom uk-margin-small-right" uk-tooltip="title: {{ t('tip_summary_print') }}; pos: right">{{ t('action_print_summary') }}</button>
               <button id="summaryDesignAllBtn" class="uk-button uk-button-default uk-margin-small-bottom" type="button">{{ t('action_design_qrcodes') }}</button>
             </div>
@@ -747,7 +747,7 @@
       <div class="uk-container uk-container-large">
         <div class="uk-flex uk-flex-between uk-flex-middle">
           <h2 class="uk-heading-bullet">{{ t('heading_results') }}</h2>
-          <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="{{ t('action_refresh') }}" aria-label="{{ t('action_refresh') }}"></button>
+          <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="{{ t('action_refresh') }}" aria-label="{{ t('action_refresh') }}" data-event-btn disabled></button>
         </div>
         <div id="rankingGrid" class="uk-grid-small uk-child-width-1-1 uk-child-width-1-3@m uk-margin-bottom" uk-grid uk-height-match="target: > div > .uk-card"></div>
         {% set resultsRows %}
@@ -1322,6 +1322,7 @@
     window.initialEvents = {{ events|json_encode|raw }};
   </script>
   <script src="{{ basePath }}/js/dashboard.js"></script>
+  <script src="{{ basePath }}/js/events.js"></script>
   <script type="module" src="{{ basePath }}/js/admin.js"></script>
   <script src="{{ basePath }}/js/subscription.js"></script>
   <script src="{{ basePath }}/js/storage.js"></script>

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -20,7 +20,7 @@
         <div id="eventSelectWrap" class="uk-flex-1">
           <select id="eventSelect" class="uk-select" aria-label="{{ t('label_events') }}"></select>
         </div>
-        <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
+        <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom" data-event-btn disabled></button>
       </div>
     {% endblock %}
   {% endembed %}
@@ -28,7 +28,7 @@
     <div id="eventNotice" class="uk-alert uk-alert-primary" hidden data-empty="{{ t('text_no_events') }}" data-required="{{ t('text_event_required') }}" data-error="{{ t('text_events_fetch_error') }}"></div>
     <div class="uk-flex uk-flex-between uk-flex-middle">
       <h2 class="uk-heading-bullet">Ergebnisse</h2>
-      <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="Aktualisieren" aria-label="Aktualisieren"></button>
+      <button id="resultsRefreshBtn" class="uk-icon-button" uk-icon="icon: refresh; ratio: 1.2" title="Aktualisieren" aria-label="Aktualisieren" data-event-btn disabled></button>
     </div>
     <div id="rankingGrid" class="uk-grid-small uk-child-width-1-1 uk-child-width-1-3@m uk-margin-bottom" uk-grid uk-height-match="target: > div > .uk-card"></div>
     <div uk-lightbox="nav: thumbnav; slidenav: false">

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -16,7 +16,7 @@
       <div class="uk-flex uk-flex-middle">
         <div id="eventSelectWrap" class="uk-flex uk-flex-middle" hidden>
           <select id="eventSelect" class="uk-select uk-flex-1" aria-label="{{ t('label_events') }}"></select>
-          <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom"></button>
+          <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom" data-event-btn disabled></button>
         </div>
         <span id="eventTitle" class="uk-navbar-title uk-text-center">{{ event.name|default('Sommerfest 2025') }}</span>
       </div>


### PR DESCRIPTION
## Summary
- swap custom event selector for native `<select>` styled with `uk-select`
- mark event-dependent buttons with `data-event-btn`
- centralize event button enable/disable logic in `events.js` and drop old select styles

## Testing
- `composer test` *(fails: Missing STRIPE configuration, some tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf65834c00832b88bb25590a0f1a28