### PR TITLE
Ensure admin interface reloads after event change

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -196,9 +196,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .then((cfg) => {
           currentEventUid = uid;
           window.quizConfig = uid ? cfg : {};
-          if (!isAdminPage) {
-            location.search = '?event=' + uid;
-          }
+          location.search = '?event=' + uid;
         })
         .catch((err) => {
           notify(err.message || 'Fehler beim Wechseln des Events', 'danger');


### PR DESCRIPTION
## Summary
- Always reload page with selected event when event selection changes

## Testing
- `composer test` *(fails: vendor/bin/phpunit not found before installing dependencies, then missing STRIPE_* env vars)*
- `vendor/bin/phpunit` *(fails: MAIN_DOMAIN misconfiguration and missing STRIPE keys)*

------
https://chatgpt.com/codex/tasks/task_e_68c041cf81dc832b84778c2a7e10e526