### PR TITLE
feat: improve sticker preview text rendering

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -213,7 +213,8 @@ body.uk-padding {
   pointer-events: none;
   white-space: pre-wrap;
   padding: 24px 8px 8px 8px;
-  font: 12px/1.3 system-ui, sans-serif;
+  font-family: system-ui, sans-serif;
+  line-height: 1.3;
   color: #000;
 }
 

--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -244,12 +244,32 @@ const withBase = (p) => basePath + p;
     debouncedSave();
   });
   function updatePreviewText() {
-    const lines = [];
-    if (printHeader.checked && baseHeader) lines.push(baseHeader);
-    if (printSubheader.checked && baseSubheader) lines.push(baseSubheader);
-    if (printCatalog.checked && baseCatalog) lines.push(baseCatalog);
-    if (printDesc.checked && baseDesc) lines.push(baseDesc);
-    textPrev.textContent = lines.join('\n');
+    if (!textPrev) return;
+    textPrev.innerHTML = '';
+    if (printHeader.checked && baseHeader) {
+      const el = document.createElement('div');
+      el.textContent = baseHeader;
+      el.style.fontSize = `${headerSize.value}px`;
+      textPrev.appendChild(el);
+    }
+    if (printSubheader.checked && baseSubheader) {
+      const el = document.createElement('div');
+      el.textContent = baseSubheader;
+      el.style.fontSize = `${subheaderSize.value}px`;
+      textPrev.appendChild(el);
+    }
+    if (printCatalog.checked && baseCatalog) {
+      const el = document.createElement('div');
+      el.textContent = baseCatalog;
+      el.style.fontSize = `${catalogSize.value}px`;
+      textPrev.appendChild(el);
+    }
+    if (printDesc.checked && baseDesc) {
+      const el = document.createElement('div');
+      el.textContent = baseDesc;
+      el.style.fontSize = `${descSize.value}px`;
+      textPrev.appendChild(el);
+    }
   }
 
   [printHeader, printSubheader, printCatalog, printDesc].forEach(cb => {
@@ -261,10 +281,10 @@ const withBase = (p) => basePath + p;
 
   qrColor?.addEventListener('change', debouncedSave);
   textColor?.addEventListener('change', debouncedSave);
-  headerSize?.addEventListener('input', debouncedSave);
-  subheaderSize?.addEventListener('input', debouncedSave);
-  catalogSize?.addEventListener('input', debouncedSave);
-  descSize?.addEventListener('input', debouncedSave);
+  headerSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
+  subheaderSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
+  catalogSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
+  descSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
 
   bgInput?.addEventListener('change', async () => {
     const file = bgInput.files?.[0];

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -618,7 +618,7 @@
                 <div id="stickerTextBox" class="dragzone" role="group" aria-label="Textfeld verschieben/größenändern">
                   <div class="drag-handle" aria-hidden="true" uk-icon="move"></div>
                   <div class="resize-handle" aria-hidden="true"></div>
-                  <div class="preview-text" id="stickerTextPreview">Beispiel-Text\nWeitere Zeile</div>
+                  <div class="preview-text" id="stickerTextPreview"></div>
                 </div>
 
                 <!-- A: QR-ZONE (quadratisch, nicht resizable) -->


### PR DESCRIPTION
## Summary
- render sticker preview lines in separate elements with configurable font sizes
- drop fixed font declaration from `.preview-text` so children can size themselves
- prepare admin template to host multiple preview text elements

## Testing
- `composer test` *(fails: Tests: 336, Assertions: 540, Errors: 43, Failures: 96, Warnings: 3, PHPUnit Deprecations: 3, Skipped: 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68c12b6695ec832b80b72f36901c0d23