### PR TITLE
feat: preserve text box position during resize

### DIFF
--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -102,13 +102,15 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
     }
   }
 
-  function syncInputsFromLayout() {
+  function syncInputsFromLayout({ lockDescPos = false } = {}) {
     const rect = preview.getBoundingClientRect();
     const tRect = textBox.getBoundingClientRect();
     const qRect = qrBox.getBoundingClientRect();
 
-    descTop.value = pxToPct(tRect.top - rect.top, rect.height).toFixed(2);
-    descLeft.value = pxToPct(tRect.left - rect.left, rect.width).toFixed(2);
+    if (!lockDescPos) {
+      descTop.value = pxToPct(tRect.top - rect.top, rect.height).toFixed(2);
+      descLeft.value = pxToPct(tRect.left - rect.left, rect.width).toFixed(2);
+    }
     descW.value = pxToPct(tRect.width, rect.width).toFixed(2);
     descH.value = pxToPct(tRect.height, rect.height).toFixed(2);
 
@@ -229,7 +231,7 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
       const onRUp = () => {
         if (!resizing) return;
         resizing = false;
-        syncInputsFromLayout();
+        syncInputsFromLayout({ lockDescPos: el === textBox });
         debouncedSave();
       };
 


### PR DESCRIPTION
## Summary
- avoid overwriting text box position when syncing from layout
- keep text box top/left unchanged after resizing while other fields still update

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* vars, PHPUnit failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c162a91f74832b9cfd6b33983d653c