### PR TITLE
Use scoped storage for solved catalogs

### DIFF
--- a/public/js/catalog.js
+++ b/public/js/catalog.js
@@ -44,7 +44,7 @@ const jsonHeaders = { Accept: 'application/json' };
 async function buildSolvedSet(cfg){
   const solved = new Set();
   try{
-    const prev = getStored?.(STORAGE_KEYS.QUIZ_SOLVED);
+    const prev = getStored(STORAGE_KEYS.QUIZ_SOLVED);
     if(prev){
       JSON.parse(prev).forEach(s => solved.add(String(s).toLowerCase()));
     }
@@ -55,7 +55,7 @@ async function buildSolvedSet(cfg){
       const res = await fetch(url, { headers: (typeof jsonHeaders !== 'undefined') ? jsonHeaders : { Accept: 'application/json' } });
       if(res.ok){
         const list = await res.json();
-        const user = (typeof getStored === 'function') ? getStored(STORAGE_KEYS.PLAYER_NAME) : sessionStorage.getItem('quizUser');
+        const user = getStored(STORAGE_KEYS.PLAYER_NAME);
         if(user){
           for(const t of list){
             if(t && t.name === user && t.catalog){
@@ -66,7 +66,7 @@ async function buildSolvedSet(cfg){
       }
     }catch(e){ /* empty */ }
     try{
-      setStored?.(STORAGE_KEYS.QUIZ_SOLVED, JSON.stringify(Array.from(solved)));
+      setStored(STORAGE_KEYS.QUIZ_SOLVED, JSON.stringify(Array.from(solved)));
     }catch(e){ /* empty */ }
   }
   return solved;

--- a/tests/test_catalog_prevent_repeat.js
+++ b/tests/test_catalog_prevent_repeat.js
@@ -24,7 +24,6 @@ const storage = () => {
 };
 
 const sessionStorage = storage();
-sessionStorage.setItem('quizSolved', JSON.stringify(['slug1']));
 const localStorage = storage();
 
 const body = new Element('body');
@@ -65,6 +64,8 @@ const context = {
 context.global = context;
 
 (async () => {
+  vm.runInNewContext(fs.readFileSync('public/js/storage.js', 'utf8'), context);
+  context.setStored(context.STORAGE_KEYS.QUIZ_SOLVED, JSON.stringify(['slug1']));
   vm.runInNewContext(fs.readFileSync('public/js/catalog.js', 'utf8'), context);
   await context.init();
   assert.strictEqual(warnings, 1);


### PR DESCRIPTION
## Summary
- replace direct sessionStorage use in buildSolvedSet with getStored/setStored to honor event-scoped keys
- load storage utilities in catalog replay test to prevent restarting solved catalogs

## Testing
- `node tests/test_catalog_prevent_repeat.js`
- `node tests/test_competition_prevent_replay.js`
- `composer test` *(fails: script @phpunit returned error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a1dfe5f4832bb45902f36417fe9e