### PR TITLE
Replace calServer scenarios slider with anchored feature navigation

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -105,39 +105,44 @@ body.qr-landing.calserver-theme .uk-card-hover:hover {
     box-shadow: 0 22px 48px -28px rgba(15, 23, 42, 0.45);
 }
 
-body.qr-landing.calserver-theme .scenario-cloud {
+body.qr-landing.calserver-theme .feature-nav {
+    margin: 0 auto 12px;
+    max-width: 1024px;
+}
+
+body.qr-landing.calserver-theme .feature-nav__list {
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
     justify-content: center;
-    margin: 32px 0 24px;
+    margin: 0;
     padding: 0;
     list-style: none;
 }
 
-body.qr-landing.calserver-theme .scenario-cloud li a {
+body.qr-landing.calserver-theme .feature-nav__pill {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     padding: 10px 18px;
     border-radius: 999px;
-    background: color-mix(in oklab, var(--calserver-primary) 12%, transparent);
+    background: color-mix(in oklab, var(--calserver-primary) 10%, transparent);
     color: var(--qr-landing-primary);
     font-weight: 600;
+    letter-spacing: 0.01em;
     text-decoration: none;
+    box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.3) inset,
+        0 14px 28px -24px rgba(31, 99, 230, 0.9);
     transition: background-color 180ms ease, color 180ms ease,
-        box-shadow 180ms ease;
+        transform 180ms ease, box-shadow 180ms ease;
 }
 
-body.qr-landing.calserver-theme .scenario-cloud li a:hover,
-body.qr-landing.calserver-theme .scenario-cloud li a:focus {
+body.qr-landing.calserver-theme .feature-nav__pill:hover,
+body.qr-landing.calserver-theme .feature-nav__pill:focus {
     background: var(--qr-landing-primary);
     color: #fff;
-    box-shadow: 0 12px 24px -18px rgba(31, 99, 230, 0.85);
-}
-
-body.qr-landing.calserver-theme .feature-usecase-slider .uk-card {
-    min-height: 270px;
+    transform: translateY(-2px);
+    box-shadow: 0 18px 32px -22px rgba(31, 99, 230, 0.9);
 }
 
 body.qr-landing.calserver-theme .testimonial-card {

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -199,7 +199,7 @@ body.qr-landing .site-footer {
   border-radius:999px;
 }
 
-/* Szenarien als Outline-Pills */
+/* Szenarien als Outline-Pills (Legacy Slider Support) */
 .scenario-cloud{
   --pill-bg: transparent;
   --pill-border: var(--qr-border);
@@ -260,6 +260,47 @@ body.qr-landing .site-footer {
 
 .usecase-slider li.uk-current .uk-card-quizrace:hover{
   transform:scale(1.08) translateY(-2px);
+}
+
+/* Feature navigation pills */
+.feature-nav{
+  margin:0 auto 12px;
+  max-width:1100px;
+}
+
+.feature-nav__list{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px 12px;
+  justify-content:center;
+  margin:0;
+  padding:0;
+  list-style:none;
+}
+
+.feature-nav__pill{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:7px 14px;
+  line-height:1.2;
+  font-size:14px;
+  font-weight:600;
+  border-radius:999px;
+  background:color-mix(in oklab, var(--qr-primary) 12%, transparent);
+  color:color-mix(in oklab, var(--qr-fg) 75%, transparent);
+  text-decoration:none;
+  border:1px solid color-mix(in oklab, var(--qr-primary) 32%, transparent);
+  box-shadow:0 12px 24px -22px rgba(15,23,42,.4);
+  transition:transform .16s ease, background .2s ease, color .2s ease, box-shadow .2s ease;
+}
+
+.feature-nav__pill:hover,
+.feature-nav__pill:focus{
+  transform:translateY(-2px);
+  background:color-mix(in oklab, var(--qr-primary) 32%, transparent);
+  color:#fff;
+  box-shadow:0 18px 36px -24px rgba(37,99,235,.55);
 }
 
 /* Karten/Kacheln auf der Landing (UIKit gezielt überstimmen) */

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -241,105 +241,28 @@
         </div>
         <div class="uk-margin-large-top">
           <div class="uk-text-center uk-margin-medium-bottom">
-            <h3 class="uk-heading-bullet">Alltagsszenarien mit calServer</h3>
-            <p class="muted">So unterstützt die Plattform Teams bei wiederkehrenden Aufgaben – vom Labor bis zum
-              Außendienst.</p>
+            <h3 class="uk-heading-bullet">Funktionen im Fokus</h3>
+            <p class="muted">Wähle die Bereiche, die dein Team täglich nutzt – und spring direkt zur passenden
+              Funktionskarte.</p>
           </div>
-          <ul class="scenario-cloud" aria-label="Alltagsszenarien">
-            <li><a href="#features">Kalibriertermine</a></li>
-            <li><a href="#features">Audit-Vorbereitung</a></li>
-            <li><a href="#features">Serviceeinsatz</a></li>
-            <li><a href="#features">Leihgeräte</a></li>
-            <li><a href="#features">Dokumente</a></li>
-            <li><a href="#features">Inventur</a></li>
-          </ul>
-          <div class="uk-position-relative uk-visible-toggle feature-usecase-slider"
-               tabindex="-1"
-               uk-slider="center: true; autoplay: true; autoplay-interval: 5200; finite: false">
-            <div class="uk-slider-container">
-              <ul class="uk-slider-items uk-child-width-1-1@s uk-child-width-1-3@m uk-grid-small">
-                <li>
-                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                    <h3 class="uk-card-title">Kalibriertermine planen</h3>
-                    <p class="muted">Wartungen &amp; Prüfungen bleiben im Blick – egal wie groß der Gerätepool ist.</p>
-                    <ul class="uk-list uk-list-bullet">
-                      <li>Automatische Intervalle &amp; Eskalationen</li>
-                      <li>Teamaufgaben direkt zuweisen</li>
-                      <li>Export für externe Dienstleister</li>
-                    </ul>
-                  </div>
-                </li>
-                <li>
-                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                    <h3 class="uk-card-title">Audit vorbereiten</h3>
-                    <p class="muted">Nachweise, Protokolle und Dokumente liegen sortiert an einem Ort.</p>
-                    <ul class="uk-list uk-list-bullet">
-                      <li>Versionierte Dokumentenablage</li>
-                      <li>Checklisten mit Freigabestatus</li>
-                      <li>Audit-Trail für Änderungen</li>
-                    </ul>
-                  </div>
-                </li>
-                <li>
-                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                    <h3 class="uk-card-title">Serviceeinsätze steuern</h3>
-                    <p class="muted">Tickets, Messwerte und Kommunikation laufen sauber zusammen.</p>
-                    <ul class="uk-list uk-list-bullet">
-                      <li>Tickets mit SLA-Tracking</li>
-                      <li>Mobile Datenerfassung</li>
-                      <li>Serienmails für Rückfragen</li>
-                    </ul>
-                  </div>
-                </li>
-                <li>
-                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                    <h3 class="uk-card-title">Leihgeräte koordinieren</h3>
-                    <p class="muted">Reservierungen bleiben transparent – Teams sehen Verfügbarkeiten live.</p>
-                    <ul class="uk-list uk-list-bullet">
-                      <li>Kalender mit Verfügbarkeiten</li>
-                      <li>Automatische Rückgabe-Erinnerung</li>
-                      <li>Übergabeprotokolle als PDF</li>
-                    </ul>
-                  </div>
-                </li>
-                <li>
-                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                    <h3 class="uk-card-title">Dokumente verteilen</h3>
-                    <p class="muted">Relevante Infos landen beim richtigen Team – nachvollziehbar versioniert.</p>
-                    <ul class="uk-list uk-list-bullet">
-                      <li>Freigaben nach Rollen</li>
-                      <li>Teilbare Links &amp; Zugriffshistorie</li>
-                      <li>Serienmail mit Anhang-Vorlagen</li>
-                    </ul>
-                  </div>
-                </li>
-                <li>
-                  <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-                    <h3 class="uk-card-title">Inventur abschließen</h3>
-                    <p class="muted">Geräteakten bleiben vollständig und revisionssicher dokumentiert.</p>
-                    <ul class="uk-list uk-list-bullet">
-                      <li>Serien- &amp; Inventarnummern im Blick</li>
-                      <li>Historie mit Messwerten vereint</li>
-                      <li>Berichte als CSV/PDF exportieren</li>
-                    </ul>
-                  </div>
-                </li>
-              </ul>
-            </div>
-            <a class="uk-position-center-left uk-position-small" href="#"
-               uk-slidenav-previous
-               uk-slider-item="previous"
-               aria-label="Vorheriges Szenario"></a>
-            <a class="uk-position-center-right uk-position-small" href="#"
-               uk-slidenav-next
-               uk-slider-item="next"
-               aria-label="Nächstes Szenario"></a>
-          </div>
+          <nav class="feature-nav" aria-label="Funktionsnavigation">
+            <ul class="feature-nav__list">
+              <li><a class="feature-nav__pill" href="#feature-inventare-intervalle">Inventare &amp; Intervalle</a></li>
+              <li><a class="feature-nav__pill" href="#feature-kalibrierscheine">Kalibrierscheine digitalisieren</a></li>
+              <li><a class="feature-nav__pill" href="#feature-email-abrufe">E-Mail-Abrufe &amp; Erinnerungen</a></li>
+              <li><a class="feature-nav__pill" href="#feature-geraeteverwaltung">Geräteverwaltung</a></li>
+              <li><a class="feature-nav__pill" href="#feature-kalibrier-reparatur">Kalibrier- &amp; Reparaturverwaltung</a></li>
+              <li><a class="feature-nav__pill" href="#feature-auftragsbearbeitung">Auftragsbearbeitung</a></li>
+              <li><a class="feature-nav__pill" href="#feature-leihverwaltung">Leihverwaltung</a></li>
+              <li><a class="feature-nav__pill" href="#feature-dokumentationen">Dokumentationen &amp; Wiki</a></li>
+              <li><a class="feature-nav__pill" href="#feature-dms">Dateimanagement (DMS)</a></li>
+            </ul>
+          </nav>
         </div>
         <div class="uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-large uk-grid-match"
              uk-grid
              uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
-          <div class="anim">
+          <div class="anim" id="feature-inventare-intervalle">
             <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
               <h3 class="uk-card-title">Inventare &amp; Intervalle</h3>
               <p>Fälligkeiten kommen zu dir – Erinnerungen, Abrufe und Planungsübersichten sorgen für Ruhe.</p>
@@ -350,7 +273,7 @@
               </ul>
             </div>
           </div>
-          <div class="anim">
+          <div class="anim" id="feature-kalibrierscheine">
             <div class="uk-card uk-card-primary uk-card-body uk-card-hover uk-box-shadow-large">
               <h3 class="uk-card-title">Kalibrierscheine digitalisieren</h3>
               <p>Einfach hochladen, alles Weitere erledigt die Zuordnung mit Versionierung &amp; Vorschau.</p>
@@ -361,7 +284,7 @@
               </ul>
             </div>
           </div>
-          <div class="anim">
+          <div class="anim" id="feature-email-abrufe">
             <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
               <h3 class="uk-card-title">E-Mail-Abrufe &amp; Erinnerungen</h3>
               <p>Persönlich und planbar – Serien mit System statt Einzelmails.</p>
@@ -372,7 +295,7 @@
               </ul>
             </div>
           </div>
-          <div class="anim">
+          <div class="anim" id="feature-geraeteverwaltung">
             <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
               <h3 class="uk-card-title">Geräteverwaltung</h3>
               <p>Ob 100 oder 100.000 Geräte – Suche, Filter und Gruppen bleiben schnell.</p>
@@ -383,7 +306,7 @@
               </ul>
             </div>
           </div>
-          <div class="anim">
+          <div class="anim" id="feature-kalibrier-reparatur">
             <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
               <h3 class="uk-card-title">Kalibrier- &amp; Reparaturverwaltung</h3>
               <p>Von Messwerten bis Bericht – ohne Medienbrüche, mit revisionssicheren Freigaben.</p>
@@ -394,7 +317,7 @@
               </ul>
             </div>
           </div>
-          <div class="anim">
+          <div class="anim" id="feature-auftragsbearbeitung">
             <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
               <h3 class="uk-card-title">Auftragsbearbeitung</h3>
               <p>Ein Flow für alles: Angebot → Auftrag → Rechnung – mit eigenem Briefpapier.</p>
@@ -405,7 +328,7 @@
               </ul>
             </div>
           </div>
-          <div class="anim">
+          <div class="anim" id="feature-leihverwaltung">
             <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
               <h3 class="uk-card-title">Leihverwaltung</h3>
               <p>Reservieren statt Telefonkette – Kalender auf, Gerät rein, fertig.</p>
@@ -416,7 +339,7 @@
               </ul>
             </div>
           </div>
-          <div class="anim">
+          <div class="anim" id="feature-dokumentationen">
             <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
               <h3 class="uk-card-title">Dokumentationen &amp; Wiki</h3>
               <p>Wissen bleibt im Team – gepflegt, versioniert und durchsuchbar.</p>
@@ -427,7 +350,7 @@
               </ul>
             </div>
           </div>
-          <div class="anim">
+          <div class="anim" id="feature-dms">
             <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
               <h3 class="uk-card-title">Dateimanagement (DMS)</h3>
               <p>„Nur speichern, nicht sortieren“ – Zuordnung läuft im Hintergrund.</p>


### PR DESCRIPTION
## Summary
- replace the improvised Alltagsszenarien slider on the calServer marketing page with a feature-focused pill navigation
- add anchors to each funktionskarte so the new navigation links jump directly to the respective content
- introduce styling hooks for the feature navigation pills in both the calServer theme and shared landing styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d10e3a8ae4832b8f8e9e730f064084