### PR TITLE
Reduce js-upload min height

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -445,10 +445,16 @@ a.uk-accordion-title {
 }
 
 .js-upload {
-  min-height: 240px;
+  min-height: 120px;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+@media (min-width: 960px) {
+  .js-upload {
+    min-height: 240px;
+  }
 }
 
 .quiz-letter {


### PR DESCRIPTION
## Summary
- shrink `.js-upload` min height to 120px for smaller screens
- add responsive media query to restore previous size on large viewports

## Testing
- `composer test` *(fails: Script vendor/bin/phpunit handling the phpunit event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68c163efa464832bb68219170c2a4e97