### PR TITLE
Show calServer use cases without placeholder KPIs

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -826,6 +826,7 @@
                     <li>Tickets + Chancen-/Risiken-Bewertung</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
+                  {#
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
                       <span class="uk-h2 uk-display-block">{TBD}</span>
@@ -840,6 +841,7 @@
                       <span class="muted uk-text-small">CAPA-Maßnahmen/Jahr</span>
                     </div>
                   </div>
+                  #}
                   <a class="uk-button uk-button-text uk-margin-top" href="#">
                     <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
@@ -874,6 +876,7 @@
                     <li>Auftragsbearbeitung als Taktgeber</li>
                     <li>DMS &amp; Reporting integriert</li>
                   </ul>
+                  {#
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
                       <span class="uk-h2 uk-display-block">{TBD} h</span>
@@ -888,6 +891,7 @@
                       <span class="muted uk-text-small">Kund:innen im Portal</span>
                     </div>
                   </div>
+                  #}
                   <a class="uk-button uk-button-text uk-margin-top" href="#">
                     <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
@@ -921,6 +925,7 @@
                     <li>Reports direkt aus den Prozessdaten</li>
                     <li>Versionierung &amp; Nachvollziehbarkeit (DMS)</li>
                   </ul>
+                  {#
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
                       <span class="uk-h2 uk-display-block">{TBD}</span>
@@ -935,6 +940,7 @@
                       <span class="muted uk-text-small">aktive Nutzer:innen</span>
                     </div>
                   </div>
+                  #}
                   <a class="uk-button uk-button-text uk-margin-top" href="#">
                     <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
@@ -968,6 +974,7 @@
                     <li>DAkkS-konforme Prüfhistorie</li>
                     <li>Serienexports &amp; Auswertungen</li>
                   </ul>
+                  {#
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
                       <span class="uk-h2 uk-display-block">{TBD}</span>
@@ -982,6 +989,7 @@
                       <span class="muted uk-text-small">Kund:innen mit Portalzugang</span>
                     </div>
                   </div>
+                  #}
                   <a class="uk-button uk-button-text uk-margin-top" href="#">
                     <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
@@ -1015,6 +1023,7 @@
                     <li>Revisionssicheres DMS für Zertifikate &amp; Historie</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
+                  {#
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
                       <span class="uk-h2 uk-display-block">{TBD}</span>
@@ -1029,6 +1038,7 @@
                       <span class="muted uk-text-small">Geräte im Bestand</span>
                     </div>
                   </div>
+                  #}
                   <a class="uk-button uk-button-text uk-margin-top" href="#">
                     <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
@@ -1062,6 +1072,7 @@
                     <li>SSO für schnellen, sicheren Zugang</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
+                  {#
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
                       <span class="uk-h2 uk-display-block">{TBD}/Tag</span>
@@ -1076,6 +1087,7 @@
                       <span class="muted uk-text-small">SSO-Nutzer:innen</span>
                     </div>
                   </div>
+                  #}
                   <a class="uk-button uk-button-text uk-margin-top" href="#">
                     <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
@@ -1109,6 +1121,7 @@
                     <li>Geplante &amp; ungeplante Wartung aus einem System</li>
                     <li>Dashboards für Verfügbarkeit &amp; Performance</li>
                   </ul>
+                  {#
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
                       <span class="uk-h2 uk-display-block">{TBD}</span>
@@ -1123,6 +1136,7 @@
                       <span class="muted uk-text-small">geplante Wartungsaufträge</span>
                     </div>
                   </div>
+                  #}
                   <a class="uk-button uk-button-text uk-margin-top" href="#">
                     <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
@@ -1156,6 +1170,7 @@
                     <li>Audit-Trails &amp; versionierte Freigaben</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
+                  {#
                   <div class="uk-grid-small uk-child-width-1-3@s uk-text-center uk-margin-top" uk-grid>
                     <div>
                       <span class="uk-h2 uk-display-block">{TBD}</span>
@@ -1170,6 +1185,7 @@
                       <span class="muted uk-text-small">schnellere Freigaben</span>
                     </div>
                   </div>
+                  #}
                   <a class="uk-button uk-button-text uk-margin-top" href="#">
                     <span class="uk-margin-small-right" uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>


### PR DESCRIPTION
## Summary
- reactivate the calServer marketing use case section
- comment out the placeholder KPI grids for all eight use case highlights so only real content stays visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d556f52478832b9a95a1e4df36d97f