### PR TITLE
Serve event images via dedicated route

### DIFF
--- a/src/Controller/EventImageController.php
+++ b/src/Controller/EventImageController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\ConfigService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Serves event-specific uploaded images.
+ */
+class EventImageController
+{
+    private ConfigService $config;
+
+    public function __construct(ConfigService $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Return an image from the event's image directory.
+     */
+    public function get(Request $request, Response $response): Response
+    {
+        $uid = (string) $request->getAttribute('uid');
+        $file = (string) $request->getAttribute('file');
+        $uid = preg_replace('~[^a-z0-9\-]~i', '', $uid);
+        $file = basename($file);
+        if ($uid === '' || $file === '') {
+            return $response->withStatus(404);
+        }
+
+        $this->config->migrateEventImages($uid);
+        $dir = $this->config->getEventImagesDir($uid);
+        $path = $dir . '/' . $file;
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+        $mime = mime_content_type($path) ?: 'application/octet-stream';
+        $response->getBody()->write((string) file_get_contents($path));
+        return $response->withHeader('Content-Type', $mime);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -80,6 +80,7 @@ use App\Controller\SubscriptionController;
 use App\Controller\AdminSubscriptionCheckoutController;
 use App\Controller\InvitationController;
 use App\Controller\CatalogStickerController;
+use App\Controller\EventImageController;
 use App\Service\ImageUploadService;
 use Slim\Views\Twig;
 use GuzzleHttp\Client;
@@ -137,6 +138,7 @@ require_once __DIR__ . '/Controller/SubscriptionController.php';
 require_once __DIR__ . '/Controller/AdminSubscriptionCheckoutController.php';
 require_once __DIR__ . '/Controller/InvitationController.php';
 require_once __DIR__ . '/Controller/CatalogStickerController.php';
+require_once __DIR__ . '/Controller/EventImageController.php';
 
 use App\Infrastructure\Migrations\Migrator;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -256,6 +258,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 new QrCodeService(),
                 $imageUploadService
             ))
+            ->withAttribute('eventImageController', new EventImageController($configService))
             ->withAttribute('importController', $importController = new ImportController(
                 $catalogService,
                 $configService,
@@ -1135,6 +1138,13 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/admin/sticker-background', function (Request $request, Response $response) {
         return $request->getAttribute('catalogStickerController')->uploadBackground($request, $response);
     })->add(new RoleAuthMiddleware(...Roles::ALL));
+
+    $app->get('/events/{uid}/images/{file}', function (Request $request, Response $response, array $args) {
+        $req = $request
+            ->withAttribute('uid', $args['uid'])
+            ->withAttribute('file', $args['file']);
+        return $request->getAttribute('eventImageController')->get($req, $response);
+    });
 
     $app->get('/admin/{path:.*}', function (Request $request, Response $response) {
         $base = \Slim\Routing\RouteContext::fromRequest($request)->getBasePath();

--- a/tests/Controller/EventImageControllerTest.php
+++ b/tests/Controller/EventImageControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class EventImageControllerTest extends TestCase
+{
+    public function testServesEventImage(): void
+    {
+        $dir = __DIR__ . '/../../data/events/evimg/images';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+        $file = $dir . '/sticker-bg.png';
+        imagepng(imagecreatetruecolor(5, 5), $file);
+
+        putenv('MAIN_DOMAIN=localhost');
+        $_ENV['MAIN_DOMAIN'] = 'localhost';
+
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/events/evimg/images/sticker-bg.png');
+        $request = $request->withUri(new \Slim\Psr7\Uri('http', 'localhost', 80, '/events/evimg/images/sticker-bg.png'));
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/png', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty((string) $response->getBody());
+
+        unlink($file);
+        rmdir($dir);
+        rmdir(dirname($dir));
+
+        putenv('MAIN_DOMAIN');
+        unset($_ENV['MAIN_DOMAIN']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `EventImageController` to deliver event image files
- expose `/events/{uid}/images/{file}` route
- test serving of sticker background image

## Testing
- `vendor/bin/phpunit tests/Controller/EventImageControllerTest.php`
- `vendor/bin/phpunit` *(fails: MAIN_DOMAIN misconfiguration and missing Stripe keys)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bda28138832b8abc174b5300b4a0