### PR TITLE
Synchronize calServer marketing page with landing theme

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1,0 +1,151 @@
+/* calServer marketing overrides for landing layout */
+
+body.qr-landing.calserver-theme {
+    --calserver-primary: #1f63e6;
+    scroll-behavior: smooth;
+}
+
+body.qr-landing.calserver-theme:not(.high-contrast) {
+    --qr-landing-primary: var(--calserver-primary);
+    --qr-hero-grad-start: #0b101a;
+    --qr-hero-grad-end: color-mix(in oklab, var(--calserver-primary) 70%, #0b101a 30%);
+    --qr-hero-gradient: linear-gradient(
+        135deg,
+        var(--qr-hero-grad-start) 0%,
+        color-mix(in oklab, var(--calserver-primary) 55%, #111827 45%) 100%
+    );
+}
+
+body.qr-landing.calserver-theme:not(.high-contrast) .hero-bg-calserver {
+    background:
+        radial-gradient(
+            580px 360px at 0% 0%,
+            color-mix(in oklab, var(--calserver-primary) 40%, transparent),
+            transparent
+        ),
+        radial-gradient(
+            520px 320px at 100% 0%,
+            color-mix(in oklab, var(--calserver-primary) 30%, transparent),
+            transparent
+        ),
+        var(--qr-hero-gradient);
+    background-color: var(--qr-hero-grad-start);
+}
+
+body.qr-landing.calserver-theme .hero-list li {
+    color: var(--qr-muted);
+}
+
+body.qr-landing.calserver-theme .pill {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+body.qr-landing.calserver-theme .pill--soft {
+    background: color-mix(in oklab, var(--calserver-primary) 15%, transparent);
+    color: var(--qr-landing-primary);
+}
+
+body.qr-landing.calserver-theme .pill--accent {
+    background: var(--qr-card);
+    color: var(--qr-landing-primary);
+    box-shadow: 0 6px 18px -10px rgba(0, 0, 0, 0.45);
+}
+
+body.qr-landing.calserver-theme .pill--badge {
+    background: rgba(255, 255, 255, 0.86);
+    color: color-mix(in oklab, var(--calserver-primary) 70%, #0c1a3a 30%);
+    border: 1px solid rgba(255, 255, 255, 0.6);
+}
+
+body.qr-landing.calserver-theme .shadow-soft {
+    box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.35),
+        0 12px 24px -18px rgba(15, 23, 42, 0.25);
+    border-radius: 18px;
+}
+
+body.qr-landing.calserver-theme .badge-card {
+    padding: 14px 12px;
+    border-radius: 12px;
+    background: var(--qr-card);
+    box-shadow: 0 10px 26px -20px rgba(15, 23, 42, 0.45);
+    font-weight: 600;
+}
+
+body.qr-landing.calserver-theme .logo-chip {
+    background: rgba(255, 255, 255, 0.16);
+    border-radius: 12px;
+    padding: 18px 12px;
+    text-align: center;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+body.qr-landing.calserver-theme .muted {
+    color: color-mix(in oklab, var(--qr-text) 60%, var(--qr-bg) 40%);
+}
+
+body.qr-landing.calserver-theme .quick-cta {
+    border-radius: 18px;
+    background: color-mix(in oklab, var(--calserver-primary) 10%, transparent);
+    padding: 24px 32px;
+}
+
+body.qr-landing.calserver-theme .uk-card-hover {
+    transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+body.qr-landing.calserver-theme .uk-card-hover:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 22px 48px -28px rgba(15, 23, 42, 0.45);
+}
+
+body.qr-landing.calserver-theme .scenario-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+    margin: 32px 0 24px;
+    padding: 0;
+    list-style: none;
+}
+
+body.qr-landing.calserver-theme .scenario-cloud li a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--calserver-primary) 12%, transparent);
+    color: var(--qr-landing-primary);
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 180ms ease, color 180ms ease,
+        box-shadow 180ms ease;
+}
+
+body.qr-landing.calserver-theme .scenario-cloud li a:hover,
+body.qr-landing.calserver-theme .scenario-cloud li a:focus {
+    background: var(--qr-landing-primary);
+    color: #fff;
+    box-shadow: 0 12px 24px -18px rgba(31, 99, 230, 0.85);
+}
+
+body.qr-landing.calserver-theme .feature-usecase-slider .uk-card {
+    min-height: 270px;
+}
+
+body.qr-landing.calserver-theme .testimonial-card {
+    min-height: 240px;
+}
+
+@media (max-width: 959px) {
+    body.qr-landing.calserver-theme .quick-cta {
+        padding: 20px;
+    }
+}

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -1,887 +1,819 @@
-<!DOCTYPE html>
-<html lang="de">
-<head>
-  <meta charset="UTF-8" />
-  <title>calServer – Marketingseite (UIkit Vorschau)</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="canonical" href="{{ canonicalUrl }}" />
-  <!-- UIkit -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.17.10/dist/css/uikit.min.css" />
-  <script src="https://cdn.jsdelivr.net/npm/uikit@3.17.10/dist/js/uikit.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/uikit@3.17.10/dist/js/uikit-icons.min.js"></script>
-  <style>
-    :root {
-      --brand-primary: #1f63e6;
-      --brand-primary-dark: #154bb4;
-    }
+{% extends 'layout.twig' %}
 
-    body {
-      scroll-behavior: smooth;
-    }
+{% set links = [
+    { 'href': '#features', 'label': 'Funktionen', 'icon': 'grid' },
+    { 'href': '#modules', 'label': 'Module', 'icon': 'database' },
+    { 'href': '#usecases', 'label': 'Anwendungsfälle', 'icon': 'users' },
+    { 'href': '#modes', 'label': 'Betriebsarten', 'icon': 'cog' },
+    { 'href': '#pricing', 'label': 'Preise', 'icon': 'credit-card' },
+    { 'href': '#faq', 'label': 'FAQ', 'icon': 'question' }
+] %}
 
-    .pill {
-      display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 999px;
-      font-size: 0.8rem;
-      font-weight: 600;
-      letter-spacing: 0.02em;
-    }
+{% block title %}calServer – Kalibrier- und Inventarverwaltung für Teams{% endblock %}
 
-    .pill--soft {
-      background: rgba(31, 99, 230, 0.08);
-      color: var(--brand-primary);
-    }
+{% block head %}
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap"
+        rel="stylesheet">
+  <link rel="preload" href="{{ basePath }}/css/landing.css" as="style">
+  <link rel="stylesheet" href="{{ basePath }}/css/landing.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/calserver.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/onboarding.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/topbar.landing.css">
+{% endblock %}
 
-    .pill--accent {
-      background: #fff;
-      color: var(--brand-primary);
-      box-shadow: 0 6px 18px -10px rgba(0, 0, 0, 0.5);
-    }
+{% block body_theme %}dark{% endblock %}
+{% block body_class %}qr-landing dark-mode calserver-theme{% endblock %}
 
-    .pill--badge {
-      background: rgba(255, 255, 255, 0.86);
-      color: var(--brand-primary-dark);
-      border: 1px solid rgba(255, 255, 255, 0.6);
-    }
+{% block body %}
+  <div class="landing-content">
+    <header class="qr-topbar">
+      <nav class="uk-navbar-container" uk-navbar>
+        <div class="uk-navbar-left">
+          <div class="uk-navbar-item">
+            <button id="offcanvas-toggle"
+                    class="uk-navbar-toggle uk-hidden@m git-btn"
+                    uk-navbar-toggle-icon
+                    uk-toggle="target: #qr-offcanvas"
+                    aria-controls="qr-offcanvas"
+                    aria-expanded="false"
+                    aria-label="Menü"></button>
+            <a class="uk-logo" href="{{ basePath }}/calserver">calServer</a>
+          </div>
+        </div>
+        <div class="uk-navbar-right">
+          <ul class="uk-navbar-nav uk-visible@m">
+            {% for link in links %}
+              <li>
+                <a href="{{ link.href }}">
+                  <span class="uk-margin-small-right" uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+          <a class="uk-navbar-item btn btn-black top-cta uk-visible@m"
+             href="https://calendly.com/calhelp/calserver-vorstellung"
+             target="_blank"
+             rel="noopener">
+            <span class="uk-margin-small-right" uk-icon="icon: calendar"></span>Demo buchen
+          </a>
+          <div class="uk-navbar-item config-menu uk-inline">
+            <button id="configMenuToggle"
+                    type="button"
+                    class="uk-button uk-button-default git-btn"
+                    aria-label="Konfiguration"
+                    aria-expanded="false">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M19.14 12.94a7.5 7.5 0 0 0 .05-.94 7.5 7.5 0 0 0-.05-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.33a.5.5 0 0 0-.6-.22l-2.39.96a7.6 7.6 0 0 0-1.63-.94l-.36-2.54a.5.5 0 0 0-.5-.43h-3.84a.5.5 0 0 0-.5.43l-.36 2.54c-.57.24-1.12.55-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.7 7.84a.5.5 0 0 0 .12.64l2.03 1.58c-.03.31-.05.63-.05.94s.02.63.05.94L2.82 13.5a.5.5 0 0 0-.12.64l1.92 3.33a.5.5 0 0 0 .6.22l2.39-.96c.51.39 1.06.7 1.63.94l.36 2.54a.5.5 0 0 0 .5.43h3.84a.5.5 0 0 0 .5-.43l.36-2.54c.57-.24 1.12-.55 1.63-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.33a.5.5 0 0 0-.12-.64l-2.03-1.58ZM12 15.5A3.5 3.5 0 1 1 12 8.5a3.5 3.5 0 0 1 0 7Z"
+                      fill="currentColor"/>
+              </svg>
+            </button>
+            <div id="menuDrop"
+                 class="uk-dropdown"
+                 hidden
+                 uk-dropdown="mode: click; pos: bottom-right; flip: false; animation: uk-animation-slide-top-small">
+              <ul class="uk-nav uk-dropdown-nav" role="menu">
+                <li>
+                  <button id="themeToggle"
+                          class="uk-button uk-button-default git-btn theme-toggle"
+                          aria-label="Design umschalten"
+                          role="menuitem">
+                    <span id="themeIcon" aria-hidden="true"></span>
+                  </button>
+                </li>
+                <li>
+                  <button id="accessibilityToggle"
+                          class="uk-button uk-button-default git-btn accessibility-toggle"
+                          aria-label="Kontrast umschalten"
+                          role="menuitem">
+                    <span id="accessibilityIcon" aria-hidden="true"></span>
+                  </button>
+                </li>
+                <li>
+                  <div class="uk-inline">
+                    <button id="languageMenuToggle"
+                            type="button"
+                            class="uk-button uk-button-default git-btn"
+                            aria-label="{{ t('language_toggle') }}"
+                            aria-expanded="false"
+                            role="menuitem">
+                      <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm6.93 6h-2.54c-.11-1.47-.43-2.87-.92-4.17 1.84.69 3.29 2.1 4.05 3.84zM12 4c.96 1.18 1.62 2.64 1.88 4H10.12c.26-1.36.92-2.82 1.88-4zM4.26 14c-.17-.64-.26-1.31-.26-2s.09-1.36.26-2h3.09c-.07.66-.11 1.32-.11 2s.04 1.34.11 2H4.26zm.81 2h2.54c.11 1.47.43 2.87.92 4.17-1.84-.69-3.29-2.1-4.05-3.84zm2.54-8H5.07c.76-1.74 2.21-3.15 4.05-3.84-.49 1.3-.81 2.7-.92 4.17zM12 20c-.96-1.18-1.62-2.64-1.88-4h3.76c-.26 1.36-.92 2.82-1.88 4zm2.62-6H9.38c-.08-.66-.12-1.32-.12-2s.04-1.34.12-2h5.24c.08.66.12 1.32.12 2s-.04 1.34-.12 2zm.81 6c.49-1.3.81-2.7.92-4.17h2.54c-.76 1.74-2.21 3.15-4.05 3.84zM16.65 14c.07-.66.11-1.32.11-2s-.04-1.34-.11-2h3.09c.17.64.26 1.31.26 2s-.09 1.36-.26 2h-3.09z"
+                              fill="currentColor"/>
+                      </svg>
+                    </button>
+                    <div id="languageDrop" class="uk-dropdown" hidden uk-dropdown="mode: click; pos: left-top; offset: 0">
+                      <ul class="uk-nav uk-dropdown-nav" role="menu">
+                        <li>
+                          <button class="uk-button uk-button-default git-btn lang-option"
+                                  data-lang="de"
+                                  role="menuitem">{{ t('german') }}</button>
+                        </li>
+                        <li>
+                          <button class="uk-button uk-button-default git-btn lang-option"
+                                  data-lang="en"
+                                  role="menuitem">{{ t('english') }}</button>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </nav>
+    </header>
 
-    .shadow-soft {
-      box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.35), 0 12px 24px -18px rgba(15, 23, 42, 0.25);
-      border-radius: 18px;
-    }
-
-    .badge-card {
-      padding: 14px 12px;
-      border-radius: 12px;
-      background: #fff;
-      box-shadow: 0 10px 26px -20px rgba(15, 23, 42, 0.45);
-      font-weight: 600;
-    }
-
-    .logo-chip {
-      background: rgba(255, 255, 255, 0.15);
-      border-radius: 12px;
-      padding: 18px 12px;
-      text-align: center;
-      font-weight: 600;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-    }
-
-    .uk-button-primary,
-    .uk-button-primary:focus,
-    .uk-button-primary:hover {
-      background-color: var(--brand-primary);
-      border-color: var(--brand-primary);
-      color: #fff;
-    }
-
-    .uk-link-text > a,
-    .uk-link-text a {
-      color: inherit;
-    }
-
-    .uk-section-primary {
-      background: linear-gradient(135deg, rgba(31, 99, 230, 0.92), rgba(21, 75, 180, 0.95));
-    }
-
-    .uk-card-primary {
-      background: var(--brand-primary);
-    }
-
-    .uk-card-primary .uk-card-title,
-    .uk-card-primary p,
-    .uk-card-primary li,
-    .uk-card-primary h3 {
-      color: #fff;
-    }
-
-    .muted {
-      color: #6b7280;
-    }
-
-    .testimonial-card {
-      min-height: 240px;
-    }
-
-    .uk-section {
-      padding-top: 88px;
-      padding-bottom: 88px;
-    }
-
-    .uk-navbar-container {
-      border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-    }
-
-    .quick-cta {
-      border-radius: 18px;
-      background: rgba(31, 99, 230, 0.08);
-      padding: 24px 32px;
-    }
-
-    .uk-card-hover {
-      transition: transform 220ms ease, box-shadow 220ms ease;
-    }
-
-    .uk-card-hover:hover {
-      transform: translateY(-6px);
-      box-shadow: 0 22px 48px -28px rgba(15, 23, 42, 0.45);
-    }
-
-    .scenario-cloud {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-      justify-content: center;
-      margin: 32px 0 24px;
-      padding: 0;
-      list-style: none;
-    }
-
-    .scenario-cloud li a {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 10px 18px;
-      border-radius: 999px;
-      background: rgba(31, 99, 230, 0.08);
-      color: var(--brand-primary);
-      font-weight: 600;
-      text-decoration: none;
-      transition: background-color 180ms ease, color 180ms ease, box-shadow 180ms ease;
-    }
-
-    .scenario-cloud li a:hover,
-    .scenario-cloud li a:focus {
-      background: var(--brand-primary);
-      color: #fff;
-      box-shadow: 0 12px 24px -18px rgba(31, 99, 230, 0.85);
-    }
-
-    .feature-usecase-slider .uk-card {
-      min-height: 270px;
-    }
-  </style>
-</head>
-<body>
-
-<!-- HEADER -->
-<nav class="uk-navbar-container" uk-navbar>
-  <div class="uk-container uk-container-expand">
-    <div class="uk-navbar-left">
-      <a class="uk-navbar-item uk-logo" href="{{ basePath }}/calserver">
-        <span uk-icon="icon: grid; ratio: 1.1" class="uk-margin-small-right" style="color: var(--brand-primary);"></span> calServer
-      </a>
-    </div>
-    <div class="uk-navbar-right">
-      <ul class="uk-navbar-nav uk-visible@m">
-        <li><a href="#features">Funktionen</a></li>
-        <li><a href="#modules">Module</a></li>
-        <li><a href="#usecases">Anwendungsfälle</a></li>
-        <li><a href="#modes">Betriebsarten</a></li>
-        <li><a href="#pricing">Preise</a></li>
-        <li><a href="#faq">FAQ</a></li>
-      </ul>
-      <div class="uk-navbar-item">
-        <a class="uk-button uk-button-default uk-margin-small-right" href="#demo">Demo buchen</a>
-        <a class="uk-button uk-button-primary" href="#trial">Jetzt testen</a>
-      </div>
-      <a class="uk-navbar-toggle uk-hidden@m" uk-navbar-toggle-icon href="#offcanvas" uk-toggle></a>
-    </div>
-  </div>
-</nav>
-
-<div id="offcanvas" uk-offcanvas="overlay:true">
-  <div class="uk-offcanvas-bar">
-    <button class="uk-offcanvas-close" type="button" uk-close></button>
-    <ul class="uk-nav uk-nav-default">
-      <li class="uk-nav-header">Navigation</li>
-      <li><a href="#features">Funktionen</a></li>
-      <li><a href="#modules">Module</a></li>
-      <li><a href="#usecases">Anwendungsfälle</a></li>
-      <li><a href="#modes">Betriebsarten</a></li>
-      <li><a href="#pricing">Preise</a></li>
-      <li><a href="#faq">FAQ</a></li>
-      <li class="uk-nav-divider"></li>
-      <li><a href="#demo">Demo buchen</a></li>
-      <li><a href="#trial">Jetzt testen</a></li>
-    </ul>
-  </div>
-</div>
-
-<!-- HERO -->
-<section class="uk-section uk-section-default uk-section-large">
-  <div class="uk-container">
-    <div class="uk-grid-large uk-flex-middle" uk-grid>
-      <div class="uk-width-1-2@m" uk-scrollspy="cls: uk-animation-slide-left-small; repeat: true">
-        <span class="pill pill--soft uk-margin-small-bottom">Software Hosted in Germany</span>
-        <h1 class="uk-heading-medium uk-margin-small-top">
-          <span class="uk-text-primary">Mehr Überblick,</span> weniger Aufwand.
-        </h1>
-        <p class="uk-text-lead">Geräte, Termine und Dokumente – organisiert an einem Ort. calServer strukturiert Ihre Kalibrier- und Inventarverwaltung für das ganze Team.</p>
-        <ul class="uk-list uk-list-bullet muted uk-margin-small">
-          <li>Fälligkeiten kommen zu dir, nicht umgekehrt.</li>
-          <li>Transparente Workflows für Labor, Service und Verwaltung.</li>
-          <li>In Deutschland betrieben, DSGVO-konform.</li>
+    <div id="qr-offcanvas" uk-offcanvas="overlay: true; flip: true">
+      <div class="uk-offcanvas-bar">
+        <button class="uk-offcanvas-close git-btn" type="button" uk-close aria-label="Menü schließen"></button>
+        <ul class="uk-nav uk-nav-default">
+          {% for link in links %}
+            <li>
+              <a href="{{ link.href }}">
+                <span class="uk-margin-small-right" uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+              </a>
+            </li>
+          {% endfor %}
         </ul>
+        <a class="uk-button uk-button-default git-btn uk-width-1-1 uk-margin-top offcanvas-cta"
+           href="https://calendly.com/calhelp/calserver-vorstellung"
+           target="_blank"
+           rel="noopener">
+          <span class="uk-margin-small-right" uk-icon="icon: calendar"></span>Demo buchen
+        </a>
+        <a class="uk-button uk-button-primary git-btn uk-width-1-1 uk-margin-top offcanvas-cta"
+           href="#trial">
+          <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt testen
+        </a>
+      </div>
+    </div>
+
+    <section class="qr-hero uk-section uk-section-large">
+      <div class="qr-hero-bg hero-bg-calserver" aria-hidden="true"></div>
+      <div class="uk-container">
+        <div class="uk-grid uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
+          <div uk-scrollspy="cls: uk-animation-slide-left-small; repeat: true">
+            <span class="qr-badge pill pill--soft">Software Hosted in Germany</span>
+            <h1 class="qr-h1">Mehr Überblick, weniger Aufwand mit calServer.</h1>
+            <p class="qr-sub">Geräte, Termine und Dokumente – organisiert an einem Ort. calServer strukturiert die
+              Kalibrier- und Inventarverwaltung für das ganze Team.</p>
+            <ul class="uk-list uk-list-bullet hero-list">
+              <li>Fälligkeiten kommen zu dir, nicht umgekehrt.</li>
+              <li>Transparente Workflows für Labor, Service und Verwaltung.</li>
+              <li>In Deutschland betrieben, DSGVO-konform.</li>
+            </ul>
+            <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
+              <a class="uk-button uk-button-primary cta-main" href="#trial">
+                <span class="uk-margin-small-right" uk-icon="icon: play"></span>Jetzt testen
+              </a>
+              <a class="btn btn-transparent" href="https://calendly.com/calhelp/calserver-vorstellung"
+                 target="_blank"
+                 rel="noopener">
+                <span class="uk-margin-small-right" uk-icon="icon: calendar"></span>Demo buchen
+              </a>
+            </div>
+            <div class="qr-proof uk-margin-top">
+              <span>Unbegrenzte Nutzer:innen · Flexible Rollenmodelle · Tägliche Datensicherung</span>
+            </div>
+          </div>
+          <div uk-scrollspy="cls: uk-animation-slide-right-small; repeat: true">
+            <div class="uk-card uk-card-default uk-card-body uk-text-center shadow-soft uk-position-relative">
+              <span class="pill pill--accent uk-position-absolute uk-position-top-right uk-margin-small">Live-Vorschau</span>
+              <div class="uk-height-medium uk-flex uk-flex-center uk-flex-middle uk-background-muted uk-border-rounded">
+                <span class="muted">[Dashboard-Mockup Platzhalter]</span>
+              </div>
+              <p class="uk-margin-small-top muted">Schnelle Suche · Klare Tabellen · Intuitive Workflows</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <div class="section-divider"></div>
+
+    <section class="uk-section uk-section-muted">
+      <div class="uk-container"
+           uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+        <div class="uk-child-width-1-2 uk-child-width-1-5@m uk-grid-small uk-text-center" uk-grid>
+          <div class="anim"><div class="badge-card">Hosting in Deutschland</div></div>
+          <div class="anim"><div class="badge-card">DSGVO-konform</div></div>
+          <div class="anim"><div class="badge-card">Software Made in Germany</div></div>
+          <div class="anim"><div class="badge-card">REST-API &amp; Webhooks</div></div>
+          <div class="anim"><div class="badge-card">Autom. Backups</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="uk-section uk-section-primary uk-light">
+      <div class="uk-container">
+        <div class="uk-flex uk-flex-middle uk-flex-between uk-margin-medium-bottom uk-flex-wrap">
+          <h2 class="uk-heading-line uk-light"><span>Vertrauen von Laboren, Service &amp; Industrie</span></h2>
+          <a class="uk-link-text" href="#usecases">Mehr Anwendungsfälle</a>
+        </div>
+        <div class="uk-position-relative uk-visible-toggle" tabindex="-1"
+             uk-slider="autoplay: true; autoplay-interval: 3800">
+          <ul class="uk-slider-items uk-child-width-1-3@s uk-child-width-1-6@m uk-grid-small">
+            <li><div class="logo-chip">AlphaLab</div></li>
+            <li><div class="logo-chip">NordWerk</div></li>
+            <li><div class="logo-chip">SolarTec</div></li>
+            <li><div class="logo-chip">PräziFit</div></li>
+            <li><div class="logo-chip">Metall IQ</div></li>
+            <li><div class="logo-chip">EnergiePro</div></li>
+          </ul>
+          <a class="uk-position-center-left uk-position-small" href="#"
+             uk-slidenav-previous
+             uk-slider-item="previous"
+             aria-label="Vorheriger Partner"></a>
+          <a class="uk-position-center-right uk-position-small" href="#"
+             uk-slidenav-next
+             uk-slider-item="next"
+             aria-label="Nächster Partner"></a>
+        </div>
+      </div>
+    </section>
+
+    <section id="features" class="uk-section uk-section-default uk-section-large">
+      <div class="uk-container">
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+          <h2 class="uk-heading-line"><span>Funktionen, die den Alltag erleichtern</span></h2>
+          <span class="muted">Scroll &amp; entdecke die wichtigsten Bereiche</span>
+        </div>
+        <div class="uk-margin-large-top">
+          <div class="uk-text-center uk-margin-medium-bottom">
+            <h3 class="uk-heading-bullet">Alltagsszenarien mit calServer</h3>
+            <p class="muted">So unterstützt die Plattform Teams bei wiederkehrenden Aufgaben – vom Labor bis zum
+              Außendienst.</p>
+          </div>
+          <ul class="scenario-cloud" aria-label="Alltagsszenarien">
+            <li><a href="#features">Kalibriertermine</a></li>
+            <li><a href="#features">Audit-Vorbereitung</a></li>
+            <li><a href="#features">Serviceeinsatz</a></li>
+            <li><a href="#features">Leihgeräte</a></li>
+            <li><a href="#features">Dokumente</a></li>
+            <li><a href="#features">Inventur</a></li>
+          </ul>
+          <div class="uk-position-relative uk-visible-toggle feature-usecase-slider"
+               tabindex="-1"
+               uk-slider="center: true; autoplay: true; autoplay-interval: 5200; finite: false">
+            <div class="uk-slider-container">
+              <ul class="uk-slider-items uk-child-width-1-1@s uk-child-width-1-3@m uk-grid-small">
+                <li>
+                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+                    <h3 class="uk-card-title">Kalibriertermine planen</h3>
+                    <p class="muted">Wartungen &amp; Prüfungen bleiben im Blick – egal wie groß der Gerätepool ist.</p>
+                    <ul class="uk-list uk-list-bullet">
+                      <li>Automatische Intervalle &amp; Eskalationen</li>
+                      <li>Teamaufgaben direkt zuweisen</li>
+                      <li>Export für externe Dienstleister</li>
+                    </ul>
+                  </div>
+                </li>
+                <li>
+                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+                    <h3 class="uk-card-title">Audit vorbereiten</h3>
+                    <p class="muted">Nachweise, Protokolle und Dokumente liegen sortiert an einem Ort.</p>
+                    <ul class="uk-list uk-list-bullet">
+                      <li>Versionierte Dokumentenablage</li>
+                      <li>Checklisten mit Freigabestatus</li>
+                      <li>Audit-Trail für Änderungen</li>
+                    </ul>
+                  </div>
+                </li>
+                <li>
+                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+                    <h3 class="uk-card-title">Serviceeinsätze steuern</h3>
+                    <p class="muted">Tickets, Messwerte und Kommunikation laufen sauber zusammen.</p>
+                    <ul class="uk-list uk-list-bullet">
+                      <li>Tickets mit SLA-Tracking</li>
+                      <li>Mobile Datenerfassung</li>
+                      <li>Serienmails für Rückfragen</li>
+                    </ul>
+                  </div>
+                </li>
+                <li>
+                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+                    <h3 class="uk-card-title">Leihgeräte koordinieren</h3>
+                    <p class="muted">Reservierungen bleiben transparent – Teams sehen Verfügbarkeiten live.</p>
+                    <ul class="uk-list uk-list-bullet">
+                      <li>Kalender mit Verfügbarkeiten</li>
+                      <li>Automatische Rückgabe-Erinnerung</li>
+                      <li>Übergabeprotokolle als PDF</li>
+                    </ul>
+                  </div>
+                </li>
+                <li>
+                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+                    <h3 class="uk-card-title">Dokumente verteilen</h3>
+                    <p class="muted">Relevante Infos landen beim richtigen Team – nachvollziehbar versioniert.</p>
+                    <ul class="uk-list uk-list-bullet">
+                      <li>Freigaben nach Rollen</li>
+                      <li>Teilbare Links &amp; Zugriffshistorie</li>
+                      <li>Serienmail mit Anhang-Vorlagen</li>
+                    </ul>
+                  </div>
+                </li>
+                <li>
+                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+                    <h3 class="uk-card-title">Inventur abschließen</h3>
+                    <p class="muted">Geräteakten bleiben vollständig und revisionssicher dokumentiert.</p>
+                    <ul class="uk-list uk-list-bullet">
+                      <li>Serien- &amp; Inventarnummern im Blick</li>
+                      <li>Historie mit Messwerten vereint</li>
+                      <li>Berichte als CSV/PDF exportieren</li>
+                    </ul>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <a class="uk-position-center-left uk-position-small" href="#"
+               uk-slidenav-previous
+               uk-slider-item="previous"
+               aria-label="Vorheriges Szenario"></a>
+            <a class="uk-position-center-right uk-position-small" href="#"
+               uk-slidenav-next
+               uk-slider-item="next"
+               aria-label="Nächstes Szenario"></a>
+          </div>
+        </div>
+        <div class="uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-large uk-grid-match"
+             uk-grid
+             uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">Inventare &amp; Intervalle</h3>
+              <p>Fälligkeiten kommen zu dir – Erinnerungen, Abrufe und Planungsübersichten sorgen für Ruhe.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Automatische Erinnerungslogik</li>
+                <li>Klare Statusfarben</li>
+                <li>Planungs-Dashboards</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-primary uk-card-body uk-card-hover uk-box-shadow-large">
+              <h3 class="uk-card-title">Kalibrierscheine digitalisieren</h3>
+              <p>Einfach hochladen, alles Weitere erledigt die Zuordnung mit Versionierung &amp; Vorschau.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Intelligente Dateinamen-Erkennung</li>
+                <li>Versionen &amp; Freigaben</li>
+                <li>Teilen per Link</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">E-Mail-Abrufe &amp; Erinnerungen</h3>
+              <p>Persönlich und planbar – Serien mit System statt Einzelmails.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Vorlagen &amp; Platzhalter</li>
+                <li>Zeitpläne je Zielgruppe</li>
+                <li>Versandprotokoll</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">Geräteverwaltung</h3>
+              <p>Ob 100 oder 100.000 Geräte – Suche, Filter und Gruppen bleiben schnell.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Schnellsuche &amp; Filter</li>
+                <li>Sets &amp; Zubehör</li>
+                <li>Exporte (CSV/PDF)</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">Kalibrier- &amp; Reparaturverwaltung</h3>
+              <p>Von Messwerten bis Bericht – ohne Medienbrüche, mit revisionssicheren Freigaben.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Messwerte erfassen/importieren</li>
+                <li>Bearbeitbare Übersichten</li>
+                <li>Berichte direkt erzeugen</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">Auftragsbearbeitung</h3>
+              <p>Ein Flow für alles: Angebot → Auftrag → Rechnung – mit eigenem Briefpapier.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Sammel- &amp; Teilrechnungen</li>
+                <li>Preislisten &amp; Nummernkreise</li>
+                <li>Automatische Status</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">Leihverwaltung</h3>
+              <p>Reservieren statt Telefonkette – Kalender auf, Gerät rein, fertig.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Drag-and-Drop Kalender</li>
+                <li>Zubehör-Sets</li>
+                <li>Rückgabe-Erinnerungen</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">Dokumentationen &amp; Wiki</h3>
+              <p>Wissen bleibt im Team – gepflegt, versioniert und durchsuchbar.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Editor mit Inhaltsverzeichnis</li>
+                <li>Versionen &amp; Berechtigungen</li>
+                <li>Interne Verlinkungen</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">Dateimanagement (DMS)</h3>
+              <p>„Nur speichern, nicht sortieren“ – Zuordnung läuft im Hintergrund.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Auto-Zuordnung</li>
+                <li>Versionierung</li>
+                <li>PDF-Viewer</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">Meldungen &amp; Tickets</h3>
+              <p>Alles an einem Ort: Anliegen, Verlauf, Benachrichtigungen.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Zentrales Ticketing</li>
+                <li>Teilnehmerwechsel</li>
+                <li>Benachrichtigungsketten</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
+              <h3 class="uk-card-title">Moderne Cloud-Basis</h3>
+              <p>Schnell, stabil und updatefreundlich – ohne großen Admin-Aufwand.</p>
+              <ul class="uk-list uk-list-bullet">
+                <li>Skalierbare Umgebung</li>
+                <li>Regelmäßige Updates</li>
+                <li>Tägliche Backups</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="uk-divider-icon">
+
+    <section id="modules" class="uk-section uk-section-muted">
+      <div class="uk-container">
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+          <h2 class="uk-heading-line"><span>Module, die den Unterschied machen</span></h2>
+          <span class="muted">Individuell kombinierbar – ohne versteckte Kosten</span>
+        </div>
+        <div class="uk-child-width-1-1 uk-child-width-1-2@m uk-grid-large uk-grid-match"
+             uk-grid
+             uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+              <h3 class="uk-card-title">Geräteverwaltung &amp; Historie</h3>
+              <p class="muted">Geräteakten, Anhänge und Historie in einer Oberfläche – inklusive Messwerten.</p>
+              <ul class="uk-list uk-list-bullet muted">
+                <li>Geräte- &amp; Standortverwaltung</li>
+                <li>Versionierte Dokumente &amp; Bilder</li>
+                <li>Messwerte direkt verknüpfen</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+              <h3 class="uk-card-title">Kalender &amp; Ressourcen</h3>
+              <p class="muted">Planung von Terminen, Leihgeräten und Personal in einer Ansicht.</p>
+              <ul class="uk-list uk-list-bullet muted">
+                <li>Gantt &amp; Kalender</li>
+                <li>Verfügbarkeits-Check in Echtzeit</li>
+                <li>Outlook/iCal-Integration</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+              <h3 class="uk-card-title">Auftrags- &amp; Ticketverwaltung</h3>
+              <p class="muted">Vom Auftrag bis zur Rechnung – mit klaren Status, Workflows und Dokumenten.</p>
+              <ul class="uk-list uk-list-bullet muted">
+                <li>Service &amp; Ticketsystem</li>
+                <li>Angebote, Aufträge, Rechnungen</li>
+                <li>Eskalationen &amp; SLAs</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+              <h3 class="uk-card-title">Self-Service &amp; Extranet</h3>
+              <p class="muted">Stellen Sie Kunden &amp; Partnern Geräteinfos, Zertifikate und Formulare bereit.</p>
+              <ul class="uk-list uk-list-bullet muted">
+                <li>Kundenportale</li>
+                <li>Dokumente &amp; Zertifikate</li>
+                <li>Individuelle Rechte</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="usecases" class="uk-section uk-section-default">
+      <div class="uk-container">
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+          <h2 class="uk-heading-line"><span>Anwendungsfälle aus der Praxis</span></h2>
+          <span class="muted">Vom Labor bis zum Außendienst</span>
+        </div>
+        <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-large uk-grid-match"
+             uk-grid
+             uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover testimonial-card">
+              <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
+              <h3 class="uk-card-title">Kalibrierlabor Dr. Keller</h3>
+              <p>„Wir haben mehr als 5.000 Geräteakten – calServer sorgt dafür, dass nichts untergeht."</p>
+              <ul class="uk-list uk-list-bullet muted">
+                <li>Workflows für Kalibrieraufträge</li>
+                <li>Digitale Übergabedokumente</li>
+                <li>Kundenportal inklusive</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover testimonial-card">
+              <span class="pill pill--badge uk-margin-small-bottom">Industrielabor</span>
+              <h3 class="uk-card-title">Industriepartner NordWerk</h3>
+              <p>„Inventur, Wartung, Arbeitssicherheit – alles im Blick, in einem Dashboard.“</p>
+              <ul class="uk-list uk-list-bullet muted">
+                <li>Inventur mit mobilen Geräten</li>
+                <li>Rollen- &amp; Rechteverwaltung</li>
+                <li>Auditberichte auf Knopfdruck</li>
+              </ul>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover testimonial-card">
+              <span class="pill pill--badge uk-margin-small-bottom">Service &amp; Außendienst</span>
+              <h3 class="uk-card-title">Service-Team EnergiePro</h3>
+              <p>„Mobile Tickets und Dokumentation sparen uns pro Einsatz mehrere Stunden.“</p>
+              <ul class="uk-list uk-list-bullet muted">
+                <li>Mobile Checklisten</li>
+                <li>Offline-Fähigkeit</li>
+                <li>Digitale Unterschriften</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="modes" class="uk-section uk-section-primary uk-light">
+      <div class="uk-container">
+        <h2 class="uk-heading-line uk-light"><span>Betriebsarten, die zu Ihnen passen</span></h2>
+        <ul class="uk-subnav uk-subnav-pill uk-margin" uk-switcher>
+          <li><a href="#">Cloud</a></li>
+          <li><a href="#">On-Premise</a></li>
+        </ul>
+        <ul class="uk-switcher uk-margin"
+            uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" uk-grid>
+              <div class="anim">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+                  <h3 class="uk-card-title">Sofort startklar</h3>
+                  <ul class="uk-list uk-list-bullet muted">
+                    <li>Bereitstellung in wenigen Tagen</li>
+                    <li>Automatisierte Updates &amp; Monitoring</li>
+                    <li>Backup-Strategie inklusive</li>
+                  </ul>
+                </div>
+              </div>
+              <div class="anim">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+                  <h3 class="uk-card-title">Sicher &amp; skalierbar</h3>
+                  <ul class="uk-list uk-list-bullet muted">
+                    <li>Rechenzentrum in Deutschland</li>
+                    <li>ISO 27001 zertifizierte Infrastruktur</li>
+                    <li>Flexible Nutzer:innenzahlen</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" uk-grid>
+              <div class="anim">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+                  <h3 class="uk-card-title">Volle Kontrolle</h3>
+                  <ul class="uk-list uk-list-bullet muted">
+                    <li>Betrieb im eigenen Netzwerk</li>
+                    <li>Unterstützung bei Installation &amp; Updates</li>
+                    <li>Integration in bestehende Systeme</li>
+                  </ul>
+                </div>
+              </div>
+              <div class="anim">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+                  <h3 class="uk-card-title">Individuelle Sicherheit</h3>
+                  <ul class="uk-list uk-list-bullet muted">
+                    <li>Anbindung an Ihr Identity-Management</li>
+                    <li>Flexible Backup- und Wartungsfenster</li>
+                    <li>Support per SLA vereinbar</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="pricing" class="uk-section uk-section-default">
+      <div class="uk-container">
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+          <h2 class="uk-heading-line"><span>Preise, die Klarheit schaffen</span></h2>
+          <span class="muted">Ehrlich, transparent, ohne versteckte Kosten.</span>
+        </div>
+        <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-large uk-grid-match"
+             uk-grid
+             uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
+              <h3>Standard</h3>
+              <p class="muted">Die solide Basis für kleine Teams.</p>
+              <p class="uk-text-large uk-text-bold">ab 250 €/Monat</p>
+              <ul class="uk-list uk-list-bullet uk-text-left muted">
+                <li>Bis 2 Mandanten</li>
+                <li>Alle Kernmodule inklusive</li>
+                <li>E-Mail-Support innerhalb von 24 h</li>
+              </ul>
+              <a class="uk-button uk-button-default" href="#offer">Unverbindliches Angebot</a>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-primary uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative">
+              <span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Empfohlen</span>
+              <h3>Performance</h3>
+              <p>Für größere Teams mit mehr Tempo.</p>
+              <p class="uk-text-large uk-text-bold">auf Anfrage</p>
+              <ul class="uk-list uk-list-bullet uk-text-left">
+                <li>Unbegrenzte Nutzer:innen</li>
+                <li>Erweiterte Automatisierungen</li>
+                <li>Priorisierter Support &amp; SLA</li>
+              </ul>
+              <a class="uk-button uk-button-default" href="#offer">Beratung anfragen</a>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
+              <h3>Enterprise</h3>
+              <p class="muted">Individuell zugeschnitten auf Ihre Prozesse.</p>
+              <p class="uk-text-large uk-text-bold">individuell</p>
+              <ul class="uk-list uk-list-bullet uk-text-left muted">
+                <li>Eigene Mandanten-Strukturen</li>
+                <li>On-Premise oder Hybrid</li>
+                <li>Integrationen &amp; Projektbegleitung</li>
+              </ul>
+              <a class="uk-button uk-button-default" href="#offer">Angebot anfordern</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="uk-section uk-section-muted">
+      <div class="uk-container">
+        <h2 class="uk-heading-line"><span>Häufige Fragen</span></h2>
+        <ul uk-accordion>
+          <li>
+            <a class="uk-accordion-title" href="#">Wie schnell bin ich mit der Cloud-Version startklar?</a>
+            <div class="uk-accordion-content">
+              <p>In der Regel innerhalb weniger Tage – wir begleiten den Kick-off persönlich.</p>
+            </div>
+          </li>
+          <li>
+            <a class="uk-accordion-title" href="#">Kann ich zwischen Cloud und On-Premise wechseln?</a>
+            <div class="uk-accordion-content">
+              <p>Ja, ein Wechsel ist jederzeit möglich. Wir unterstützen bei Migration und Datenübernahme.</p>
+            </div>
+          </li>
+          <li>
+            <a class="uk-accordion-title" href="#">Welche Datenimporte sind möglich?</a>
+            <div class="uk-accordion-content">
+              <p>Excel/CSV-Importe, API-Schnittstellen sowie individuelle Integrationen.</p>
+            </div>
+          </li>
+          <li>
+            <a class="uk-accordion-title" href="#">Wie funktioniert der Support?</a>
+            <div class="uk-accordion-content">
+              <p>Support per E-Mail, Telefon oder Ticketsystem – je nach Paket sogar mit SLA.</p>
+            </div>
+          </li>
+          <li>
+            <a class="uk-accordion-title" href="#">Was passiert mit meinen Daten nach dem Test?</a>
+            <div class="uk-accordion-content">
+              <p>Nach Testende entscheiden Sie: weiter nutzen, exportieren oder löschen lassen – ganz transparent.</p>
+            </div>
+          </li>
+        </ul>
+        <div class="uk-margin-top">
+          <span class="muted">Noch nicht fündig geworden?</span>
+          <a class="uk-margin-small-left" href="{{ basePath }}/kontakt">Weitere Fragen → Kontakt</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="demo" class="uk-section uk-section-primary uk-light uk-text-center">
+      <div class="uk-container">
+        <h3 class="uk-heading-small uk-margin-small">Bereit, calServer live zu erleben?</h3>
+        <p>Jetzt testen oder Demo buchen – wir zeigen, wie Ihre Prozesse in calServer aussehen.</p>
         <p class="uk-margin-medium-top">
-          <a class="uk-button uk-button-primary uk-margin-small-right" href="#trial">Jetzt testen</a>
-          <a class="uk-button uk-button-default" href="#demo">Demo buchen</a>
+          <a class="uk-button uk-button-default uk-margin-small-right"
+             href="https://calendly.com/calhelp/calserver-vorstellung"
+             target="_blank"
+             rel="noopener">Demo buchen</a>
+          <a id="trial" class="uk-button uk-button-primary" href="#offer">Jetzt testen</a>
         </p>
-        <p class="muted">Unbegrenzte Nutzer:innen · Flexible Rollenmodelle · Tägliche Datensicherung</p>
+        <p class="uk-text-small uk-margin-small">* Demo-Zugang und Testumgebung nach kurzer Abstimmung.</p>
       </div>
-      <div class="uk-width-1-2@m" uk-scrollspy="cls: uk-animation-slide-right-small; repeat: true">
-        <div class="uk-card uk-card-default uk-card-body uk-text-center shadow-soft uk-position-relative">
-          <span class="pill pill--accent uk-position-absolute uk-position-top-right uk-margin-small">Live-Vorschau</span>
-          <div class="uk-height-medium uk-flex uk-flex-center uk-flex-middle uk-background-muted uk-border-rounded">
-            <span class="muted">[Dashboard-Mockup Platzhalter]</span>
+    </section>
+
+    <section class="uk-section uk-section-default">
+      <div class="uk-container">
+        <div class="quick-cta uk-margin-large-bottom">
+          <div class="uk-grid-large uk-flex-middle" uk-grid>
+            <div class="uk-width-expand@m">
+              <h4 class="uk-margin-remove">Noch Fragen?</h4>
+              <p class="muted uk-margin-small">Schreiben Sie uns – wir beraten zu Betriebsart, Datenübernahme und Preisen.</p>
+            </div>
+            <div class="uk-width-auto@m">
+              <a class="uk-button uk-button-primary" href="{{ basePath }}/kontakt">Kontakt aufnehmen</a>
+            </div>
           </div>
-          <p class="uk-margin-small-top muted">Schnelle Suche · Klare Tabellen · Intuitive Workflows</p>
+        </div>
+        <div class="uk-grid-large" uk-grid>
+          <div class="uk-width-1-2@m">
+            <h4>calServer</h4>
+            <p class="muted">Cloud-Software für Kalibrier- und Inventarverwaltung – entwickelt in Deutschland.</p>
+          </div>
+          <div class="uk-width-1-4@m">
+            <h5>Produkt</h5>
+            <ul class="uk-list uk-link-text">
+              <li><a href="#features">Funktionen</a></li>
+              <li><a href="#modules">Module</a></li>
+              <li><a href="#usecases">Anwendungsfälle</a></li>
+              <li><a href="#pricing">Preise</a></li>
+            </ul>
+          </div>
+          <div class="uk-width-1-4@m">
+            <h5>Rechtliches</h5>
+            <ul class="uk-list uk-link-text">
+              <li><a href="{{ basePath }}/impressum">Impressum</a></li>
+              <li><a href="{{ basePath }}/datenschutz">Datenschutz</a></li>
+              <li><a href="{{ basePath }}/lizenz">AGB</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="uk-text-center uk-text-small muted uk-margin-top">
+          © 2025 calHelp Inh. René Buske – Alle Rechte vorbehalten.
         </div>
       </div>
-    </div>
+    </section>
   </div>
-</section>
+{% endblock %}
 
-<!-- TRUST BADGES -->
-<section class="uk-section uk-section-muted">
-  <div class="uk-container" uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
-    <div class="uk-child-width-1-2 uk-child-width-1-5@m uk-grid-small uk-text-center" uk-grid>
-      <div class="anim"><div class="badge-card">Hosting in Deutschland</div></div>
-      <div class="anim"><div class="badge-card">DSGVO-konform</div></div>
-      <div class="anim"><div class="badge-card">Software Made in Germany</div></div>
-      <div class="anim"><div class="badge-card">REST-API &amp; Webhooks</div></div>
-      <div class="anim"><div class="badge-card">Autom. Backups</div></div>
+{% block footer %}
+  <div class="footer-columns">
+    <div class="footer-section footer-about">
+      <strong>calServer</strong>
+      <p>Kalibrier- und Inventarverwaltung aus Deutschland – mit klaren Workflows und sicheren Prozessen.</p>
     </div>
-  </div>
-</section>
-
-<!-- LOGO SLIDER -->
-<section class="uk-section uk-section-primary uk-light">
-  <div class="uk-container">
-    <div class="uk-flex uk-flex-middle uk-flex-between uk-margin-medium-bottom uk-flex-wrap">
-      <h2 class="uk-heading-line uk-light"><span>Vertrauen von Laboren, Service &amp; Industrie</span></h2>
-      <a class="uk-link-text" href="#usecases">Mehr Anwendungsfälle</a>
+    <div class="footer-section footer-contact">
+      <strong>Kontakt</strong>
+      <p>
+        René Buske<br>
+        <a href="mailto:office@quizrace.app">office@quizrace.app</a><br>
+        <a href="tel:+4933203609080">+49&nbsp;33203&nbsp;609080</a>
+      </p>
     </div>
-    <div class="uk-position-relative uk-visible-toggle" tabindex="-1" uk-slider="autoplay: true; autoplay-interval: 3800">
-      <ul class="uk-slider-items uk-child-width-1-3@s uk-child-width-1-6@m uk-grid-small">
-        <li>
-          <div class="logo-chip">AlphaLab</div>
-        </li>
-        <li>
-          <div class="logo-chip">NordWerk</div>
-        </li>
-        <li>
-          <div class="logo-chip">SolarTec</div>
-        </li>
-        <li>
-          <div class="logo-chip">PräziFit</div>
-        </li>
-        <li>
-          <div class="logo-chip">Metall IQ</div>
-        </li>
-        <li>
-          <div class="logo-chip">EnergiePro</div>
-        </li>
+    <div class="footer-section footer-legal">
+      <strong>Rechtliches</strong>
+      <ul>
+        <li><a href="{{ basePath }}/impressum">{{ t('imprint') }}</a></li>
+        <li><a href="{{ basePath }}/datenschutz">{{ t('privacy') }}</a></li>
+        <li><a href="{{ basePath }}/lizenz">{{ t('license') }}</a></li>
       </ul>
-      <a class="uk-position-center-left uk-position-small" href="#" uk-slidenav-previous uk-slider-item="previous"></a>
-      <a class="uk-position-center-right uk-position-small" href="#" uk-slidenav-next uk-slider-item="next"></a>
     </div>
   </div>
-</section>
+{% endblock %}
 
-<!-- FEATURES -->
-<section id="features" class="uk-section uk-section-default uk-section-large">
-  <div class="uk-container">
-    <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
-      <h2 class="uk-heading-line"><span>Funktionen, die den Alltag erleichtern</span></h2>
-      <span class="muted">Scroll &amp; entdecke die wichtigsten Bereiche</span>
-    </div>
-    <div class="uk-margin-large-top">
-      <div class="uk-text-center uk-margin-medium-bottom">
-        <h3 class="uk-heading-bullet">Alltagsszenarien mit calServer</h3>
-        <p class="muted">So unterstützt die Plattform Teams bei wiederkehrenden Aufgaben – vom Labor bis zum Außendienst.</p>
-      </div>
-      <ul class="scenario-cloud" aria-label="Alltagsszenarien">
-        <li><a href="#features">Kalibriertermine</a></li>
-        <li><a href="#features">Audit-Vorbereitung</a></li>
-        <li><a href="#features">Serviceeinsatz</a></li>
-        <li><a href="#features">Leihgeräte</a></li>
-        <li><a href="#features">Dokumente</a></li>
-        <li><a href="#features">Inventur</a></li>
-      </ul>
-      <div class="uk-position-relative uk-visible-toggle feature-usecase-slider" tabindex="-1" uk-slider="center: true; autoplay: true; autoplay-interval: 5200; finite: false">
-        <div class="uk-slider-container">
-          <ul class="uk-slider-items uk-child-width-1-1@s uk-child-width-1-3@m uk-grid-small">
-            <li>
-              <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                <h3 class="uk-card-title">Kalibriertermine planen</h3>
-                <p class="muted">Wartungen &amp; Prüfungen bleiben im Blick – egal wie groß der Gerätepool ist.</p>
-                <ul class="uk-list uk-list-bullet">
-                  <li>Automatische Intervalle &amp; Eskalationen</li>
-                  <li>Teamaufgaben direkt zuweisen</li>
-                  <li>Export für externe Dienstleister</li>
-                </ul>
-              </div>
-            </li>
-            <li>
-              <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                <h3 class="uk-card-title">Audit vorbereiten</h3>
-                <p class="muted">Nachweise, Protokolle und Dokumente liegen sortiert an einem Ort.</p>
-                <ul class="uk-list uk-list-bullet">
-                  <li>Versionierte Dokumentenablage</li>
-                  <li>Checklisten mit Freigabestatus</li>
-                  <li>Audit-Trail für Änderungen</li>
-                </ul>
-              </div>
-            </li>
-            <li>
-              <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                <h3 class="uk-card-title">Serviceeinsätze steuern</h3>
-                <p class="muted">Tickets, Messwerte und Kommunikation laufen sauber zusammen.</p>
-                <ul class="uk-list uk-list-bullet">
-                  <li>Tickets mit SLA-Tracking</li>
-                  <li>Mobile Datenerfassung</li>
-                  <li>Serienmails für Rückfragen</li>
-                </ul>
-              </div>
-            </li>
-            <li>
-              <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                <h3 class="uk-card-title">Leihgeräte koordinieren</h3>
-                <p class="muted">Reservierungen bleiben transparent – Teams sehen Verfügbarkeiten live.</p>
-                <ul class="uk-list uk-list-bullet">
-                  <li>Kalender mit Verfügbarkeiten</li>
-                  <li>Automatische Rückgabe-Erinnerung</li>
-                  <li>Übergabeprotokolle als PDF</li>
-                </ul>
-              </div>
-            </li>
-            <li>
-              <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                <h3 class="uk-card-title">Dokumente verteilen</h3>
-                <p class="muted">Relevante Infos landen beim richtigen Team – nachvollziehbar versioniert.</p>
-                <ul class="uk-list uk-list-bullet">
-                  <li>Freigaben nach Rollen</li>
-                  <li>Teilbare Links &amp; Zugriffshistorie</li>
-                  <li>Serienmail mit Anhang-Vorlagen</li>
-                </ul>
-              </div>
-            </li>
-            <li>
-              <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                <h3 class="uk-card-title">Inventur abschließen</h3>
-                <p class="muted">Geräteakten bleiben vollständig und revisionssicher dokumentiert.</p>
-                <ul class="uk-list uk-list-bullet">
-                  <li>Serien- &amp; Inventarnummern im Blick</li>
-                  <li>Historie mit Messwerten vereint</li>
-                  <li>Berichte als CSV/PDF exportieren</li>
-                </ul>
-              </div>
-            </li>
-          </ul>
-        </div>
-        <a class="uk-position-center-left uk-position-small" href="#" uk-slidenav-previous uk-slider-item="previous" aria-label="Vorheriges Szenario"></a>
-        <a class="uk-position-center-right uk-position-small" href="#" uk-slidenav-next uk-slider-item="next" aria-label="Nächstes Szenario"></a>
-      </div>
-    </div>
-    <div class="uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-large uk-grid-match" uk-grid
-         uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Inventare &amp; Intervalle</h3>
-          <p>Fälligkeiten kommen zu dir – Erinnerungen, Abrufe und Planungsübersichten sorgen für Ruhe.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Automatische Erinnerungslogik</li>
-            <li>Klare Statusfarben</li>
-            <li>Planungs-Dashboards</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-primary uk-card-body uk-card-hover uk-box-shadow-large">
-          <h3 class="uk-card-title">Kalibrierscheine digitalisieren</h3>
-          <p>Einfach hochladen, alles Weitere erledigt die Zuordnung mit Versionierung &amp; Vorschau.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Intelligente Dateinamen-Erkennung</li>
-            <li>Versionen &amp; Freigaben</li>
-            <li>Teilen per Link</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">E-Mail-Abrufe &amp; Erinnerungen</h3>
-          <p>Persönlich und planbar – Serien mit System statt Einzelmails.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Vorlagen &amp; Platzhalter</li>
-            <li>Zeitpläne je Zielgruppe</li>
-            <li>Versandprotokoll</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Geräteverwaltung</h3>
-          <p>Ob 100 oder 100.000 Geräte – Suche, Filter und Gruppen bleiben schnell.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Schnellsuche &amp; Filter</li>
-            <li>Sets &amp; Zubehör</li>
-            <li>Exporte (CSV/PDF)</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Kalibrier- &amp; Reparaturverwaltung</h3>
-          <p>Von Messwerten bis Bericht – ohne Medienbrüche, mit revisionssicheren Freigaben.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Messwerte erfassen/importieren</li>
-            <li>Bearbeitbare Übersichten</li>
-            <li>Berichte direkt erzeugen</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Auftragsbearbeitung</h3>
-          <p>Ein Flow für alles: Angebot → Auftrag → Rechnung – mit eigenem Briefpapier.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Sammel- &amp; Teilrechnungen</li>
-            <li>Preislisten &amp; Nummernkreise</li>
-            <li>Automatische Status</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Leihverwaltung</h3>
-          <p>Reservieren statt Telefonkette – Kalender auf, Gerät rein, fertig.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Drag-and-Drop Kalender</li>
-            <li>Zubehör-Sets</li>
-            <li>Rückgabe-Erinnerungen</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Dokumentationen &amp; Wiki</h3>
-          <p>Wissen bleibt im Team – gepflegt, versioniert und durchsuchbar.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Editor mit Inhaltsverzeichnis</li>
-            <li>Versionen &amp; Berechtigungen</li>
-            <li>Interne Verlinkungen</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Dateimanagement (DMS)</h3>
-          <p>„Nur speichern, nicht sortieren“ – Zuordnung läuft im Hintergrund.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Auto-Zuordnung</li>
-            <li>Versionierung</li>
-            <li>PDF-Viewer</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Meldungen &amp; Tickets</h3>
-          <p>Alles an einem Ort: Anliegen, Verlauf, Benachrichtigungen.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Zentrales Ticketing</li>
-            <li>Teilnehmerwechsel</li>
-            <li>Benachrichtigungsketten</li>
-          </ul>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Moderne Cloud-Basis</h3>
-          <p>Schnell, stabil und updatefreundlich – ohne großen Admin-Aufwand.</p>
-          <ul class="uk-list uk-list-bullet">
-            <li>Skalierbare Umgebung</li>
-            <li>Regelmäßige Updates</li>
-            <li>Tägliche Backups</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<hr class="uk-divider-icon">
-
-<!-- MODULE -->
-<section id="modules" class="uk-section uk-section-muted">
-  <div class="uk-container">
-    <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
-      <h2 class="uk-heading-line"><span>Module, die den Unterschied machen</span></h2>
-      <span class="muted">Individuell kombinierbar – ohne versteckte Kosten</span>
-    </div>
-    <div class="uk-child-width-1-2@m uk-grid-large uk-grid-match" uk-grid
-         uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Abruflisten &amp; E-Mail-Erinnerungen</h3>
-          <p>Planbare Serien mit persönlicher Ansprache – so bleiben Fristen entspannt.</p>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Leihverwaltung</h3>
-          <p>Kalenderbasierte Buchungen für Geräte und Sets – inklusive Benachrichtigungen.</p>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-primary uk-card-body uk-card-hover uk-box-shadow-large">
-          <h3 class="uk-card-title">Tickets &amp; Meldungen</h3>
-          <p>Sichtbar für alle Beteiligten, nachvollziehbar für jedes Team – inklusive SLA-Tracking.</p>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-          <h3 class="uk-card-title">Benutzer &amp; Rollen</h3>
-          <p>Jede:r sieht nur das Wesentliche – flexibel, sicher, auditierbar.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- SCREEN SLIDESHOW -->
-<section id="screens" class="uk-section uk-section-primary uk-light">
-  <div class="uk-container">
-    <h2 class="uk-heading-line uk-light"><span>Screens &amp; Workflows im Überblick</span></h2>
-    <div class="uk-position-relative uk-visible-toggle" tabindex="-1" uk-slideshow="ratio: 16:9; animation: push">
-      <ul class="uk-slideshow-items">
-        <li>
-          <div class="uk-cover-container uk-flex uk-flex-center uk-flex-middle">
-            <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-text-center">
-              <h3 class="uk-card-title">Dashboard</h3>
-              <p class="muted">Live-KPIs zu Fälligkeiten, offenen Tickets und Auslastung.</p>
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="uk-cover-container uk-flex uk-flex-center uk-flex-middle">
-            <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-text-center">
-              <h3 class="uk-card-title">Kalibrierauftrag</h3>
-              <p class="muted">Schritt-für-Schritt-Workflow mit Messwerten und Freigaben.</p>
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="uk-cover-container uk-flex uk-flex-center uk-flex-middle">
-            <div class="uk-card uk-card-default uk-card-body uk-width-1-1 uk-text-center">
-              <h3 class="uk-card-title">Geräteakte</h3>
-              <p class="muted">Historie, Dokumente und Termine auf einen Blick.</p>
-            </div>
-          </div>
-        </li>
-      </ul>
-      <a class="uk-position-center-left uk-position-small" href="#" uk-slidenav-previous uk-slideshow-item="previous"></a>
-      <a class="uk-position-center-right uk-position-small" href="#" uk-slidenav-next uk-slideshow-item="next"></a>
-    </div>
-  </div>
-</section>
-
-<!-- USE CASE STORIES -->
-<section id="usecases" class="uk-section uk-section-default">
-  <div class="uk-container">
-    <h2 class="uk-heading-line"><span>Anwendungsfälle aus der Praxis</span></h2>
-    <div class="uk-margin-large" uk-grid="masonry: true">
-      <div class="uk-width-1-1">
-        <div class="uk-grid-large uk-flex-middle" uk-grid uk-scrollspy="cls: uk-animation-slide-bottom-small; repeat: true">
-          <div class="uk-width-1-2@m">
-            <span class="pill pill--soft uk-text-uppercase">Labor &amp; Prüfstände</span>
-            <h3 class="uk-heading-bullet">Laborverwaltung – Ordnung für Prüfstände &amp; Geräte.</h3>
-            <p class="muted">Kalibrierintervalle, Prüfprotokolle und Auslastungsplanung bleiben in einem System. Dashboards zeigen, welche Geräte als nächstes dran sind.</p>
-            <a class="uk-link-toggle" href="#demo"><span class="uk-link-heading">Mehr erfahren</span> <span uk-icon="icon: arrow-right"></span></a>
-          </div>
-          <div class="uk-width-1-2@m">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-large shadow-soft">
-              <div class="uk-height-medium uk-flex uk-flex-center uk-flex-middle uk-background-muted">
-                <span class="muted">[Labor-Kalender Mockup]</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="uk-width-1-1">
-        <div class="uk-grid-large uk-flex-middle uk-flex-right" uk-grid uk-scrollspy="cls: uk-animation-slide-bottom-small; repeat: true">
-          <div class="uk-width-1-2@m uk-flex-first@m">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-large shadow-soft">
-              <div class="uk-height-medium uk-flex uk-flex-center uk-flex-middle uk-background-muted">
-                <span class="muted">[Serviceauftrag Mockup]</span>
-              </div>
-            </div>
-          </div>
-          <div class="uk-width-1-2@m">
-            <span class="pill pill--soft uk-text-uppercase">Service &amp; Außendienst</span>
-            <h3 class="uk-heading-bullet">MET/TEAM Oberfläche – vertraut für Umsteiger:innen.</h3>
-            <p class="muted">Serviceaufträge, Checklisten und Messwerte wandern sauber ins System. Teams arbeiten synchron – auch mobil.</p>
-            <a class="uk-link-toggle" href="#demo"><span class="uk-link-heading">Mehr erfahren</span> <span uk-icon="icon: arrow-right"></span></a>
-          </div>
-        </div>
-      </div>
-      <div class="uk-width-1-1">
-        <div class="uk-grid-large uk-flex-middle" uk-grid uk-scrollspy="cls: uk-animation-slide-bottom-small; repeat: true">
-          <div class="uk-width-1-2@m">
-            <span class="pill pill--soft uk-text-uppercase">Industrie &amp; Energie</span>
-            <h3 class="uk-heading-bullet">Geräteverwaltung für Solar- &amp; Energieanlagen.</h3>
-            <p class="muted">Von Werkzeug bis Großanlage: Standorte, Wartungen und Sicherheitsprüfungen bleiben nachweisbar dokumentiert.</p>
-            <a class="uk-link-toggle" href="#demo"><span class="uk-link-heading">Mehr erfahren</span> <span uk-icon="icon: arrow-right"></span></a>
-          </div>
-          <div class="uk-width-1-2@m">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-large shadow-soft">
-              <div class="uk-height-medium uk-flex uk-flex-center uk-flex-middle uk-background-muted">
-                <span class="muted">[Asset-Übersicht Mockup]</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- TESTIMONIALS -->
-<section class="uk-section uk-section-muted">
-  <div class="uk-container">
-    <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
-      <h2 class="uk-heading-line"><span>„So bleiben wir audit-ready.“</span></h2>
-      <span class="muted">Ausgewählte Stimmen unserer Kund:innen</span>
-    </div>
-    <div class="uk-position-relative uk-visible-toggle" tabindex="-1" uk-slider="autoplay: true; autoplay-interval: 5200">
-      <ul class="uk-slider-items uk-child-width-1-1 uk-child-width-1-3@m" uk-grid>
-        <li>
-          <div class="uk-card uk-card-default uk-card-body uk-card-hover testimonial-card">
-            <p class="uk-text-large">„Mit calServer wissen alle sofort, welche Geräte wann fällig sind – ohne Excel-Listen.“</p>
-            <p class="muted uk-margin-small">Leitung Qualitätssicherung, AlphaLab</p>
-          </div>
-        </li>
-        <li>
-          <div class="uk-card uk-card-primary uk-card-body uk-card-hover testimonial-card">
-            <p class="uk-text-large">„Die Umstellung von MET/TEAM war in zwei Wochen erledigt. Das Team fühlte sich sofort zuhause.“</p>
-            <p class="uk-margin-small">Technischer Leiter, NordWerk Services</p>
-          </div>
-        </li>
-        <li>
-          <div class="uk-card uk-card-default uk-card-body uk-card-hover testimonial-card">
-            <p class="uk-text-large">„Unsere Audits laufen entspannter, weil Dokumente und Prüfprotokolle sauber abgelegt sind.“</p>
-            <p class="muted uk-margin-small">QS-Managerin, SolarTec GmbH</p>
-          </div>
-        </li>
-      </ul>
-      <a class="uk-position-center-left uk-position-small" href="#" uk-slidenav-previous uk-slider-item="previous"></a>
-      <a class="uk-position-center-right uk-position-small" href="#" uk-slidenav-next uk-slider-item="next"></a>
-    </div>
-  </div>
-</section>
-
-<!-- MODES SWITCHER -->
-<section id="modes" class="uk-section uk-section-primary uk-light">
-  <div class="uk-container">
-    <h2 class="uk-heading-line uk-light"><span>Betriebsarten, die zu Ihnen passen</span></h2>
-    <ul class="uk-subnav uk-subnav-pill uk-margin" uk-switcher>
-      <li><a href="#">Cloud</a></li>
-      <li><a href="#">On-Premise</a></li>
-    </ul>
-    <ul class="uk-switcher uk-margin" uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
-      <li>
-        <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" uk-grid>
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
-              <h3 class="uk-card-title">Sofort startklar</h3>
-              <ul class="uk-list uk-list-bullet muted">
-                <li>Bereitstellung in wenigen Tagen</li>
-                <li>Automatisierte Updates &amp; Monitoring</li>
-                <li>Backup-Strategie inklusive</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
-              <h3 class="uk-card-title">Sicher &amp; skalierbar</h3>
-              <ul class="uk-list uk-list-bullet muted">
-                <li>Rechenzentrum in Deutschland</li>
-                <li>ISO 27001 zertifizierte Infrastruktur</li>
-                <li>Flexible Nutzer:innenzahlen</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li>
-        <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" uk-grid>
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
-              <h3 class="uk-card-title">Volle Kontrolle</h3>
-              <ul class="uk-list uk-list-bullet muted">
-                <li>Betrieb im eigenen Netzwerk</li>
-                <li>Unterstützung bei Installation &amp; Updates</li>
-                <li>Integration in bestehende Systeme</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
-              <h3 class="uk-card-title">Individuelle Sicherheit</h3>
-              <ul class="uk-list uk-list-bullet muted">
-                <li>Anbindung an Ihr Identity-Management</li>
-                <li>Flexible Backup- und Wartungsfenster</li>
-                <li>Support per SLA vereinbar</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </li>
-    </ul>
-  </div>
-</section>
-
-<!-- PRICING -->
-<section id="pricing" class="uk-section uk-section-default">
-  <div class="uk-container">
-    <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
-      <h2 class="uk-heading-line"><span>Preise, die Klarheit schaffen</span></h2>
-      <span class="muted">Ehrlich, transparent, ohne versteckte Kosten.</span>
-    </div>
-    <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-large uk-grid-match" uk-grid
-         uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
-          <h3>Standard</h3>
-          <p class="muted">Die solide Basis für kleine Teams.</p>
-          <p class="uk-text-large uk-text-bold">ab 250 €/Monat</p>
-          <ul class="uk-list uk-list-bullet uk-text-left muted">
-            <li>Bis 2 Mandanten</li>
-            <li>Alle Kernmodule inklusive</li>
-            <li>E-Mail-Support innerhalb von 24 h</li>
-          </ul>
-          <a class="uk-button uk-button-default" href="#offer">Unverbindliches Angebot</a>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-primary uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative">
-          <span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Empfohlen</span>
-          <h3>Performance</h3>
-          <p>Für größere Teams mit mehr Tempo.</p>
-          <p class="uk-text-large uk-text-bold">auf Anfrage</p>
-          <ul class="uk-list uk-list-bullet uk-text-left">
-            <li>Unbegrenzte Nutzer:innen</li>
-            <li>Erweiterte Automatisierungen</li>
-            <li>Priorisierter Support &amp; SLA</li>
-          </ul>
-          <a class="uk-button uk-button-default" href="#offer">Beratung anfragen</a>
-        </div>
-      </div>
-      <div class="anim">
-        <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
-          <h3>Enterprise</h3>
-          <p class="muted">Individuell zugeschnitten auf Ihre Prozesse.</p>
-          <p class="uk-text-large uk-text-bold">individuell</p>
-          <ul class="uk-list uk-list-bullet uk-text-left muted">
-            <li>Eigene Mandanten-Strukturen</li>
-            <li>On-Premise oder Hybrid</li>
-            <li>Integrationen &amp; Projektbegleitung</li>
-          </ul>
-          <a class="uk-button uk-button-default" href="#offer">Angebot anfordern</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- FAQ -->
-<section id="faq" class="uk-section uk-section-muted">
-  <div class="uk-container">
-    <h2 class="uk-heading-line"><span>Häufige Fragen</span></h2>
-    <ul uk-accordion>
-      <li>
-        <a class="uk-accordion-title" href="#">Wie schnell bin ich mit der Cloud-Version startklar?</a>
-        <div class="uk-accordion-content"><p>In der Regel innerhalb weniger Tage – wir begleiten den Kick-off persönlich.</p></div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Kann ich zwischen Cloud und On-Premise wechseln?</a>
-        <div class="uk-accordion-content"><p>Ja, ein Wechsel ist jederzeit möglich. Wir unterstützen bei Migration und Datenübernahme.</p></div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Welche Datenimporte sind möglich?</a>
-        <div class="uk-accordion-content"><p>Excel/CSV-Importe, API-Schnittstellen sowie individuelle Integrationen.</p></div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Wie funktioniert der Support?</a>
-        <div class="uk-accordion-content"><p>Support per E-Mail, Telefon oder Ticketsystem – je nach Paket sogar mit SLA.</p></div>
-      </li>
-      <li>
-        <a class="uk-accordion-title" href="#">Was passiert mit meinen Daten nach dem Test?</a>
-        <div class="uk-accordion-content"><p>Nach Testende entscheiden Sie: weiter nutzen, exportieren oder löschen lassen – ganz transparent.</p></div>
-      </li>
-    </ul>
-    <div class="uk-margin-top">
-      <span class="muted">Noch nicht fündig geworden?</span>
-      <a class="uk-margin-small-left" href="{{ basePath }}/kontakt">Weitere Fragen → Kontakt</a>
-    </div>
-  </div>
-</section>
-
-<!-- CTA ABSCHLUSS -->
-<section id="demo" class="uk-section uk-section-primary uk-light uk-text-center">
-  <div class="uk-container">
-    <h3 class="uk-heading-small uk-margin-small">Bereit, calServer live zu erleben?</h3>
-    <p>Jetzt testen oder Demo buchen – wir zeigen, wie Ihre Prozesse in calServer aussehen.</p>
-    <p class="uk-margin-medium-top">
-      <a class="uk-button uk-button-default uk-margin-small-right" href="https://calendly.com/calhelp/calserver-vorstellung" target="_blank" rel="noopener">Demo buchen</a>
-      <a id="trial" class="uk-button uk-button-primary" href="#!">Jetzt testen</a>
-    </p>
-    <p class="uk-text-small uk-margin-small">* Demo-Zugang und Testumgebung nach kurzer Abstimmung.</p>
-  </div>
-</section>
-
-<!-- FOOTER -->
-<footer class="uk-section uk-section-default">
-  <div class="uk-container">
-    <div class="quick-cta uk-margin-large-bottom">
-      <div class="uk-grid-large uk-flex-middle" uk-grid>
-        <div class="uk-width-expand@m">
-          <h4 class="uk-margin-remove">Noch Fragen?</h4>
-          <p class="muted uk-margin-small">Schreiben Sie uns – wir beraten zu Betriebsart, Datenübernahme und Preisen.</p>
-        </div>
-        <div class="uk-width-auto@m">
-          <a class="uk-button uk-button-primary" href="{{ basePath }}/kontakt">Kontakt aufnehmen</a>
-        </div>
-      </div>
-    </div>
-    <div class="uk-grid-large" uk-grid>
-      <div class="uk-width-1-2@m">
-        <h4>calServer</h4>
-        <p class="muted">Cloud-Software für Kalibrier- und Inventarverwaltung – entwickelt in Deutschland.</p>
-      </div>
-      <div class="uk-width-1-4@m">
-        <h5>Produkt</h5>
-        <ul class="uk-list uk-link-text">
-          <li><a href="#features">Funktionen</a></li>
-          <li><a href="#modules">Module</a></li>
-          <li><a href="#usecases">Anwendungsfälle</a></li>
-          <li><a href="#pricing">Preise</a></li>
-        </ul>
-      </div>
-      <div class="uk-width-1-4@m">
-        <h5>Rechtliches</h5>
-        <ul class="uk-list uk-link-text">
-          <li><a href="{{ basePath }}/impressum">Impressum</a></li>
-          <li><a href="{{ basePath }}/datenschutz">Datenschutz</a></li>
-          <li><a href="{{ basePath }}/lizenz">AGB</a></li>
-        </ul>
-      </div>
-    </div>
-    <div class="uk-text-center uk-text-small muted uk-margin-top">© 2025 calHelp Inh. René Buske – Alle Rechte vorbehalten.</div>
-  </div>
-</footer>
-
-</body>
-</html>
+{% block scripts %}
+  <script src="{{ basePath }}/js/storage.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
+  <script src="{{ basePath }}/js/landing.js" defer></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- refactor the calServer marketing template to extend the shared layout, reuse the landing top bar/offcanvas, and embed the existing sections with a matching footer
- add a dedicated calServer stylesheet that piggybacks on landing tokens while keeping the original brand colour accents

## Testing
- composer phpunit *(fails: MAIN_DOMAIN misconfiguration and missing STRIPE_* secrets in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1096fdcd8832b927a5be7cdb1e6ab