### PR TITLE
Remove demo booking button from calServer top menu

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -52,12 +52,6 @@
               </li>
             {% endfor %}
           </ul>
-          <a class="uk-navbar-item btn btn-black top-cta uk-visible@m"
-             href="https://calendly.com/calhelp/calserver-vorstellung"
-             target="_blank"
-             rel="noopener">
-            <span class="uk-margin-small-right" uk-icon="icon: calendar"></span>Demo buchen
-          </a>
           <div class="uk-navbar-item config-menu uk-inline">
             <button id="configMenuToggle"
                     type="button"


### PR DESCRIPTION
## Summary
- remove the "Demo buchen" button from the calServer top navigation bar on the marketing page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d14695e62c832b816587736207d72f