### PR TITLE
docs: note management role redirect

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,6 +1,6 @@
 # Administration
 
-Die Administrationsoberfläche erreichen Sie über `/admin/dashboard` (kurz `/admin`) nach einem erfolgreichen Login. Die Navigation ist in folgende Kategorien gegliedert:
+Die Administrationsoberfläche erreichen Sie über `/admin/dashboard` (kurz `/admin`) nach einem erfolgreichen Login. Alle Management-Rollen (z. B. `event-manager`, `team-manager`) werden nach dem Login automatisch zum Admin-Dashboard weitergeleitet. Die Navigation ist in folgende Kategorien gegliedert:
 
 * **Event**
   * **Startseite** – `/admin/dashboard`


### PR DESCRIPTION
## Summary
- clarify that management roles like `event-manager` and `team-manager` redirect to admin dashboard after login

## Testing
- `composer test` *(fails: Tests: 327, Assertions: 549, Errors: 32, Failures: 94)*

------
https://chatgpt.com/codex/tasks/task_e_68bf75be0e80832ba4d7a46650c97cab