### PR TITLE
Replace calserver marquee logos with feature highlights

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -204,7 +204,15 @@ body.qr-landing.calserver-theme .calserver-logo-marquee__item {
     align-items: center;
     justify-content: center;
     min-width: 130px;
-    opacity: 0.88;
+    padding: 10px 24px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--calserver-primary) 16%, transparent);
+    border: 1px solid color-mix(in oklab, var(--calserver-primary) 32%, transparent);
+    color: color-mix(in oklab, var(--calserver-primary) 85%, #f8fafc 15%);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-align: center;
+    opacity: 0.96;
 }
 
 body.qr-landing.calserver-theme .calserver-logo-marquee__item img {

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -229,56 +229,38 @@
         </div>
 
         <div class="calserver-logo-marquee"
-             aria-label="Unternehmen, die calServer vertrauen">
-          <div class="calserver-logo-marquee__track">
-            <div class="calserver-logo-marquee__item">
-              <img src="{{ basePath }}/img/calserver/trust/alphalab.svg"
-                   alt="AlphaLab"
-                   loading="lazy">
+             aria-label="calServer Leistungsversprechen">
+          <div class="calserver-logo-marquee__track" role="list">
+            <div class="calserver-logo-marquee__item" role="listitem">
+              Hosting in Deutschland
             </div>
-            <div class="calserver-logo-marquee__item">
-              <img src="{{ basePath }}/img/calserver/trust/nordwerk.svg"
-                   alt="NordWerk"
-                   loading="lazy">
+            <div class="calserver-logo-marquee__item" role="listitem">
+              DSGVO-konform
             </div>
-            <div class="calserver-logo-marquee__item">
-              <img src="{{ basePath }}/img/calserver/trust/solartec.svg"
-                   alt="SolarTec"
-                   loading="lazy">
+            <div class="calserver-logo-marquee__item" role="listitem">
+              Software Made in Germany
             </div>
-            <div class="calserver-logo-marquee__item">
-              <img src="{{ basePath }}/img/calserver/trust/praezifit.svg"
-                   alt="PräziFit"
-                   loading="lazy">
+            <div class="calserver-logo-marquee__item" role="listitem">
+              REST-API &amp; Webhooks
             </div>
-            <div class="calserver-logo-marquee__item">
-              <img src="{{ basePath }}/img/calserver/trust/metalliq.svg"
-                   alt="Metall IQ"
-                   loading="lazy">
-            </div>
-            <div class="calserver-logo-marquee__item">
-              <img src="{{ basePath }}/img/calserver/trust/energiepro.svg"
-                   alt="EnergiePro"
-                   loading="lazy">
+            <div class="calserver-logo-marquee__item" role="listitem">
+              Autom. Backups und weitere keys
             </div>
 
-            <div class="calserver-logo-marquee__item" aria-hidden="true">
-              <img src="{{ basePath }}/img/calserver/trust/alphalab.svg" alt="" loading="lazy">
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              Hosting in Deutschland
             </div>
-            <div class="calserver-logo-marquee__item" aria-hidden="true">
-              <img src="{{ basePath }}/img/calserver/trust/nordwerk.svg" alt="" loading="lazy">
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              DSGVO-konform
             </div>
-            <div class="calserver-logo-marquee__item" aria-hidden="true">
-              <img src="{{ basePath }}/img/calserver/trust/solartec.svg" alt="" loading="lazy">
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              Software Made in Germany
             </div>
-            <div class="calserver-logo-marquee__item" aria-hidden="true">
-              <img src="{{ basePath }}/img/calserver/trust/praezifit.svg" alt="" loading="lazy">
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              REST-API &amp; Webhooks
             </div>
-            <div class="calserver-logo-marquee__item" aria-hidden="true">
-              <img src="{{ basePath }}/img/calserver/trust/metalliq.svg" alt="" loading="lazy">
-            </div>
-            <div class="calserver-logo-marquee__item" aria-hidden="true">
-              <img src="{{ basePath }}/img/calserver/trust/energiepro.svg" alt="" loading="lazy">
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              Autom. Backups und weitere keys
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the logo marquee on the calServer landing page with feature highlight text entries requested for the hero section
- update the marquee styling so the new text items appear as emphasized pills that still work with the existing animation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d141ee936c832b96d9a382f4106e72