### PR TITLE
Add background upload translation

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', function () {
         .then(r => r.json().then(data => ({ ok: r.ok, data })))
         .then(({ ok, data }) => {
           if (!ok) throw new Error(data.error || 'Fehler');
-          notify(window.transImageReady || 'Image bereit', 'success');
+          notify(window.transImageReady, 'success');
         })
         .catch(err => notify(err.message || 'Fehler beim Erstellen', 'danger'))
         .finally(() => {
@@ -1245,7 +1245,7 @@ document.addEventListener('DOMContentLoaded', function () {
     xhr.addEventListener('load', () => {
       const text = (xhr.responseText || '').trim();
       if (xhr.status >= 200 && xhr.status < 300) {
-        notify(window.transImageReady || 'Image bereit', 'success');
+        notify(window.transImageReady, 'success');
         const path = currentEventUid
           ? `/data/events/${encodeURIComponent(currentEventUid)}/sticker-bg.png?${Date.now()}`
           : `/data/uploads/sticker-bg.png?${Date.now()}`;

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -260,6 +260,7 @@ return [
     'action_restart_tenant' => 'Docker neu starten',
     'action_send_welcome_mail' => 'Willkommensmail senden',
     'text_image_ready' => 'Docker-Image bereit',
+    'text_background_uploaded' => 'Hintergrundbild hochgeladen',
     'help_admin_pass' => 'Setzt das Admin-Passwort für den neuen Mandanten. Bleibt das Feld leer, wird ein zufälliges Passwort erstellt.',
     'info_admin_email' => 'Der Link zum Admin-Passwort kommt per E-Mail.',
     'text_admin_email_sent' => 'Ein Link zum Setzen des Admin-Passworts wurde an %s gesendet.',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -262,6 +262,7 @@ return [
     'action_restart_tenant' => 'Restart Docker',
     'action_send_welcome_mail' => 'Send welcome email',
     'text_image_ready' => 'Docker image ready',
+    'text_background_uploaded' => 'Background image uploaded',
     'help_admin_pass' => 'Defines the admin password for the new tenant. Leave empty to generate a random one',
     'info_admin_email' => 'The link to set the admin password will be sent by email.',
     'text_admin_email_sent' => 'A link to set the admin password has been sent to %s.',

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1347,7 +1347,7 @@
     window.transUpgradeAction = '{{ t('action_upgrade') }}';
     window.transUpgradeDocker = '{{ t('action_upgrade_docker') }}';
     window.transRestartTenant = '{{ t('action_restart_tenant') }}';
-    window.transImageReady = '{{ t('text_image_ready') }}';
+    window.transImageReady = '{{ t('text_background_uploaded') }}';
     window.transEventSettingsHelp = '{{ t('text_event_settings_help')|e('js') }}';
     window.transTeamPdf = '{{ t('tip_team_pdf') }}';
     window.transActions = '{{ t('column_actions') }}';


### PR DESCRIPTION
## Summary
- add `text_background_uploaded` translation for DE/EN
- reference new background uploaded message in admin template
- use translated text for image-ready notifications

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68c037ab24d0832ba886ddf9fed0a6e0