### PR TITLE
Limit uploaded image pixel count

### DIFF
--- a/src/Service/ImageUploadService.php
+++ b/src/Service/ImageUploadService.php
@@ -13,6 +13,7 @@ class ImageUploadService
     public const QUALITY_LOGO = 80;
     public const QUALITY_STICKER = 90;
     public const QUALITY_PHOTO = 70;
+    public const MAX_PIXELS = 20_000_000;
 
     private string $dataDir;
     private ImageManager $manager;
@@ -55,6 +56,13 @@ class ImageUploadService
     {
         $stream = $file->getStream();
         $image = $this->manager->read($stream->detach());
+        $width = $image->width();
+        $height = $image->height();
+        $pixelCount = $width * $height;
+        if ($pixelCount > self::MAX_PIXELS) {
+            $ratio = sqrt(self::MAX_PIXELS / $pixelCount);
+            $image->scaleDown((int) floor($width * $ratio), (int) floor($height * $ratio));
+        }
         if ($autoOrient) {
             $image->orient();
         }

--- a/tests/Service/ImageUploadServiceTest.php
+++ b/tests/Service/ImageUploadServiceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\ImageUploadService;
+use Slim\Psr7\Stream;
+use Slim\Psr7\UploadedFile;
+use Tests\TestCase;
+
+class ImageUploadServiceTest extends TestCase
+{
+    public function testReadImageScalesDownLargeImages(): void
+    {
+        $service = new ImageUploadService();
+        $file = tempnam(sys_get_temp_dir(), 'img');
+        $image = imagecreatetruecolor(6000, 4000);
+        imagepng($image, $file);
+        imagedestroy($image);
+        $stream = fopen($file, 'rb');
+        $uploaded = new UploadedFile(new Stream($stream), 'large.png', 'image/png', filesize($file), UPLOAD_ERR_OK);
+
+        $result = $service->readImage($uploaded);
+
+        $this->assertTrue($result->width() < 6000);
+        $this->assertLessThanOrEqual(ImageUploadService::MAX_PIXELS, $result->width() * $result->height());
+        unlink($file);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce 20MP limit on uploaded images and scale down if exceeded
- add test verifying large images are reduced

## Testing
- `vendor/bin/phpcs src/Service/ImageUploadService.php tests/Service/ImageUploadServiceTest.php`
- `vendor/bin/phpunit tests/Service/ImageUploadServiceTest.php` *(1 PHPUnit deprecation)*

------
https://chatgpt.com/codex/tasks/task_e_68c12df15038832b8385c0b5f39b8385