### PR TITLE
Add modal listing remaining quiz catalogs

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -74,6 +74,7 @@
   <script>
     window.sessionPlayerName = {{ player_name|json_encode|raw }};
   </script>
+  <script id="catalogs-data" type="application/json">{{ catalogs|json_encode|raw }}</script>
   <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/session.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- Add modal helper to show remaining unsolved catalogs in competition mode
- Trigger modal instead of notification when solved catalog is picked
- Embed catalog data on start page for remaining catalog lookup

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration: "" (request host: "") )*


------
https://chatgpt.com/codex/tasks/task_e_68c04cd00168832ba930bb28250b4a20