### PR TITLE
Restore full sticker settings editor

### DIFF
--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -89,6 +89,14 @@ class CatalogStickerController
             'stickerQrTop' => $cfg['stickerQrTop'] ?? 10,
             'stickerQrLeft' => $cfg['stickerQrLeft'] ?? 75,
             'stickerQrSizePct' => $cfg['stickerQrSizePct'] ?? 28,
+            'stickerPrintDesc' => (bool)($cfg['stickerPrintDesc'] ?? false),
+            'stickerQrColor' => $cfg['stickerQrColor'] ?? '000000',
+            'stickerTextColor' => $cfg['stickerTextColor'] ?? '000000',
+            'stickerHeaderFontSize' => (int)($cfg['stickerHeaderFontSize'] ?? 12),
+            'stickerSubheaderFontSize' => (int)($cfg['stickerSubheaderFontSize'] ?? 10),
+            'stickerCatalogFontSize' => (int)($cfg['stickerCatalogFontSize'] ?? 11),
+            'stickerDescFontSize' => (int)($cfg['stickerDescFontSize'] ?? 10),
+            'stickerBgPath' => $cfg['stickerBgPath'] ?? null,
         ];
         $response->getBody()->write(json_encode($data));
         return $response->withHeader('Content-Type', 'application/json');
@@ -111,6 +119,11 @@ class CatalogStickerController
             ? (string)$data['stickerTemplate']
             : 'avery_l7163';
 
+        $qrColor = preg_replace('/[^0-9A-Fa-f]/', '', (string)($data['stickerQrColor'] ?? '000000'));
+        $qrColor = substr(str_pad($qrColor, 6, '0'), 0, 6);
+        $textColor = preg_replace('/[^0-9A-Fa-f]/', '', (string)($data['stickerTextColor'] ?? '000000'));
+        $textColor = substr(str_pad($textColor, 6, '0'), 0, 6);
+
         $save = [
             'event_uid' => $uid,
             'stickerTemplate' => $tpl,
@@ -121,6 +134,13 @@ class CatalogStickerController
             'stickerQrTop' => $this->pct($data['stickerQrTop'] ?? 10),
             'stickerQrLeft' => $this->pct($data['stickerQrLeft'] ?? 75),
             'stickerQrSizePct' => $this->pct($data['stickerQrSizePct'] ?? 28),
+            'stickerPrintDesc' => filter_var($data['stickerPrintDesc'] ?? false, FILTER_VALIDATE_BOOLEAN),
+            'stickerQrColor' => $qrColor,
+            'stickerTextColor' => $textColor,
+            'stickerHeaderFontSize' => (int)($data['stickerHeaderFontSize'] ?? 12),
+            'stickerSubheaderFontSize' => (int)($data['stickerSubheaderFontSize'] ?? 10),
+            'stickerCatalogFontSize' => (int)($data['stickerCatalogFontSize'] ?? 11),
+            'stickerDescFontSize' => (int)($data['stickerDescFontSize'] ?? 10),
         ];
         $this->config->saveConfig($save);
         return $response->withStatus(204);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -540,7 +540,7 @@
 
             <form id="catalogStickerForm" class="uk-form-stacked">
               <div class="uk-margin">
-                <label class="uk-form-label">Template</label>
+                <label class="uk-form-label" for="catalogStickerTemplate">{{ t('label_template') }}</label>
                 <div class="uk-form-controls">
                   <select id="catalogStickerTemplate" class="uk-select">
                     <option value="avery_l7163">Avery L7163 (99.1×38.1)</option>
@@ -576,12 +576,64 @@
 
               <div class="uk-grid-small" uk-grid>
                 <div class="uk-width-1-2">
-                  <label class="uk-form-label">QR-Größe (%)</label>
+                  <label class="uk-form-label">{{ t('label_qr_size_pct') }}</label>
                   <input id="catalogStickerQrSizePct" type="range" min="10" max="80" step="1" class="uk-range">
                 </div>
                 <div class="uk-width-1-2">
                   <label class="uk-form-label">Vorschau-Text</label>
                   <input id="catalogStickerText" class="uk-input" placeholder="Vorschau-Text">
+                </div>
+              </div>
+
+              <div class="uk-margin">
+                <label><input class="uk-checkbox" id="catalogStickerPrintDesc" type="checkbox"> {{ t('label_print_catalog_desc') }}</label>
+              </div>
+
+              <div class="uk-grid-small" uk-grid>
+                <div class="uk-width-1-2">
+                  <label class="uk-form-label">{{ t('label_qr_color') }}</label>
+                  <input id="catalogStickerQrColor" class="uk-input" type="color">
+                </div>
+                <div class="uk-width-1-2">
+                  <label class="uk-form-label">{{ t('label_text_color') }}</label>
+                  <input id="catalogStickerTextColor" class="uk-input" type="color">
+                </div>
+              </div>
+
+              <div class="uk-grid-small" uk-grid>
+                <div class="uk-width-1-2">
+                  <label class="uk-form-label">{{ t('label_header_font_size') }}</label>
+                  <input id="catalogStickerHeaderFontSize" class="uk-input" type="number">
+                </div>
+                <div class="uk-width-1-2">
+                  <label class="uk-form-label">{{ t('label_subheader_font_size') }}</label>
+                  <input id="catalogStickerSubheaderFontSize" class="uk-input" type="number">
+                </div>
+              </div>
+
+              <div class="uk-grid-small" uk-grid>
+                <div class="uk-width-1-2">
+                  <label class="uk-form-label">{{ t('label_catalog_font_size') }}</label>
+                  <input id="catalogStickerCatalogFontSize" class="uk-input" type="number">
+                </div>
+                <div class="uk-width-1-2">
+                  <label class="uk-form-label">{{ t('label_desc_font_size') }}</label>
+                  <input id="catalogStickerDescFontSize" class="uk-input" type="number">
+                </div>
+              </div>
+
+              <div class="uk-margin">
+                <label class="uk-form-label" for="catalogStickerBg">{{ t('label_sticker_bg') }}</label>
+                <div class="uk-form-controls">
+                  <div class="js-upload uk-placeholder uk-text-center">
+                    <span uk-icon="icon: cloud-upload"></span>
+                    <span class="uk-text-middle">{{ t('label_drag_file') }}&nbsp;</span>
+                    <div uk-form-custom>
+                      <input type="file" id="catalogStickerBg" accept="image/png,image/jpeg,image/webp">
+                      <span class="uk-link">{{ t('action_select') }}</span>
+                    </div>
+                  </div>
+                  <progress id="stickerBgProgress" class="uk-progress" value="0" max="100" hidden></progress>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- Reintroduce missing sticker configuration fields in admin UI
- Persist sticker color, font, and description options through new editor
- Expand backend controller to handle extended sticker settings

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68c045818048832bb784e7e30c3fa2ea