### PR TITLE
Enhance calServer hero and stats section layering

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -9,6 +9,17 @@ body.qr-landing.calserver-theme {
     --cs-card-focus-border: color-mix(in oklab, var(--calserver-primary) 35%, transparent);
     --cs-card-focus-shadow: 0 22px 48px -32px rgba(15, 23, 42, 0.55),
         0 14px 25px rgba(0, 0, 0, 0.16);
+    --cs-hero-overlay-top: color-mix(in oklab, var(--calserver-primary) 16%, transparent);
+    --cs-hero-overlay-bottom: color-mix(in oklab, var(--calserver-primary) 4%, transparent);
+    --cs-hero-shadow: 0 42px 82px -58px rgba(15, 23, 42, 0.6);
+    --cs-highlight-bg: color-mix(in oklab, var(--calserver-primary) 12%, var(--qr-card) 88%);
+    --cs-highlight-border-top: color-mix(in oklab, var(--calserver-primary) 22%, transparent);
+    --cs-highlight-border-bottom: color-mix(in oklab, var(--calserver-primary) 14%, transparent);
+    --cs-highlight-shadow: 0 -18px 46px -38px rgba(15, 23, 42, 0.4),
+        0 24px 52px -40px rgba(15, 23, 42, 0.45);
+    --cs-highlight-card-bg: color-mix(in oklab, var(--calserver-primary) 12%, transparent);
+    --cs-highlight-card-border: color-mix(in oklab, var(--calserver-primary) 30%, transparent);
+    --cs-highlight-card-shadow: 0 18px 34px -28px rgba(15, 23, 42, 0.5);
     scroll-behavior: smooth;
 }
 
@@ -25,6 +36,21 @@ body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) {
         var(--qr-hero-grad-start) 0%,
         color-mix(in oklab, var(--calserver-primary) 55%, #111827 45%) 100%
     );
+    --cs-hero-overlay-top: color-mix(in oklab, var(--calserver-primary) 42%, rgba(7, 12, 26, 0.9));
+    --cs-hero-overlay-bottom: color-mix(in oklab, var(--calserver-primary) 22%, rgba(5, 9, 19, 0.92));
+    --cs-hero-shadow: 0 48px 90px -60px rgba(5, 10, 22, 0.85);
+    --cs-highlight-bg: linear-gradient(
+        180deg,
+        color-mix(in oklab, var(--calserver-primary) 26%, rgba(7, 12, 26, 0.96)) 0%,
+        color-mix(in oklab, var(--calserver-primary) 18%, rgba(5, 10, 21, 0.94)) 100%
+    );
+    --cs-highlight-border-top: color-mix(in oklab, var(--calserver-primary) 58%, rgba(255, 255, 255, 0.14));
+    --cs-highlight-border-bottom: color-mix(in oklab, var(--calserver-primary) 42%, rgba(255, 255, 255, 0.12));
+    --cs-highlight-shadow: 0 -28px 72px -54px rgba(5, 10, 20, 0.78),
+        0 36px 84px -52px rgba(6, 12, 28, 0.88);
+    --cs-highlight-card-bg: color-mix(in oklab, var(--calserver-primary) 28%, rgba(6, 12, 26, 0.86));
+    --cs-highlight-card-border: color-mix(in oklab, var(--calserver-primary) 60%, rgba(255, 255, 255, 0.18));
+    --cs-highlight-card-shadow: 0 26px 46px -30px rgba(4, 10, 24, 0.72);
 }
 
 body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .uk-card-primary,
@@ -178,6 +204,21 @@ body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast) {
     );
     --cs-card-focus-bg: color-mix(in oklab, var(--calserver-primary) 62%, var(--cs-card-dark) 38%);
     --cs-card-focus-border: color-mix(in oklab, var(--calserver-primary) 68%, transparent);
+    --cs-hero-overlay-top: color-mix(in oklab, var(--calserver-primary) 18%, rgba(248, 251, 255, 0.94));
+    --cs-hero-overlay-bottom: color-mix(in oklab, var(--calserver-primary) 8%, rgba(255, 255, 255, 0.96));
+    --cs-hero-shadow: 0 34px 76px -54px rgba(38, 72, 150, 0.45);
+    --cs-highlight-bg: linear-gradient(
+        180deg,
+        color-mix(in oklab, var(--calserver-primary) 10%, rgba(243, 247, 255, 0.96)) 0%,
+        color-mix(in oklab, var(--calserver-primary) 6%, rgba(255, 255, 255, 0.98)) 100%
+    );
+    --cs-highlight-border-top: color-mix(in oklab, var(--calserver-primary) 34%, rgba(17, 49, 105, 0.18));
+    --cs-highlight-border-bottom: color-mix(in oklab, var(--calserver-primary) 22%, rgba(17, 49, 105, 0.14));
+    --cs-highlight-shadow: 0 -20px 48px -36px rgba(58, 100, 200, 0.22),
+        0 26px 54px -38px rgba(34, 68, 140, 0.18);
+    --cs-highlight-card-bg: color-mix(in oklab, var(--calserver-primary) 9%, rgba(255, 255, 255, 0.96));
+    --cs-highlight-card-border: color-mix(in oklab, var(--calserver-primary) 26%, rgba(17, 49, 105, 0.12));
+    --cs-highlight-card-shadow: 0 22px 42px -28px rgba(31, 73, 160, 0.22);
 }
 
 body.qr-landing.calserver-theme:not(.high-contrast) .hero-bg-calserver {
@@ -192,8 +233,10 @@ body.qr-landing.calserver-theme:not(.high-contrast) .hero-bg-calserver {
             color-mix(in oklab, var(--calserver-primary) 30%, transparent),
             transparent
         ),
+        linear-gradient(180deg, var(--cs-hero-overlay-top) 0%, var(--cs-hero-overlay-bottom) 100%),
         var(--qr-hero-gradient);
     background-color: var(--qr-hero-grad-start);
+    box-shadow: var(--cs-hero-shadow);
 }
 
 body.qr-landing.calserver-theme .calserver-hero-grid {
@@ -429,10 +472,11 @@ body.qr-landing.calserver-theme .pricing-card--featured li {
 body.qr-landing.calserver-theme .calserver-highlight {
     position: relative;
     padding: 32px 0 28px;
-    background: color-mix(in oklab, var(--calserver-primary) 12%, var(--qr-card) 88%);
-    border-top: 1px solid color-mix(in oklab, var(--calserver-primary) 22%, transparent);
-    border-bottom: 1px solid color-mix(in oklab, var(--calserver-primary) 14%, transparent);
+    background: var(--cs-highlight-bg);
+    border-top: 1px solid var(--cs-highlight-border-top);
+    border-bottom: 1px solid var(--cs-highlight-border-bottom);
     overflow: hidden;
+    box-shadow: var(--cs-highlight-shadow);
     z-index: 0;
 }
 
@@ -477,9 +521,9 @@ body.qr-landing.calserver-theme .calserver-stats-strip {
 body.qr-landing.calserver-theme .calserver-stats-strip__item {
     padding: 18px 20px;
     border-radius: 18px;
-    background: color-mix(in oklab, var(--calserver-primary) 12%, transparent);
-    border: 1px solid color-mix(in oklab, var(--calserver-primary) 30%, transparent);
-    box-shadow: 0 18px 34px -28px rgba(15, 23, 42, 0.5);
+    background: var(--cs-highlight-card-bg);
+    border: 1px solid var(--cs-highlight-card-border);
+    box-shadow: var(--cs-highlight-card-shadow);
     display: flex;
     flex-direction: column;
     gap: 6px;


### PR DESCRIPTION
## Summary
- introduce theme-aware custom properties to control calServer hero and highlight layering
- refresh hero background and highlight section styling to create clearer separation in light and dark themes
- align stats cards with new highlight surface variables for consistent elevation cues

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a3d936cc832b9dbb99439d6d2ac6