### PR TITLE
test: update sticker background upload route

### DIFF
--- a/tests/Controller/CatalogStickerControllerTest.php
+++ b/tests/Controller/CatalogStickerControllerTest.php
@@ -226,12 +226,12 @@ class CatalogStickerControllerTest extends TestCase
         $controller = new CatalogStickerController($config, $events, $catalogs, $qr, $images);
 
         $filePath = sys_get_temp_dir() . '/bg.png';
-        $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAADElEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
+        $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAADElEQVQImWNgYGAAAAAEAAGjChXjAAAAAElFTkSuQmCC');
         file_put_contents($filePath, $img);
         $stream = fopen($filePath, 'rb');
         $uploaded = new UploadedFile(new Stream($stream), 'bg.png', 'image/png', filesize($filePath), UPLOAD_ERR_OK);
 
-        $request = $this->createRequest('POST', '/admin/sticker-bg')
+        $request = $this->createRequest('POST', '/admin/sticker-background')
             ->withUploadedFiles(['file' => $uploaded])
             ->withQueryParams(['event_uid' => 'ev1']);
         $response = $controller->uploadBackground($request, new Response());


### PR DESCRIPTION
## Summary
- adjust sticker background upload test to call `/admin/sticker-background`
- use a valid PNG fixture for background upload test

## Testing
- `vendor/bin/phpunit tests/Controller/CatalogStickerControllerTest.php`
- `python3 tests/test_html_validity.py`
- `python3 tests/test_json_validity.py`
- `node tests/test_catalog_smoke.js`


------
https://chatgpt.com/codex/tasks/task_e_68c18638053c832bba23d9a1b61fe199