### PR TITLE
Use scoped storage for solved quizzes and strengthen competition test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
             "node tests/test_catalog_autostart_path.js",
             "node tests/test_shuffle_questions.js",
             "node tests/test_team_name_suggestion.js",
-            "node tests/test_catalog_prevent_repeat.js"
+            "node tests/test_catalog_prevent_repeat.js",
+            "node tests/test_competition_prevent_replay.js"
         ]
     }
 }

--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -44,9 +44,9 @@ const jsonHeaders = { Accept: 'application/json' };
 async function buildSolvedSet(cfg){
   const solved = new Set();
   try{
-    const prev = sessionStorage.getItem('quizSolved');
+    const prev = getStored?.(STORAGE_KEYS.QUIZ_SOLVED);
     if(prev){
-      JSON.parse(prev).forEach(s=>solved.add(String(s).toLowerCase()));
+      JSON.parse(prev).forEach(s => solved.add(String(s).toLowerCase()));
     }
   }catch(e){ /* empty */ }
   if(cfg?.competitionMode){
@@ -55,7 +55,7 @@ async function buildSolvedSet(cfg){
       const res = await fetch(url, { headers: (typeof jsonHeaders !== 'undefined') ? jsonHeaders : { Accept: 'application/json' } });
       if(res.ok){
         const list = await res.json();
-        const user = sessionStorage.getItem('quizUser');
+        const user = (typeof getStored === 'function') ? getStored(STORAGE_KEYS.PLAYER_NAME) : sessionStorage.getItem('quizUser');
         if(user){
           for(const t of list){
             if(t && t.name === user && t.catalog){
@@ -66,7 +66,7 @@ async function buildSolvedSet(cfg){
       }
     }catch(e){ /* empty */ }
     try{
-      sessionStorage.setItem('quizSolved', JSON.stringify(Array.from(solved)));
+      setStored?.(STORAGE_KEYS.QUIZ_SOLVED, JSON.stringify(Array.from(solved)));
     }catch(e){ /* empty */ }
   }
   return solved;

--- a/tests/test_competition_prevent_replay.js
+++ b/tests/test_competition_prevent_replay.js
@@ -44,7 +44,7 @@ let started = 0;
 const window = {
   document,
   location: { search: '?slug=slug1' },
-  quizConfig: { competitionMode: true },
+  quizConfig: { competitionMode: true, event_uid: 'event1' },
   basePath: '',
   startQuiz: () => { started++; }
 };
@@ -64,8 +64,9 @@ const context = {
 context.global = context;
 
 (async () => {
+  vm.runInNewContext(fs.readFileSync('public/js/storage.js', 'utf8'), context);
+  context.setStored(context.STORAGE_KEYS.QUIZ_SOLVED, JSON.stringify(['slug1']));
   vm.runInNewContext(fs.readFileSync('public/js/catalog.js', 'utf8'), context);
-  context.buildSolvedSet = async () => new Set(['slug1']);
   await context.init();
   assert.strictEqual(warnings, 1);
   assert.strictEqual(started, 0);


### PR DESCRIPTION
## Summary
- use getStored/setStored with QUIZ_SOLVED key to respect event-specific naming
- cover competition replay prevention via storage module and add test to composer script

## Testing
- `composer test` *(fails: Tests: 331, Assertions: 546, Errors: 37, Failures: 91, Warnings: 4, PHPUnit Deprecations: 3, Skipped: 1)*
- `node tests/test_competition_prevent_replay.js`


------
https://chatgpt.com/codex/tasks/task_e_68c03df72118832bb2452f22349cba8f