### PR TITLE
Move calserver KPI titles into label row

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -214,8 +214,7 @@
                 1.668
               </span>
               <div class="calserver-stats-strip__title-group">
-                <span class="calserver-stats-strip__title">umgesetzte Kund:innen-Wünsche</span>
-                <span class="calserver-stats-strip__label">Stand: 23.09.2025</span>
+                <span class="calserver-stats-strip__label">umgesetzte Kund:innen-Wünsche</span>
               </div>
               <span class="calserver-stats-strip__tooltip"
                     uk-icon="icon: info"
@@ -236,8 +235,7 @@
                 99,9 %
               </span>
               <div class="calserver-stats-strip__title-group">
-                <span class="calserver-stats-strip__title">Systemverfügbarkeit</span>
-                <span class="calserver-stats-strip__label">Stand: 23.09.2025</span>
+                <span class="calserver-stats-strip__label">Systemverfügbarkeit</span>
               </div>
               <span class="calserver-stats-strip__tooltip"
                     uk-icon="icon: info"
@@ -257,8 +255,7 @@
                 &gt; 15
               </span>
               <div class="calserver-stats-strip__title-group">
-                <span class="calserver-stats-strip__title">Jahre am Markt</span>
-                <span class="calserver-stats-strip__label">Stand: 23.09.2025</span>
+                <span class="calserver-stats-strip__label">Jahre am Markt</span>
               </div>
               <span class="calserver-stats-strip__tooltip"
                     uk-icon="icon: info"


### PR DESCRIPTION
## Summary
- remove the hard-coded "Stand: 23.09.2025" label from the calServer KPI cards
- show each KPI title in the label row beneath the metric value instead of the removed date

## Testing
- composer test *(fails: requires project-specific environment configuration such as MAIN_DOMAIN and Stripe keys)*

------
https://chatgpt.com/codex/tasks/task_e_68d2511d961c832bbc016a746006ef4a