### PR TITLE
Limit sticker background upload size

### DIFF
--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -510,8 +510,8 @@ class CatalogStickerController
                 $file,
                 $dir,
                 'sticker-bg',
-                null,
-                null,
+                2000,
+                2000,
                 ImageUploadService::QUALITY_STICKER,
                 true
             );


### PR DESCRIPTION
## Summary
- constrain sticker background uploads to 2000x2000 pixels

## Testing
- `composer phpunit` (fails: Tests: 337, Assertions: 543, Errors: 43, Failures: 96)
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_catalog_smoke.js` (session/catalog request failed ReferenceError: postSession is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68c145e5ae84832b86db3fe585083164