### PR TITLE
Refine sticker background upload UI

### DIFF
--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -29,6 +29,7 @@ const withBase = (p) => basePath + p;
   const catalogSize = document.getElementById('catalogStickerCatalogFontSize');
   const descSize = document.getElementById('catalogStickerDescFontSize');
   const bgInput = document.getElementById('catalogStickerBg');
+  const bgNameInput = document.getElementById('catalogStickerBgName');
   const bgProgress = document.getElementById('stickerBgProgress');
 
   const descTop = document.getElementById('stickerDescTop');
@@ -245,7 +246,11 @@ const withBase = (p) => basePath + p;
 
   bgInput?.addEventListener('change', async () => {
     const file = bgInput.files?.[0];
-    if (!file) return;
+    if (!file) {
+      if (bgNameInput) bgNameInput.value = '';
+      return;
+    }
+    if (bgNameInput) bgNameInput.value = file.name;
     const fd = new FormData();
     fd.append('file', file);
     bgProgress?.removeAttribute('hidden');

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -622,16 +622,13 @@
                 </div>
               </div>
 
-              <div class="uk-margin">
+              <div class="uk-margin-small">
                 <label class="uk-form-label" for="catalogStickerBg">{{ t('label_sticker_bg') }}</label>
                 <div class="uk-form-controls">
-                  <div class="js-upload uk-placeholder uk-text-center">
-                    <span uk-icon="icon: cloud-upload"></span>
-                    <span class="uk-text-middle">{{ t('label_drag_file') }}&nbsp;</span>
-                    <div uk-form-custom>
-                      <input type="file" id="catalogStickerBg" accept="image/png,image/jpeg,image/webp">
-                      <span class="uk-link">{{ t('action_select') }}</span>
-                    </div>
+                  <div uk-form-custom>
+                    <input type="file" id="catalogStickerBg" accept="image/png,image/jpeg,image/webp" hidden>
+                    <input class="uk-input uk-form-small" id="catalogStickerBgName" type="text" readonly>
+                    <button class="uk-button uk-button-default uk-form-small">Datei wählen</button>
                   </div>
                   <progress id="stickerBgProgress" class="uk-progress" value="0" max="100" hidden></progress>
                 </div>


### PR DESCRIPTION
## Summary
- replace bulky sticker background upload block with compact custom file picker
- show chosen file name and wire change listener to existing upload logic

## Testing
- `composer test` *(fails: Tests: 332, Assertions: 545, Errors: 37, Failures: 95, Warnings: 5)*

------
https://chatgpt.com/codex/tasks/task_e_68c0831a11a8832ba6b4a7420f1e30d3