### PR TITLE
Ensure calServer cards use white headings in dark mode

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -27,6 +27,15 @@ body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) {
     );
 }
 
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card .uk-card-title,
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card h3,
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card h4,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card .uk-card-title,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card h3,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card h4 {
+    color: var(--cs-text-on-dark) !important;
+}
+
 body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast),
 body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast) {
     --qr-hero-grad-start: var(--qr-brand-50);


### PR DESCRIPTION
## Summary
- override calServer dark-mode card heading styles so they inherit the light-on-dark token
- cover both `.uk-card-title` and plain `h3`/`h4` headings to support all landing page cards

## Testing
- not run (UI-only CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68d1490c49b8832b9da4c2a1992c7ba5