### PR TITLE
Fix sticker template rows for Avery sheets

### DIFF
--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -46,7 +46,7 @@ class CatalogStickerController
         ],
         'avery_l7651' => [
             'page' => 'A4',
-            'rows' => 8,
+            'rows' => 7,
             'cols' => 3,
             'label_w' => 63.5,
             'label_h' => 38.1,
@@ -72,7 +72,7 @@ class CatalogStickerController
         ],
         'avery_j8165' => [
             'page' => 'A4',
-            'rows' => 8,
+            'rows' => 4,
             'cols' => 1,
             'label_w' => 199.6,
             'label_h' => 67.7,
@@ -85,11 +85,11 @@ class CatalogStickerController
         ],
         'avery_l7168' => [
             'page' => 'A4',
-            'rows' => 4,
+            'rows' => 2,
             'cols' => 1,
             'label_w' => 199.6,
             'label_h' => 143.5,
-            'margin_top' => 10.0,
+            'margin_top' => 5.0,
             'margin_left' => 5.2,
             'gutter_x' => 0.0,
             'gutter_y' => 2.5,


### PR DESCRIPTION
## Summary
- fix row counts for Avery L7651 and J8165 sticker templates
- reduce Avery L7168 row count and top margin to fit on A4 sheets

## Testing
- `vendor/bin/phpcs src/Controller/CatalogStickerController.php`
- `vendor/bin/phpunit` *(fails: Failed to reload nginx: reload failed)*
- `curl -s -o /tmp/stickers.pdf -w "%{http_code}\n" http://localhost:8000/admin/reports/catalog-stickers.pdf` *(500)*

------
https://chatgpt.com/codex/tasks/task_e_68c26657ec6c832b864f21a16a6e8c12