### PR TITLE
Restrict results actions by role

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -384,7 +384,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const commentToolbar = document.getElementById('catalogCommentToolbar');
   const catalogEditInput = document.getElementById('catalogEditInput');
   const catalogEditError = document.getElementById('catalogEditError');
-  const resultsResetModal = window.UIkit ? UIkit.modal('#resultsResetModal') : null;
+  const resultsResetModalEl = document.getElementById('resultsResetModal');
+  const resultsResetModal = resultsResetModalEl && window.UIkit ? UIkit.modal(resultsResetModalEl) : null;
   const resultsResetConfirm = document.getElementById('resultsResetConfirm');
   let puzzleFeedback = '';
   let inviteText = '';
@@ -2127,7 +2128,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   resultsResetBtn?.addEventListener('click', function (e) {
     e.preventDefault();
-    resultsResetModal.show();
+    resultsResetModal?.show();
   });
 
   resultsResetConfirm?.addEventListener('click', function () {
@@ -2135,7 +2136,7 @@ document.addEventListener('DOMContentLoaded', function () {
       .then(r => {
         if (!r.ok) throw new Error(r.statusText);
         notify('Ergebnisse gelöscht', 'success');
-        resultsResetModal.hide();
+        resultsResetModal?.hide();
         window.location.reload();
       })
       .catch(err => {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -786,14 +786,23 @@
           </div>
         </div>
         <ul id="resultsPagination" class="uk-pagination uk-flex-center"></ul>
-        <div class="uk-margin uk-flex uk-flex-between">
+        {% set showReset = role == 'admin' %}
+        {% set showDownloads = role in ['admin','analyst'] %}
+        {% if showReset or showDownloads %}
+        <div class="uk-margin uk-flex {% if showReset and showDownloads %}uk-flex-between{% elseif showDownloads %}uk-flex-right{% endif %}">
+          {% if showReset %}
           <button id="resultsResetBtn" class="uk-button uk-button-default" uk-tooltip="title: {{ t('tip_results_reset') }}; pos: right">{{ t('action_reset') }}</button>
+          {% endif %}
+          {% if showDownloads %}
           <div class="uk-flex">
             <button id="resultsPdfBtn" class="uk-button uk-button-primary uk-margin-right" uk-tooltip="title: {{ t('tip_results_pdf') }}; pos: right">{{ t('action_open_evaluation') }}</button>
             <button id="resultsDownloadBtn" class="uk-button uk-button-primary" uk-tooltip="title: {{ t('tip_results_download') }}; pos: right">{{ t('action_download') }}</button>
           </div>
+          {% endif %}
         </div>
+        {% endif %}
 
+        {% if showReset %}
         <div id="resultsResetModal" uk-modal>
           <div class="uk-modal-dialog uk-modal-body">
             <p>Beim Zurücksetzen der Statistik werden auch alle hochgeladenen Beweisfotos unwiderruflich gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.<br>Soll die Statistik nun zurückgesetzt werden?</p>
@@ -803,6 +812,7 @@
             </div>
           </div>
         </div>
+        {% endif %}
       </div>
     </li>
     <li class="{{ activeRoute == 'statistics' ? 'uk-active' }}">


### PR DESCRIPTION
## Summary
- Show results reset controls only for admins
- Limit results PDF/CSV download buttons to admin and analyst roles
- Guard JS initialisation when results controls are absent

## Testing
- `composer test` *(fails: DFFFF.FFEE.F.FF....EE........F...FFFFF....FEEEEEFFFF...........  63 / 327 ( 19%))*

------
https://chatgpt.com/codex/tasks/task_e_68bf7b6e7758832b8561d1d9768859fb