### PR TITLE
Align calserver stats header content

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -488,7 +488,7 @@ body.qr-landing.calserver-theme .calserver-stats-strip__item {
 
 body.qr-landing.calserver-theme .calserver-stats-strip__header {
     display: flex;
-    align-items: flex-start;
+    align-items: flex-end;
     gap: 14px;
     flex-wrap: wrap;
 }


### PR DESCRIPTION
## Summary
- align the calServer stats header elements to the bottom so the label sits level with the value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d26235b524832b92cb621106b34496