### PR TITLE
Ensure event QR code uses full event URL

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -179,6 +179,7 @@ class AdminController
         }
 
         $baseUrl = UrlService::determineBaseUrl($request);
+        $eventUrl = $uid !== '' ? $baseUrl . '/?event=' . rawurlencode($uid) : $baseUrl;
         $uri = $request->getUri();
 
         $mainDomain = getenv('MAIN_DOMAIN')
@@ -198,6 +199,7 @@ class AdminController
               'events' => $events,
               'roles' => Roles::ALL,
               'baseUrl' => $baseUrl,
+              'eventUrl' => $eventUrl,
               'main_domain' => $mainDomain,
               'event' => $event,
               'role' => $role,

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -504,7 +504,16 @@
           </div>
           <div class="uk-text-center uk-margin-small-bottom">
             {% if event.uid %}
-              <img id="summaryEventQr" class="qr-img" src="{{ basePath }}/qr/event?event={{ event.uid }}&t={{ (baseUrl ? baseUrl ~ '/?event=' ~ event.uid : '?event=' ~ event.uid)|url_encode }}&size=150&margin=40" alt="QR">
+              <img
+                id="summaryEventQr"
+                class="qr-img"
+                data-endpoint="/qr/event"
+                data-target="{{ eventUrl }}"
+                src="{{ basePath }}/qr/event?event={{ event.uid }}&t={{ eventUrl|url_encode }}&size=150&margin=40"
+                width="150"
+                height="150"
+                alt="QR"
+              >
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Build event-specific link on admin dashboard and pass to template
- Render event QR with data attributes and fixed dimensions for consistent sizing

## Testing
- `composer install`
- `composer test` *(fails: Tests: 330, Assertions: 545, Errors: 36, Failures: 93)*

------
https://chatgpt.com/codex/tasks/task_e_68c02aba1c30832b9d400545683dae0b