### PR TITLE
Vereinheitliche KPI-Labels auf der calServer-Seite

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -496,7 +496,7 @@ body.qr-landing.calserver-theme .calserver-stats-strip__header {
 body.qr-landing.calserver-theme .calserver-stats-strip__title-group {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 2px;
     flex: 1;
     min-width: 0;
 }
@@ -534,7 +534,7 @@ body.qr-landing.calserver-theme .calserver-stats-strip__label {
 }
 
 body.qr-landing.calserver-theme .calserver-stats-strip__benefit {
-    margin: 10px 0 0;
+    margin: 8px 0 0;
     color: var(--qr-text);
     font-size: 0.95rem;
     line-height: 1.45;

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -215,7 +215,7 @@
               </span>
               <div class="calserver-stats-strip__title-group">
                 <span class="calserver-stats-strip__title">umgesetzte Kund:innen-Wünsche</span>
-                <span class="calserver-stats-strip__label">Letzte 12 Monate &bull; Stand: 23.09.2025</span>
+                <span class="calserver-stats-strip__label">Stand: 23.09.2025</span>
               </div>
               <span class="calserver-stats-strip__tooltip"
                     uk-icon="icon: info"
@@ -237,7 +237,7 @@
               </span>
               <div class="calserver-stats-strip__title-group">
                 <span class="calserver-stats-strip__title">Systemverfügbarkeit</span>
-                <span class="calserver-stats-strip__label">Verlässlich im Betrieb &bull; Stand: 23.09.2025</span>
+                <span class="calserver-stats-strip__label">Stand: 23.09.2025</span>
               </div>
               <span class="calserver-stats-strip__tooltip"
                     uk-icon="icon: info"
@@ -258,7 +258,7 @@
               </span>
               <div class="calserver-stats-strip__title-group">
                 <span class="calserver-stats-strip__title">Jahre am Markt</span>
-                <span class="calserver-stats-strip__label">Kontinuierlich im Einsatz &bull; Stand: 23.09.2025</span>
+                <span class="calserver-stats-strip__label">Stand: 23.09.2025</span>
               </div>
               <span class="calserver-stats-strip__tooltip"
                     uk-icon="icon: info"


### PR DESCRIPTION
## Summary
- kürzt die Labeltexte der drei KPI-Karten auf einen einheitlichen "Stand: 23.09.2025"
- passt die vertikalen Abstände der KPI-Karten an, damit Titel und Nutzenzeile nach der Vereinheitlichung weiterhin gleichmäßig wirken

## Testing
- ✅ Manuelle Sichtprüfung der calServer-Marketingseite im Browser (Desktop & Mobil)

------
https://chatgpt.com/codex/tasks/task_e_68d1ce1a8ad4832bbcba1e83d417deb5