### PR TITLE
Validate event UID before activation

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -53,6 +53,9 @@ class AdminController
         $params = $request->getQueryParams();
         if (array_key_exists('event', $params)) {
             $uid = (string) $params['event'];
+            if ($eventSvc->getByUid($uid) === null) {
+                return $response->withStatus(404);
+            }
             $cfgSvc->setActiveEventUid($uid);
         } else {
             $uid = (string) $cfgSvc->getActiveEventUid();

--- a/src/routes.php
+++ b/src/routes.php
@@ -197,7 +197,7 @@ return function (\Slim\App $app, TranslationService $translator) {
 
         $request = $request
             ->withAttribute('plan', $plan)
-            ->withAttribute('configController', new ConfigController($configService, new ConfigValidator()))
+            ->withAttribute('configController', new ConfigController($configService, new ConfigValidator(), $eventService))
             ->withAttribute('catalogController', new CatalogController($catalogService))
             ->withAttribute('adminCatalogController', new AdminCatalogController($catalogService))
             ->withAttribute('resultController', new ResultController(


### PR DESCRIPTION
## Summary
- ensure `ConfigController` and admin dashboard only activate existing events
- verify unknown event IDs are rejected with a 404
- cover event UID validation with controller tests

## Testing
- `vendor/bin/phpunit tests/Controller/ConfigControllerTest.php`
- `vendor/bin/phpunit tests/Controller/AdminControllerTest.php --filter testInvalidEventQueryReturns404`
- `vendor/bin/phpcs src/Controller/ConfigController.php src/Controller/AdminController.php tests/Controller/ConfigControllerTest.php tests/Controller/AdminControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68bfb9de6f08832b835d5c16eed63d41