### PR TITLE
Handle network errors in event switcher

### DIFF
--- a/public/js/event-switcher.js
+++ b/public/js/event-switcher.js
@@ -38,5 +38,11 @@ export function setCurrentEvent(uid, name) {
         new CustomEvent('current-event-changed', { detail: { uid, name, config: cfg } })
       );
       return cfg;
+    })
+    .catch((err) => {
+      if (err instanceof TypeError) {
+        throw new Error('Server unreachable');
+      }
+      throw err;
     });
 }


### PR DESCRIPTION
## Summary
- catch network TypeErrors when switching events
- rethrow a clearer `Server unreachable` error for callers

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration / Missing STRIPE_* envs)*

------
https://chatgpt.com/codex/tasks/task_e_68c048e29d08832b8077377038d1d4f0