### PR TITLE
Replace module screenshots with placeholder asset

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -559,6 +559,139 @@ body.qr-landing.calserver-theme .feature-slider__list > li.is-center .feature-ca
     box-shadow: var(--cs-card-focus-shadow);
 }
 
+body.qr-landing.calserver-theme #modules .calserver-modules-grid {
+    display: grid;
+    gap: 32px;
+    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+    margin-top: 40px;
+    align-items: start;
+}
+
+body.qr-landing.calserver-theme .calserver-modules-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    border-bottom: none;
+}
+
+body.qr-landing.calserver-theme .calserver-modules-nav__link {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 100%;
+    padding: 18px 20px;
+    border-radius: 18px;
+    background: color-mix(in oklab, var(--calserver-primary) 10%, transparent);
+    border: 1px solid color-mix(in oklab, var(--calserver-primary) 15%, var(--qr-card-border) 85%);
+    box-shadow: 0 18px 36px -28px rgba(15, 23, 42, 0.28);
+    color: var(--qr-text);
+    text-decoration: none;
+    transition: background-color 200ms ease, border-color 200ms ease, box-shadow 200ms ease,
+        transform 200ms ease;
+}
+
+body.qr-landing.calserver-theme .calserver-modules-nav__title {
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+
+body.qr-landing.calserver-theme .calserver-modules-nav__desc {
+    color: color-mix(in oklab, var(--qr-text) 68%, var(--qr-bg) 32%);
+    font-size: 0.92rem;
+}
+
+body.qr-landing.calserver-theme .calserver-modules-nav li.uk-active .calserver-modules-nav__link,
+body.qr-landing.calserver-theme .calserver-modules-nav__link:hover {
+    background: color-mix(in oklab, var(--calserver-primary) 18%, var(--qr-card) 82%);
+    border-color: color-mix(in oklab, var(--calserver-primary) 45%, transparent);
+    box-shadow: 0 24px 48px -30px rgba(15, 23, 42, 0.42);
+    transform: translateY(-2px);
+}
+
+body.qr-landing.calserver-theme .calserver-modules-nav__link:focus-visible {
+    outline: 3px solid color-mix(in oklab, var(--calserver-primary) 60%, #ffffff 40%);
+    outline-offset: 3px;
+}
+
+body.qr-landing.calserver-theme .calserver-modules-nav > li {
+    margin: 0;
+}
+
+body.qr-landing.calserver-theme .calserver-modules-switcher {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+body.qr-landing.calserver-theme .calserver-modules-switcher > li {
+    list-style: none;
+}
+
+body.qr-landing.calserver-theme .calserver-module-figure {
+    margin: 0;
+    background: var(--qr-card);
+    border: 1px solid var(--qr-card-border);
+    border-radius: 22px;
+    overflow: hidden;
+    box-shadow: 0 22px 48px -28px rgba(15, 23, 42, 0.35);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+body.qr-landing.calserver-theme .calserver-module-figure img {
+    display: block;
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+}
+
+body.qr-landing.calserver-theme .calserver-module-figure figcaption {
+    padding: 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+body.qr-landing.calserver-theme .calserver-module-figure h3 {
+    margin: 0;
+}
+
+body.qr-landing.calserver-theme .calserver-module-figure .uk-list {
+    margin-bottom: 0;
+}
+
+@media (max-width: 1024px) {
+    body.qr-landing.calserver-theme #modules .calserver-modules-grid {
+        grid-template-columns: 1fr;
+    }
+
+    body.qr-landing.calserver-theme .calserver-modules-nav {
+        flex-direction: row;
+        overflow-x: auto;
+        padding-bottom: 8px;
+        margin-bottom: 12px;
+    }
+
+    body.qr-landing.calserver-theme .calserver-modules-nav > li {
+        min-width: 240px;
+        flex: 0 0 auto;
+    }
+}
+
+@media (max-width: 640px) {
+    body.qr-landing.calserver-theme .calserver-modules-nav__link {
+        padding: 16px;
+    }
+
+    body.qr-landing.calserver-theme .calserver-module-figure figcaption {
+        padding: 22px;
+    }
+}
+
 body.qr-landing.calserver-theme .feature-slider__list > li.is-center .feature-card:not(.feature-card--focus) {
     box-shadow: 0 22px 48px -32px rgba(15, 23, 42, 0.45);
 }

--- a/public/img/calserver/modules/module-placeholder.svg
+++ b/public/img/calserver/modules/module-placeholder.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Platzhaltergrafik für calServer-Modulscreenshots">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f63e6" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#0b1532" stop-opacity="0.95" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.94" />
+      <stop offset="100%" stop-color="#e2e8f0" stop-opacity="0.94" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)" />
+  <g opacity="0.28">
+    <circle cx="180" cy="120" r="96" fill="#ffffff" />
+    <circle cx="1020" cy="540" r="120" fill="#1f63e6" />
+    <circle cx="840" cy="156" r="72" fill="#22d3ee" />
+  </g>
+  <rect x="140" y="128" width="920" height="420" rx="28" fill="url(#panel)" stroke="#cbd5f5" stroke-width="4" />
+  <g font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" text-anchor="middle" fill="#0f172a">
+    <text x="600" y="252" font-size="58" font-weight="700">calServer Modul</text>
+    <text x="600" y="324" font-size="28" opacity="0.82">Hier wird später ein Screenshot eingebunden.</text>
+    <text x="600" y="392" font-size="24" opacity="0.72">Dieser Platzhalter markiert die benötigte Grafik.</text>
+  </g>
+  <g transform="translate(200 460)" opacity="0.88">
+    <rect width="720" height="68" rx="14" fill="#1f63e6" />
+    <text x="360" y="46" font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="28" font-weight="600" fill="#ffffff">
+      Screenshot folgt im finalen Stand
+    </text>
+  </g>
+</svg>

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -600,58 +600,103 @@
 
     <hr class="uk-divider-icon">
 
+    {% set modulePlaceholder = 'module-placeholder.svg' %}
+    {% set modules = [
+      {
+        'slug': 'device-management',
+        'title': 'Geräteverwaltung & Historie',
+        'description': 'Geräteakten, Anhänge und Historie in einer Oberfläche – inklusive Messwerten.',
+        'alt': 'Platzhaltergrafik für die calServer-Geräteverwaltung – finaler Screenshot folgt',
+        'image': modulePlaceholder,
+        'features': [
+          'Geräte- & Standortverwaltung',
+          'Versionierte Dokumente & Bilder',
+          'Messwerte direkt verknüpfen'
+        ]
+      },
+      {
+        'slug': 'calendar-resources',
+        'title': 'Kalender & Ressourcen',
+        'description': 'Planung von Terminen, Leihgeräten und Personal in einer Ansicht.',
+        'alt': 'Platzhaltergrafik für den calServer-Kalender – finaler Screenshot folgt',
+        'image': modulePlaceholder,
+        'features': [
+          'Gantt & Kalender',
+          'Verfügbarkeits-Check in Echtzeit',
+          'Outlook/iCal-Integration'
+        ]
+      },
+      {
+        'slug': 'order-ticketing',
+        'title': 'Auftrags- & Ticketverwaltung',
+        'description': 'Vom Auftrag bis zur Rechnung – mit klaren Status, Workflows und Dokumenten.',
+        'alt': 'Platzhaltergrafik für die calServer-Auftragsverwaltung – finaler Screenshot folgt',
+        'image': modulePlaceholder,
+        'features': [
+          'Service & Ticketsystem',
+          'Angebote, Aufträge, Rechnungen',
+          'Eskalationen & SLAs'
+        ]
+      },
+      {
+        'slug': 'self-service',
+        'title': 'Self-Service & Extranet',
+        'description': 'Stellen Sie Kunden & Partnern Geräteinfos, Zertifikate und Formulare bereit.',
+        'alt': 'Platzhaltergrafik für das calServer-Kundenportal – finaler Screenshot folgt',
+        'image': modulePlaceholder,
+        'features': [
+          'Kundenportale',
+          'Dokumente & Zertifikate',
+          'Individuelle Rechte'
+        ]
+      }
+    ] %}
     <section id="modules" class="uk-section uk-section-muted">
       <div class="uk-container">
         <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
           <h2 class="uk-heading-line"><span>Module, die den Unterschied machen</span></h2>
           <span class="muted">Individuell kombinierbar – ohne versteckte Kosten</span>
         </div>
-        <div class="uk-child-width-1-1 uk-child-width-1-2@m uk-grid-large uk-grid-match"
-             uk-grid
-             uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
-              <h3 class="uk-card-title">Geräteverwaltung &amp; Historie</h3>
-              <p class="muted">Geräteakten, Anhänge und Historie in einer Oberfläche – inklusive Messwerten.</p>
-              <ul class="uk-list uk-list-bullet muted">
-                <li>Geräte- &amp; Standortverwaltung</li>
-                <li>Versionierte Dokumente &amp; Bilder</li>
-                <li>Messwerte direkt verknüpfen</li>
-              </ul>
-            </div>
+        <div class="calserver-modules-grid" uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > *; delay: 100; repeat: true">
+          <div>
+            <ul class="uk-tab calserver-modules-nav"
+                uk-switcher="connect: #calserver-modules-switcher; animation: uk-animation-fade">
+              {% for module in modules %}
+                <li>
+                  <a class="calserver-modules-nav__link" href="#module-{{ module.slug }}">
+                    <span class="calserver-modules-nav__title">{{ module.title }}</span>
+                    <span class="calserver-modules-nav__desc">{{ module.description }}</span>
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
           </div>
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
-              <h3 class="uk-card-title">Kalender &amp; Ressourcen</h3>
-              <p class="muted">Planung von Terminen, Leihgeräten und Personal in einer Ansicht.</p>
-              <ul class="uk-list uk-list-bullet muted">
-                <li>Gantt &amp; Kalender</li>
-                <li>Verfügbarkeits-Check in Echtzeit</li>
-                <li>Outlook/iCal-Integration</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
-              <h3 class="uk-card-title">Auftrags- &amp; Ticketverwaltung</h3>
-              <p class="muted">Vom Auftrag bis zur Rechnung – mit klaren Status, Workflows und Dokumenten.</p>
-              <ul class="uk-list uk-list-bullet muted">
-                <li>Service &amp; Ticketsystem</li>
-                <li>Angebote, Aufträge, Rechnungen</li>
-                <li>Eskalationen &amp; SLAs</li>
-              </ul>
-            </div>
-          </div>
-          <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-card-hover">
-              <h3 class="uk-card-title">Self-Service &amp; Extranet</h3>
-              <p class="muted">Stellen Sie Kunden &amp; Partnern Geräteinfos, Zertifikate und Formulare bereit.</p>
-              <ul class="uk-list uk-list-bullet muted">
-                <li>Kundenportale</li>
-                <li>Dokumente &amp; Zertifikate</li>
-                <li>Individuelle Rechte</li>
-              </ul>
-            </div>
+          <div>
+            <ul id="calserver-modules-switcher" class="uk-switcher calserver-modules-switcher">
+              {% for module in modules %}
+                <li>
+                  <figure id="module-{{ module.slug }}" class="calserver-module-figure">
+                    <img src="{{ basePath }}/img/calserver/modules/{{ module.image|default('module-placeholder.svg') }}"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="{{ module.alt }}">
+                    <figcaption>
+                      <h3 class="uk-h3">{{ module.title }}</h3>
+                      <p class="muted">{{ module.description }}</p>
+                      {% if module.features is not empty %}
+                        <ul class="uk-list uk-list-bullet muted">
+                          {% for feature in module.features %}
+                            <li>{{ feature }}</li>
+                          {% endfor %}
+                        </ul>
+                      {% endif %}
+                    </figcaption>
+                  </figure>
+                </li>
+              {% endfor %}
+            </ul>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the calServer module screenshot references with a shared placeholder asset and updated descriptive alt texts
- add a themed SVG placeholder graphic for the marketing page modules while removing binary WEBP files from the repository

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1b4ac8104832b80cdc47e7827f806