### PR TITLE
Replace calServer hero placeholder with video

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -176,8 +176,13 @@
           <div uk-scrollspy="cls: uk-animation-slide-right-small; repeat: true">
             <div class="uk-card uk-card-default uk-card-body uk-text-center shadow-soft uk-position-relative">
               <span class="pill pill--accent uk-position-absolute uk-position-top-right uk-margin-small">Live-Vorschau</span>
-              <div class="uk-height-medium uk-flex uk-flex-center uk-flex-middle uk-background-muted uk-border-rounded">
-                <span class="muted">[Dashboard-Mockup Platzhalter]</span>
+              <div class="uk-cover-container uk-border-rounded uk-overflow-hidden uk-height-medium">
+                <iframe src="https://www.youtube-nocookie.com/embed/ovHo2SF84u0"
+                        title="calServer Vorstellung"
+                        loading="lazy"
+                        allowfullscreen
+                        uk-responsive
+                        class="uk-cover"></iframe>
               </div>
               <p class="uk-margin-small-top muted">Schnelle Suche · Klare Tabellen · Intuitive Workflows</p>
             </div>


### PR DESCRIPTION
## Summary
- embed the calServer introduction video in the hero card instead of the placeholder text
- ensure the iframe uses UIkit cover utilities for a responsive fit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1c517d250832bae58a8bf47c69409