### PR TITLE
Handle sticker settings without explicit event UID

### DIFF
--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -294,8 +294,12 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
   catalogSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
   descSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
   if (bgInput && window.UIkit && UIkit.upload) {
+    const uid = (window.quizConfig || {}).event_uid || '';
+    const uploadUrl = uid
+      ? withBase(`/admin/sticker-background?event_uid=${encodeURIComponent(uid)}`)
+      : withBase('/admin/sticker-background');
     UIkit.upload('#catalogStickerBg', {
-      url: withBase('/admin/sticker-background'),
+      url: uploadUrl,
       name: 'file',
       multiple: false,
       beforeAll: function () {
@@ -344,8 +348,12 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
   }
 
   async function loadStickerSettings() {
+    const uid = (window.quizConfig || {}).event_uid || '';
+    const url = uid
+      ? withBase(`/admin/sticker-settings?event_uid=${encodeURIComponent(uid)}`)
+      : withBase('/admin/sticker-settings');
     try {
-      const res = await fetch(withBase('/admin/sticker-settings'));
+      const res = await fetch(url);
       const data = await res.json();
       tplSel.value = data.stickerTemplate || 'avery_l7163';
       descTop.value = data.stickerDescTop ?? '10';
@@ -390,6 +398,7 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
   }
 
   async function saveStickerSettings() {
+    const uid = (window.quizConfig || {}).event_uid || '';
     const payload = {
       stickerTemplate: tplSel.value,
       stickerDescTop: descTop.value,
@@ -410,6 +419,9 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
       stickerCatalogFontSize: catalogSize.value,
       stickerDescFontSize: descSize.value
     };
+    if (uid) {
+      payload.event_uid = uid;
+    }
     try {
       await fetch(withBase('/admin/sticker-settings'), {
         method: 'POST',

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -130,11 +130,14 @@ class CatalogStickerController
     public function getSettings(Request $request, Response $response): Response
     {
         $params = $request->getQueryParams();
-        $uid = (string)($params['event_uid'] ?? '');
+        $uid = (string) ($params['event_uid'] ?? '');
         if ($uid === '') {
+            // default to active event when no UID is provided
             $uid = $this->config->getActiveEventUid();
         }
-        $cfg = $this->config->getConfigForEvent($uid);
+        $cfg = $uid !== ''
+            ? $this->config->getConfigForEvent($uid)
+            : $this->config->getConfig();
         $printHeader = (bool)($cfg['stickerPrintHeader'] ?? true);
         $printSubheader = (bool)($cfg['stickerPrintSubheader'] ?? true);
         $printCatalog = (bool)($cfg['stickerPrintCatalog'] ?? true);
@@ -186,8 +189,9 @@ class CatalogStickerController
         if (!is_array($data)) {
             return $response->withStatus(400);
         }
-        $uid = (string)($data['event_uid'] ?? '');
+        $uid = (string) ($data['event_uid'] ?? '');
         if ($uid === '') {
+            // fall back to active event or global configuration
             $uid = $this->config->getActiveEventUid();
         }
         $tpl = in_array(


### PR DESCRIPTION
## Summary
- Support uploading sticker backgrounds and saving settings with the active event as fallback
- Serve sticker settings from active event or global config when no event UID is provided

## Testing
- `composer test` *(fails: DFFFF.FF.EE)*

------
https://chatgpt.com/codex/tasks/task_e_68c15ef7daac832bb963941b51ec142e