### PR TITLE
Prevent setting unknown active events

### DIFF
--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use JsonException;
 use PDO;
+use PDOException;
 use RuntimeException;
 use Throwable;
 
@@ -294,6 +295,18 @@ class ConfigService
      */
     public function setActiveEventUid(string $uid): void
     {
+        if ($uid !== '') {
+            try {
+                $check = $this->pdo->prepare('SELECT 1 FROM events WHERE uid = ? LIMIT 1');
+                $check->execute([$uid]);
+                if ($check->fetchColumn() === false) {
+                    return;
+                }
+            } catch (PDOException) {
+                return;
+            }
+        }
+
         $this->pdo->beginTransaction();
         try {
             $this->pdo->exec('DELETE FROM active_event');


### PR DESCRIPTION
## Summary
- ignore unknown event UIDs when setting the active event and avoid foreign key violations
- add regression test for missing events
- ensure test database includes required tables

## Testing
- `vendor/bin/phpunit tests/Service/ConfigServiceTest.php`
- `vendor/bin/phpcs src/Service/ConfigService.php tests/Service/ConfigServiceTest.php`
- `composer test` *(fails: Missing STRIPE_* env vars, MAIN_DOMAIN misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68c07e9fc228832b949ccf6f4556d359