### PR TITLE
Add contact block to calServer marketing page

### DIFF
--- a/src/Controller/Marketing/CalserverController.php
+++ b/src/Controller/Marketing/CalserverController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Marketing;
 
+use App\Service\MailService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
@@ -16,6 +17,12 @@ class CalserverController
     public function __invoke(Request $request, Response $response): Response
     {
         $view = Twig::fromRequest($request);
-        return $view->render($response, 'marketing/calserver.twig');
+        $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
+        $_SESSION['csrf_token'] = $csrf;
+
+        return $view->render($response, 'marketing/calserver.twig', [
+            'mailConfigured' => MailService::isConfigured(),
+            'csrf_token' => $csrf,
+        ]);
     }
 }

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -1150,6 +1150,65 @@
       </div>
     </section>
 
+    <section id="contact-us" class="uk-section">
+      <div class="uk-container">
+        <h2 class="uk-heading-medium uk-text-center" uk-scrollspy="cls: uk-animation-slide-top-small">Noch Fragen? Wir sind für Sie da.</h2>
+        <p class="uk-text-lead uk-text-center" uk-scrollspy="cls: uk-animation-fade; delay: 150">Ob Testzugang, Angebot oder individuelle Beratung – wir melden uns garantiert persönlich zurück.</p>
+        <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
+          <div>
+            {% if mailConfigured %}
+              <form id="contact-form" class="uk-form-stacked uk-width-large uk-margin-auto">
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="form-name">Ihr Name</label>
+                  <input class="uk-input" id="form-name" name="name" type="text" required>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="form-email">E-Mail</label>
+                  <input class="uk-input" id="form-email" name="email" type="email" required>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="form-msg">Nachricht</label>
+                  <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
+                </div>
+                <div class="uk-margin">
+                  <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
+                </div>
+                <input type="text" name="company" autocomplete="off" tabindex="-1" class="uk-hidden" aria-hidden="true">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <button class="btn btn-black uk-button uk-button-secondary uk-button-large uk-width-1-1" type="submit">Senden</button>
+              </form>
+            {% else %}
+              <p class="uk-text-center">Kontaktformular derzeit nicht verfügbar.</p>
+            {% endif %}
+          </div>
+          <div>
+            <div class="uk-grid uk-child-width-1-1 uk-grid-small">
+              <div><div class="uk-form-label" aria-hidden="true">&nbsp;</div></div>
+              <div>
+                <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
+                  <p class="uk-margin-small-bottom uk-text-large">E-Mail</p>
+                  <a href="mailto:office@quizrace.app" class="uk-text-lead uk-link-reset">office@quizrace.app</a>
+                </div>
+              </div>
+              <div>
+                <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
+                  <p class="uk-margin-small-bottom uk-text-large">Telefon</p>
+                  <a href="tel:+4933203609080" class="uk-text-lead uk-link-reset">+49 33203 609080</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div id="contact-modal" uk-modal>
+      <div class="uk-modal-dialog uk-modal-body">
+        <p id="contact-modal-message" aria-live="polite"></p>
+        <button class="uk-button uk-button-primary uk-modal-close" type="button">OK</button>
+      </div>
+    </div>
+
   </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add the landing page contact section to the calServer marketing page
- expose the CSRF token and mail configuration flag so the form behaves like on /landing

## Testing
- composer phpunit *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d39dabfae0832b875b2859d4dc23c3