### PR TITLE
Include marketing domains in proxy TLS configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,8 +93,8 @@ services:
       - ./config/php.ini:/usr/local/etc/php/conf.d/custom.ini:ro
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      - VIRTUAL_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}
-      - LETSENCRYPT_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}
+      - VIRTUAL_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}${MARKETING_DOMAINS:+,${MARKETING_DOMAINS}}
+      - LETSENCRYPT_HOST=${SLIM_VIRTUAL_HOST:-${DOMAIN}}${MARKETING_DOMAINS:+,${MARKETING_DOMAINS}}
       - VIRTUAL_PORT=8080
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
       - POSTGRES_DSN=${POSTGRES_DSN}

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -33,7 +33,7 @@ Die Anwendung unterscheidet über die Umgebungsvariable `MAIN_DOMAIN` zwischen d
 - `admin.` – Administrationsoberfläche
 - `{tenant}.` – individuelle Mandanteninstanzen
 
-Zusätzlich lassen sich weitere Marketing-Domains über die Umgebungsvariable `MARKETING_DOMAINS` (Komma- oder Zeilen-separiert) freischalten. Diese Domains liefern die Inhalte der Landing Pages aus, ohne eine Mandanten-Subdomain verwenden zu müssen.
+Zusätzlich lassen sich weitere Marketing-Domains über die Umgebungsvariable `MARKETING_DOMAINS` (Komma- oder Zeilen-separiert) freischalten. Diese Domains liefern die Inhalte der Landing Pages aus, ohne eine Mandanten-Subdomain verwenden zu müssen. Damit der Reverse Proxy automatisch TLS-Zertifikate für diese Hosts anfordert, sollten die Domains kommagetrennt eingetragen werden; die Liste wird dann direkt an `VIRTUAL_HOST`/`LETSENCRYPT_HOST` des Slim-Containers durchgereicht.
 
 Die `DomainMiddleware` prüft bei jeder Anfrage den Host gegen `MAIN_DOMAIN` und die Marketing-Liste und setzt entsprechend das Attribut `domainType` (`main`, `tenant` oder `marketing`). Ist `MAIN_DOMAIN` leer oder stimmt keine der konfigurierten Domains mit der aufgerufenen Domain überein, blockiert die Middleware den Zugriff mit `403 Invalid main domain configuration.`
 

--- a/sample.env
+++ b/sample.env
@@ -10,6 +10,7 @@ COMPOSE_PROJECT_NAME=sommerfest-quiz
 DOMAIN=example.com            # Basis-Domain aller Mandanten
 MAIN_DOMAIN=quizrace.app      # Hauptdomain des Quiz-Containers
 # Komma- oder zeilengetrennte Liste zusätzlicher Marketing-Domains für Landing Pages
+# (für TLS-Zertifikate bitte kommagetrennt eintragen)
 MARKETING_DOMAINS=
 APP_IMAGE=sommerfest-quiz:latest # Docker-Image für Tenant-Container
 # Tag des lokal gebauten Slim-Images (docker build -t <tag> .),


### PR DESCRIPTION
## Summary
- include marketing domains in the slim container's VIRTUAL_HOST/LETSENCRYPT_HOST values so nginx-proxy requests certificates for them
- document the TLS requirement for marketing domains in the sample environment file and admin guide

## Testing
- not run (configuration/documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d58e1ab48c832b99e5866c04c54ac8