### PR TITLE
Improve sticker editor drag handles

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -170,6 +170,14 @@ body.uk-padding {
   display: block;
 }
 
+#stickerTextBox,
+#stickerQrHandle {
+  border: 1px dashed #333;
+  background: rgba(0, 0, 0, 0.1);
+  cursor: move;
+  z-index: 10;
+}
+
 /* Ensure dropdown menus appear above table rows */
 .uk-dropdown {
   z-index: 1200;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -580,7 +580,7 @@
                 <div id="stickerTextBox" class="uk-position-absolute"></div>
                 <input type="hidden" id="stickerDescTop" name="stickerDescTop" value="">
                 <input type="hidden" id="stickerDescLeft" name="stickerDescLeft" value="">
-                <div id="stickerQrHandle" class="uk-position-absolute" uk-tooltip="title: Verschieben; pos: bottom" aria-label="Verschieben"></div>
+                <div id="stickerQrHandle" class="uk-position-absolute" uk-tooltip="title: Verschieben; pos: bottom" aria-label="Verschieben"><span uk-icon="icon: move"></span></div>
                 <input type="hidden" id="stickerQrTop" name="stickerQrTop" value="">
                 <input type="hidden" id="stickerQrLeft" name="stickerQrLeft" value="">
               </div>


### PR DESCRIPTION
## Summary
- style sticker placeholders with dashed border, subtle background, move cursor and raised z-index
- add visible move icon to QR handle in admin editor

## Testing
- `composer test` *(fails: Failed asserting that 7 is identical to 2; Tests: 331, Assertions: 546, Errors: 37, Failures: 91, Warnings: 4, PHPUnit Deprecations: 3, Skipped: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c037d70540832b92ae4a49b0656303