### PR TITLE
Enhance calserver pricing highlight card for dark mode

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -27,6 +27,77 @@ body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) {
     );
 }
 
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary {
+    background: linear-gradient(
+            135deg,
+            color-mix(in oklab, var(--calserver-primary) 56%, #1c2f55 44%) 0%,
+            color-mix(in oklab, var(--calserver-primary) 82%, #0c1529 18%) 100%
+        ) !important;
+    border-color: color-mix(in oklab, var(--calserver-primary) 60%, rgba(255, 255, 255, 0.26)) !important;
+    color: var(--cs-text-on-dark);
+    box-shadow: 0 32px 58px -34px rgba(20, 66, 153, 0.65),
+        0 24px 44px -32px rgba(5, 13, 30, 0.72);
+}
+
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary.uk-card-primary--highlight,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary.uk-card-primary--highlight {
+    background: linear-gradient(
+            145deg,
+            color-mix(in oklab, var(--calserver-primary) 68%, #233a6b 32%) 0%,
+            color-mix(in oklab, var(--calserver-primary) 94%, #142348 6%) 100%
+        ) !important;
+    border-color: color-mix(in oklab, var(--calserver-primary) 78%, rgba(255, 255, 255, 0.38)) !important;
+    box-shadow: 0 42px 72px -36px color-mix(in oklab, var(--calserver-primary) 52%, rgba(28, 108, 255, 0.65)),
+        0 26px 52px -34px rgba(4, 10, 25, 0.82);
+}
+
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary p,
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary li,
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary .muted,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary p,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary li,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary .muted {
+    color: color-mix(in oklab, #ffffff 92%, rgba(255, 255, 255, 0.68) 8%) !important;
+}
+
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary .uk-list-bullet > li::before,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary .uk-list-bullet > li::before {
+    border-color: color-mix(in oklab, #ffffff 80%, rgba(31, 99, 230, 0.36) 20%);
+}
+
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary .uk-button-default,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary .uk-button-default {
+    background: color-mix(in oklab, #ffffff 88%, var(--calserver-primary) 12%);
+    color: color-mix(in oklab, var(--calserver-primary) 90%, #030a1c 10%);
+    border-color: color-mix(in oklab, var(--calserver-primary) 42%, rgba(255, 255, 255, 0.45));
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--calserver-primary) 46%, rgba(255, 255, 255, 0.42)) inset,
+        0 16px 30px -20px rgba(19, 71, 179, 0.6);
+}
+
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary .uk-button-default:hover,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary .uk-button-default:hover {
+    background: color-mix(in oklab, #ffffff 74%, var(--calserver-primary) 26%);
+    color: color-mix(in oklab, var(--calserver-primary) 94%, #050b1e 6%);
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--calserver-primary) 58%, rgba(255, 255, 255, 0.48)) inset,
+        0 22px 36px -22px rgba(31, 99, 230, 0.65);
+}
+
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary .uk-button-default:focus-visible,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary .uk-button-default:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--calserver-primary) 75%, #7eaaff 25%);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--calserver-primary) 54%, rgba(255, 255, 255, 0.4));
+}
+
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary .pill--badge,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .uk-card-primary .pill--badge {
+    background: color-mix(in oklab, #ffffff 90%, var(--calserver-primary) 10%);
+    color: color-mix(in oklab, var(--calserver-primary) 78%, #020817 22%);
+    border-color: color-mix(in oklab, var(--calserver-primary) 46%, rgba(255, 255, 255, 0.6));
+    box-shadow: 0 18px 32px -22px rgba(31, 99, 230, 0.55);
+}
+
 body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card .uk-card-title,
 body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card h3,
 body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card h4,

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -993,7 +993,7 @@
             </div>
           </div>
           <div class="anim">
-            <div class="uk-card uk-card-primary uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative">
+            <div class="uk-card uk-card-primary uk-card-primary--highlight uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative">
               <span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Empfohlen</span>
               <h3>Performance</h3>
               <p>Für größere Teams mit mehr Tempo.</p>


### PR DESCRIPTION
## Summary
- add dark-mode specific gradients, borders, and focus treatments for the calServer highlight card so it stands out while keeping WCAG contrast
- tune button, text, and badge colors on the highlighted card for readability in dark mode
- apply a dedicated modifier class to the recommended pricing card to opt-in to the new styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1c64eb3a8832bbb09bf20e6cb7276