### PR TITLE
Handle sticker sticker settings without explicit event

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -791,9 +791,11 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   async function loadStickerSettings () {
-    if (!currentEventUid) return;
     try {
-      const res = await apiFetch(`/admin/sticker-settings?event_uid=${encodeURIComponent(currentEventUid)}`);
+      const url = currentEventUid
+        ? `/admin/sticker-settings?event_uid=${encodeURIComponent(currentEventUid)}`
+        : '/admin/sticker-settings';
+      const res = await apiFetch(url);
       const data = await res.json();
       if (data.stickerTemplate && catalogStickerTemplate) catalogStickerTemplate.value = data.stickerTemplate;
       if (catalogStickerDesc) catalogStickerDesc.checked = !!data.stickerPrintDesc;
@@ -819,14 +821,13 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   async function saveStickerSettings () {
-    if (!currentEventUid) return;
     if (!descWidthInput?.value || !descHeightInput?.value ||
         !descTopInput?.value || !descLeftInput?.value ||
         !qrTopInput?.value || !qrLeftInput?.value) {
       drawCatalogStickerPreview();
     }
     const payload = {
-      event_uid: currentEventUid,
+      ...(currentEventUid ? { event_uid: currentEventUid } : {}),
       stickerTemplate: catalogStickerTemplate?.value || '',
       stickerPrintDesc: catalogStickerDesc?.checked || false,
       stickerQrColor: (catalogStickerQrColor?.value || '#000000').replace(/^#/, ''),


### PR DESCRIPTION
## Summary
- Allow admin UI to load and save sticker settings even when no event UID is provided, defaulting to the active event
- Ensure backend sticker settings fall back to the active or global configuration and persist uploaded backgrounds

## Testing
- `vendor/bin/phpcs src/Controller/CatalogStickerController.php`
- `vendor/bin/phpstan analyse src/Controller/CatalogStickerController.php`
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c037b210a0832b990c4fc53d2820f3