### PR TITLE
Preserve solved catalogs in competition mode

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -273,7 +273,9 @@ async function handleSelection(opt, autostart = false) {
 
   setStored(STORAGE_KEYS.CATALOG, opt.value || opt.dataset.slug || '');
 
-  clearStored(STORAGE_KEYS.QUIZ_SOLVED);
+  if (!cfg.competitionMode) {
+    clearStored(STORAGE_KEYS.QUIZ_SOLVED);
+  }
   clearStored(STORAGE_KEYS.PUZZLE_SOLVED);
   clearStored(STORAGE_KEYS.PUZZLE_TIME);
   clearStored(STORAGE_KEYS.LETTER);


### PR DESCRIPTION
## Summary
- keep solved catalog list when competition mode is active

## Testing
- `node tests/test_catalog_prevent_repeat.js`
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and missing STRIPE_* env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68c02b9506c8832b9e16944663d0dcde