### PR TITLE
Restrict catalog nav item by role

### DIFF
--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -17,7 +17,7 @@
   {
     header: t('menu_content'),
     items: [
-      { href: basePath ~ '/admin/catalogs', icon: 'database', text: t('tab_catalogs') },
+      { href: basePath ~ '/admin/catalogs', icon: 'database', text: t('tab_catalogs'), roles: ['admin', 'catalog-editor'] },
       { href: basePath ~ '/admin/questions', icon: 'question', text: t('tab_questions') },
       { href: basePath ~ '/admin/pages', icon: 'file-edit', text: t('tab_pages'), admin: true },
     ]
@@ -56,10 +56,12 @@
 <ul class="uk-nav uk-nav-default">
   {% for group in groups %}
     {% if group.header is defined %}
-      {% if group.admin is not defined or role == 'admin' %}
+      {% if (group.admin is not defined or role == 'admin') and (group.roles is not defined or role in group.roles) %}
         <li class="uk-nav-header">{{ group.header }}</li>
         {% for it in group.items %}
-          {% if (it.admin is not defined or role == 'admin') and (it.domain is not defined or it.domain == domainType) %}
+          {% if (it.roles is not defined or role in it.roles)
+              and (it.admin is not defined or role == 'admin')
+              and (it.domain is not defined or it.domain == domainType) %}
             {% set active = current starts with it.href ? 'uk-active' : '' %}
             <li class="{{ active }}">
               <a href="{{ it.href ~ (it.noEvent ? '' : eventSuffix) }}">
@@ -72,7 +74,9 @@
       {% endif %}
     {% else %}
       {% for it in group.items %}
-        {% if (it.admin is not defined or role == 'admin') and (it.domain is not defined or it.domain == domainType) %}
+        {% if (it.roles is not defined or role in it.roles)
+            and (it.admin is not defined or role == 'admin')
+            and (it.domain is not defined or it.domain == domainType) %}
           {% set active = current starts with it.href ? 'uk-active' : '' %}
           <li class="{{ active }}">
             <a href="{{ it.href ~ (it.noEvent ? '' : eventSuffix) }}">


### PR DESCRIPTION
## Summary
- restrict catalog navigation entry to admin or catalog-editor roles
- allow navigation groups and items to specify roles arrays for visibility control

## Testing
- `composer test` *(fails: Tests: 327, Assertions: 549, Errors: 32, Failures: 94)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7b5239b0832bb30858f2398bed1d