### PR TITLE
refactor: centralize image uploads

### DIFF
--- a/src/Service/ImageUploadService.php
+++ b/src/Service/ImageUploadService.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\ImageInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+class ImageUploadService
+{
+    private string $dataDir;
+    private ImageManager $manager;
+
+    public function __construct(?string $dataDir = null)
+    {
+        $this->dataDir = $dataDir ?? dirname(__DIR__, 2) . '/data';
+        $this->manager = extension_loaded('imagick') ? ImageManager::imagick() : ImageManager::gd();
+    }
+
+    public function getDataDir(): string
+    {
+        return $this->dataDir;
+    }
+
+    public function validate(
+        UploadedFileInterface $file,
+        int $maxSize,
+        array $allowedExtensions,
+        array $allowedMimeTypes = []
+    ): void {
+        if ($file->getError() !== UPLOAD_ERR_OK) {
+            throw new \RuntimeException('upload error');
+        }
+        $size = $file->getSize();
+        if ($size !== null && $size > $maxSize) {
+            throw new \RuntimeException('file too large');
+        }
+        $extension = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
+        if (!in_array($extension, $allowedExtensions, true)) {
+            throw new \RuntimeException('unsupported file type');
+        }
+        $mime = strtolower($file->getClientMediaType() ?? '');
+        if ($allowedMimeTypes !== [] && !in_array($mime, $allowedMimeTypes, true)) {
+            throw new \RuntimeException('invalid mime type');
+        }
+    }
+
+    public function readImage(UploadedFileInterface $file): ImageInterface
+    {
+        $stream = $file->getStream();
+        return $this->manager->read($stream->detach());
+    }
+
+    public function saveImage(
+        ImageInterface $image,
+        string $dir,
+        string $filename,
+        ?int $maxWidth = null,
+        ?int $maxHeight = null,
+        int $quality = 80
+    ): string {
+        if ($maxWidth !== null || $maxHeight !== null) {
+            $image->scaleDown($maxWidth ?? 0, $maxHeight ?? 0);
+        }
+        $dir = trim($dir, '/');
+        $targetDir = $this->dataDir . '/' . $dir;
+        if (!is_dir($targetDir) && !mkdir($targetDir, 0775, true) && !is_dir($targetDir)) {
+            throw new \RuntimeException('unable to create directory');
+        }
+        $path = $targetDir . '/' . $filename;
+        $image->save($path, $quality);
+        return '/' . $dir . '/' . $filename;
+    }
+
+    public function saveUploadedFile(
+        UploadedFileInterface $file,
+        string $dir,
+        string $baseName,
+        ?int $maxWidth = null,
+        ?int $maxHeight = null,
+        int $quality = 80
+    ): string {
+        $extension = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
+        $filename = $baseName . '.' . $extension;
+        $image = $this->readImage($file);
+        return $this->saveImage($image, $dir, $filename, $maxWidth, $maxHeight, $quality);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -80,6 +80,7 @@ use App\Controller\SubscriptionController;
 use App\Controller\AdminSubscriptionCheckoutController;
 use App\Controller\InvitationController;
 use App\Controller\CatalogStickerController;
+use App\Service\ImageUploadService;
 use Slim\Views\Twig;
 use GuzzleHttp\Client;
 use Psr\Log\NullLogger;
@@ -194,6 +195,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         $auditLogger = new AuditLogger($pdo);
         $sessionService = new SessionService($pdo);
         $playerService = new PlayerService($pdo);
+        $imageUploadService = new ImageUploadService();
 
         $request = $request
             ->withAttribute('plan', $plan)
@@ -210,7 +212,7 @@ return function (\Slim\App $app, TranslationService $translator) {
             ))
             ->withAttribute('teamController', new TeamController($teamService, $configService))
             ->withAttribute('eventController', new EventController($eventService))
-            ->withAttribute('eventConfigController', new EventConfigController($eventService, $configService))
+            ->withAttribute('eventConfigController', new EventConfigController($eventService, $configService, $imageUploadService))
             ->withAttribute(
                 'tenantController',
                 new TenantController(
@@ -244,14 +246,15 @@ return function (\Slim\App $app, TranslationService $translator) {
             ))
             ->withAttribute('onboardingEmailController', new OnboardingEmailController($emailConfirmService))
             ->withAttribute('catalogDesignController', new CatalogDesignController($catalogService))
-            ->withAttribute('logoController', new LogoController($configService))
-            ->withAttribute('qrLogoController', new QrLogoController($configService))
+            ->withAttribute('logoController', new LogoController($configService, $imageUploadService))
+            ->withAttribute('qrLogoController', new QrLogoController($configService, $imageUploadService))
             ->withAttribute('summaryController', new SummaryController($configService, $eventService))
             ->withAttribute('catalogStickerController', new CatalogStickerController(
                 $configService,
                 $eventService,
                 $catalogService,
-                new QrCodeService()
+                new QrCodeService(),
+                $imageUploadService
             ))
             ->withAttribute('importController', $importController = new ImportController(
                 $catalogService,
@@ -280,8 +283,8 @@ return function (\Slim\App $app, TranslationService $translator) {
                 $resultService,
                 $consentService,
                 $summaryService,
-                new NullLogger(),
-                __DIR__ . '/../data/photos'
+                $imageUploadService,
+                new NullLogger()
             ))
             ->withAttribute('pdo', $pdo)
             ->withAttribute('translator', $translator)


### PR DESCRIPTION
## Summary
- add ImageUploadService handling validation, scaling and storage
- refactor logo, QR logo, sticker background, evidence and event config uploads to use the service
- wire up ImageUploadService in routes for reuse across controllers

## Testing
- `composer phpunit` *(fails: MAIN_DOMAIN misconfiguration, Missing STRIPE_* keys)*
- `vendor/bin/phpcs` *(fails: tests/test_event_search_visibility.js line indent)*

------
https://chatgpt.com/codex/tasks/task_e_68c11020a920832b95957bd538f1d649