### PR TITLE
Ensure public event image directories and notify sticker editor errors

### DIFF
--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -531,6 +531,7 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
       : withBase('/admin/sticker-settings');
     try {
       const res = await fetch(url);
+      if (!res.ok) throw new Error(await res.text());
       const data = await res.json();
       tplSel.value = data.stickerTemplate || 'avery_l7163';
       descTop.value = data.stickerDescTop ?? '10';
@@ -568,7 +569,14 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
         });
       }
     } catch (e) {
-      // ignore
+      const msg = window.transStickerLoadError || 'Sticker-Einstellungen konnten nicht geladen werden.';
+      if (typeof window.notify === 'function') {
+        window.notify(msg, 'danger');
+      } else if (typeof UIkit !== 'undefined' && UIkit.notification) {
+        UIkit.notification({ message: msg, status: 'danger' });
+      } else {
+        alert(msg);
+      }
     }
     applyPositionsWhenVisible();
     qrImg.src = makeDemoQr();
@@ -600,13 +608,21 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
       payload.event_uid = uid;
     }
     try {
-      await fetch(withBase('/admin/sticker-settings'), {
+      const res = await fetch(withBase('/admin/sticker-settings'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });
+      if (!res.ok) throw new Error(await res.text());
     } catch (e) {
-      // ignore
+      const msg = window.transStickerSaveError || 'Sticker-Einstellungen konnten nicht gespeichert werden.';
+      if (typeof window.notify === 'function') {
+        window.notify(msg, 'danger');
+      } else if (typeof UIkit !== 'undefined' && UIkit.notification) {
+        UIkit.notification({ message: msg, status: 'danger' });
+      } else {
+        alert(msg);
+      }
     }
   }
 

--- a/src/Service/ImageUploadService.php
+++ b/src/Service/ImageUploadService.php
@@ -86,6 +86,20 @@ class ImageUploadService
         if (!is_dir($targetDir) && !mkdir($targetDir, 0775, true) && !is_dir($targetDir)) {
             throw new \RuntimeException('unable to create directory');
         }
+        @chown($targetDir, 'www-data');
+        @chgrp($targetDir, 'www-data');
+        @chmod($targetDir, 0775);
+
+        if (preg_match('#^events/[^/]+/images$#', $dir) && basename($this->dataDir) === 'data') {
+            $publicDir = dirname($this->dataDir) . '/public/' . $dir;
+            if (!is_dir($publicDir) && !mkdir($publicDir, 0775, true) && !is_dir($publicDir)) {
+                throw new \RuntimeException('unable to create public directory');
+            }
+            @chown($publicDir, 'www-data');
+            @chgrp($publicDir, 'www-data');
+            @chmod($publicDir, 0775);
+        }
+
         $path = $targetDir . '/' . $filename;
         $format = strtolower($format ?? pathinfo($filename, PATHINFO_EXTENSION));
         match ($format) {


### PR DESCRIPTION
## Summary
- Ensure event image directories under public exist with www-data ownership and permissions
- Show sticker editor load/save errors via notify alerts

## Testing
- `composer test` *(fails: Tests: 341, Assertions: 546, Errors: 46, Failures: 96)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d1c89b30832b89ac7f9ea766252e