### PR TITLE
Avoid saving during sticker drag/resize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
             "node tests/test_shuffle_questions.js",
             "node tests/test_team_name_suggestion.js",
             "node tests/test_catalog_prevent_repeat.js",
-            "node tests/test_event_summary_switch.js"
+            "node tests/test_event_summary_switch.js",
+            "node tests/test_sticker_editor_save_events.js"
         ]
     }
 }

--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -424,6 +424,9 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
     qrBox.style.width = `${px}px`;
     qrBox.style.height = `${px}px`;
     syncInputsFromLayout();
+  });
+  qrSize.addEventListener('change', () => {
+    syncInputsFromLayout();
     debouncedSave();
   });
   function updatePreviewText() {
@@ -464,10 +467,10 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
 
   qrColor?.addEventListener('change', debouncedSave);
   textColor?.addEventListener('change', debouncedSave);
-  headerSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
-  subheaderSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
-  catalogSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
-  descSize?.addEventListener('input', () => { updatePreviewText(); debouncedSave(); });
+  [headerSize, subheaderSize, catalogSize, descSize].forEach(inp => {
+    inp?.addEventListener('input', updatePreviewText);
+    ['change', 'mouseup', 'touchend'].forEach(ev => inp?.addEventListener(ev, debouncedSave));
+  });
   if (bgInput) {
     bgInput.addEventListener('change', async () => {
       const file = bgInput.files && bgInput.files[0];
@@ -622,8 +625,8 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
         qrSize.value = inp.value;
       }
       applyPositionsFromInputs();
-      debouncedSave();
     });
+    ['change', 'mouseup', 'touchend'].forEach(ev => inp?.addEventListener(ev, debouncedSave));
   });
 
   tplSel.addEventListener('change', () => {

--- a/tests/test_sticker_editor_save_events.js
+++ b/tests/test_sticker_editor_save_events.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const code = fs.readFileSync('public/js/sticker-editor.js', 'utf8');
+
+// Ensure no debouncedSave in input listeners (check up to next 10 lines)
+const lines = code.split('\n');
+for (let i = 0; i < lines.length; i++) {
+  if (lines[i].includes("addEventListener('input'")) {
+    for (let j = i; j < lines.length; j++) {
+      if (lines[j].includes('debouncedSave')) {
+        throw new Error('debouncedSave should not be called in input listeners');
+      }
+      if (lines[j].includes(');')) {
+        break;
+      }
+    }
+  }
+}
+
+// Ensure qrSize uses change event for saving
+if (!/qrSize\.addEventListener\('change',[\s\S]*debouncedSave\(\)/.test(code)) {
+  throw new Error('qrSize should save on change events');
+}
+
+console.log('ok');


### PR DESCRIPTION
## Summary
- prevent auto-saving on every input event in the sticker editor
- save sticker settings only on change/mouseup/touchend events
- add regression test ensuring saves are not triggered during drag/resize

## Testing
- `node tests/test_sticker_editor_save_events.js`
- `composer test` *(fails: many phpunit errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cb9a4134832b98a57ea2bdf7f27d