### PR TITLE
Guard event switches with pending/error flags

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2,7 +2,11 @@
 
 import TableManager from './table-manager.js';
 import { createCellEditor } from './edit-helpers.js';
-import { setCurrentEvent as switchEvent } from './event-switcher.js';
+import {
+  setCurrentEvent as switchEvent,
+  switchPending,
+  lastSwitchFailed
+} from './event-switcher.js';
 
 const basePath = window.basePath || '';
 const withBase = path => basePath + path;
@@ -1781,7 +1785,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     eventSelect.value = currentEventUid || '';
-    eventSelect.dispatchEvent(new Event('change'));
+    if (!switchPending && !lastSwitchFailed) {
+      eventSelect.dispatchEvent(new Event('change'));
+    }
     eventDependentSections.forEach(sec => { sec.hidden = !currentEventUid; });
     if (eventSelectWrap) eventSelectWrap.hidden = false;
     if (eventSearchInput) {
@@ -2032,7 +2038,9 @@ document.addEventListener('DOMContentLoaded', function () {
       const opt = Array.from(eventSelect.options).find(o => o.value === uid);
       if (opt) {
         eventSelect.value = opt.value;
-        eventSelect.dispatchEvent(new Event('change'));
+        if (!switchPending && !lastSwitchFailed) {
+          eventSelect.dispatchEvent(new Event('change'));
+        }
       }
     }
     updateEventSelectDisplay();
@@ -2050,6 +2058,11 @@ document.addEventListener('DOMContentLoaded', function () {
     const name = eventSelect.options[eventSelect.selectedIndex]?.textContent || '';
     if (eventOpenBtn) {
       eventOpenBtn.disabled = !uid;
+    }
+    if (switchPending) {
+      eventSelect.value = currentEventUid;
+      if (eventOpenBtn) eventOpenBtn.disabled = !currentEventUid;
+      return;
     }
     if (uid && uid !== currentEventUid) {
       setCurrentEvent(uid, name);

--- a/public/js/event-switcher.js
+++ b/public/js/event-switcher.js
@@ -5,7 +5,20 @@ const getCsrfToken = () =>
   document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ||
   window.csrfToken || '';
 
+export let switchPending = false;
+export let lastSwitchFailed = false;
+
+export function resetSwitchError() {
+  lastSwitchFailed = false;
+}
+
+export function markSwitchFailed() {
+  lastSwitchFailed = true;
+}
+
 export function setCurrentEvent(uid, name) {
+  switchPending = true;
+  lastSwitchFailed = false;
   const token = getCsrfToken();
   const headers = {
     'Content-Type': 'application/json',
@@ -38,5 +51,12 @@ export function setCurrentEvent(uid, name) {
         new CustomEvent('current-event-changed', { detail: { uid, name, config: cfg } })
       );
       return cfg;
+    })
+    .catch((err) => {
+      lastSwitchFailed = true;
+      throw err;
+    })
+    .finally(() => {
+      switchPending = false;
     });
 }


### PR DESCRIPTION
## Summary
- Track pending and failed event switches with new flags
- Prevent auto-dispatch of event-select changes when switches are in progress or failed
- Reset or mark error states during config loading and respect flags in change handlers

## Testing
- `composer test` *(fails: Tests: 331, Assertions: 546, Errors: 37, Failures: 91, Warnings: 4, PHPUnit Deprecations: 3, Skipped: 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68c048f67888832b804016dde58ddad8