### PR TITLE
Remove manual sticker save button

### DIFF
--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -43,7 +43,6 @@ const withBase = (p) => basePath + p;
   const qrLeft = document.getElementById('stickerQrLeft');
   const qrSizePct = document.getElementById('stickerQrSize');
 
-  const saveBtn = document.getElementById('saveStickerBtn');
   const pdfCreateBtn = document.getElementById('catalogStickerPdfCreateBtn');
 
   let baseHeader = '';
@@ -414,7 +413,6 @@ const withBase = (p) => basePath + p;
     loadStickerSettings();
   }
 
-  saveBtn.addEventListener('click', saveStickerSettings);
   pdfCreateBtn?.addEventListener('click', () => {
     saveStickerSettings();
     const params = new URLSearchParams({

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -639,8 +639,7 @@
               </div>
 
               <div class="uk-margin uk-flex uk-flex-right">
-                <button type="button" class="uk-button uk-button-primary" id="saveStickerBtn">Speichern</button>
-                <button type="button" class="uk-button uk-button-default uk-margin-left" id="catalogStickerPdfCreateBtn">PDF erstellen</button>
+                <button type="button" class="uk-button uk-button-default" id="catalogStickerPdfCreateBtn">PDF erstellen</button>
               </div>
             </form>
           </div>


### PR DESCRIPTION
## Summary
- remove obsolete save button from admin sticker editor
- drop related `saveBtn` JS references, relying on auto-save and PDF handler

## Testing
- `composer test` *(fails: Missing STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_STARTER, STRIPE_PRICE_STANDARD, STRIPE_PRICE_PROFESSIONAL, STRIPE_PRICING_TABLE_ID, STRIPE_WEBHOOK_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68c12f961308832b8022b76cf25ca374