### PR TITLE
Hide admin event search when few events

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2255,7 +2255,7 @@ document.addEventListener('DOMContentLoaded', function () {
     eventDependentSections.forEach(sec => { sec.hidden = !currentEventUid; });
     if (eventSelectWrap) eventSelectWrap.hidden = false;
     if (eventSearchInput) {
-      eventSearchInput.hidden = !(Array.isArray(list) && list.length > 0);
+      eventSearchInput.hidden = !(Array.isArray(list) && list.length >= 10);
       eventSearchInput.value = '';
       eventSearchInput.dispatchEvent(new Event('input'));
     }

--- a/tests/test_event_search_visibility.js
+++ b/tests/test_event_search_visibility.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const code = fs.readFileSync('public/js/admin.js', 'utf8');
+
+if (!/eventSearchInput\.hidden = !(Array\.isArray\(list\) && list\.length >= 10)/.test(code)) {
+  throw new Error('event search visibility condition missing');
+}
+
+console.log('ok');


### PR DESCRIPTION
## Summary
- show event search box only when at least 10 events exist
- add regression test covering event search visibility

## Testing
- `composer test` *(fails: Tests 327, Assertions 549, Errors 32, Failures 94, Warnings 4)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f4e2770832b92058da568c20a2a