### PR TITLE
Fix optional parameter order in EvidenceController

### DIFF
--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -33,15 +33,15 @@ class EvidenceController
         ResultService $results,
         PhotoConsentService $consent,
         SummaryPhotoService $summary,
-        ?ImageUploadService $images = null,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        ?ImageUploadService $images = null
     ) {
         $this->config = $config;
         $this->results = $results;
         $this->consent = $consent;
         $this->summary = $summary;
-        $this->images = $images ?? new ImageUploadService(sys_get_temp_dir());
         $this->logger = $logger;
+        $this->images = $images ?? new ImageUploadService(sys_get_temp_dir());
     }
 
     /**

--- a/src/routes.php
+++ b/src/routes.php
@@ -284,8 +284,8 @@ return function (\Slim\App $app, TranslationService $translator) {
                 $resultService,
                 $consentService,
                 $summaryService,
-                $imageUploadService,
-                new NullLogger()
+                new NullLogger(),
+                $imageUploadService
             ))
             ->withAttribute('pdo', $pdo)
             ->withAttribute('translator', $translator)


### PR DESCRIPTION
## Summary
- avoid PHP deprecation by placing required logger parameter before optional ImageUploadService in EvidenceController
- update routes to match new constructor signature

## Testing
- `composer test` *(fails: multiple PHP unit failures and MAIN_DOMAIN misconfiguration warnings)*
- `vendor/bin/phpcs src/Controller/EvidenceController.php src/routes.php`

------
https://chatgpt.com/codex/tasks/task_e_68c1224165c8832b851bdcdfcaee0c8b