### PR TITLE
Add GD/Imagick checks and image processing error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ FROM php:8.2.29-alpine
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 RUN apk add --no-cache \
-    libpng libjpeg-turbo freetype libwebp postgresql-client \
+    libpng libjpeg-turbo freetype libwebp postgresql-client imagemagick \
     && apk add --no-cache --virtual .build-deps \
-       libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev postgresql-dev $PHPIZE_DEPS \
+       libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev postgresql-dev imagemagick-dev $PHPIZE_DEPS \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) gd pdo_pgsql exif \
+    && pecl install imagick \
+    && docker-php-ext-enable imagick \
     && apk del .build-deps
 
 # install composer

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -19,9 +19,12 @@ RUN apk add --no-cache \
         freetype-dev \
         libwebp-dev \
         postgresql-dev \
+        imagemagick-dev \
         $PHPIZE_DEPS \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install gd pdo_pgsql exif \
+    && pecl install imagick \
+    && docker-php-ext-enable imagick \
     && apk del .build-deps \
     && pip3 install --no-cache-dir pytest
 


### PR DESCRIPTION
## Summary
- ensure background upload works only when GD or Imagick extensions are loaded
- wrap image read/save in try/catch and surface processing failures
- install imagick extension alongside gd and run composer install during image build

## Testing
- `vendor/bin/phpcs src/Controller/CatalogStickerController.php`
- `composer test` *(fails: DFFFF.FF.EE.F.FF....EE........EEEEE.E.EE.E.FFF....FEEEEEFFFF...  63 / 336 ( 18%))*

------
https://chatgpt.com/codex/tasks/task_e_68c109c0d414832b8b12eac31c56e169