### PR TITLE
Convert calServer feature cards to slider

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -160,6 +160,37 @@ body.qr-landing.calserver-theme .feature-nav__pill:focus {
     box-shadow: 0 18px 32px -22px rgba(31, 99, 230, 0.9);
 }
 
+body.qr-landing.calserver-theme .feature-slider {
+    margin-top: 40px;
+}
+
+body.qr-landing.calserver-theme .feature-slider__list > li {
+    display: flex;
+    position: relative;
+    padding: 12px;
+}
+
+body.qr-landing.calserver-theme .feature-slider__card {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+body.qr-landing.calserver-theme .feature-slider__item.uk-current .feature-slider__card {
+    transform: scale(1.04);
+    box-shadow: 0 22px 48px -32px rgba(15, 23, 42, 0.45);
+}
+
+body.qr-landing.calserver-theme .feature-slider__item.uk-current .feature-slider__card:hover {
+    transform: scale(1.04) translateY(-2px);
+}
+
+body.qr-landing.calserver-theme .feature-slider__item:not(.uk-current) .feature-slider__card:hover {
+    transform: translateY(-4px);
+}
+
 body.qr-landing.calserver-theme .testimonial-card {
     min-height: 240px;
 }

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -246,144 +246,213 @@
               Funktionskarte.</p>
           </div>
           <nav class="feature-nav" aria-label="Funktionsnavigation">
-            <ul class="feature-nav__list">
-              <li><a class="feature-nav__pill" href="#feature-inventare-intervalle">Inventare &amp; Intervalle</a></li>
-              <li><a class="feature-nav__pill" href="#feature-kalibrierscheine">Kalibrierscheine digitalisieren</a></li>
-              <li><a class="feature-nav__pill" href="#feature-email-abrufe">E-Mail-Abrufe &amp; Erinnerungen</a></li>
-              <li><a class="feature-nav__pill" href="#feature-geraeteverwaltung">Geräteverwaltung</a></li>
-              <li><a class="feature-nav__pill" href="#feature-kalibrier-reparatur">Kalibrier- &amp; Reparaturverwaltung</a></li>
-              <li><a class="feature-nav__pill" href="#feature-auftragsbearbeitung">Auftragsbearbeitung</a></li>
-              <li><a class="feature-nav__pill" href="#feature-leihverwaltung">Leihverwaltung</a></li>
-              <li><a class="feature-nav__pill" href="#feature-dokumentationen">Dokumentationen &amp; Wiki</a></li>
-              <li><a class="feature-nav__pill" href="#feature-dms">Dateimanagement (DMS)</a></li>
+            <ul id="feature-nav" class="feature-nav__list">
+              <li><a class="feature-nav__pill" href="#" data-target="feature-inventare-intervalle">Inventare &amp; Intervalle</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-kalibrierscheine">Kalibrierscheine digitalisieren</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-email-abrufe">E-Mail-Abrufe &amp; Erinnerungen</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-geraeteverwaltung">Geräteverwaltung</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-kalibrier-reparatur">Kalibrier- &amp; Reparaturverwaltung</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-auftragsbearbeitung">Auftragsbearbeitung</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-leihverwaltung">Leihverwaltung</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-dokumentationen">Dokumentationen &amp; Wiki</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-dms">Dateimanagement (DMS)</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-meldungen">Meldungen &amp; Tickets</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-cloud">Moderne Cloud-Basis</a></li>
             </ul>
           </nav>
         </div>
-        <div class="uk-child-width-1-2@s uk-child-width-1-3@m uk-grid-large uk-grid-match"
-             uk-grid
-             uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
-          <div class="anim" id="feature-inventare-intervalle">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">Inventare &amp; Intervalle</h3>
-              <p>Fälligkeiten kommen zu dir – Erinnerungen, Abrufe und Planungsübersichten sorgen für Ruhe.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Automatische Erinnerungslogik</li>
-                <li>Klare Statusfarben</li>
-                <li>Planungs-Dashboards</li>
-              </ul>
-            </div>
+        <div id="feature-slider"
+             class="uk-position-relative uk-visible-toggle feature-slider"
+             tabindex="-1"
+             uk-slider="center: true; autoplay: true; autoplay-interval: 4200; finite: false">
+          <div class="uk-slider-container">
+            <ul class="uk-slider-items uk-child-width-1-1@s uk-child-width-1-2@m uk-child-width-1-3@l feature-slider__list"
+                uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .feature-slider__item; delay: 75; repeat: true">
+              <li class="feature-slider__item" id="feature-inventare-intervalle">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">Inventare &amp; Intervalle</h3>
+                  <p>Fälligkeiten kommen zu dir – Erinnerungen, Abrufe und Planungsübersichten sorgen für Ruhe.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Automatische Erinnerungslogik</li>
+                    <li>Klare Statusfarben</li>
+                    <li>Planungs-Dashboards</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-kalibrierscheine">
+                <div class="uk-card uk-card-primary uk-card-body uk-card-hover uk-box-shadow-large feature-slider__card">
+                  <h3 class="uk-card-title">Kalibrierscheine digitalisieren</h3>
+                  <p>Einfach hochladen, alles Weitere erledigt die Zuordnung mit Versionierung &amp; Vorschau.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Intelligente Dateinamen-Erkennung</li>
+                    <li>Versionen &amp; Freigaben</li>
+                    <li>Teilen per Link</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-email-abrufe">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">E-Mail-Abrufe &amp; Erinnerungen</h3>
+                  <p>Persönlich und planbar – Serien mit System statt Einzelmails.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Vorlagen &amp; Platzhalter</li>
+                    <li>Zeitpläne je Zielgruppe</li>
+                    <li>Versandprotokoll</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-geraeteverwaltung">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">Geräteverwaltung</h3>
+                  <p>Ob 100 oder 100.000 Geräte – Suche, Filter und Gruppen bleiben schnell.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Schnellsuche &amp; Filter</li>
+                    <li>Sets &amp; Zubehör</li>
+                    <li>Exporte (CSV/PDF)</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-kalibrier-reparatur">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">Kalibrier- &amp; Reparaturverwaltung</h3>
+                  <p>Von Messwerten bis Bericht – ohne Medienbrüche, mit revisionssicheren Freigaben.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Messwerte erfassen/importieren</li>
+                    <li>Bearbeitbare Übersichten</li>
+                    <li>Berichte direkt erzeugen</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-auftragsbearbeitung">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">Auftragsbearbeitung</h3>
+                  <p>Ein Flow für alles: Angebot → Auftrag → Rechnung – mit eigenem Briefpapier.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Sammel- &amp; Teilrechnungen</li>
+                    <li>Preislisten &amp; Nummernkreise</li>
+                    <li>Automatische Status</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-leihverwaltung">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">Leihverwaltung</h3>
+                  <p>Reservieren statt Telefonkette – Kalender auf, Gerät rein, fertig.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Drag-and-Drop Kalender</li>
+                    <li>Zubehör-Sets</li>
+                    <li>Rückgabe-Erinnerungen</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-dokumentationen">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">Dokumentationen &amp; Wiki</h3>
+                  <p>Wissen bleibt im Team – gepflegt, versioniert und durchsuchbar.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Editor mit Inhaltsverzeichnis</li>
+                    <li>Versionen &amp; Berechtigungen</li>
+                    <li>Interne Verlinkungen</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-dms">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">Dateimanagement (DMS)</h3>
+                  <p>„Nur speichern, nicht sortieren“ – Zuordnung läuft im Hintergrund.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Auto-Zuordnung</li>
+                    <li>Versionierung</li>
+                    <li>PDF-Viewer</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-meldungen">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">Meldungen &amp; Tickets</h3>
+                  <p>Alles an einem Ort: Anliegen, Verlauf, Benachrichtigungen.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Zentrales Ticketing</li>
+                    <li>Teilnehmerwechsel</li>
+                    <li>Benachrichtigungsketten</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="feature-slider__item" id="feature-cloud">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small feature-slider__card">
+                  <h3 class="uk-card-title">Moderne Cloud-Basis</h3>
+                  <p>Schnell, stabil und updatefreundlich – ohne großen Admin-Aufwand.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Skalierbare Umgebung</li>
+                    <li>Regelmäßige Updates</li>
+                    <li>Tägliche Backups</li>
+                  </ul>
+                </div>
+              </li>
+            </ul>
           </div>
-          <div class="anim" id="feature-kalibrierscheine">
-            <div class="uk-card uk-card-primary uk-card-body uk-card-hover uk-box-shadow-large">
-              <h3 class="uk-card-title">Kalibrierscheine digitalisieren</h3>
-              <p>Einfach hochladen, alles Weitere erledigt die Zuordnung mit Versionierung &amp; Vorschau.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Intelligente Dateinamen-Erkennung</li>
-                <li>Versionen &amp; Freigaben</li>
-                <li>Teilen per Link</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim" id="feature-email-abrufe">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">E-Mail-Abrufe &amp; Erinnerungen</h3>
-              <p>Persönlich und planbar – Serien mit System statt Einzelmails.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Vorlagen &amp; Platzhalter</li>
-                <li>Zeitpläne je Zielgruppe</li>
-                <li>Versandprotokoll</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim" id="feature-geraeteverwaltung">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">Geräteverwaltung</h3>
-              <p>Ob 100 oder 100.000 Geräte – Suche, Filter und Gruppen bleiben schnell.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Schnellsuche &amp; Filter</li>
-                <li>Sets &amp; Zubehör</li>
-                <li>Exporte (CSV/PDF)</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim" id="feature-kalibrier-reparatur">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">Kalibrier- &amp; Reparaturverwaltung</h3>
-              <p>Von Messwerten bis Bericht – ohne Medienbrüche, mit revisionssicheren Freigaben.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Messwerte erfassen/importieren</li>
-                <li>Bearbeitbare Übersichten</li>
-                <li>Berichte direkt erzeugen</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim" id="feature-auftragsbearbeitung">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">Auftragsbearbeitung</h3>
-              <p>Ein Flow für alles: Angebot → Auftrag → Rechnung – mit eigenem Briefpapier.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Sammel- &amp; Teilrechnungen</li>
-                <li>Preislisten &amp; Nummernkreise</li>
-                <li>Automatische Status</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim" id="feature-leihverwaltung">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">Leihverwaltung</h3>
-              <p>Reservieren statt Telefonkette – Kalender auf, Gerät rein, fertig.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Drag-and-Drop Kalender</li>
-                <li>Zubehör-Sets</li>
-                <li>Rückgabe-Erinnerungen</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim" id="feature-dokumentationen">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">Dokumentationen &amp; Wiki</h3>
-              <p>Wissen bleibt im Team – gepflegt, versioniert und durchsuchbar.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Editor mit Inhaltsverzeichnis</li>
-                <li>Versionen &amp; Berechtigungen</li>
-                <li>Interne Verlinkungen</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim" id="feature-dms">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">Dateimanagement (DMS)</h3>
-              <p>„Nur speichern, nicht sortieren“ – Zuordnung läuft im Hintergrund.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Auto-Zuordnung</li>
-                <li>Versionierung</li>
-                <li>PDF-Viewer</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">Meldungen &amp; Tickets</h3>
-              <p>Alles an einem Ort: Anliegen, Verlauf, Benachrichtigungen.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Zentrales Ticketing</li>
-                <li>Teilnehmerwechsel</li>
-                <li>Benachrichtigungsketten</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover uk-box-shadow-small">
-              <h3 class="uk-card-title">Moderne Cloud-Basis</h3>
-              <p>Schnell, stabil und updatefreundlich – ohne großen Admin-Aufwand.</p>
-              <ul class="uk-list uk-list-bullet">
-                <li>Skalierbare Umgebung</li>
-                <li>Regelmäßige Updates</li>
-                <li>Tägliche Backups</li>
-              </ul>
-            </div>
-          </div>
+          <a class="uk-position-center-left uk-position-small uk-hidden-hover"
+             href="#"
+             uk-slidenav-previous
+             uk-slider-item="previous"
+             aria-label="Vorherige Funktion"></a>
+          <a class="uk-position-center-right uk-position-small uk-hidden-hover"
+             href="#"
+             uk-slidenav-next
+             uk-slider-item="next"
+             aria-label="Nächste Funktion"></a>
         </div>
+        <script>
+          document.addEventListener('DOMContentLoaded', () => {
+            const sliderElement = document.getElementById('feature-slider');
+            const navElement = document.getElementById('feature-nav');
+            if (!sliderElement || !navElement || typeof UIkit === 'undefined') {
+              return;
+            }
+
+            const slider = UIkit.slider(sliderElement);
+            const pills = Array.from(navElement.querySelectorAll('li'));
+            const slides = Array.from(sliderElement.querySelectorAll('.feature-slider__item'));
+            const indexById = new Map(slides.map((slide, index) => [slide.id, index]));
+
+            const setActive = (index) => {
+              pills.forEach((li, i) => li.classList.toggle('uk-active', i === index));
+            };
+
+            const setCurrent = (index) => {
+              slides.forEach((slide, i) => slide.classList.toggle('uk-current', i === index));
+            };
+
+            pills.forEach((li) => {
+              const link = li.querySelector('a[data-target]');
+              if (!link) {
+                return;
+              }
+
+              const targetId = link.dataset.target;
+              const targetIndex = indexById.get(targetId);
+              if (typeof targetIndex === 'undefined') {
+                return;
+              }
+
+              link.addEventListener('click', (event) => {
+                event.preventDefault();
+                slider.show(targetIndex);
+                setActive(targetIndex);
+                setCurrent(targetIndex);
+              });
+            });
+
+            UIkit.util.on(sliderElement, 'itemshown', () => {
+              setActive(slider.index);
+              setCurrent(slider.index);
+            });
+
+            const initialIndex = typeof slider.index === 'number' ? slider.index : 0;
+            setActive(initialIndex);
+            setCurrent(initialIndex);
+          });
+        </script>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- replace the Funktionen im Fokus card grid on the calServer marketing page with a UIkit slider connected to the pills navigation
- add inline scripting to sync slider navigation and active slide highlights, mirroring the landing page behaviour
- introduce slider-specific styling tweaks to support the new layout and hover effects in the calServer theme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d111ddc398832bbf82dde8dd19e215