### PR TITLE
Obfuscate marketing contact emails

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -549,7 +549,12 @@
           <div>
             <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
               <p class="uk-margin-small-bottom uk-text-large">E-Mail</p>
-              <a href="mailto:office@quizrace.app" class="uk-text-lead uk-link-reset">office@quizrace.app</a>
+              <a
+                class="uk-text-lead uk-link-reset js-email-link"
+                data-user="office"
+                data-domain="calhelp.de"
+                href="#"
+              >office [at] calhelp.de</a>
             </div>
           </div>
           <div>
@@ -563,6 +568,20 @@
     </div>
   </div>
 </section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.js-email-link').forEach(function (anchor) {
+      var user = anchor.getAttribute('data-user');
+      var domain = anchor.getAttribute('data-domain');
+      if (user && domain) {
+        var email = user + '@' + domain;
+        anchor.href = 'mailto:' + email;
+        anchor.textContent = email;
+      }
+    });
+  });
+</script>
 
 <div id="contact-modal" uk-modal>
   <div class="uk-modal-dialog uk-modal-body">

--- a/migrations/20250304_import_page_files.sql
+++ b/migrations/20250304_import_page_files.sql
@@ -549,7 +549,12 @@ INSERT INTO pages (slug, title, content) VALUES ('landing', 'Landing', '<!-- Soc
           <div>
             <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
               <p class="uk-margin-small-bottom uk-text-large">E-Mail</p>
-              <a href="mailto:office@quizrace.app" class="uk-text-lead uk-link-reset">office@quizrace.app</a>
+              <a
+                class="uk-text-lead uk-link-reset js-email-link"
+                data-user="office"
+                data-domain="calhelp.de"
+                href="#"
+              >office [at] calhelp.de</a>
             </div>
           </div>
           <div>
@@ -563,6 +568,20 @@ INSERT INTO pages (slug, title, content) VALUES ('landing', 'Landing', '<!-- Soc
     </div>
   </div>
 </section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.js-email-link').forEach(function (anchor) {
+      var user = anchor.getAttribute('data-user');
+      var domain = anchor.getAttribute('data-domain');
+      if (user && domain) {
+        var email = user + '@' + domain;
+        anchor.href = 'mailto:' + email;
+        anchor.textContent = email;
+      }
+    });
+  });
+</script>
 
 <div id="contact-modal" uk-modal>
   <div class="uk-modal-dialog uk-modal-body">

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -1187,7 +1187,12 @@
               <div>
                 <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
                   <p class="uk-margin-small-bottom uk-text-large">E-Mail</p>
-                  <a href="mailto:office@quizrace.app" class="uk-text-lead uk-link-reset">office@quizrace.app</a>
+                  <a
+                    class="uk-text-lead uk-link-reset js-email-link"
+                    data-user="office"
+                    data-domain="calhelp.de"
+                    href="#"
+                  >office [at] calhelp.de</a>
                 </div>
               </div>
               <div>
@@ -1222,7 +1227,12 @@
       <strong>Kontakt</strong>
       <p>
         René Buske<br>
-        <a href="mailto:office@quizrace.app">office@quizrace.app</a><br>
+        <a
+          class="js-email-link"
+          data-user="office"
+          data-domain="calhelp.de"
+          href="#"
+        >office [at] calhelp.de</a><br>
         <a href="tel:+4933203609080">+49&nbsp;33203&nbsp;609080</a>
       </p>
     </div>
@@ -1248,6 +1258,19 @@
 {% block scripts %}
   <script src="{{ basePath }}/js/custom-icons.js" defer></script>
   <script src="{{ basePath }}/js/storage.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      document.querySelectorAll('.js-email-link').forEach(function (anchor) {
+        var user = anchor.getAttribute('data-user');
+        var domain = anchor.getAttribute('data-domain');
+        if (user && domain) {
+          var email = user + '@' + domain;
+          anchor.href = 'mailto:' + email;
+          anchor.textContent = email;
+        }
+      });
+    });
+  </script>
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/landing.js" defer></script>
 {% endblock %}

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -157,7 +157,12 @@
       <strong>Kontakt</strong>
       <p>
         René Buske<br>
-        <a href="mailto:office@quizrace.app">office@quizrace.app</a><br>
+        <a
+          class="js-email-link"
+          data-user="office"
+          data-domain="calhelp.de"
+          href="#"
+        >office [at] calhelp.de</a><br>
         <a href="tel:+4933203609080">+49&nbsp;33203&nbsp;609080</a>
       </p>
     </div>
@@ -176,4 +181,17 @@
   <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/landing.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      document.querySelectorAll('.js-email-link').forEach(function (anchor) {
+        var user = anchor.getAttribute('data-user');
+        var domain = anchor.getAttribute('data-domain');
+        if (user && domain) {
+          var email = user + '@' + domain;
+          anchor.href = 'mailto:' + email;
+          anchor.textContent = email;
+        }
+      });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- update marketing contact information to use the new office@calhelp.de address
- obfuscate exposed email links in marketing templates, static content, and SQL seed HTML via a shared data-attribute script

## Testing
- composer test *(fails: vendor/bin/phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c59f1ca0832b875637071ff43a98