### PR TITLE
Increase landing topbar button sizing

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -464,6 +464,18 @@ body.dark-mode .qr-landing .qr-topbar{
   box-shadow:0 0 0 3px var(--topbar-focus-ring);
 }
 .git-btn svg{width:24px;height:24px;}
+.qr-landing .qr-topbar .git-btn{
+  width:48px;
+  height:48px;
+  min-height:48px;
+  min-width:48px;
+  line-height:1;
+  padding:0;
+}
+.qr-landing .qr-topbar .git-btn svg{
+  width:26px;
+  height:26px;
+}
 .qr-landing .qr-topbar #offcanvas-toggle.git-btn{
   width:56px;
   height:56px;


### PR DESCRIPTION
## Summary
- expand landing page topbar git buttons to a 48px square to match other controls
- slightly enlarge the embedded SVG icons so they remain centered within the bigger targets

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d13f2cd0d8832ba98a197412296464