### PR TITLE
refactor: centralize event switching logic

### DIFF
--- a/public/js/event-switcher.js
+++ b/public/js/event-switcher.js
@@ -1,0 +1,42 @@
+const basePath = window.basePath || '';
+const withBase = (p) => basePath + p;
+
+const getCsrfToken = () =>
+  document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ||
+  window.csrfToken || '';
+
+export function setCurrentEvent(uid, name) {
+  const token = getCsrfToken();
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { 'X-CSRF-Token': token } : {})
+  };
+  return fetch(withBase('/config.json'), {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers,
+    body: JSON.stringify({ event_uid: uid })
+  })
+    .then((resp) => {
+      if (!resp.ok) {
+        return resp.text().then((text) => {
+          throw new Error(text || 'Fehler beim Wechseln des Events');
+        });
+      }
+      if (uid) {
+        return fetch(withBase(`/events/${encodeURIComponent(uid)}/config.json`), {
+          headers: { Accept: 'application/json' },
+          credentials: 'same-origin'
+        })
+          .then((r) => r.json())
+          .catch(() => ({}));
+      }
+      return {};
+    })
+    .then((cfg) => {
+      document.dispatchEvent(
+        new CustomEvent('current-event-changed', { detail: { uid, name, config: cfg } })
+      );
+      return cfg;
+    });
+}

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -1,3 +1,4 @@
+import { setCurrentEvent } from './event-switcher.js';
 const currentScript = document.currentScript;
 const basePath = window.basePath || (currentScript ? currentScript.dataset.base || '' : '');
 const withBase = (p) => basePath + p;
@@ -188,10 +189,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
   eventSelect?.addEventListener('change', () => {
     const uid = eventSelect.value;
+    const name = eventSelect.options[eventSelect.selectedIndex]?.textContent || '';
     updateEventButtons(uid);
-    if (!isAdminPage && uid && uid !== currentEventUid) {
-      location.search = '?event=' + uid;
+    if (uid && uid !== currentEventUid) {
+      setCurrentEvent(uid, name)
+        .then((cfg) => {
+          currentEventUid = uid;
+          window.quizConfig = uid ? cfg : {};
+          if (!isAdminPage) {
+            location.search = '?event=' + uid;
+          }
+        })
+        .catch((err) => {
+          notify(err.message || 'Fehler beim Wechseln des Events', 'danger');
+          eventSelect.value = currentEventUid;
+          updateEventButtons(currentEventUid);
+        });
     }
+  });
+
+  document.addEventListener('current-event-changed', (e) => {
+    const uid = e.detail.uid || '';
+    currentEventUid = uid;
+    updateEventButtons(uid);
   });
 
   eventOpenBtn?.addEventListener('click', () => {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1345,7 +1345,7 @@
     window.initialEvents = {{ events|json_encode|raw }};
   </script>
   <script src="{{ basePath }}/js/dashboard.js"></script>
-  <script src="{{ basePath }}/js/events.js"></script>
+  <script type="module" src="{{ basePath }}/js/events.js"></script>
   <script type="module" src="{{ basePath }}/js/admin.js"></script>
   <script src="{{ basePath }}/js/subscription.js"></script>
   <script src="{{ basePath }}/js/storage.js"></script>

--- a/templates/events_overview.twig
+++ b/templates/events_overview.twig
@@ -62,5 +62,5 @@
 {% block scripts %}
   <script src="{{ basePath }}/js/custom-icons.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
-  <script src="{{ basePath }}/js/events.js" data-base="{{ basePath }}"></script>
+  <script type="module" src="{{ basePath }}/js/events.js" data-base="{{ basePath }}"></script>
 {% endblock %}

--- a/templates/results.twig
+++ b/templates/results.twig
@@ -70,6 +70,6 @@
 
 {% block scripts %}
   <script src="{{ basePath }}/js/app.js"></script>
-  <script src="{{ basePath }}/js/events.js"></script>
+  <script type="module" src="{{ basePath }}/js/events.js"></script>
   <script src="{{ basePath }}/js/results.js"></script>
 {% endblock %}

--- a/templates/summary.twig
+++ b/templates/summary.twig
@@ -41,7 +41,7 @@
 {% block scripts %}
   <script src="{{ basePath }}/js/custom-icons.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
-  <script src="{{ basePath }}/js/events.js"></script>
+  <script type="module" src="{{ basePath }}/js/events.js"></script>
   <script>
     window.quizConfig = {{ config|json_encode|raw }};
   </script>


### PR DESCRIPTION
## Summary
- add shared event switcher helper to set current event and dispatch change
- consume helper in admin and public scripts to avoid duplicate event selection logic
- load events.js as module across templates

## Testing
- `composer install`
- `composer test` *(fails: MAIN_DOMAIN misconfiguration; Missing STRIPE_* keys)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcfb71c30832bb62367b5a6f0b19d