### PR TITLE
feat: refine sticker QR size field

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -107,4 +107,5 @@ curl -X POST http://$DOMAIN/users.json \
 * [Datenschutz](datenschutz.md)
 * [Impressum](impressum.md)
 * [Lizenz](lizenz.md)
+* [Migrationen](migrationen.md)
 * [Landing-Seiten-Stile](landing-style-overrides.md)

--- a/docs/migrationen.md
+++ b/docs/migrationen.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Migrationen
+---
+
+## Datenbank-Migrationen
+
+Datenbankänderungen werden als SQL-Dateien im Verzeichnis `migrations/` verwaltet.
+Um alle offenen Migrationen anzuwenden, steht das Skript `scripts/run_migrations.php` bereit:
+
+```bash
+php scripts/run_migrations.php
+```
+
+Das Skript führt neue Migrationen in chronologischer Reihenfolge aus und protokolliert sie in der Tabelle `migrations`.

--- a/migrations/20250311_alter_sticker_fields.sql
+++ b/migrations/20250311_alter_sticker_fields.sql
@@ -1,0 +1,4 @@
+-- Refine sticker QR size field type
+ALTER TABLE config
+  ALTER COLUMN "stickerQrSizePct" TYPE NUMERIC(6,2)
+    USING REPLACE(CAST("stickerQrSizePct" AS TEXT), ',', '.')::NUMERIC;

--- a/migrations/20250311_change_sticker_qr_size_pct_type.sql
+++ b/migrations/20250311_change_sticker_qr_size_pct_type.sql
@@ -1,2 +1,0 @@
--- Change stickerQrSizePct to REAL to allow decimal percentages
-ALTER TABLE config ALTER COLUMN stickerQrSizePct TYPE REAL USING stickerQrSizePct::REAL;

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS config (
     stickerPrintCatalog BOOLEAN,
     stickerPrintDesc BOOLEAN,
     stickerQrColor TEXT,
-    stickerQrSizePct REAL,
+    stickerQrSizePct NUMERIC(6,2),
     stickerDescTop REAL,
     stickerDescLeft REAL,
     stickerQrTop REAL,


### PR DESCRIPTION
## Summary
- change `stickerQrSizePct` to NUMERIC(6,2) and handle comma separators
- align SQLite schema with new numeric type
- document running migrations via `scripts/run_migrations.php`

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration: "" (request host: ""))*

------
https://chatgpt.com/codex/tasks/task_e_68c1cff9dd70832b89e6a8bf3e8a1bdb