### PR TITLE
feat: auto orient image uploads

### DIFF
--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -506,7 +506,7 @@ class CatalogStickerController
 
         $dir = $uid !== '' ? 'events/' . $uid : 'uploads';
         try {
-            $path = $this->images->saveUploadedFile($file, $dir, 'sticker-bg', null, null, 90);
+            $path = $this->images->saveUploadedFile($file, $dir, 'sticker-bg', null, null, 90, true);
         } catch (Throwable $e) {
             $response->getBody()->write('image processing failed');
             return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');

--- a/src/Controller/EventConfigController.php
+++ b/src/Controller/EventConfigController.php
@@ -79,7 +79,7 @@ class EventConfigController
                     ['png', 'webp'],
                     ['image/png', 'image/webp']
                 );
-                $data['logoPath'] = $this->images->saveUploadedFile($file, 'events/' . $uid, 'logo', 512, 512, 80);
+                $data['logoPath'] = $this->images->saveUploadedFile($file, 'events/' . $uid, 'logo', 512, 512, 80, true);
             } catch (\RuntimeException $e) {
                 $response->getBody()->write($e->getMessage());
                 return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -89,7 +89,7 @@ class LogoController
 
         $uid = $this->config->getActiveEventUid();
         $dir = $uid !== '' ? 'events/' . $uid . '/images' : 'uploads';
-        $path = $this->images->saveUploadedFile($file, $dir, 'logo', 512, 512, 80);
+        $path = $this->images->saveUploadedFile($file, $dir, 'logo', 512, 512, 80, true);
 
         if ($uid !== '') {
             $cfg = $this->config->getConfig();

--- a/src/Controller/QrLogoController.php
+++ b/src/Controller/QrLogoController.php
@@ -101,7 +101,7 @@ class QrLogoController
             return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
 
-        $path = $this->images->saveUploadedFile($file, 'events/' . $uid . '/images', 'qrlogo', 512, 512, 80);
+        $path = $this->images->saveUploadedFile($file, 'events/' . $uid . '/images', 'qrlogo', 512, 512, 80, true);
 
         $cfg = $this->config->getConfigForEvent($uid);
         $cfg['event_uid'] = $uid;

--- a/src/Service/ImageUploadService.php
+++ b/src/Service/ImageUploadService.php
@@ -47,10 +47,14 @@ class ImageUploadService
         }
     }
 
-    public function readImage(UploadedFileInterface $file): ImageInterface
+    public function readImage(UploadedFileInterface $file, bool $autoOrient = false): ImageInterface
     {
         $stream = $file->getStream();
-        return $this->manager->read($stream->detach());
+        $image = $this->manager->read($stream->detach());
+        if ($autoOrient) {
+            $image->orient();
+        }
+        return $image;
     }
 
     public function saveImage(
@@ -80,11 +84,12 @@ class ImageUploadService
         string $baseName,
         ?int $maxWidth = null,
         ?int $maxHeight = null,
-        int $quality = 80
+        int $quality = 80,
+        bool $autoOrient = false
     ): string {
         $extension = strtolower(pathinfo($file->getClientFilename(), PATHINFO_EXTENSION));
         $filename = $baseName . '.' . $extension;
-        $image = $this->readImage($file);
+        $image = $this->readImage($file, $autoOrient);
         return $this->saveImage($image, $dir, $filename, $maxWidth, $maxHeight, $quality);
     }
 }


### PR DESCRIPTION
## Summary
- allow auto-orienting uploaded images in ImageUploadService
- enable auto orientation for logo, QR logo, sticker background, and event logo uploads

## Testing
- `composer test` *(fails: Tests: 336, Assertions: 540, Errors: 43, Failures: 96)*

------
https://chatgpt.com/codex/tasks/task_e_68c125d04bf0832b81015df9d9e8f4ea