### PR TITLE
Fix Calserver slider card text contrast

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -178,6 +178,28 @@ body.qr-landing.calserver-theme .feature-slider__card {
     transition: transform 220ms ease, box-shadow 220ms ease;
 }
 
+body.qr-landing.calserver-theme .feature-slider__card p {
+    color: var(--qr-muted);
+}
+
+body.qr-landing.calserver-theme .feature-slider__card.uk-card-primary {
+    background: color-mix(in oklab, var(--calserver-primary) 18%, var(--qr-card) 82%) !important;
+    border-color: color-mix(in oklab, var(--calserver-primary) 35%, transparent);
+    color: var(--qr-text) !important;
+}
+
+body.qr-landing.calserver-theme .feature-slider__card.uk-card-primary .uk-card-title {
+    color: var(--qr-text) !important;
+}
+
+body.qr-landing.calserver-theme .feature-slider__card.uk-card-primary p {
+    color: var(--qr-muted) !important;
+}
+
+body.qr-landing.calserver-theme .feature-slider__card.uk-card-primary li {
+    color: var(--qr-text) !important;
+}
+
 body.qr-landing.calserver-theme .feature-slider__item.uk-current .feature-slider__card {
     transform: scale(1.04);
     box-shadow: 0 22px 48px -32px rgba(15, 23, 42, 0.45);


### PR DESCRIPTION
## Summary
- ensure the Calserver slider cards keep the muted copy styling instead of inheriting the white uk-card-primary text
- adjust the highlighted slider card background and border mix so the copy stays legible while preserving the accent look

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d11efaed5c832b9af253e5fa246fe1