### PR TITLE
feat: add image format option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,15 @@ pull request for each branch. This allows us to review and pull in new features 
 ## Style Guide
 
 All pull requests must adhere to the [PSR-12 standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md).
+
+## Image Standards
+
+Image uploads should use the following formats and quality settings:
+
+| Type    | Quality | Notes                                  |
+|---------|---------|----------------------------------------|
+| Logo    | 80      | Saved losslessly when using PNG        |
+| Sticker | 90      |                                        |
+| Photo   | 70      |                                        |
+
+PNG images are stored without quality loss, while JPEG and WEBP images use the given quality values. Use the constants defined in `ImageUploadService` (`QUALITY_LOGO`, `QUALITY_STICKER`, `QUALITY_PHOTO`) to ensure consistent quality across the project.

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -506,7 +506,15 @@ class CatalogStickerController
 
         $dir = $uid !== '' ? 'events/' . $uid : 'uploads';
         try {
-            $path = $this->images->saveUploadedFile($file, $dir, 'sticker-bg', null, null, 90, true);
+            $path = $this->images->saveUploadedFile(
+                $file,
+                $dir,
+                'sticker-bg',
+                null,
+                null,
+                ImageUploadService::QUALITY_STICKER,
+                true
+            );
         } catch (Throwable $e) {
             $response->getBody()->write('image processing failed');
             return $response->withStatus(500)->withHeader('Content-Type', 'text/plain');

--- a/src/Controller/EventConfigController.php
+++ b/src/Controller/EventConfigController.php
@@ -79,7 +79,15 @@ class EventConfigController
                     ['png', 'webp'],
                     ['image/png', 'image/webp']
                 );
-                $data['logoPath'] = $this->images->saveUploadedFile($file, 'events/' . $uid, 'logo', 512, 512, 80, true);
+                $data['logoPath'] = $this->images->saveUploadedFile(
+                    $file,
+                    'events/' . $uid,
+                    'logo',
+                    512,
+                    512,
+                    ImageUploadService::QUALITY_LOGO,
+                    true
+                );
             } catch (\RuntimeException $e) {
                 $response->getBody()->write($e->getMessage());
                 return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');

--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -100,7 +100,14 @@ class EvidenceController
         $dir = $uid !== ''
             ? 'events/' . $uid . '/images/photos/' . $safeUser
             : 'photos/' . $safeUser;
-        $stored = $this->images->saveImage($img, $dir, $fileName, 1500, 1500, 70);
+        $stored = $this->images->saveImage(
+            $img,
+            $dir,
+            $fileName,
+            1500,
+            1500,
+            ImageUploadService::QUALITY_PHOTO
+        );
 
         $this->consent->add($team, time());
 

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -89,7 +89,15 @@ class LogoController
 
         $uid = $this->config->getActiveEventUid();
         $dir = $uid !== '' ? 'events/' . $uid . '/images' : 'uploads';
-        $path = $this->images->saveUploadedFile($file, $dir, 'logo', 512, 512, 80, true);
+        $path = $this->images->saveUploadedFile(
+            $file,
+            $dir,
+            'logo',
+            512,
+            512,
+            ImageUploadService::QUALITY_LOGO,
+            true
+        );
 
         if ($uid !== '') {
             $cfg = $this->config->getConfig();

--- a/src/Controller/QrLogoController.php
+++ b/src/Controller/QrLogoController.php
@@ -101,7 +101,15 @@ class QrLogoController
             return $response->withStatus(400)->withHeader('Content-Type', 'text/plain');
         }
 
-        $path = $this->images->saveUploadedFile($file, 'events/' . $uid . '/images', 'qrlogo', 512, 512, 80, true);
+        $path = $this->images->saveUploadedFile(
+            $file,
+            'events/' . $uid . '/images',
+            'qrlogo',
+            512,
+            512,
+            ImageUploadService::QUALITY_LOGO,
+            true
+        );
 
         $cfg = $this->config->getConfigForEvent($uid);
         $cfg['event_uid'] = $uid;


### PR DESCRIPTION
## Summary
- allow ImageUploadService to accept optional format and ensure PNG files are saved losslessly
- use constants for logo, sticker and photo quality values
- document standard image formats and qualities

## Testing
- `composer test` *(fails: vendor/bin/phpunit handling the phpunit event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c12882f28c832b813a5a474f6f8a32