### PR TITLE
Fix Postgres migration quoting for sticker fields

### DIFF
--- a/migrations/20250311_alter_sticker_fields.sql
+++ b/migrations/20250311_alter_sticker_fields.sql
@@ -1,4 +1,16 @@
--- Refine sticker QR size field type
+-- Refine sticker configuration field types
 ALTER TABLE config
-  ALTER COLUMN "stickerQrSizePct" TYPE NUMERIC(6,2)
-    USING REPLACE(CAST("stickerQrSizePct" AS TEXT), ',', '.')::NUMERIC;
+  ALTER COLUMN stickerqrsizepct TYPE NUMERIC(6,2)
+    USING REPLACE(stickerqrsizepct::text, ',', '.')::numeric,
+  ALTER COLUMN stickerdesctop TYPE NUMERIC(6,2)
+    USING REPLACE(stickerdesctop::text, ',', '.')::numeric,
+  ALTER COLUMN stickerdescleft TYPE NUMERIC(6,2)
+    USING REPLACE(stickerdescleft::text, ',', '.')::numeric,
+  ALTER COLUMN stickerdescwidth TYPE NUMERIC(6,2)
+    USING REPLACE(stickerdescwidth::text, ',', '.')::numeric,
+  ALTER COLUMN stickerdescheight TYPE NUMERIC(6,2)
+    USING REPLACE(stickerdescheight::text, ',', '.')::numeric,
+  ALTER COLUMN stickerqrtop TYPE NUMERIC(6,2)
+    USING REPLACE(stickerqrtop::text, ',', '.')::numeric,
+  ALTER COLUMN stickerqrleft TYPE NUMERIC(6,2)
+    USING REPLACE(stickerqrleft::text, ',', '.')::numeric;


### PR DESCRIPTION
## Summary
- use unquoted lowercase column names in sticker migration
- cast sticker field values to NUMERIC(6,2) for consistent decimal handling

## Testing
- `composer test` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* env variables)*
- `vendor/bin/phpunit` *(fails: MAIN_DOMAIN misconfiguration, missing STRIPE_* env variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d5e9aab0832bb586417d48f663c9