### PR TITLE
Fix draggable bounds to use client size

### DIFF
--- a/public/js/sticker-editor.js
+++ b/public/js/sticker-editor.js
@@ -234,10 +234,10 @@ const apiFetch = window.apiFetch || ((p, o) => fetch(withBase(p), o));
     let startTop = 0;
 
     function moveTo(nx, ny) {
-      const maxX = Math.floor(stage.clientWidth - el.offsetWidth);
-      const maxY = Math.floor(stage.clientHeight - el.offsetHeight);
-      let x = Math.round(nx);
-      let y = Math.round(ny);
+      const maxX = stage.clientWidth - el.clientWidth;
+      const maxY = stage.clientHeight - el.clientHeight;
+      let x = nx;
+      let y = ny;
       if (x < 0) x = 0; else if (x > maxX) x = maxX;
       if (y < 0) y = 0; else if (y > maxY) y = maxY;
       el.style.left = `${x}px`;


### PR DESCRIPTION
## Summary
- ensure draggable elements use client width/height to compute bounds
- remove rounding in `moveTo` so elements can reach exact stage edges

## Testing
- `vendor/bin/phpunit --no-progress` *(fails: Missing STRIPE_SECRET_KEY and other env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ec616c30832b86ac7a500b2ef304