### PR TITLE
Refresh admin data after switching events

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -4020,7 +4020,14 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
 
-  document.addEventListener('current-event-changed', () => {
+  document.addEventListener('current-event-changed', e => {
+    const { uid, name, config } = e.detail || {};
+    currentEventUid = uid || '';
+    cfgInitial.event_uid = currentEventUid;
+    Object.assign(cfgInitial, config || {});
+    window.quizConfig = config || {};
+    updateActiveHeader(name, uid);
+    eventDependentSections.forEach(sec => { sec.hidden = !uid; });
     if (catSelect) loadCatalogs();
     if (teamListEl) loadTeamList();
     loadSummary();


### PR DESCRIPTION
## Summary
- update `current-event-changed` handler to update state and reload event data

## Testing
- `composer test` *(fails: Tests: 331, Assertions: 546, Errors: 37, Failures: 91)*

------
https://chatgpt.com/codex/tasks/task_e_68c032e67e20832baa81b7730f229cf6