### PR TITLE
feat: persist puzzle letter

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -244,6 +244,7 @@ async function handleSelection(opt, autostart = false) {
 
   const cfg = window.quizConfig || {};
   const slug = (opt.value || opt.dataset.slug || '').toLowerCase();
+  const letter = opt.dataset.letter || '';
   if (cfg.competitionMode && solvedSet.has(slug)) {
     UIkit?.notification?.({ message: 'Dieser Katalog wurde bereits gelöst', status: 'warning' });
     opt.disabled = true;
@@ -276,6 +277,12 @@ async function handleSelection(opt, autostart = false) {
   clearStored(STORAGE_KEYS.PUZZLE_SOLVED);
   clearStored(STORAGE_KEYS.PUZZLE_TIME);
   clearStored(STORAGE_KEYS.LETTER);
+
+  if (cfg.puzzleWordEnabled && letter) {
+    setStored(STORAGE_KEYS.LETTER, letter);
+  } else {
+    clearStored(STORAGE_KEYS.LETTER);
+  }
 
   const puzzleText = document.getElementById('puzzle-solved-text');
   if (puzzleText) {

--- a/tests/test_catalog_handle_selection.js
+++ b/tests/test_catalog_handle_selection.js
@@ -29,6 +29,13 @@ const localStorage = storage();
 let uiWarnings = 0;
 const UIkit = { notification: () => { uiWarnings++; } };
 
+const STORAGE_KEYS = {
+  CATALOG: 'quizCatalog',
+  LETTER: 'quizLetter'
+};
+
+const postSession = () => Promise.resolve();
+
 const fetchCalls = [];
 const fetch = async (url, opts) => {
   fetchCalls.push({ url, opts });
@@ -51,11 +58,13 @@ const context = {
   document,
   sessionStorage,
   localStorage,
+  STORAGE_KEYS,
   fetch,
   UIkit,
   alert: () => {},
   console,
-  URLSearchParams
+  URLSearchParams,
+  postSession
 };
 context.window.window = context.window;
 context.global = context;
@@ -65,10 +74,12 @@ context.global = context;
   // prevent DOM side effects
   context.showCatalogIntro = () => {};
 
+  context.window.quizConfig = { puzzleWordEnabled: true };
+  const letter = 'A';
   const opt = {
     textContent: 'Test',
     value: 'slug1',
-    dataset: { file: 'foo.json', uid: '1', sortOrder: '1' }
+    dataset: { file: 'foo.json', uid: '1', sortOrder: '1', letter }
   };
   await context.handleSelection(opt);
 
@@ -87,6 +98,12 @@ context.global = context;
   }
   if (localStorage.getItem('quizCatalog') !== 'slug1') {
     throw new Error('localStorage quizCatalog not set');
+  }
+  if (sessionStorage.getItem('quizLetter') !== letter) {
+    throw new Error('sessionStorage quizLetter not set');
+  }
+  if (localStorage.getItem('quizLetter') !== letter) {
+    throw new Error('localStorage quizLetter not set');
   }
   console.log('ok');
 })().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- persist letter in storage when puzzle word mode is active
- test that quiz letter is stored in session and local storage

## Testing
- `node tests/test_catalog_handle_selection.js`
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* keys)*

------
https://chatgpt.com/codex/tasks/task_e_68c00ab47dd0832bb4436b1985d5bdbf