### PR TITLE
Add calServer marketing page

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Disallow: /
 Allow: /$
 Allow: /landing$
+Allow: /calserver$

--- a/src/Controller/Marketing/CalserverController.php
+++ b/src/Controller/Marketing/CalserverController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Marketing;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Views\Twig;
+
+/**
+ * Displays the calServer marketing preview page.
+ */
+class CalserverController
+{
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $view = Twig::fromRequest($request);
+        return $view->render($response, 'marketing/calserver.twig');
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -66,6 +66,7 @@ use App\Controller\Admin\PageController;
 use App\Controller\Admin\LandingpageController;
 use App\Controller\TenantController;
 use App\Controller\Marketing\LandingController;
+use App\Controller\Marketing\CalserverController;
 use App\Controller\Marketing\ContactController;
 use App\Controller\RegisterController;
 use App\Controller\OnboardingController;
@@ -371,6 +372,20 @@ return function (\Slim\App $app, TranslationService $translator) {
             return $response->withStatus(404);
         }
         $controller = new LandingController();
+        return $controller($request, $response);
+    });
+    $app->get('/calserver', function (Request $request, Response $response) {
+        $domainType = $request->getAttribute('domainType');
+        if ($domainType === null) {
+            $host = $request->getUri()->getHost();
+            $mainDomain = getenv('MAIN_DOMAIN') ?: '';
+            $domainType = $host === $mainDomain || $mainDomain === '' ? 'main' : 'tenant';
+            $request = $request->withAttribute('domainType', $domainType);
+        }
+        if ($domainType !== 'main') {
+            return $response->withStatus(404);
+        }
+        $controller = new CalserverController();
         return $controller($request, $response);
     });
     $app->post('/landing/contact', ContactController::class)

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -1,0 +1,426 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <title>calServer – Marketingseite (UIkit Vorschau)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="canonical" href="{{ canonicalUrl }}" />
+  <!-- UIkit -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.17.10/dist/css/uikit.min.css" />
+  <script src="https://cdn.jsdelivr.net/npm/uikit@3.17.10/dist/js/uikit.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/uikit@3.17.10/dist/js/uikit-icons.min.js"></script>
+  <style>
+    /* Kleine Helfer für konsistenten Look */
+    .pill { display:inline-block; padding:.25rem .6rem; border:1px solid rgba(0,0,0,.08); border-radius:9999px; font-size:.8rem; }
+    .shadow-soft { box-shadow: 0 12px 28px -12px rgba(0,0,0,.15), 0 6px 12px -8px rgba(0,0,0,.08); }
+    .brand-primary { color:#1f63e6; }
+    .uk-card-primary { background:#1f63e6; }
+    .uk-card-primary .uk-card-title, .uk-card-primary p { color:#fff; }
+    .badge-card { padding:14px 10px; border:1px solid rgba(0,0,0,.06); border-radius:12px; background:#fff; }
+    .muted { color:#6b7280; }
+  </style>
+</head>
+<body>
+
+<!-- HEADER -->
+<nav class="uk-navbar-container" uk-navbar>
+  <div class="uk-container uk-container-expand">
+    <div class="uk-navbar-left">
+      <a class="uk-navbar-item uk-logo" href="{{ basePath }}/calserver">
+        <span uk-icon="icon: grid; ratio: 1.1" class="brand-primary uk-margin-small-right"></span> calServer
+      </a>
+    </div>
+    <div class="uk-navbar-right">
+      <ul class="uk-navbar-nav uk-visible@m">
+        <li><a href="#features">Funktionen</a></li>
+        <li><a href="#modules">Module</a></li>
+        <li><a href="#usecases">Anwendungsfälle</a></li>
+        <li><a href="#modes">Betriebsarten</a></li>
+        <li><a href="#pricing">Preise</a></li>
+        <li><a href="#faq">FAQ</a></li>
+      </ul>
+      <div class="uk-navbar-item">
+        <a class="uk-button uk-button-default uk-margin-small-right" href="#demo">Demo buchen</a>
+        <a class="uk-button uk-button-primary" href="#trial">Jetzt testen</a>
+      </div>
+      <a class="uk-navbar-toggle uk-hidden@m" uk-navbar-toggle-icon href="#offcanvas" uk-toggle></a>
+    </div>
+  </div>
+</nav>
+
+<div id="offcanvas" uk-offcanvas="overlay:true">
+  <div class="uk-offcanvas-bar">
+    <button class="uk-offcanvas-close" type="button" uk-close></button>
+    <ul class="uk-nav uk-nav-default">
+      <li class="uk-nav-header">Navigation</li>
+      <li><a href="#features">Funktionen</a></li>
+      <li><a href="#modules">Module</a></li>
+      <li><a href="#usecases">Anwendungsfälle</a></li>
+      <li><a href="#modes">Betriebsarten</a></li>
+      <li><a href="#pricing">Preise</a></li>
+      <li><a href="#faq">FAQ</a></li>
+      <li class="uk-nav-divider"></li>
+      <li><a href="#demo">Demo buchen</a></li>
+      <li><a href="#trial">Jetzt testen</a></li>
+    </ul>
+  </div>
+</div>
+
+<!-- HERO -->
+<section class="uk-section uk-section-default">
+  <div class="uk-container">
+    <div class="uk-grid-large uk-flex-middle" uk-grid>
+      <div class="uk-width-1-2@m">
+        <span class="pill uk-margin-small-bottom">Software Hosted in Germany</span>
+        <h1 class="uk-heading-medium uk-margin-small-top">Ihre Kalibrier- und Inventarverwaltung. Einfach in der Cloud.</h1>
+        <p class="uk-text-lead">Geräte, Kalibrierungen und Aufträge – alles an einem Ort. Klar strukturiert, leicht zu bedienen und sofort einsatzbereit.</p>
+        <p class="uk-margin-medium-top">
+          <a class="uk-button uk-button-primary uk-margin-small-right" href="#trial">Kostenfrei testen</a>
+          <a class="uk-button uk-button-default" href="#demo">Live-Demo buchen</a>
+        </p>
+        <p class="muted">Unbegrenzte Nutzer:innen · Flexible Rollen · Tägliche Datensicherung</p>
+      </div>
+      <div class="uk-width-1-2@m">
+        <div class="uk-card uk-card-default uk-card-body uk-text-center shadow-soft">
+          <div class="uk-height-medium uk-flex uk-flex-center uk-flex-middle uk-background-muted">
+            <span class="muted">[Dashboard-Mockup Platzhalter]</span>
+          </div>
+          <p class="uk-margin-small-top muted">Schnelle Suche · Klare Tabellen · Intuitive Workflows</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- TRUST BADGES (ohne Normbezug) -->
+<section class="uk-section uk-section-muted">
+  <div class="uk-container">
+    <div class="uk-child-width-1-2 uk-child-width-1-5@m uk-grid-small uk-text-center" uk-grid>
+      <div><div class="badge-card">Hosting in Deutschland</div></div>
+      <div><div class="badge-card">DSGVO-konform</div></div>
+      <div><div class="badge-card">Software Made in Germany</div></div>
+      <div><div class="badge-card">REST-API</div></div>
+      <div><div class="badge-card">Autom. Backups</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- FUNKTIONEN -->
+<section id="features" class="uk-section">
+  <div class="uk-container">
+    <h2 class="uk-heading-line"><span>Funktionen, die den Alltag erleichtern</span></h2>
+
+    <div class="uk-child-width-1-2@s uk-child-width-1-3@m" uk-grid>
+      <!-- F1 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Inventare & Intervalle</h3>
+          <p>Fälligkeiten kommen zu dir: Erinnerungen, Abrufe und Planungsübersichten sorgen für Ruhe im Tagesgeschäft.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Automatische Erinnerungslogik</li>
+            <li>Klare Statusfarben</li>
+            <li>Planungs-Dashboards</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F2 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Kalibrierscheine digitalisieren</h3>
+          <p>Ablage ohne Umwege: Datei ablegen, der Rest ist Zuordnung & Versionierung.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Intelligente Dateinamen-Zuordnung</li>
+            <li>Versionen & Vorschau</li>
+            <li>Teilen per Link</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F3 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">E-Mail-Abrufe & Erinnerungen</h3>
+          <p>Persönlich und planbar: Serien mit System statt Einzelmails.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Vorlagen & Platzhalter</li>
+            <li>Zeitpläne je Zielgruppe</li>
+            <li>Versandprotokoll</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F4 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Geräteverwaltung</h3>
+          <p>Ob 100 oder 100.000 Geräte – Suche, Filter und Gruppen bleiben schnell.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Schnellsuche & Filter</li>
+            <li>Sets & Zubehör</li>
+            <li>Export (CSV/PDF)</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F5 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Kalibrier- & Reparaturverwaltung</h3>
+          <p>Von Messwerten bis Bericht – ohne Medienbrüche.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Bearbeitbare Übersichten</li>
+            <li>Messwerte erfassen/importieren</li>
+            <li>Berichte direkt erzeugen</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F6 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Auftragsbearbeitung</h3>
+          <p>Ein Flow für alles: Angebot → Auftrag → Rechnung.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Sammel- & Teilrechnungen</li>
+            <li>Preislisten & Nummernkreise</li>
+            <li>Eigenes Briefpapier</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F7 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Leihverwaltung</h3>
+          <p>Reservieren statt rumtelefonieren: Kalender auf, Gerät rein, fertig.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Drag-and-Drop Kalender</li>
+            <li>Zubehör-Sets</li>
+            <li>Rückgabe-Erinnerungen</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F8 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Dokumentationen & Wiki</h3>
+          <p>Wissen bleibt im Team – gepflegt, versioniert und durchsuchbar.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Editor mit Inhaltsverzeichnis</li>
+            <li>Versionen & Berechtigungen</li>
+            <li>Interne Links</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F9 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Dateimanagement (DMS)</h3>
+          <p>„Nur speichern, nicht sortieren“ – Zuordnung läuft im Hintergrund.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Auto-Zuordnung</li>
+            <li>Versionierung</li>
+            <li>PDF-Viewer</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F10 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Meldungen & Tickets</h3>
+          <p>Alles an einem Ort: Anliegen, Verlauf, Benachrichtigungen.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Zentrales Ticketing</li>
+            <li>Teilnehmerwechsel</li>
+            <li>Benachrichtigungsketten</li>
+          </ul>
+        </div>
+      </div>
+      <!-- F11 -->
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Moderne Cloud-Basis</h3>
+          <p>Schnell, stabil und updatefreundlich – ohne großen Admin-Aufwand.</p>
+          <ul class="uk-list uk-list-bullet">
+            <li>Skalierbare Umgebung</li>
+            <li>Regelmäßige Updates</li>
+            <li>Tägliche Backups</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- MODULE -->
+<section id="modules" class="uk-section uk-section-muted">
+  <div class="uk-container">
+    <h2 class="uk-heading-line"><span>Module, die den Unterschied machen</span></h2>
+    <div class="uk-child-width-1-2@m" uk-grid>
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Abruflisten & E-Mail-Erinnerungen</h3>
+          <p>Planbare Serien mit persönlicher Ansprache – so bleiben Fristen entspannt.</p>
+        </div>
+      </div>
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Leihverwaltung</h3>
+          <p>Kalenderbasierte Buchungen für Geräte und Sets – inklusive Benachrichtigungen.</p>
+        </div>
+      </div>
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Tickets & Meldungen</h3>
+          <p>Sichtbar für alle Beteiligten, nachvollziehbar für jedes Team.</p>
+        </div>
+      </div>
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Benutzer & Rollen</h3>
+          <p>Jede:r sieht nur das Wesentliche – flexibel und sicher.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ANWENDUNGSFÄLLE -->
+<section id="usecases" class="uk-section">
+  <div class="uk-container">
+    <h2 class="uk-heading-line"><span>Anwendungsfälle aus der Praxis</span></h2>
+    <div class="uk-child-width-1-2@s uk-child-width-1-3@m" uk-grid>
+      <div><div class="uk-card uk-card-default uk-card-body">Laborverwaltung – Ordnung für Prüfstände & Geräte.</div></div>
+      <div><div class="uk-card uk-card-default uk-card-body">MET/TEAM Oberfläche – vertraut für Umsteiger:innen.</div></div>
+      <div><div class="uk-card uk-card-default uk-card-body">Geräteverwaltung – von Werkzeug bis Großanlage.</div></div>
+      <div><div class="uk-card uk-card-default uk-card-body">Projektverwaltung – Budgets, Termine, Teams im Griff.</div></div>
+      <div><div class="uk-card uk-card-default uk-card-body">Solar & Energie – Gerätemanagement für Anlagen.</div></div>
+      <div><div class="uk-card uk-card-default uk-card-body">Individuelle Szenarien – passend zu Ihren Abläufen.</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- BETRIEBSARTEN -->
+<section id="modes" class="uk-section uk-section-muted">
+  <div class="uk-container">
+    <h2 class="uk-heading-line"><span>Betriebsarten</span></h2>
+    <div class="uk-child-width-1-2@m" uk-grid>
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">Cloud</h3>
+          <p>Sofort startklar, in Deutschland gehostet und flexibel erweiterbar.</p>
+        </div>
+      </div>
+      <div>
+        <div class="uk-card uk-card-default uk-card-body">
+          <h3 class="uk-card-title">On-Premise</h3>
+          <p>Volle Kontrolle in Ihrer eigenen IT – mit maximaler Flexibilität.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- PREISE -->
+<section id="pricing" class="uk-section">
+  <div class="uk-container">
+    <h2 class="uk-heading-line"><span>Preise, die Klarheit schaffen</span></h2>
+    <div class="uk-child-width-1-3@m" uk-grid>
+      <div>
+        <div class="uk-card uk-card-default uk-card-body uk-text-center shadow-soft">
+          <h3>Standard</h3>
+          <p class="uk-margin-small">Die solide Basis für jedes Team</p>
+          <p class="uk-text-large uk-text-bold">ab 250 €/Monat</p>
+          <a class="uk-button uk-button-default" href="#offer">Unverbindliches Angebot</a>
+        </div>
+      </div>
+      <div>
+        <div class="uk-card uk-card-primary uk-card-body uk-text-center shadow-soft">
+          <h3>Performance</h3>
+          <p class="uk-margin-small">Für größere Teams mit mehr Tempo</p>
+          <p class="uk-text-large uk-text-bold">auf Anfrage</p>
+          <a class="uk-button uk-button-default" href="#offer">Beratung anfragen</a>
+        </div>
+      </div>
+      <div>
+        <div class="uk-card uk-card-default uk-card-body uk-text-center shadow-soft">
+          <h3>Enterprise</h3>
+          <p class="uk-margin-small">Individuell zugeschnitten</p>
+          <p class="uk-text-large uk-text-bold">individuell</p>
+          <a class="uk-button uk-button-default" href="#offer">Angebot anfordern</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section id="faq" class="uk-section uk-section-muted">
+  <div class="uk-container">
+    <h2 class="uk-heading-line"><span>Häufige Fragen</span></h2>
+    <ul uk-accordion>
+      <li>
+        <a class="uk-accordion-title" href="#">Gibt es eine Begrenzung der Nutzer:innen?</a>
+        <div class="uk-accordion-content"><p>Nein – beliebig viele Accounts möglich.</p></div>
+      </li>
+      <li>
+        <a class="uk-accordion-title" href="#">Kann ich zwischen Cloud und On-Premise wechseln?</a>
+        <div class="uk-accordion-content"><p>Ja, beide Modelle sind flexibel nutzbar.</p></div>
+      </li>
+      <li>
+        <a class="uk-accordion-title" href="#">Wie schnell bin ich startklar?</a>
+        <div class="uk-accordion-content"><p>Cloud meist innerhalb weniger Tage, On-Premise nach gemeinsamer Einrichtung.</p></div>
+      </li>
+      <li>
+        <a class="uk-accordion-title" href="#">Kann ich bestehende Daten übernehmen?</a>
+        <div class="uk-accordion-content"><p>Ja, z. B. via Excel-Import oder über Schnittstellen.</p></div>
+      </li>
+      <li>
+        <a class="uk-accordion-title" href="#">Gibt es Support?</a>
+        <div class="uk-accordion-content"><p>Ja, per E-Mail, Telefon oder Ticketsystem.</p></div>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<!-- CTA ABSCHLUSS -->
+<section id="demo" class="uk-section uk-section-default uk-text-center">
+  <div class="uk-container">
+    <h3 class="uk-heading-small uk-margin-small">Bereit, calServer live zu erleben?</h3>
+    <p class="muted">Buchen Sie eine Demo oder starten Sie mit einem kostenlosen Test.</p>
+    <p class="uk-margin-medium-top">
+      <a class="uk-button uk-button-primary uk-margin-small-right" href="https://calendly.com/calhelp/calserver-vorstellung" target="_blank" rel="noopener">Demo buchen</a>
+      <a id="trial" class="uk-button uk-button-default" href="#!">Kostenlos testen</a>
+    </p>
+    <p class="muted uk-text-small uk-margin-small">* Demo-Zugang und Testumgebung nach kurzer Abstimmung.</p>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="uk-section uk-section-muted">
+  <div class="uk-container">
+    <div class="uk-grid-large" uk-grid>
+      <div class="uk-width-1-2@m">
+        <h4>calServer</h4>
+        <p class="muted">Cloud-Software für Kalibrier- und Inventarverwaltung – entwickelt in Deutschland.</p>
+      </div>
+      <div class="uk-width-1-4@m">
+        <h5>Produkt</h5>
+        <ul class="uk-list uk-link-text">
+          <li><a href="#features">Funktionen</a></li>
+          <li><a href="#modules">Module</a></li>
+          <li><a href="#usecases">Anwendungsfälle</a></li>
+          <li><a href="#pricing">Preise</a></li>
+        </ul>
+      </div>
+      <div class="uk-width-1-4@m">
+        <h5>Rechtliches</h5>
+        <ul class="uk-list uk-link-text">
+          <li><a href="{{ basePath }}/impressum">Impressum</a></li>
+          <li><a href="{{ basePath }}/datenschutz">Datenschutz</a></li>
+          <li><a href="{{ basePath }}/lizenz">AGB</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="uk-text-center uk-text-small muted uk-margin-top">© 2025 calHelp Inh. René Buske – Alle Rechte vorbehalten.</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/tests/Controller/CalserverControllerTest.php
+++ b/tests/Controller/CalserverControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class CalserverControllerTest extends TestCase
+{
+    public function testCalserverPage(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/calserver');
+        $request = $request->withUri($request->getUri()->withHost('main.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('calServer – Marketingseite', $body);
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+
+    public function testCalserverPageTenant(): void
+    {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/calserver');
+        $request = $request->withUri($request->getUri()->withHost('tenant.main.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(404, $response->getStatusCode());
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a standalone Twig template with the full calServer UIkit preview markup
- register a /calserver marketing route restricted to the main domain via a new controller
- cover the new page with controller/domain tests and allow it in robots.txt

## Testing
- vendor/bin/phpunit --filter CalserverControllerTest
- vendor/bin/phpunit --filter DomainAccessTest

------
https://chatgpt.com/codex/tasks/task_e_68d05d2a86dc832b89d691ac4893d01f