### PR TITLE
Ensure sticker canvas renders beneath overlays

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -925,8 +925,9 @@ document.addEventListener('DOMContentLoaded', function () {
     let canvas = catalogStickerPreview.querySelector('canvas');
     if (!canvas) {
       canvas = document.createElement('canvas');
-      catalogStickerPreview.appendChild(canvas);
+      catalogStickerPreview.prepend(canvas);
     }
+    canvas.style.zIndex = '0';
     canvas.width = w;
     canvas.height = h;
     const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- Insert sticker preview canvas before draggable elements and apply low z-index for proper stacking

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration / many test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c03a2908c0832b90fd580a4e4c87b0