### PR TITLE
feat: widen sticker editor modal

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -535,7 +535,7 @@
           {{ t('action_catalog_stickers_pdf') }}
         </button>
         <div id="catalogStickerModal" uk-modal>
-          <div class="uk-modal-dialog uk-modal-body">
+          <div class="uk-modal-dialog uk-modal-body" style="width: 800px;">
             <h2 class="uk-modal-title">Sticker-Editor</h2>
 
             <form id="catalogStickerForm" class="uk-form-stacked">
@@ -615,7 +615,7 @@
                 </div>
               </div>
 
-              <div id="catalogStickerPreview" class="uk-margin uk-position-relative uk-border-rounded" style="width: 600px; aspect-ratio: 99.1/38.1; background: #fff url('') center/100% 100% no-repeat; border:1px solid rgba(0,0,0,.1)">
+              <div id="catalogStickerPreview" class="uk-margin uk-margin-auto uk-position-relative uk-border-rounded" style="width: 600px; aspect-ratio: 99.1/38.1; background: #fff url('') center/100% 100% no-repeat; border:1px solid rgba(0,0,0,.1)">
                 <!-- B: TEXT-BOX -->
                 <div id="stickerTextBox" class="dragzone" role="group" aria-label="Textfeld verschieben/größenändern">
                   <div class="drag-handle" aria-hidden="true" uk-icon="move"></div>


### PR DESCRIPTION
## Summary
- make sticker editor modal wider than embedded preview
- center sticker preview inside modal

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c093b16638832ba727688d43e576d0