### PR TITLE
Fix event selector reset on failed event switch

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2283,8 +2283,14 @@ document.addEventListener('DOMContentLoaded', function () {
       .then(resp => {
         if (!resp.ok) {
           return resp.text().then(text => {
-            notify(text || 'Fehler beim Wechseln des Events', 'danger');
-            eventSelect.value = prevUid;
+            if (eventSelect) {
+              eventSelect.value = prevUid;
+              updateEventSelectDisplay();
+            }
+            if (eventOpenBtn) {
+              eventOpenBtn.disabled = !prevUid;
+            }
+            throw new Error(text || 'Fehler beim Wechseln des Events');
           });
         }
         if (uid) {
@@ -2310,9 +2316,13 @@ document.addEventListener('DOMContentLoaded', function () {
       })
       .catch(err => {
         console.error(err);
-        notify('Fehler beim Wechseln des Events', 'danger');
+        notify(err.message || 'Fehler beim Wechseln des Events', 'danger');
         if (eventSelect) {
           eventSelect.value = prevUid;
+          updateEventSelectDisplay();
+        }
+        if (eventOpenBtn) {
+          eventOpenBtn.disabled = !prevUid;
         }
         updateActiveHeader(prevName, prevUid);
         eventDependentSections.forEach(sec => { sec.hidden = !prevUid; });


### PR DESCRIPTION
## Summary
- Reset event selector to previous event when switching fails
- Refresh selector display and reopen button state after error

## Testing
- `composer test` *(fails: Tests: 327, Assertions: 549, Errors: 32, Failures: 94, Warnings: 4)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6ef645b0832b822fd90cb1567266