### PR TITLE
feat: prevent admin event change auto reload

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -94,6 +94,9 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentEventUid = '';
   const params = new URLSearchParams(window.location.search);
   const pageEventUid = params.get('event') || '';
+  if (isAdminPage) {
+    currentEventUid = eventSelect?.value || pageEventUid;
+  }
 
   const updateEventButtons = (uid) => {
     eventButtons.forEach((btn) => {
@@ -187,11 +190,12 @@ document.addEventListener('DOMContentLoaded', () => {
     updateEventButtons(eventSelect.value);
   }
 
-  eventSelect?.addEventListener('change', () => {
+  eventSelect?.addEventListener('change', (e) => {
     const uid = eventSelect.value;
     const name = eventSelect.options[eventSelect.selectedIndex]?.textContent || '';
     updateEventButtons(uid);
-    if (uid && uid !== currentEventUid) {
+    const urlEventUid = new URLSearchParams(window.location.search).get('event') || '';
+    if (e.isTrusted && uid && uid !== currentEventUid && uid !== urlEventUid) {
       setCurrentEvent(uid, name)
         .then((cfg) => {
           currentEventUid = uid;


### PR DESCRIPTION
## Summary
- initialize currentEventUid on admin pages
- avoid auto reload when event unchanged or programmatic

## Testing
- `composer test` *(fails: Tests: 331, Assertions: 546, Errors: 37, Failures: 91)*

------
https://chatgpt.com/codex/tasks/task_e_68c04678a570832b9400d843ee0cb0d0