### PR TITLE
feat: add mm grid snapping for sticker editor

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -205,8 +205,9 @@ body.uk-padding {
   background: rgba(255,255,255,.9);
 }
 
+/* allow resizing on square dragzones (e.g., QR) */
 .dragzone--square .resize-handle {
-  display: none;
+  display: block;
 }
 
 .preview-text {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -621,9 +621,10 @@
                   <div class="preview-text" id="stickerTextPreview"></div>
                 </div>
 
-                <!-- A: QR-ZONE (quadratisch, nicht resizable) -->
+                <!-- A: QR-ZONE (quadratisch, resizable) -->
                 <div id="stickerQrHandle" class="dragzone dragzone--square" role="group" aria-label="QR-Position verschieben">
                   <div class="drag-handle" aria-hidden="true" uk-icon="move"></div>
+                  <div class="resize-handle" aria-hidden="true"></div>
                   <img id="qrPreview" alt="QR-Vorschau" />
                 </div>
 


### PR DESCRIPTION
## Summary
- add mm<->px helpers and grid snapping for sticker editor elements
- allow resizable square QR zone with minimum sizes
- expose resize handle for square drag zones

## Testing
- `composer test` *(fails: Errors: 44, Failures: 95)*

------
https://chatgpt.com/codex/tasks/task_e_68c18e7e94fc832ba0c92e0b2c2da274