### PR TITLE
Add removed calServer use cases

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -783,6 +783,10 @@
           <li><a href="#">KSW Kalibrierservice GmbH</a></li>
           <li><a href="#">Systems Engineering GmbH</a></li>
           <li><a href="#">TERAMESS (DAkkS-Labor)</a></li>
+          <li><a href="#">Thermo Fisher Scientific (EMEA)</a></li>
+          <li><a href="#">ZF Friedrichshafen</a></li>
+          <li><a href="#">Berliner Stadtwerke</a></li>
+          <li><a href="#">VDE Deutschland</a></li>
         </ul>
         <ul class="uk-switcher uk-margin-large-top"
             uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .usecase-story, .usecase-highlight; delay: 100; repeat: true">
@@ -970,6 +974,194 @@
                 <div class="usecase-visual uk-margin-top">
                   <div class="uk-height-medium uk-background-muted uk-border-rounded uk-flex uk-flex-middle uk-flex-center">
                     <span class="muted">DAkkS-Zertifikate &amp; Historie</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
+              <div class="usecase-story">
+                <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
+                <h3 class="uk-h2">Thermo Fisher Scientific – EMEA Labore</h3>
+                <p class="uk-text-lead">calServer orchestriert EMEA-weit Leihgeräte, Geräteakten und ISO-/DAkkS-konforme Zertifikate auf einer Plattform.</p>
+                <p>Mehrere Labore arbeiten in einem konsistenten Workflow: Leihverwaltung, Prüffristen und Zertifikate werden zentral gesteuert, während Aufträge und Rückgaben standortübergreifend nachvollziehbar bleiben. Die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL hält Stammdaten, Kalibrierläufe und Ergebnisse automatisch aktuell.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Zentrale Leihverwaltung mit Termin- &amp; Rückgabe-Erinnerungen</li>
+                  <li>Revisionssicheres DMS für Zertifikate &amp; Historie</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>EMEA-weit einheitliche Leihverwaltung &amp; Geräteakten</li>
+                    <li>Revisionssicheres DMS für Zertifikate &amp; Historie</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
+                  </ul>
+                  <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">EMEA-Standorte</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD} %</span>
+                      <span class="muted uk-text-small">weniger Dispositionsaufwand</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">Geräte im Bestand</span>
+                    </div>
+                  </div>
+                  <a class="uk-button uk-button-text uk-margin-top" href="#">
+                    <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="usecase-visual uk-margin-top">
+                  <div class="uk-height-medium uk-background-muted uk-border-rounded uk-flex uk-flex-middle uk-flex-center">
+                    <span class="muted">Leihverwaltung &amp; Geräteakten</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
+              <div class="usecase-story">
+                <span class="pill pill--badge uk-margin-small-bottom">Industrielabor</span>
+                <h3 class="uk-h2">ZF – API-Messwerte auf Kubernetes mit SSO</h3>
+                <p class="uk-text-lead">calServer verbindet skalierbare Messwert-APIs auf Kubernetes mit SSO und Geräteakten-Management.</p>
+                <p>Messwerte fließen über Microservices automatisiert ein; Geräte, Zertifikate und Auswertungen bleiben im Zugriff der berechtigten Teams. Single Sign-On vereinfacht den Zugang, die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL stellt durchgehend konsistente Kalibrierdaten sicher.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>API-Ingestion von Messwerten (Microservices/Kubernetes)</li>
+                  <li>SSO (z. B. EntraID/Google) für nahtlosen Zugriff</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Microservices auf Kubernetes</li>
+                    <li>SSO für schnellen, sicheren Zugang</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
+                  </ul>
+                  <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}/Tag</span>
+                      <span class="muted uk-text-small">Messwerte verarbeitet</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD} %</span>
+                      <span class="muted uk-text-small">automatisierte Flows</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">SSO-Nutzer:innen</span>
+                    </div>
+                  </div>
+                  <a class="uk-button uk-button-text uk-margin-top" href="#">
+                    <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="usecase-visual uk-margin-top">
+                  <div class="uk-height-medium uk-background-muted uk-border-rounded uk-flex uk-flex-middle uk-flex-center">
+                    <span class="muted">Messwerte &amp; SSO-Workflows</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
+              <div class="usecase-story">
+                <span class="pill pill--badge uk-margin-small-bottom">Assetmanagement</span>
+                <h3 class="uk-h2">Berliner Stadtwerke – Projekte &amp; Wartung für erneuerbare Anlagen</h3>
+                <p class="uk-text-lead">calServer steuert Projekte, Wartungspläne und Einsätze für regenerative Energieanlagen der Stadt Berlin.</p>
+                <p>Vom Maßnahmenplan bis zur Einsatzplanung: Teams behalten Verfügbarkeit, Leistung und Kosten im Blick. Checklisten, Offline-Fähigkeit und Eskalationslogik sichern die fristgerechte Abarbeitung. (Ohne MET/CAL/MET/TEAM – Fokus auf Projekt- &amp; Wartungssteuerung.)</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Projekt- &amp; Maßnahmensteuerung inkl. Einsatzplanung</li>
+                  <li>Geplante/ungeplante Wartung mit Checklisten &amp; Offline-Modus</li>
+                  <li>Dashboards für Verfügbarkeit, Leistung &amp; Kosten/Nutzen</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Stadtweite EE-Anlagen im Überblick</li>
+                    <li>Geplante &amp; ungeplante Wartung aus einem System</li>
+                    <li>Dashboards für Verfügbarkeit &amp; Performance</li>
+                  </ul>
+                  <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">Anlagen/Standorte</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD} %</span>
+                      <span class="muted uk-text-small">höhere Anlagenverfügbarkeit</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}/Monat</span>
+                      <span class="muted uk-text-small">geplante Wartungsaufträge</span>
+                    </div>
+                  </div>
+                  <a class="uk-button uk-button-text uk-margin-top" href="#">
+                    <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="usecase-visual uk-margin-top">
+                  <div class="uk-height-medium uk-background-muted uk-border-rounded uk-flex uk-flex-middle uk-flex-center">
+                    <span class="muted">Wartungs- &amp; Projektplanung</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" uk-grid>
+              <div class="usecase-story">
+                <span class="pill pill--badge uk-margin-small-bottom">Qualitätsmanagement</span>
+                <h3 class="uk-h2">VDE – Agile Auftragssteuerung &amp; Intranet</h3>
+                <p class="uk-text-lead">calServer bündelt agile Auftragssteuerung und Dokumentenflüsse für Prüf- und Zertifizierungsprozesse.</p>
+                <p>Teams planen, priorisieren und dokumentieren Vorgänge auf einem anpassbaren Board; Freigaben sind versioniert, nachvollziehbar und auditfest. Rollen und Vorlagen verteilen Informationen zielgerichtet. Die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL sorgt für konsistente Mess- und Auftragsdaten.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Agiles Auftragsboard mit SLAs, Eskalationen und Vorlagen</li>
+                  <li>Revisionssichere DMS-Ablage inkl. Freigabe-Workflow</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Agiles Auftragsboard (SLAs, Eskalationslogik)</li>
+                    <li>Audit-Trails &amp; versionierte Freigaben</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
+                  </ul>
+                  <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}</span>
+                      <span class="muted uk-text-small">aktive Vorgänge/Monat</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD} %</span>
+                      <span class="muted uk-text-small">Termintreue</span>
+                    </div>
+                    <div>
+                      <span class="uk-h2 uk-display-block">{TBD}×</span>
+                      <span class="muted uk-text-small">schnellere Freigaben</span>
+                    </div>
+                  </div>
+                  <a class="uk-button uk-button-text uk-margin-top" href="#">
+                    <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="usecase-visual uk-margin-top">
+                  <div class="uk-height-medium uk-background-muted uk-border-rounded uk-flex uk-flex-middle uk-flex-center">
+                    <span class="muted">Agiles Auftragsboard &amp; DMS</span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- restore the four previously removed customer tabs on the calServer marketing page
- add detailed stories and key facts for Thermo Fisher, ZF Friedrichshafen, Berliner Stadtwerke, and VDE Deutschland alongside the existing cases

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68d3c6d226b0832baf59d0a718d25204