### PR TITLE
Update admin headings on event change

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2276,6 +2276,9 @@ document.addEventListener('DOMContentLoaded', function () {
   const eventSearchInput = document.getElementById('eventSearchInput');
   const eventOpenBtn = document.getElementById('eventOpenBtn');
   const eventDependentSections = document.querySelectorAll('[data-event-dependent]');
+  const eventSettingsHeading = document.getElementById('eventSettingsHeading');
+  const catalogsHeading = document.getElementById('catalogsHeading');
+  const questionsHeading = document.getElementById('questionsHeading');
   const langSelect = document.getElementById('langSelect');
   let eventManager;
   let eventEditor;
@@ -4020,6 +4023,11 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
 
+  function updateHeading(el, name) {
+    if (!el) return;
+    el.textContent = name ? `${name} – ${el.dataset.title}` : el.dataset.title;
+  }
+
   document.addEventListener('current-event-changed', e => {
     const { uid, name, config } = e.detail || {};
     currentEventUid = uid || '';
@@ -4027,6 +4035,9 @@ document.addEventListener('DOMContentLoaded', function () {
     Object.assign(cfgInitial, config || {});
     window.quizConfig = config || {};
     updateActiveHeader(name, uid);
+    updateHeading(eventSettingsHeading, name);
+    updateHeading(catalogsHeading, name);
+    updateHeading(questionsHeading, name);
     eventDependentSections.forEach(sec => { sec.hidden = !uid; });
     if (catSelect) loadCatalogs();
     if (teamListEl) loadTeamList();

--- a/public/js/event-config.js
+++ b/public/js/event-config.js
@@ -47,6 +47,7 @@
   const logoInput = document.getElementById('logo');
   const logoPreview = document.getElementById('logoPreview');
   const publishBtn = document.querySelector('.event-config-sidebar .uk-button-primary');
+  const eventSettingsHeading = document.getElementById('eventSettingsHeading');
 
   function applyRules() {
     if (puzzleWordEnabled && puzzleWord && puzzleFeedback) {
@@ -137,10 +138,15 @@
   }
 
   document.addEventListener('current-event-changed', (e) => {
-    const uid = e.detail?.uid || '';
+    const { uid = '', name = '' } = e.detail || {};
     eventId = uid;
     isDirty = false;
     clearForm();
+    if (eventSettingsHeading) {
+      eventSettingsHeading.textContent = name
+        ? `${name} – ${eventSettingsHeading.dataset.title}`
+        : eventSettingsHeading.dataset.title;
+    }
     if (uid) {
       loadConfig(uid).catch(() => {
         window.location.href = withBase(`/admin/event-config?event=${uid}`);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -206,7 +206,11 @@
     <li class="{{ activeRoute == 'event/settings' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
         {% set eventName = event.name|default('') %}
-        <h2 class="uk-heading-bullet">{{ eventName|e }}{% if eventName %} – {% endif %}{{ t('heading_event_settings') }}</h2>
+        <h2
+          id="eventSettingsHeading"
+          class="uk-heading-bullet"
+          data-title="{{ t('heading_event_settings') }}"
+        >{{ eventName|e }}{% if eventName %} – {% endif %}{{ t('heading_event_settings') }}</h2>
         <p class="uk-text-meta uk-margin-small">{{ 'Änderungen werden automatisch gespeichert.' }}</p>
         <form id="configForm" class="uk-form-stacked" method="post" action="/config.json">
           <div class="uk-child-width-1-1 uk-child-width-1-2@m uk-grid-small" uk-grid>
@@ -413,7 +417,11 @@
       <div class="uk-container uk-container-large">
         <div>
           {% set eventName = event.name|default('') %}
-          <h2 class="uk-heading-bullet">{{ eventName|e }}{% if eventName %} – {% endif %}{{ t('heading_catalogs') }}</h2>
+          <h2
+            id="catalogsHeading"
+            class="uk-heading-bullet"
+            data-title="{{ t('heading_catalogs') }}"
+          >{{ eventName|e }}{% if eventName %} – {% endif %}{{ t('heading_catalogs') }}</h2>
           {% from 'components/table.twig' import qr_rowcards %}
           <div class="uk-overflow-auto uk-visible@m">
             <table class="uk-table uk-table-divider uk-table-small uk-table-hover uk-table-responsive">
@@ -449,7 +457,11 @@
     <li class="{{ activeRoute == 'questions' ? 'uk-active' }}">
       <div class="uk-container uk-container-large">
         {% set eventName = event.name|default('') %}
-        <h2 class="uk-heading-bullet">{{ eventName|e }}{% if eventName %} – {% endif %}{{ t('heading_questions') }}</h2>
+        <h2
+          id="questionsHeading"
+          class="uk-heading-bullet"
+          data-title="{{ t('heading_questions') }}"
+        >{{ eventName|e }}{% if eventName %} – {% endif %}{{ t('heading_questions') }}</h2>
         <div class="uk-margin">
           <label class="uk-form-label" for="catalogSelect">{{ t('label_catalog_select') }}
             <span class="uk-margin-small-left help-icon" uk-icon="icon: info" uk-tooltip="title: {{ t('tip_catalog_select') }}; pos: right" aria-label="{{ t('tip_catalog_select') }}" tabindex="0"></span>


### PR DESCRIPTION
## Summary
- Add IDs and translation data to admin page section headings
- Dynamically refresh event settings, catalog, and questions headings when the active event changes
- Ensure event-config script also updates heading on current-event-changed

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing Stripe keys, test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c037bd2bf4832b8a25a10b2bf08b25