### PR TITLE
Update calServer use case tabs with real case studies

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -776,10 +776,10 @@
           <span class="muted">Vom Labor bis zum Außendienst</span>
         </div>
         <ul class="uk-subnav uk-subnav-pill uk-margin-large-top usecase-tabs" uk-switcher="animation: uk-animation-fade">
-          <li><a href="#">Kalibrierlabor</a></li>
-          <li><a href="#">Industrielabor</a></li>
-          <li><a href="#">Service &amp; Außendienst</a></li>
-          <li><a href="#">Qualitätsmanagement</a></li>
+          <li><a href="#">Thermo Fisher Scientific (EMEA)</a></li>
+          <li><a href="#">ZF Friedrichshafen</a></li>
+          <li><a href="#">Berliner Stadtwerke</a></li>
+          <li><a href="#">VDE Deutschland</a></li>
         </ul>
         <ul class="uk-switcher uk-margin-large-top"
             uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .usecase-story, .usecase-highlight; delay: 100; repeat: true">
@@ -787,41 +787,44 @@
             <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
               <div class="usecase-story">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
-                <h3 class="uk-h2">Kalibrierlabor Dr. Keller</h3>
-                <p class="uk-text-lead">calServer orchestriert 5.000 Geräteakten und ISO-konforme Zertifikate an einem Ort.</p>
-                <p>Kalibrieraufträge werden automatisch priorisiert, Abnahmen dokumentiert und Zertifikate revisionssicher abgelegt.
-                  Das Team arbeitet mit digitalen Checklisten und spart sich Papierstapel sowie Abstimmungsrunden.</p>
+                <h3 class="uk-h2">Thermo Fisher Scientific – EMEA Labore</h3>
+                <p class="uk-text-lead">calServer orchestriert EMEA-weit Leihgeräte, Geräteakten und ISO-/DAkkS-konforme Zertifikate auf einer Plattform.</p>
+                <p>Mehrere Labore arbeiten in einem konsistenten Workflow: Leihverwaltung, Prüffristen und Zertifikate werden zentral gesteuert, während Aufträge und Rückgaben standortübergreifend nachvollziehbar bleiben. Die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL hält Stammdaten, Kalibrierläufe und Ergebnisse automatisch aktuell.</p>
                 <ul class="uk-list uk-list-bullet muted">
-                  <li>Automatische Erinnerung an Prüffristen und Kalibrierketten</li>
-                  <li>Digitale Prüfprotokolle inkl. Freigabe-Workflow</li>
-                  <li>Kundenportal für Zertifikate &amp; Gerätestammdaten</li>
+                  <li>Zentrale Leihverwaltung mit Termin- &amp; Rückgabe-Erinnerungen</li>
+                  <li>Revisionssicheres DMS für Zertifikate &amp; Historie</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
                 </ul>
               </div>
               <div class="usecase-highlight">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
                   <h4 class="uk-heading-bullet">Key Facts</h4>
                   <ul class="uk-list uk-list-divider">
-                    <li><strong>ISO/IEC 17025</strong> konforme Ablage und Versionierung</li>
-                    <li><strong>Dashboard</strong> für Durchlaufzeiten &amp; Rückstände</li>
-                    <li><strong>Digitale Signatur</strong> für Freigaben &amp; Zertifikate</li>
+                    <li>EMEA-weit einheitliche Leihverwaltung &amp; Geräteakten</li>
+                    <li>Revisionssicheres DMS für Zertifikate &amp; Historie</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
-                  <div class="uk-grid-small uk-child-width-1-2@s uk-text-center uk-margin-top" uk-grid>
+                  <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
-                      <span class="uk-h2 uk-display-block">5.000+</span>
-                      <span class="muted uk-text-small">Messmittel im Bestand</span>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">EMEA-Standorte</span>
                     </div>
                     <div>
-                      <span class="uk-h2 uk-display-block">48&nbsp;h</span>
-                      <span class="muted uk-text-small">Ø Durchlaufzeit pro Auftrag</span>
+                      <span class="uk-h2 uk-display-block">{TBD} %</span>
+                      <span class="muted uk-text-small">weniger Dispositionsaufwand</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">Geräte im Bestand</span>
                     </div>
                   </div>
-                  <a class="uk-button uk-button-text uk-margin-top" href="{{ basePath }}/downloads/case-kalibrierlabor.pdf">
-                    <span class="uk-margin-small-right" uk-icon="icon: download"></span>Case Study herunterladen
+                  <a class="uk-button uk-button-text uk-margin-top" href="#">
+                    <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
                 <div class="usecase-visual uk-margin-top">
                   <div class="uk-height-medium uk-background-muted uk-border-rounded uk-flex uk-flex-middle uk-flex-center">
-                    <span class="muted">Kalibrierschein-Vorschau</span>
+                    <span class="muted">Leihverwaltung &amp; Geräteakten</span>
                   </div>
                 </div>
               </div>
@@ -831,45 +834,44 @@
             <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
               <div class="usecase-story">
                 <span class="pill pill--badge uk-margin-small-bottom">Industrielabor</span>
-                <h3 class="uk-h2">NordWerk Industries</h3>
-                <p class="uk-text-lead">Von der Betriebsmittelverwaltung bis zur Arbeitssicherheit: alles in einem Dashboard.</p>
-                <p>NordWerk steuert 12 Standorte zentral und hat jederzeit Klarheit über Auslastungen, Wartungen und Compliance.
-                  Eskalationen werden automatisch angestoßen und Teams erhalten rollenspezifische Aufgabenlisten.</p>
+                <h3 class="uk-h2">ZF – API-Messwerte auf Kubernetes mit SSO</h3>
+                <p class="uk-text-lead">calServer verbindet skalierbare Messwert-APIs auf Kubernetes mit SSO und Geräteakten-Management.</p>
+                <p>Messwerte fließen über Microservices automatisiert ein; Geräte, Zertifikate und Auswertungen bleiben im Zugriff der berechtigten Teams. Single Sign-On vereinfacht den Zugang, die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL stellt durchgehend konsistente Kalibrierdaten sicher.</p>
                 <ul class="uk-list uk-list-bullet muted">
-                  <li>Mobile Inventur mit QR-Codes und Offline-Modus</li>
-                  <li>Verknüpfung mit ERP &amp; Instandhaltungsplanung</li>
-                  <li>Auditberichte auf Knopfdruck für QS &amp; HSE</li>
+                  <li>API-Ingestion von Messwerten (Microservices/Kubernetes)</li>
+                  <li>SSO (z. B. EntraID/Google) für nahtlosen Zugriff</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
                 </ul>
               </div>
               <div class="usecase-highlight">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
                   <h4 class="uk-heading-bullet">Key Facts</h4>
                   <ul class="uk-list uk-list-divider">
-                    <li><strong>12 Standorte</strong> in einem Mandanten verwaltet</li>
-                    <li><strong>99&nbsp;%</strong> Termintreue dank Eskalationslogik</li>
-                    <li><strong>IoT-Anbindung</strong> für Zustandsüberwachung</li>
+                    <li>Microservices auf Kubernetes</li>
+                    <li>SSO für schnellen, sicheren Zugang</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
-                      <span class="uk-h2 uk-display-block">3x</span>
-                      <span class="muted uk-text-small">Schnellere Inventur</span>
+                      <span class="uk-h2 uk-display-block">{TBD}/Tag</span>
+                      <span class="muted uk-text-small">Messwerte verarbeitet</span>
                     </div>
                     <div>
-                      <span class="uk-h2 uk-display-block">-25&nbsp;%</span>
-                      <span class="muted uk-text-small">Stillstandszeiten</span>
+                      <span class="uk-h2 uk-display-block">{TBD} %</span>
+                      <span class="muted uk-text-small">automatisierte Flows</span>
                     </div>
                     <div>
-                      <span class="uk-h2 uk-display-block">24/7</span>
-                      <span class="muted uk-text-small">Live-Monitoring</span>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">SSO-Nutzer:innen</span>
                     </div>
                   </div>
-                  <a class="uk-button uk-button-text uk-margin-top" href="{{ basePath }}/downloads/case-industrielabor.pdf">
-                    <span class="uk-margin-small-right" uk-icon="icon: cloud-download"></span>Highlights als PDF
+                  <a class="uk-button uk-button-text uk-margin-top" href="#">
+                    <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
                 <div class="usecase-visual uk-margin-top">
                   <div class="uk-height-medium uk-background-muted uk-border-rounded uk-flex uk-flex-middle uk-flex-center">
-                    <span class="muted">Produktionslinie &amp; Dashboard</span>
+                    <span class="muted">Messwerte &amp; SSO-Workflows</span>
                   </div>
                 </div>
               </div>
@@ -878,42 +880,45 @@
           <li>
             <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
               <div class="usecase-story">
-                <span class="pill pill--badge uk-margin-small-bottom">Service &amp; Außendienst</span>
-                <h3 class="uk-h2">EnergiePro Field Services</h3>
-                <p class="uk-text-lead">Tickets, Checklisten und Messwerte werden direkt vor Ort abgeschlossen.</p>
-                <p>Techniker:innen synchronisieren Einsätze über die mobile App, dokumentieren Ergebnisse mit Fotos und Signaturen und
-                  reduzieren Nachbearbeitung im Büro. Disponent:innen sehen Anfahrtszeiten, Materialbedarf und Einsatzstatus live.</p>
+                <span class="pill pill--badge uk-margin-small-bottom">Assetmanagement</span>
+                <h3 class="uk-h2">Berliner Stadtwerke – Projekte &amp; Wartung für erneuerbare Anlagen</h3>
+                <p class="uk-text-lead">calServer steuert Projekte, Wartungspläne und Einsätze für regenerative Energieanlagen der Stadt Berlin.</p>
+                <p>Vom Maßnahmenplan bis zur Einsatzplanung: Teams behalten Verfügbarkeit, Leistung und Kosten im Blick. Checklisten, Offline-Fähigkeit und Eskalationslogik sichern die fristgerechte Abarbeitung. (Ohne MET/CAL/MET/TEAM – Fokus auf Projekt- &amp; Wartungssteuerung.)</p>
                 <ul class="uk-list uk-list-bullet muted">
-                  <li>Offline-fähige Einsatzberichte mit digitaler Unterschrift</li>
-                  <li>Automatische Übergabe an Service- &amp; ERP-Systeme</li>
-                  <li>Intelligente Planung nach Skills, Region und SLA</li>
+                  <li>Projekt- &amp; Maßnahmensteuerung inkl. Einsatzplanung</li>
+                  <li>Geplante/ungeplante Wartung mit Checklisten &amp; Offline-Modus</li>
+                  <li>Dashboards für Verfügbarkeit, Leistung &amp; Kosten/Nutzen</li>
                 </ul>
               </div>
               <div class="usecase-highlight">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
                   <h4 class="uk-heading-bullet">Key Facts</h4>
                   <ul class="uk-list uk-list-divider">
-                    <li><strong>-3&nbsp;h</strong> Nacharbeit pro Einsatz</li>
-                    <li><strong>Live-Tracking</strong> für Status &amp; Materialverbrauch</li>
-                    <li><strong>Mobiler Zugriff</strong> auf Messmittelhistorien</li>
+                    <li>Stadtweite EE-Anlagen im Überblick</li>
+                    <li>Geplante &amp; ungeplante Wartung aus einem System</li>
+                    <li>Dashboards für Verfügbarkeit &amp; Performance</li>
                   </ul>
-                  <div class="uk-grid-small uk-child-width-1-2@s uk-text-center uk-margin-top" uk-grid>
+                  <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
-                      <span class="uk-h2 uk-display-block">100&nbsp;%</span>
-                      <span class="muted uk-text-small">Digitale Einsatzdokumentation</span>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">Anlagen/Standorte</span>
                     </div>
                     <div>
-                      <span class="uk-h2 uk-display-block">15&nbsp;Min.</span>
-                      <span class="muted uk-text-small">Onboarding pro Techniker:in</span>
+                      <span class="uk-h2 uk-display-block">{TBD} %</span>
+                      <span class="muted uk-text-small">höhere Anlagenverfügbarkeit</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}/Monat</span>
+                      <span class="muted uk-text-small">geplante Wartungsaufträge</span>
                     </div>
                   </div>
-                  <a class="uk-button uk-button-text uk-margin-top" href="{{ basePath }}/downloads/checkliste-aussendienst.xlsx">
-                    <span class="uk-margin-small-right" uk-icon="icon: file-text"></span>Checkliste herunterladen
+                  <a class="uk-button uk-button-text uk-margin-top" href="#">
+                    <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
                 <div class="usecase-visual uk-margin-top">
                   <div class="uk-height-medium uk-background-muted uk-border-rounded uk-flex uk-flex-middle uk-flex-center">
-                    <span class="muted">Mobile Einsatzansicht</span>
+                    <span class="muted">Wartungs- &amp; Projektplanung</span>
                   </div>
                 </div>
               </div>
@@ -923,45 +928,44 @@
             <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
               <div class="usecase-story">
                 <span class="pill pill--badge uk-margin-small-bottom">Qualitätsmanagement</span>
-                <h3 class="uk-h2">MedTech Qualitätssicherung</h3>
-                <p class="uk-text-lead">Validierungen, Dokumentation und Lieferantenfreigaben sind immer auditbereit.</p>
-                <p>Das QM-Team steuert Prüfmittel, Änderungsstände und Chargenverfolgung zentral. CAPA-Maßnahmen werden strukturiert
-                  abgearbeitet, während Mitarbeiterschulungen automatisiert nachverfolgt werden.</p>
+                <h3 class="uk-h2">VDE – Agile Auftragssteuerung &amp; Intranet</h3>
+                <p class="uk-text-lead">calServer bündelt agile Auftragssteuerung und Dokumentenflüsse für Prüf- und Zertifizierungsprozesse.</p>
+                <p>Teams planen, priorisieren und dokumentieren Vorgänge auf einem anpassbaren Board; Freigaben sind versioniert, nachvollziehbar und auditfest. Rollen und Vorlagen verteilen Informationen zielgerichtet. Die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL sorgt für konsistente Mess- und Auftragsdaten.</p>
                 <ul class="uk-list uk-list-bullet muted">
-                  <li>Verknüpfung von Prüfplänen, SOPs und Schulungsstatus</li>
-                  <li>CAPA-Workflows mit Eskalationen und Erinnerungen</li>
-                  <li>Lieferantenbewertungen mit Scorecards &amp; Historie</li>
+                  <li>Agiles Auftragsboard mit SLAs, Eskalationen und Vorlagen</li>
+                  <li>Revisionssichere DMS-Ablage inkl. Freigabe-Workflow</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
                 </ul>
               </div>
               <div class="usecase-highlight">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
                   <h4 class="uk-heading-bullet">Key Facts</h4>
                   <ul class="uk-list uk-list-divider">
-                    <li><strong>FDA &amp; MDR</strong> konforme Audit-Trails</li>
-                    <li><strong>Versionierung</strong> inkl. elektronischer Signaturen</li>
-                    <li><strong>Risikomatrix</strong> mit Live-Updates</li>
+                    <li>Agiles Auftragsboard (SLAs, Eskalationslogik)</li>
+                    <li>Audit-Trails &amp; versionierte Freigaben</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
-                      <span class="uk-h2 uk-display-block">0</span>
-                      <span class="muted uk-text-small">Abweichungen im letzten Audit</span>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">aktive Vorgänge/Monat</span>
                     </div>
                     <div>
-                      <span class="uk-h2 uk-display-block">2x</span>
-                      <span class="muted uk-text-small">Schnellere Freigaben</span>
+                      <span class="uk-h2 uk-display-block">{TBD} %</span>
+                      <span class="muted uk-text-small">Termintreue</span>
                     </div>
                     <div>
-                      <span class="uk-h2 uk-display-block">360°</span>
-                      <span class="muted uk-text-small">Blick auf Lieferanten</span>
+                      <span class="uk-h2 uk-display-block">{TBD}×</span>
+                      <span class="muted uk-text-small">schnellere Freigaben</span>
                     </div>
                   </div>
-                  <a class="uk-button uk-button-text uk-margin-top" href="{{ basePath }}/downloads/qm-whitepaper.pdf">
-                    <span class="uk-margin-small-right" uk-icon="icon: book"></span>Whitepaper anfordern
+                  <a class="uk-button uk-button-text uk-margin-top" href="#">
+                    <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
                 <div class="usecase-visual uk-margin-top">
                   <div class="uk-height-medium uk-background-muted uk-border-rounded uk-flex uk-flex-middle uk-flex-center">
-                    <span class="muted">Audit-Dashboard Vorschau</span>
+                    <span class="muted">Agiles Auftragsboard &amp; DMS</span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- replace the calServer use case tab labels with the featured customer references
- rewrite each tab with the official Thermo Fisher Scientific, ZF Friedrichshafen, Berliner Stadtwerke, and VDE case study copy
- align key facts, KPIs, and CTAs with the provided reference data and remove non-existent downloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d262db5050832b99dd85806643311e