### PR TITLE
Cache-bust sticker background images

### DIFF
--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -322,8 +322,9 @@ const withBase = (p) => basePath + p;
       catalogSize.value = data.stickerCatalogFontSize ?? '11';
       descSize.value = data.stickerDescFontSize ?? '10';
       if (data.stickerBgPath) {
+        const cacheBustedBg = `${data.stickerBgPath}?${Date.now()}`;
         Object.keys(templates).forEach(k => {
-          templates[k].bg = withBase(data.stickerBgPath);
+          templates[k].bg = withBase(cacheBustedBg);
         });
       } else {
         Object.keys(templates).forEach(k => {


### PR DESCRIPTION
## Summary
- Cache-bust sticker editor background by appending a timestamp query so new images load immediately

## Testing
- `composer test` *(fails: Failed to reload nginx; PHPUnit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a0589984832bb2905c91ddd1846a