### PR TITLE
Adjust calServer stats colors for theme contrast

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -157,6 +157,16 @@ body.qr-landing.calserver-theme .calserver-stats-strip__value {
     letter-spacing: -0.01em;
 }
 
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .calserver-stats-strip__value,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .calserver-stats-strip__value {
+    color: var(--qr-text);
+}
+
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast) .calserver-stats-strip__value,
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast) .calserver-stats-strip__value {
+    color: color-mix(in oklab, var(--calserver-primary) 86%, #0c1a3a 14%);
+}
+
 body.qr-landing.calserver-theme .calserver-stats-strip__label {
     color: var(--qr-muted);
     font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- add dark theme override so calServer stats values inherit the main text color for improved readability
- ensure light theme keeps a high-contrast accent color for the stat values with an oklab color mix

## Testing
- Manual verification: toggled calServer hero theme to confirm all three stat values pass contrast


------
https://chatgpt.com/codex/tasks/task_e_68d145a36c38832bb3b8d57a06ff86e1