### PR TITLE
Adjust calserver hero gradients for theme variants

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -7,12 +7,27 @@ body.qr-landing.calserver-theme {
 
 body.qr-landing.calserver-theme:not(.high-contrast) {
     --qr-landing-primary: var(--calserver-primary);
+}
+
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast),
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) {
     --qr-hero-grad-start: #0b101a;
     --qr-hero-grad-end: color-mix(in oklab, var(--calserver-primary) 70%, #0b101a 30%);
     --qr-hero-gradient: linear-gradient(
         135deg,
         var(--qr-hero-grad-start) 0%,
         color-mix(in oklab, var(--calserver-primary) 55%, #111827 45%) 100%
+    );
+}
+
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast),
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast) {
+    --qr-hero-grad-start: var(--qr-brand-50);
+    --qr-hero-grad-end: var(--qr-brand-300);
+    --qr-hero-gradient: linear-gradient(
+        135deg,
+        var(--qr-hero-grad-start) 0%,
+        var(--qr-hero-grad-end) 100%
     );
 }
 


### PR DESCRIPTION
## Summary
- scope the calServer hero gradient overrides to the dark theme selectors
- add complementary light theme gradient tokens aligned with landing defaults to improve contrast

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d10f928a18832b821ab14746ab9743