### PR TITLE
Ensure backup directory exists and is writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ WORKDIR /var/www
 COPY . /var/www
 RUN composer install --no-interaction --prefer-dist --no-progress
 RUN mkdir -p /var/www/logs && chown www-data:www-data /var/www/logs
+RUN mkdir -p /var/www/backup \
+    && chown www-data:www-data /var/www/backup \
+    && test -w /var/www/backup
 
 # include custom PHP configuration
 COPY config/php.ini /usr/local/etc/php/conf.d/custom.ini

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,6 +22,12 @@ if [ ! -d /var/www/logs ]; then
 fi
 chown -R www-data:www-data /var/www/logs 2>/dev/null || true
 
+# Ensure backup directory exists and is writable
+if [ ! -d /var/www/backup ]; then
+    mkdir -p /var/www/backup
+fi
+chown -R www-data:www-data /var/www/backup 2>/dev/null || true
+
 # Copy default data if no config exists in /var/www/data
 if [ ! -f /var/www/data/config.json ] && [ -d /var/www/data-default ]; then
     cp -a /var/www/data-default/. /var/www/data/


### PR DESCRIPTION
## Summary
- create `/var/www/backup` during image build and verify it's writable
- check/create `/var/www/backup` at container startup

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c12e3e7a18832ba34f72face904821