### PR TITLE
Sanitize session cookie domain

### DIFF
--- a/src/Application/Middleware/SessionMiddleware.php
+++ b/src/Application/Middleware/SessionMiddleware.php
@@ -28,8 +28,12 @@ class SessionMiddleware implements Middleware
         }
 
         if (session_status() === PHP_SESSION_NONE && !headers_sent()) {
-            $host = $request->getUri()->getHost();
-            $domain = getenv('MAIN_DOMAIN') ?: '';
+            $host = strtolower($request->getUri()->getHost());
+            $host = (string) preg_replace('/^(www|admin)\./', '', $host);
+
+            $domain = strtolower((string) getenv('MAIN_DOMAIN'));
+            $domain = (string) preg_replace('/^(www|admin)\./', '', $domain);
+
             if ($domain === '' || !$this->hostMatchesDomain($host, $domain)) {
                 $domain = $host;
             }


### PR DESCRIPTION
## Summary
- strip `www`/`admin` prefixes from configured domain before setting session cookie

## Testing
- `composer test` *(fails: Tests: 329, Assertions: 545, Errors: 35, Failures: 91, Warnings: 4, PHPUnit Deprecations: 3, Notices: 1, Skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c01b1d1098832bb5c5acf917c61d72