### PR TITLE
feat: hide event selector on small screens

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -38,12 +38,12 @@
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
-        <label for="eventSelect" class="uk-form-label uk-margin-small-right">{{ t('label_event_select') }}</label>
-        <div id="eventSelectWrap" class="uk-flex-1">
+        <label for="eventSelect" class="uk-form-label uk-margin-small-right uk-visible@m">{{ t('label_event_select') }}</label>
+        <div id="eventSelectWrap" class="uk-flex-1 uk-visible@m">
           <select id="eventSelect" class="uk-select" aria-label="{{ t('label_event_select') }}"></select>
         </div>
         <input id="eventSearchInput" class="uk-input uk-form-small uk-width-small uk-margin-small-left" type="search" placeholder="Suchen" hidden>
-        <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left uk-visible@s" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom" data-event-btn disabled></button>
+        <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left uk-visible@m" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom" data-event-btn disabled></button>
       </div>
     {% endblock %}
     {% block right %}{% endblock %}

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -17,10 +17,10 @@
     {% endblock %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
-        <div id="eventSelectWrap" class="uk-flex-1">
+        <div id="eventSelectWrap" class="uk-flex-1 uk-visible@m">
           <select id="eventSelect" class="uk-select" aria-label="{{ t('label_events') }}"></select>
         </div>
-        <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom" data-event-btn disabled></button>
+        <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left uk-visible@m" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom" data-event-btn disabled></button>
       </div>
     {% endblock %}
   {% endembed %}

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -14,7 +14,7 @@
   {% embed 'topbar.twig' %}
     {% block center %}
       <div class="uk-flex uk-flex-middle">
-        <div id="eventSelectWrap" class="uk-flex uk-flex-middle" hidden>
+        <div id="eventSelectWrap" class="uk-flex uk-flex-middle uk-visible@m" hidden>
           <select id="eventSelect" class="uk-select uk-flex-1" aria-label="{{ t('label_events') }}"></select>
           <button id="eventOpenBtn" class="uk-icon-button uk-margin-small-left" uk-icon="icon: link-external" aria-label="{{ t('tip_event_open') }}" uk-tooltip="title: {{ t('tip_event_open') }}; pos: bottom" data-event-btn disabled></button>
         </div>


### PR DESCRIPTION
## Summary
- hide event selector in admin topbar on small screens
- apply same responsive visibility in summary and results views

## Testing
- ⚠️ `composer test` *(missing Stripe and domain configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f71003c832b879fcd1af5c36234