### PR TITLE
Fix sticker background path after migration

### DIFF
--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -508,7 +508,7 @@ class CatalogStickerController
             $uid = $this->config->getActiveEventUid();
         }
 
-        $dir = $uid !== '' ? 'events/' . $uid : 'uploads';
+        $dir = $uid !== '' ? 'events/' . $uid . '/images' : 'uploads';
         try {
             $path = $this->images->saveUploadedFile(
                 $file,

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -423,6 +423,13 @@ class ConfigService
             @rename($globalSticker, $newSticker);
         }
 
+        if (is_file($newSticker)) {
+            $this->saveConfig([
+                'event_uid' => $uid,
+                'stickerBgPath' => $this->getEventImagesPath($uid) . '/sticker-bg.png',
+            ]);
+        }
+
         $oldPhotos = $dataDir . '/photos';
         if (is_dir($oldPhotos)) {
             $newPhotos = $target . '/photos';


### PR DESCRIPTION
## Summary
- Save uploaded sticker backgrounds in the event's image directory
- Update stored sticker background path during image migration

## Testing
- `composer test` *(fails: DFFFF.FF.EE.F.FF....EE........EEEEE.E.EE.E.FFF..EEFEEEEEFFFF...  63 / 337 ( 18%))*

------
https://chatgpt.com/codex/tasks/task_e_68c1677d60f8832bac342e810fe21860