### PR TITLE
Highlight active feature pill on calServer page

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1062,6 +1062,13 @@ body.qr-landing.calserver-theme .feature-nav__pill {
         transform 180ms ease, box-shadow 180ms ease;
 }
 
+body.qr-landing.calserver-theme .feature-nav__pill.is-active {
+    background: var(--qr-landing-primary);
+    color: #fff;
+    box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.4) inset,
+        0 20px 34px -24px rgba(31, 99, 230, 0.95);
+}
+
 body.qr-landing.calserver-theme .feature-nav__pill:hover,
 body.qr-landing.calserver-theme .feature-nav__pill:focus {
     background: var(--qr-landing-primary);

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -624,7 +624,22 @@
             };
 
             const setActive = (index) => {
-              pills.forEach((li, i) => li.classList.toggle('uk-active', i === index));
+              pills.forEach((li, i) => {
+                const isActive = i === index;
+                li.classList.toggle('uk-active', isActive);
+
+                const link = li.querySelector('.feature-nav__pill');
+                if (!link) {
+                  return;
+                }
+
+                link.classList.toggle('is-active', isActive);
+                if (isActive) {
+                  link.setAttribute('aria-current', 'true');
+                } else {
+                  link.removeAttribute('aria-current');
+                }
+              });
             };
 
             const setCurrent = (index) => {


### PR DESCRIPTION
## Summary
- add visual styling for the active pill in the "Funktionen im Fokus" navigation on the calServer page
- sync the pill state with the slider by toggling an `is-active` class and `aria-current`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d55545b628832b8ae588c3cc40a653