### PR TITLE
Adjust feature slider focus midpoint

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -516,8 +516,9 @@
                 return;
               }
 
-              const containerRect = itemsContainer.getBoundingClientRect();
-              const midpoint = containerRect.left + containerRect.width / 2;
+              const viewportElement = sliderElement.querySelector('.uk-slider-container') || sliderElement;
+              const viewportRect = viewportElement.getBoundingClientRect();
+              const midpoint = viewportRect.left + viewportRect.width / 2;
 
               let nearest = null;
               let minDistance = Number.POSITIVE_INFINITY;


### PR DESCRIPTION
## Summary
- determine the feature slider midpoint using the viewport element instead of the items list
- keep slide iteration unchanged while comparing slide centers against the viewport midpoint

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1402c449c832b86e062c477de2ad5