### PR TITLE
Handle missing backup directory and report export errors

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2662,12 +2662,21 @@ document.addEventListener('DOMContentLoaded', function () {
   function loadBackups() {
     if (!backupTableBody) return;
     apiFetch('/backups')
-      .then(r => r.text())
+      .then(r => {
+        if (!r.ok) {
+          return r.json().then(data => {
+            throw new Error(data.error || r.statusText);
+          });
+        }
+
+        return r.text();
+      })
       .then(html => {
         backupTableBody.innerHTML = html;
       })
-      .catch(() => {
+      .catch(err => {
         backupTableBody.innerHTML = '<tr><td colspan="2">Fehler</td></tr>';
+        notify(err.message || 'Fehlende Berechtigungen oder Ordner', 'danger');
       });
   }
 
@@ -2740,13 +2749,17 @@ document.addEventListener('DOMContentLoaded', function () {
     e.preventDefault();
     apiFetch('/export', { method: 'POST' })
       .then(r => {
-        if (!r.ok) throw new Error(r.statusText);
+        if (!r.ok) {
+          return r.json().then(data => {
+            throw new Error(data.error || r.statusText);
+          });
+        }
         notify('Export abgeschlossen', 'success');
         loadBackups();
       })
       .catch(err => {
         console.error(err);
-        notify('Fehler beim Export', 'danger');
+        notify(err.message || 'Fehlende Berechtigungen oder Ordner', 'danger');
       });
   });
 

--- a/src/Controller/BackupController.php
+++ b/src/Controller/BackupController.php
@@ -31,6 +31,26 @@ class BackupController
      */
     public function index(Request $request, Response $response): Response
     {
+        if (!is_dir($this->dir)) {
+            $response->getBody()->write(json_encode([
+                'error' => 'Backup directory not found',
+            ]));
+
+            return $response
+                ->withStatus(404)
+                ->withHeader('Content-Type', 'application/json');
+        }
+
+        if (!is_readable($this->dir)) {
+            $response->getBody()->write(json_encode([
+                'error' => 'Backup directory not readable',
+            ]));
+
+            return $response
+                ->withStatus(403)
+                ->withHeader('Content-Type', 'application/json');
+        }
+
         $dirs = glob($this->dir . '/*', GLOB_ONLYDIR) ?: [];
         rsort($dirs);
         $names = array_map('basename', $dirs);

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -61,6 +61,26 @@ class ExportController
      */
     public function post(Request $request, Response $response): Response
     {
+        if (!is_dir($this->backupDir)) {
+            if (!mkdir($this->backupDir, 0777, true)) {
+                $response->getBody()->write(json_encode([
+                    'error' => 'Failed to create backup directory',
+                ]));
+
+                return $response
+                    ->withStatus(500)
+                    ->withHeader('Content-Type', 'application/json');
+            }
+        } elseif (!is_writable($this->backupDir)) {
+            $response->getBody()->write(json_encode([
+                'error' => 'Backup directory not writable',
+            ]));
+
+            return $response
+                ->withStatus(500)
+                ->withHeader('Content-Type', 'application/json');
+        }
+
         $timestamp = date('Y-m-d_His');
         $backupPath = $this->backupDir . '/' . $timestamp;
         $this->exportToDir($this->dataDir);


### PR DESCRIPTION
## Summary
- Validate backup directory existence/readability before listing backups and return JSON errors when missing
- Ensure export endpoint creates or uses writable backup directory and fail with JSON on error
- Notify admins when backup listing or export requests fail due to permissions or missing folder

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c1283f61e4832baf7da88d32107747