### PR TITLE
Add trust and impact section to calServer landing

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -83,22 +83,52 @@ body.qr-landing.calserver-theme .shadow-soft {
     border-radius: 18px;
 }
 
-body.qr-landing.calserver-theme .badge-card {
-    padding: 14px 12px;
-    border-radius: 12px;
+body.qr-landing.calserver-theme #trust .uk-card {
+    border-radius: 14px;
+    box-shadow: 0 18px 38px -28px rgba(15, 23, 42, 0.45);
     background: var(--qr-card);
-    box-shadow: 0 10px 26px -20px rgba(15, 23, 42, 0.45);
+    color: var(--qr-text);
+}
+
+body.qr-landing.calserver-theme #trust .uk-card-default {
+    border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+body.qr-landing.calserver-theme #trust .uk-card-default .uk-card-body {
+    padding: 18px 12px;
+}
+
+body.qr-landing.calserver-theme #trust .trust-logo {
+    max-height: 40px;
+    width: auto;
+    display: inline-block;
+    filter: drop-shadow(0 4px 8px rgba(15, 23, 42, 0.12));
+}
+
+body.qr-landing.calserver-theme #trust .kpi {
+    min-height: 120px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+body.qr-landing.calserver-theme #trust .kpi .uk-text-bold {
+    color: var(--qr-landing-primary);
+}
+
+body.qr-landing.calserver-theme #trust .trust-badge {
+    padding: 16px 14px;
+    border-radius: 14px;
+    background: var(--qr-card);
+    box-shadow: 0 16px 32px -26px rgba(15, 23, 42, 0.45);
     font-weight: 600;
 }
 
-body.qr-landing.calserver-theme .logo-chip {
-    background: rgba(255, 255, 255, 0.16);
-    border-radius: 12px;
-    padding: 18px 12px;
-    text-align: center;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
+body.qr-landing.calserver-theme #trust .testimonial-card {
+    background: color-mix(in oklab, var(--calserver-primary) 22%, #102347 78%);
+    border: 1px solid color-mix(in oklab, var(--calserver-primary) 38%, transparent);
 }
 
 body.qr-landing.calserver-theme .muted {

--- a/public/img/calserver/trust/alphalab.svg
+++ b/public/img/calserver/trust/alphalab.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40" role="img" aria-labelledby="title">
+  <title>AlphaLab</title>
+  <defs>
+    <linearGradient id="alphaGrad" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#1f63e6" />
+      <stop offset="100%" stop-color="#39b0ff" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="40" rx="12" fill="rgba(31,99,230,0.08)" />
+  <g transform="translate(18 8)">
+    <path d="M12 0L24 24H0L12 0Z" fill="url(#alphaGrad)" />
+    <circle cx="12" cy="12" r="6" fill="#0b1c3f" opacity="0.9" />
+    <circle cx="12" cy="12" r="3" fill="#fff" opacity="0.95" />
+  </g>
+  <text x="56" y="24" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="18" fill="#102347">AlphaLab</text>
+</svg>

--- a/public/img/calserver/trust/energiepro.svg
+++ b/public/img/calserver/trust/energiepro.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40" role="img" aria-labelledby="title">
+  <title>EnergiePro</title>
+  <defs>
+    <linearGradient id="energieGrad" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#34d399" />
+      <stop offset="100%" stop-color="#10b981" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="40" rx="12" fill="rgba(16,185,129,0.1)" />
+  <g transform="translate(18 6)">
+    <path d="M14 0l-6 12h6l-4 12 12-16h-6l4-8z" fill="url(#energieGrad)" />
+    <circle cx="22" cy="18" r="4" fill="#0f172a" opacity="0.25" />
+    <circle cx="6" cy="18" r="4" fill="#0f172a" opacity="0.25" />
+  </g>
+  <text x="64" y="24" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="18" fill="#102347">EnergiePro</text>
+</svg>

--- a/public/img/calserver/trust/metalliq.svg
+++ b/public/img/calserver/trust/metalliq.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40" role="img" aria-labelledby="title">
+  <title>Metall IQ</title>
+  <defs>
+    <linearGradient id="metalGrad" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#94a3b8" />
+      <stop offset="100%" stop-color="#1f2937" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="40" rx="12" fill="rgba(15,23,42,0.08)" />
+  <g transform="translate(18 8)">
+    <rect x="0" y="0" width="24" height="24" rx="6" fill="url(#metalGrad)" />
+    <path d="M6 12h12M6 8h12M6 16h8" stroke="#f8fafc" stroke-width="2" stroke-linecap="round" />
+    <circle cx="18" cy="18" r="3" fill="#facc15" />
+  </g>
+  <text x="64" y="24" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="18" fill="#102347">Metall IQ</text>
+</svg>

--- a/public/img/calserver/trust/nordwerk.svg
+++ b/public/img/calserver/trust/nordwerk.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40" role="img" aria-labelledby="title">
+  <title>NordWerk</title>
+  <defs>
+    <linearGradient id="nordGrad" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#7dd3fc" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="40" rx="12" fill="rgba(15,23,42,0.06)" />
+  <g transform="translate(18 7)" fill="url(#nordGrad)">
+    <path d="M0 26L10 0l10 26h-6l-4-12-4 12H0z" />
+    <path d="M24 0h6l-3 26h-6l3-26z" opacity="0.45" />
+  </g>
+  <text x="64" y="24" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="18" fill="#102347">NordWerk</text>
+</svg>

--- a/public/img/calserver/trust/praezifit.svg
+++ b/public/img/calserver/trust/praezifit.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40" role="img" aria-labelledby="title">
+  <title>PräziFit</title>
+  <defs>
+    <linearGradient id="praeziGrad" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="40" rx="12" fill="rgba(14,165,233,0.08)" />
+  <g transform="translate(18 6)">
+    <rect x="0" y="8" width="28" height="8" rx="4" fill="#0b1c3f" opacity="0.2" />
+    <path d="M0 20c4-8 8-12 14-12s10 4 14 12" stroke="url(#praeziGrad)" stroke-width="4" fill="none" stroke-linecap="round" />
+    <circle cx="14" cy="10" r="6" fill="url(#praeziGrad)" opacity="0.8" />
+    <circle cx="14" cy="10" r="2" fill="#fff" />
+  </g>
+  <text x="64" y="24" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="18" fill="#102347">PräziFit</text>
+</svg>

--- a/public/img/calserver/trust/solartec.svg
+++ b/public/img/calserver/trust/solartec.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40" role="img" aria-labelledby="title">
+  <title>SolarTec</title>
+  <defs>
+    <radialGradient id="solarGrad" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#fde047" />
+      <stop offset="100%" stop-color="#f97316" />
+    </radialGradient>
+  </defs>
+  <rect width="160" height="40" rx="12" fill="rgba(249,115,22,0.08)" />
+  <g transform="translate(18 6)">
+    <circle cx="14" cy="14" r="12" fill="url(#solarGrad)" />
+    <path d="M14 2v-2M14 30v-2M2 14H0m30 0h-2M5.2 5.2l-1.4-1.4m22 22 1.4 1.4M5.2 22.8l-1.4 1.4m22-22 1.4-1.4" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" />
+  </g>
+  <text x="64" y="24" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="18" fill="#102347">SolarTec</text>
+</svg>

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -192,44 +192,134 @@
     </section>
     <div class="section-divider"></div>
 
-    <section class="uk-section uk-section-muted">
-      <div class="uk-container"
-           uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
-        <div class="uk-child-width-1-2 uk-child-width-1-5@m uk-grid-small uk-text-center" uk-grid>
-          <div class="anim"><div class="badge-card">Hosting in Deutschland</div></div>
-          <div class="anim"><div class="badge-card">DSGVO-konform</div></div>
-          <div class="anim"><div class="badge-card">Software Made in Germany</div></div>
-          <div class="anim"><div class="badge-card">REST-API &amp; Webhooks</div></div>
-          <div class="anim"><div class="badge-card">Autom. Backups</div></div>
-        </div>
-      </div>
-    </section>
-
-    <section class="uk-section uk-section-primary uk-light">
+    <section id="trust" class="uk-section uk-section-muted">
       <div class="uk-container">
-        <div class="uk-flex uk-flex-middle uk-flex-between uk-margin-medium-bottom uk-flex-wrap">
-          <h2 class="uk-heading-line uk-light"><span>Vertrauen von Laboren, Service &amp; Industrie</span></h2>
-          <a class="uk-link-text" href="#usecases">Mehr Anwendungsfälle</a>
+
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-margin-medium-bottom">
+          <h2 class="uk-heading-line uk-margin-remove"><span>Vertrauen von Laboren, Service &amp; Industrie</span></h2>
+          <a class="uk-link-toggle uk-visible@m" href="#usecases">
+            <span class="uk-link-text">Mehr Anwendungsfälle</span> <span uk-icon="icon: arrow-right"></span>
+          </a>
         </div>
-        <div class="uk-position-relative uk-visible-toggle" tabindex="-1"
-             uk-slider="autoplay: true; autoplay-interval: 3800">
-          <ul class="uk-slider-items uk-child-width-1-3@s uk-child-width-1-6@m uk-grid-small">
-            <li><div class="logo-chip">AlphaLab</div></li>
-            <li><div class="logo-chip">NordWerk</div></li>
-            <li><div class="logo-chip">SolarTec</div></li>
-            <li><div class="logo-chip">PräziFit</div></li>
-            <li><div class="logo-chip">Metall IQ</div></li>
-            <li><div class="logo-chip">EnergiePro</div></li>
+
+        <div class="uk-position-relative" tabindex="-1" uk-slider="autoplay: true; autoplay-interval: 2400">
+          <ul class="uk-slider-items uk-child-width-1-3@s uk-child-width-1-6@m uk-grid-small uk-text-center">
+            <li>
+              <div class="uk-card uk-card-default uk-card-body">
+                <img src="{{ basePath }}/img/calserver/trust/alphalab.svg"
+                     class="trust-logo"
+                     alt="AlphaLab" uk-img>
+              </div>
+            </li>
+            <li>
+              <div class="uk-card uk-card-default uk-card-body">
+                <img src="{{ basePath }}/img/calserver/trust/nordwerk.svg"
+                     class="trust-logo"
+                     alt="NordWerk" uk-img>
+              </div>
+            </li>
+            <li>
+              <div class="uk-card uk-card-default uk-card-body">
+                <img src="{{ basePath }}/img/calserver/trust/solartec.svg"
+                     class="trust-logo"
+                     alt="SolarTec" uk-img>
+              </div>
+            </li>
+            <li>
+              <div class="uk-card uk-card-default uk-card-body">
+                <img src="{{ basePath }}/img/calserver/trust/praezifit.svg"
+                     class="trust-logo"
+                     alt="PräziFit" uk-img>
+              </div>
+            </li>
+            <li>
+              <div class="uk-card uk-card-default uk-card-body">
+                <img src="{{ basePath }}/img/calserver/trust/metalliq.svg"
+                     class="trust-logo"
+                     alt="Metall IQ" uk-img>
+              </div>
+            </li>
+            <li>
+              <div class="uk-card uk-card-default uk-card-body">
+                <img src="{{ basePath }}/img/calserver/trust/energiepro.svg"
+                     class="trust-logo"
+                     alt="EnergiePro" uk-img>
+              </div>
+            </li>
           </ul>
-          <a class="uk-position-center-left uk-position-small" href="#"
-             uk-slidenav-previous
-             uk-slider-item="previous"
-             aria-label="Vorheriger Partner"></a>
-          <a class="uk-position-center-right uk-position-small" href="#"
-             uk-slidenav-next
-             uk-slider-item="next"
-             aria-label="Nächster Partner"></a>
+
+          <a class="uk-position-center-left uk-position-small uk-hidden-hover" href="#" uk-slidenav-previous
+             uk-slider-item="previous" aria-label="Vorheriger Partner"></a>
+          <a class="uk-position-center-right uk-position-small uk-hidden-hover" href="#" uk-slidenav-next
+             uk-slider-item="next" aria-label="Nächster Partner"></a>
         </div>
+
+        <div class="uk-grid-large uk-margin-large-top" uk-grid>
+          <div class="uk-width-2-3@m">
+            <div class="uk-child-width-1-2@s uk-child-width-1-4@m" uk-grid
+                 uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .kpi; delay: 75;">
+              <div>
+                <div class="uk-card uk-card-default uk-card-body uk-text-center kpi">
+                  <div class="uk-text-bold uk-text-large">100.000+</div>
+                  <div class="uk-text-meta">verwaltete Geräte</div>
+                </div>
+              </div>
+              <div>
+                <div class="uk-card uk-card-default uk-card-body uk-text-center kpi">
+                  <div class="uk-text-bold uk-text-large">Sekundenschnell</div>
+                  <div class="uk-text-meta">Suche &amp; Filter</div>
+                </div>
+              </div>
+              <div>
+                <div class="uk-card uk-card-default uk-card-body uk-text-center kpi">
+                  <div class="uk-text-bold uk-text-large">Beliebig viele</div>
+                  <div class="uk-text-meta">Nutzer:innen &amp; Rollen</div>
+                </div>
+              </div>
+              <div>
+                <div class="uk-card uk-card-default uk-card-body uk-text-center kpi">
+                  <div class="uk-text-bold uk-text-large">Tägliche</div>
+                  <div class="uk-text-meta">Datensicherung</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="uk-width-1-3@m">
+            <div class="uk-card uk-card-primary uk-light uk-card-body uk-border-rounded uk-box-shadow-medium testimonial-card">
+              <div class="uk-flex uk-flex-middle uk-margin-small-bottom">
+                <span class="uk-margin-small-right" uk-icon="icon: quote-right; ratio: 1.2"></span>
+                <strong>„30% weniger Suchaufwand im Alltag.“</strong>
+              </div>
+              <p class="uk-margin-small-top uk-margin-remove-bottom">
+                calServer bringt Ordnung in Geräte, Termine und Dokumente. Wir arbeiten schneller – und entspannter.
+              </p>
+              <div class="uk-margin-small-top uk-text-meta">Leitung Kalibrierlabor · Beispiel GmbH</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="uk-margin-large-top uk-visible@m">
+          <div class="uk-child-width-1-2 uk-child-width-1-5@m uk-grid-small uk-text-center" uk-grid
+               uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .trust-badge; delay: 75;">
+            <div>
+              <div class="uk-card uk-card-default uk-card-body trust-badge">Hosting in Deutschland</div>
+            </div>
+            <div>
+              <div class="uk-card uk-card-default uk-card-body trust-badge">DSGVO-konform</div>
+            </div>
+            <div>
+              <div class="uk-card uk-card-default uk-card-body trust-badge">Software Made in Germany</div>
+            </div>
+            <div>
+              <div class="uk-card uk-card-default uk-card-body trust-badge">REST-API &amp; Webhooks</div>
+            </div>
+            <div>
+              <div class="uk-card uk-card-default uk-card-body trust-badge">Autom. Backups</div>
+            </div>
+          </div>
+        </div>
+
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- integrate the new trust and impact block beneath the calServer hero with logo slider, KPIs, testimonial, and relocated trust badges
- add custom styling and bespoke SVG partner logos to match the landing page design

## Testing
- not run (frontend only change)


------
https://chatgpt.com/codex/tasks/task_e_68d138cd0788832b9d045b5dafa3259b