### PR TITLE
Redirect login to admin for dashboard roles

### DIFF
--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Domain\Roles;
 use App\Service\UserService;
 use App\Service\SessionService;
 use App\Infrastructure\Database;
@@ -101,7 +102,22 @@ class LoginController
                     ->withHeader('Location', $scheme . '://' . $mainDomain . '/admin')
                     ->withStatus(302);
             }
-            $target = $record['role'] === 'admin' ? '/admin' : '/';
+            $dashboardRoles = [
+                Roles::ADMIN,
+                Roles::CATALOG_EDITOR,
+                Roles::EVENT_MANAGER,
+                Roles::ANALYST,
+                Roles::TEAM_MANAGER,
+            ];
+            // Service accounts are excluded: they are for automation and have no dashboard.
+            if (in_array($record['role'], $dashboardRoles, true)) {
+                $target = '/admin';
+            } elseif ($record['role'] === Roles::SERVICE_ACCOUNT) {
+                // Service accounts are used for automation and have no UI.
+                $target = '/';
+            } else {
+                $target = '/help';
+            }
             $basePath = RouteContext::fromRequest($request)->getBasePath();
             return $response->withHeader('Location', $basePath . $target)->withStatus(302);
         }


### PR DESCRIPTION
## Summary
- import Roles into LoginController
- centralize list of roles with dashboard access
- redirect service accounts away from dashboard with explanation

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*
- `composer phpunit` *(fails: Missing STRIPE_SECRET_KEY, Missing STRIPE_PUBLISHABLE_KEY, Missing STRIPE_PRICE_STARTER, Missing STRIPE_PRICE_STANDARD, Missing STRIPE_PRICE_PROFESSIONAL, Missing STRIPE_PRICING_TABLE_ID, Missing STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68bf68505fa0832b922de36e52a4d56e