### PR TITLE
Remove sticker preview text

### DIFF
--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -15,7 +15,6 @@ const withBase = (p) => basePath + p;
 
   const textBox = document.getElementById('stickerTextBox');
   const textPrev = document.getElementById('stickerTextPreview');
-  const textInput = document.getElementById('catalogStickerText');
 
   const qrBox = document.getElementById('stickerQrHandle');
   const qrImg = document.getElementById('qrPreview');
@@ -246,15 +245,8 @@ const withBase = (p) => basePath + p;
     if (printSubheader.checked && baseSubheader) lines.push(baseSubheader);
     if (printCatalog.checked && baseCatalog) lines.push(baseCatalog);
     if (printDesc.checked && baseDesc) lines.push(baseDesc);
-    const t = lines.join('\n');
-    textInput.value = t;
-    textPrev.textContent = t;
+    textPrev.textContent = lines.join('\n');
   }
-
-  textInput.addEventListener('input', () => {
-    textPrev.textContent = textInput.value.replace(/\n/g, '\n');
-    debouncedSave();
-  });
 
   [printHeader, printSubheader, printCatalog, printDesc].forEach(cb => {
     cb?.addEventListener('change', () => {
@@ -357,8 +349,7 @@ const withBase = (p) => basePath + p;
       stickerHeaderFontSize: headerSize.value,
       stickerSubheaderFontSize: subheaderSize.value,
       stickerCatalogFontSize: catalogSize.value,
-      stickerDescFontSize: descSize.value,
-      previewText: textInput.value
+      stickerDescFontSize: descSize.value
     };
     try {
       await fetch(withBase('/admin/sticker-settings'), {

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -93,20 +93,6 @@ class CatalogStickerController
         $catName = (string)($cat['name'] ?? '');
         $catDesc = (string)($cat['description'] ?? '');
 
-        $lines = [];
-        if ($eventTitle !== '') {
-            $lines[] = $eventTitle;
-        }
-        if ($eventDesc !== '') {
-            $lines[] = $eventDesc;
-        }
-        if ($catName !== '') {
-            $lines[] = $catName;
-        }
-        if ($printDesc && $catDesc !== '') {
-            $lines[] = $catDesc;
-        }
-
         $data = [
             'stickerTemplate' => $cfg['stickerTemplate'] ?? 'avery_l7163',
             'stickerDescTop' => $cfg['stickerDescTop'] ?? 10,
@@ -131,7 +117,6 @@ class CatalogStickerController
             'previewSubheader' => $eventDesc,
             'previewCatalog' => $catName,
             'previewDesc' => $catDesc,
-            'previewText' => implode("\n", $lines),
         ];
         $response->getBody()->write(json_encode($data));
         return $response->withHeader('Content-Type', 'application/json');
@@ -371,20 +356,20 @@ class CatalogStickerController
             $maxTextH = $descHeight;
 
             $curY = $innerY;
-        $linesData = [];
-        if ($printHeader && $eventTitle !== '') {
-            $linesData[] = ['Arial', 'B', $headerSize, $eventTitle];
-        }
-        if ($printSubheader && $eventDesc !== '') {
-            $linesData[] = ['Arial', '', $subheaderSize, $eventDesc];
-        }
-        if ($printCatalog) {
-            $linesData[] = ['Arial', 'B', $catalogSize, (string)($cat['name'] ?? '')];
-        }
-        $desc = (string)($cat['description'] ?? '');
-        if ($printDesc && $desc !== '') {
-            $linesData[] = ['Arial', '', $descSize, $desc];
-        }
+            $linesData = [];
+            if ($printHeader && $eventTitle !== '') {
+                $linesData[] = ['Arial', 'B', $headerSize, $eventTitle];
+            }
+            if ($printSubheader && $eventDesc !== '') {
+                $linesData[] = ['Arial', '', $subheaderSize, $eventDesc];
+            }
+            if ($printCatalog) {
+                $linesData[] = ['Arial', 'B', $catalogSize, (string)($cat['name'] ?? '')];
+            }
+            $desc = (string)($cat['description'] ?? '');
+            if ($printDesc && $desc !== '') {
+                $linesData[] = ['Arial', '', $descSize, $desc];
+            }
 
             foreach ($linesData as $data) {
                 [$fam, $style, $sizePx, $text] = $data;

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -548,15 +548,9 @@
                   </select>
                 </div>
               </div>
-              <div class="uk-grid-small" uk-grid>
-                <div class="uk-width-1-2">
-                  <label class="uk-form-label">{{ t('label_qr_size_pct') }}</label>
-                  <input id="catalogStickerQrSizePct" type="range" min="10" max="80" step="1" class="uk-range">
-                </div>
-                <div class="uk-width-1-2">
-                  <label class="uk-form-label">Vorschau-Text</label>
-                  <input id="catalogStickerText" class="uk-input" placeholder="Vorschau-Text">
-                </div>
+              <div class="uk-margin">
+                <label class="uk-form-label">{{ t('label_qr_size_pct') }}</label>
+                <input id="catalogStickerQrSizePct" type="range" min="10" max="80" step="1" class="uk-range">
               </div>
               <div class="uk-grid-small" uk-grid>
                 <div class="uk-width-1-2">

--- a/tests/Controller/CatalogStickerControllerTest.php
+++ b/tests/Controller/CatalogStickerControllerTest.php
@@ -151,7 +151,7 @@ class CatalogStickerControllerTest extends TestCase
         $this->assertSame(1, preg_match_all('/\/Subtype\s*\/Image\b/', $withBg));
     }
 
-    public function testGetSettingsProvidesPreviewText(): void
+    public function testGetSettingsProvidesPreviewFields(): void
     {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, description, published, sort_order) VALUES('ev1','ev1','EventTitle','EventDesc',1,0)");
@@ -173,20 +173,13 @@ class CatalogStickerControllerTest extends TestCase
         $response = $controller->getSettings($request, new Response());
         $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
         $data = json_decode((string)$response->getBody(), true);
-        $this->assertSame("EventTitle\nEventDesc\nCatName\nCatDesc", $data['previewText']);
+        $this->assertSame('EventTitle', $data['previewHeader']);
+        $this->assertSame('EventDesc', $data['previewSubheader']);
+        $this->assertSame('CatName', $data['previewCatalog']);
+        $this->assertSame('CatDesc', $data['previewDesc']);
+        $this->assertArrayNotHasKey('previewText', $data);
         $this->assertFalse($data['stickerPrintHeader']);
         $this->assertFalse($data['stickerPrintSubheader']);
         $this->assertFalse($data['stickerPrintCatalog']);
-
-        $config->saveConfig([
-            'event_uid' => 'ev1',
-            'stickerPrintHeader' => false,
-            'stickerPrintSubheader' => false,
-            'stickerPrintCatalog' => false,
-            'stickerPrintDesc' => false,
-        ]);
-        $response = $controller->getSettings($request, new Response());
-        $data = json_decode((string)$response->getBody(), true);
-        $this->assertSame("EventTitle\nEventDesc\nCatName", $data['previewText']);
     }
 }


### PR DESCRIPTION
## Summary
- remove unused preview text field from sticker editor
- drop previewText handling from backend and tests

## Testing
- `vendor/bin/phpunit tests/Controller/CatalogStickerControllerTest.php`
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*
- `vendor/bin/phpcs src/Controller/CatalogStickerController.php`
- `vendor/bin/phpcs tests/Controller/CatalogStickerControllerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c09f98d320832ba01f0c07750fa100