### PR TITLE
Add honeypot guard for marketing contact form

### DIFF
--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -19,47 +19,136 @@ class ContactControllerTest extends TestCase
         $_SESSION['csrf_token'] = 'token';
         $_COOKIE[session_name()] = session_id();
 
-        $mailer = new class extends MailService {
-            public array $args = [];
-            public function __construct()
-            {
+        $oldMainDomain = getenv('MAIN_DOMAIN');
+        $oldEnvMainDomain = $_ENV['MAIN_DOMAIN'] ?? null;
+        putenv('MAIN_DOMAIN=main.test');
+        $_ENV['MAIN_DOMAIN'] = 'main.test';
+
+        try {
+            $mailer = new class extends MailService {
+                public array $args = [];
+                public function __construct()
+                {
+                }
+                public function sendContact(string $to, string $name, string $replyTo, string $message): void
+                {
+                    $this->args = [$to, $name, $replyTo, $message];
+                }
+            };
+
+            $body = json_encode([
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'message' => 'Hello',
+                'company' => '',
+            ], JSON_THROW_ON_ERROR);
+
+            $request = $this->createRequest(
+                'POST',
+                '/landing/contact',
+                [
+                    'Content-Type' => 'application/json',
+                    'X-CSRF-Token' => 'token',
+                ],
+                [session_name() => session_id()]
+            );
+            $request->getBody()->write($body);
+            $request->getBody()->rewind();
+            $request = $request
+                ->withUri($request->getUri()->withHost('main.test'))
+                ->withAttribute('mailService', $mailer);
+
+            $app = $this->getAppInstance();
+            $response = $app->handle($request);
+
+            $this->assertEquals(204, $response->getStatusCode());
+            $pdo = new \PDO((string) getenv('POSTGRES_DSN'));
+            $email = $pdo->query("SELECT imprint_email FROM tenants WHERE subdomain = 'main'")?->fetchColumn();
+            $this->assertSame([
+                (string) $email,
+                'John Doe',
+                'john@example.com',
+                'Hello',
+            ], $mailer->args);
+        } finally {
+            if ($oldMainDomain === false) {
+                putenv('MAIN_DOMAIN');
+            } else {
+                putenv('MAIN_DOMAIN=' . $oldMainDomain);
             }
-            public function sendContact(string $to, string $name, string $replyTo, string $message): void
-            {
-                $this->args = [$to, $name, $replyTo, $message];
+            if ($oldEnvMainDomain === null) {
+                unset($_ENV['MAIN_DOMAIN']);
+            } else {
+                $_ENV['MAIN_DOMAIN'] = $oldEnvMainDomain;
             }
-        };
+        }
+    }
 
-        $body = json_encode([
-            'name' => 'John Doe',
-            'email' => 'john@example.com',
-            'message' => 'Hello',
-        ], JSON_THROW_ON_ERROR);
+    public function testContactFormHoneypotBlocksMail(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        session_id('contacthoneypot');
+        session_start();
+        $_SESSION['csrf_token'] = 'token';
+        $_COOKIE[session_name()] = session_id();
 
-        $request = $this->createRequest(
-            'POST',
-            '/landing/contact',
-            [
-                'Content-Type' => 'application/json',
-                'X-CSRF-Token' => 'token',
-            ],
-            [session_name() => session_id()]
-        );
-        $request->getBody()->write($body);
-        $request->getBody()->rewind();
-        $request = $request->withAttribute('mailService', $mailer);
+        $oldMainDomain = getenv('MAIN_DOMAIN');
+        $oldEnvMainDomain = $_ENV['MAIN_DOMAIN'] ?? null;
+        putenv('MAIN_DOMAIN=main.test');
+        $_ENV['MAIN_DOMAIN'] = 'main.test';
 
-        $app = $this->getAppInstance();
-        $response = $app->handle($request);
+        try {
+            $mailer = new class extends MailService {
+                public bool $called = false;
+                public function __construct()
+                {
+                }
+                public function sendContact(string $to, string $name, string $replyTo, string $message): void
+                {
+                    $this->called = true;
+                }
+            };
 
-        $this->assertEquals(204, $response->getStatusCode());
-        $pdo = new \PDO((string) getenv('POSTGRES_DSN'));
-        $email = $pdo->query("SELECT imprint_email FROM tenants WHERE subdomain = 'main'")?->fetchColumn();
-        $this->assertSame([
-            (string) $email,
-            'John Doe',
-            'john@example.com',
-            'Hello',
-        ], $mailer->args);
+            $body = json_encode([
+                'name' => 'Bot User',
+                'email' => 'bot@example.com',
+                'message' => 'Spam',
+                'company' => 'Malicious Inc.',
+            ], JSON_THROW_ON_ERROR);
+
+            $request = $this->createRequest(
+                'POST',
+                '/landing/contact',
+                [
+                    'Content-Type' => 'application/json',
+                    'X-CSRF-Token' => 'token',
+                ],
+                [session_name() => session_id()]
+            );
+            $request->getBody()->write($body);
+            $request->getBody()->rewind();
+            $request = $request
+                ->withUri($request->getUri()->withHost('main.test'))
+                ->withAttribute('mailService', $mailer);
+
+            $app = $this->getAppInstance();
+            $response = $app->handle($request);
+
+            $this->assertEquals(204, $response->getStatusCode());
+            $this->assertFalse($mailer->called, 'Honeypot submissions must not trigger mail delivery.');
+        } finally {
+            if ($oldMainDomain === false) {
+                putenv('MAIN_DOMAIN');
+            } else {
+                putenv('MAIN_DOMAIN=' . $oldMainDomain);
+            }
+            if ($oldEnvMainDomain === null) {
+                unset($_ENV['MAIN_DOMAIN']);
+            } else {
+                $_ENV['MAIN_DOMAIN'] = $oldEnvMainDomain;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- short-circuit marketing contact submissions when the honeypot field is populated and throttle spam logging
- keep the existing mail delivery path for valid requests untouched
- add controller tests that cover successful submissions and honeypot-triggered early exits

## Testing
- ./vendor/bin/phpunit tests/Controller/ContactControllerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c5e070d8832b9e99c0ef32a693cb