### PR TITLE
Fix ranking team name truncation

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -932,4 +932,10 @@ body.admin-page {
   color: #999;
 }
 
+/* Prevent truncation of long team names in rankings */
+.ranking-team {
+  overflow: visible;
+  white-space: normal;
+}
+
 

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -336,7 +336,7 @@ document.addEventListener('DOMContentLoaded', () => {
             gridItem.setAttribute('uk-grid', '');
 
             const teamDiv = document.createElement('div');
-            teamDiv.className = 'uk-width-expand';
+            teamDiv.className = 'uk-width-expand ranking-team';
             teamDiv.setAttribute('uk-leader', '');
             teamDiv.style.setProperty('--uk-leader-fill-content', ' ');
             teamDiv.textContent = `${i + 1}. ${item.name}`;


### PR DESCRIPTION
## Summary
- prevent team names in rankings from being cut off by adding a `ranking-team` class and corresponding CSS

## Testing
- `composer test` *(fails: Failed to reload nginx)*

------
https://chatgpt.com/codex/tasks/task_e_68c07cfee5f4832babb38a2ca1ced237