### PR TITLE
Scale sticker positioning percentages before mm conversion

### DIFF
--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -272,25 +272,25 @@ class CatalogStickerController
 
         $innerMaxW = $tpl['label_w'] - 2 * $tpl['padding'];
         $innerMaxH = $tpl['label_h'] - 2 * $tpl['padding'];
-        $descTop = max(0.0, min(1.0, $descTopPct)) * $innerMaxH;
-        $descLeft = max(0.0, min(1.0, $descLeftPct)) * $innerMaxW;
+        $descTop = max(0.0, min(100.0, $descTopPct)) / 100.0 * $innerMaxH;
+        $descLeft = max(0.0, min(100.0, $descLeftPct)) / 100.0 * $innerMaxW;
         $innerW = $innerMaxW - $descLeft;
         $innerH = $innerMaxH - $descTop;
         $descWidth = $descWidthPct !== null
-            ? max(0.0, min(1.0, $descWidthPct)) * $innerMaxW
+            ? max(0.0, min(100.0, $descWidthPct)) / 100.0 * $innerMaxW
             : null;
         $descHeight = $descHeightPct !== null
-            ? max(0.0, min(1.0, $descHeightPct)) * $innerMaxH
+            ? max(0.0, min(100.0, $descHeightPct)) / 100.0 * $innerMaxH
             : null;
         $descWidth = $descWidth !== null ? max(0.0, min($innerW, $descWidth)) : $innerW * 0.6;
         $descHeight = $descHeight !== null ? max(0.0, min($innerH, $descHeight)) : $innerH - 6.0;
         $qrSize = min($innerW, $innerH) * ($qrSizePct / 100.0);
         $qrPad = 2.0;
         $qrLeft = $qrLeftPct !== null
-            ? max(0.0, min(1.0, $qrLeftPct)) * $innerMaxW
+            ? max(0.0, min(100.0, $qrLeftPct)) / 100.0 * $innerMaxW
             : null;
         $qrTop = $qrTopPct !== null
-            ? max(0.0, min(1.0, $qrTopPct)) * $innerMaxH
+            ? max(0.0, min(100.0, $qrTopPct)) / 100.0 * $innerMaxH
             : null;
         $qrLeft = $qrLeft !== null
             ? max(0.0, min($innerMaxW - $qrSize, $qrLeft))


### PR DESCRIPTION
## Summary
- Normalize description and QR layout percentages to 0–100 before converting to millimeters.

## Testing
- `php -r '$innerMaxW=100;$innerMaxH=50;$descTopPct=10;$descLeftPct=20;$descWidthPct=60;$descHeightPct=60;$qrTopPct=10;$qrLeftPct=75;$qrSizePct=28;$descTop=max(0,min(100,$descTopPct))/100*$innerMaxH;$descLeft=max(0,min(100,$descLeftPct))/100*$innerMaxW;$innerW=$innerMaxW-$descLeft;$innerH=$innerMaxH-$descTop;$descWidth=$descWidthPct!==null?max(0,min(100,$descWidthPct))/100*$innerMaxW:null;$descHeight=$descHeightPct!==null?max(0,min(100,$descHeightPct))/100*$innerMaxH:null;$descWidth=$descWidth!==null?max(0,min($innerW,$descWidth)):$innerW*0.6;$descHeight=$descHeight!==null?max(0,min($innerH,$descHeight)):$innerH-6.0;$qrSize=min($innerW,$innerH)*($qrSizePct/100.0);$qrPad=2.0;$qrLeft=$qrLeftPct!==null?max(0,min(100,$qrLeftPct))/100*$innerMaxW:null;$qrTop=$qrTopPct!==null?max(0,min(100,$qrTopPct))/100*$innerMaxH:null;$qrLeft=$qrLeft!==null?max(0,min($innerMaxW-$qrSize,$qrLeft)):$innerMaxW-$qrPad-$qrSize;$qrTop=$qrTop!==null?max(0,min($innerMaxH-$qrSize,$qrTop)):$innerMaxH-$qrPad-$qrSize;var_export([$descTop,$descLeft,$descWidth,$descHeight,$qrLeft,$qrTop,$qrSize]);'`
- `composer test` *(fails: MAIN_DOMAIN misconfiguration and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c09aefce20832bb14292e929181c97