### PR TITLE
Fix mobile alignment for calServer module buttons

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1264,6 +1264,7 @@ body.qr-landing.calserver-theme .calserver-module-figure .uk-list {
     body.qr-landing.calserver-theme .calserver-modules-nav > li {
         min-width: 0;
         width: min(100%, 360px);
+        margin-inline: auto;
     }
 
     body.qr-landing.calserver-theme .calserver-modules-nav__link {


### PR DESCRIPTION
## Summary
- center the module switcher buttons on small screens by applying automatic inline margins

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d59b46ee20832bbbaee153f35f086f