### PR TITLE
Support multiple SEO configurations for marketing pages

### DIFF
--- a/public/js/seo-form.js
+++ b/public/js/seo-form.js
@@ -5,7 +5,6 @@ export function initSeoForm() {
   if (!form) return;
 
   const inputs = form.querySelectorAll('[data-maxlength]');
-
   inputs.forEach(input => {
     const max = parseInt(input.dataset.maxlength, 10);
     const counter = form.querySelector(`.char-count[data-for="${input.id}"]`);
@@ -18,6 +17,91 @@ export function initSeoForm() {
       input.dispatchEvent(new Event('input'));
     }
   });
+
+  const hiddenPageId = form.querySelector('input[name="pageId"]');
+  const pageSelect = form.querySelector('#seoPageSelect');
+
+  const fieldMap = {
+    metaTitle: 'metaTitle',
+    metaDescription: 'metaDescription',
+    slug: 'slug',
+    canonicalUrl: 'canonical',
+    robotsMeta: 'robots',
+    ogTitle: 'ogTitle',
+    ogDescription: 'ogDescription',
+    ogImage: 'ogImage',
+    schemaJson: 'schema',
+    hreflang: 'hreflang'
+  };
+
+  const pageConfigs = {};
+  const pageMeta = {};
+
+  const applyConfig = config => {
+    if (!config) return;
+    const pageId = config.pageId ?? config.id;
+    if (hiddenPageId && pageId) {
+      hiddenPageId.value = pageId;
+    }
+    Object.entries(fieldMap).forEach(([key, elementId]) => {
+      const field = form.querySelector(`#${elementId}`);
+      if (!field) return;
+      const value = config[key] ?? '';
+      if (field.value !== value) {
+        field.value = value;
+      }
+      field.dispatchEvent(new Event('input'));
+    });
+  };
+
+  if (pageSelect) {
+    try {
+      const configs = JSON.parse(pageSelect.dataset.configs || '[]');
+      configs.forEach(entry => {
+        if (!entry || typeof entry !== 'object') return;
+        const id = String(entry.id ?? entry.config?.pageId ?? '');
+        if (!id) return;
+        const config = entry.config || {};
+        pageConfigs[id] = {
+          pageId: config.pageId ?? Number(id),
+          metaTitle: config.metaTitle ?? '',
+          metaDescription: config.metaDescription ?? '',
+          slug: config.slug ?? '',
+          canonicalUrl: config.canonicalUrl ?? '',
+          robotsMeta: config.robotsMeta ?? '',
+          ogTitle: config.ogTitle ?? '',
+          ogDescription: config.ogDescription ?? '',
+          ogImage: config.ogImage ?? '',
+          schemaJson: config.schemaJson ?? '',
+          hreflang: config.hreflang ?? ''
+        };
+        pageMeta[id] = {
+          slug: entry.slug || '',
+          title: entry.title || ''
+        };
+      });
+    } catch (error) {
+      // ignore malformed JSON
+    }
+
+    const initialId = pageSelect.dataset.selected || pageSelect.value;
+    if (initialId && pageConfigs[initialId]) {
+      applyConfig(pageConfigs[initialId]);
+    }
+
+    pageSelect.addEventListener('change', () => {
+      const selectedId = pageSelect.value;
+      if (hiddenPageId) {
+        hiddenPageId.value = selectedId;
+      }
+      pageSelect.dataset.selected = selectedId;
+      if (pageConfigs[selectedId]) {
+        applyConfig(pageConfigs[selectedId]);
+      } else {
+        applyConfig({ pageId: selectedId });
+      }
+    });
+  }
 
   const importBtn = form.querySelector('.import-seo-example');
   if (importBtn) {
@@ -97,9 +181,52 @@ export function initSeoForm() {
         if (!r.ok) throw new Error('save-failed');
         return r.json().catch(() => ({}));
       })
-      .then(() => {
+      .then(data => {
+        if (data && data.config && data.page) {
+          const id = String(data.page.id);
+          pageConfigs[id] = {
+            pageId: data.config.pageId ?? data.page.id,
+            metaTitle: data.config.metaTitle ?? '',
+            metaDescription: data.config.metaDescription ?? '',
+            slug: data.config.slug ?? '',
+            canonicalUrl: data.config.canonicalUrl ?? '',
+            robotsMeta: data.config.robotsMeta ?? '',
+            ogTitle: data.config.ogTitle ?? '',
+            ogDescription: data.config.ogDescription ?? '',
+            ogImage: data.config.ogImage ?? '',
+            schemaJson: data.config.schemaJson ?? '',
+            hreflang: data.config.hreflang ?? ''
+          };
+          pageMeta[id] = {
+            slug: data.page.slug || '',
+            title: data.page.title || ''
+          };
+
+          if (pageSelect) {
+            let option = pageSelect.querySelector(`option[value="${CSS.escape(id)}"]`);
+            if (!option) {
+              option = document.createElement('option');
+              option.value = id;
+              pageSelect.append(option);
+            }
+            option.dataset.slug = pageMeta[id].slug;
+            option.dataset.title = pageMeta[id].title;
+            option.textContent = `${pageMeta[id].title} (${pageMeta[id].slug})`;
+            pageSelect.value = id;
+            pageSelect.dataset.selected = id;
+            pageSelect.dataset.configs = JSON.stringify(
+              Object.entries(pageConfigs).map(([pageId, config]) => ({
+                id: Number(pageId),
+                slug: pageMeta[pageId]?.slug || '',
+                title: pageMeta[pageId]?.title || '',
+                config
+              }))
+            );
+          }
+
+          applyConfig(pageConfigs[id]);
+        }
         notify('Einstellungen gespeichert', 'success');
-        window.location.reload();
       })
       .catch(() => notify('Fehler beim Speichern', 'danger'));
   });

--- a/src/Application/Seo/PageSeoConfigService.php
+++ b/src/Application/Seo/PageSeoConfigService.php
@@ -134,6 +134,28 @@ class PageSeoConfigService
         $this->dispatcher->dispatch($event);
     }
 
+    /**
+     * Build a default configuration array for the given page.
+     *
+     * @return array<string,mixed>
+     */
+    public function defaultConfig(int $pageId): array
+    {
+        return [
+            'pageId' => $pageId,
+            'slug' => '',
+            'metaTitle' => null,
+            'metaDescription' => null,
+            'canonicalUrl' => null,
+            'robotsMeta' => null,
+            'ogTitle' => null,
+            'ogDescription' => null,
+            'ogImage' => null,
+            'schemaJson' => null,
+            'hreflang' => null,
+        ];
+    }
+
     private function normalizeSchemaJson(?string $json): ?string
     {
         if ($json === null) {

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -917,9 +917,33 @@
           </ul>
           <ul id="pageSwitcher" class="uk-switcher uk-margin">
             <li>
+              {% if seo_pages|default([]) is empty %}
+                <div class="uk-alert uk-alert-warning">Keine Marketing-Seiten gefunden.</div>
+              {% else %}
               <form class="uk-form-stacked seo-form" action="{{ basePath }}/admin/landingpage/seo" method="post">
-                <input type="hidden" name="pageId" value="1">
+                <input type="hidden" name="pageId" value="{{ seo_config.pageId|default(selectedSeoPageId|default('')) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="seoPageSelect">Marketing-Seite</label>
+                  <div class="uk-form-controls">
+                    <select
+                      id="seoPageSelect"
+                      class="uk-select"
+                      data-configs="{{ seo_pages|json_encode|e('html_attr') }}"
+                      data-selected="{{ selectedSeoPageId|default(seo_config.pageId|default('')) }}"
+                    >
+                      {% for page in seo_pages %}
+                        <option
+                          value="{{ page.id }}"{% if page.id == selectedSeoPageId %} selected{% endif %}
+                          data-slug="{{ page.slug }}"
+                          data-title="{{ page.title }}"
+                        >
+                          {{ page.title }} ({{ page.slug }})
+                        </option>
+                      {% endfor %}
+                    </select>
+                  </div>
+                </div>
                 <div class="uk-margin">
                   <label class="uk-form-label" for="metaTitle">Meta Title</label>
                   <div class="uk-form-controls">
@@ -977,6 +1001,7 @@
                   <button type="submit" class="uk-button uk-button-primary uk-margin-left">Speichern</button>
                 </div>
               </form>
+              {% endif %}
             </li>
             {% for slug, html in pages %}
             <li>

--- a/templates/admin/landingpage/edit.html.twig
+++ b/templates/admin/landingpage/edit.html.twig
@@ -13,9 +13,33 @@
 {% block body %}
   <div class="uk-container uk-container-small">
     <h1 class="uk-heading-bullet">Landingpage bearbeiten</h1>
+    {% if seoPages|default([]) is empty %}
+      <div class="uk-alert uk-alert-warning">Keine Marketing-Seiten gefunden.</div>
+    {% else %}
     <form class="uk-form-stacked seo-form" action="{{ basePath }}/admin/landingpage/seo" method="post">
-      <input type="hidden" name="pageId" value="1">
+      <input type="hidden" name="pageId" value="{{ config.pageId|default(selectedPageId)|default('') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+      <div class="uk-margin">
+        <label class="uk-form-label" for="seoPageSelect">Marketing-Seite</label>
+        <div class="uk-form-controls">
+          <select
+            id="seoPageSelect"
+            class="uk-select"
+            data-configs="{{ seoPages|json_encode|e('html_attr') }}"
+            data-selected="{{ selectedPageId|default(config.pageId|default('')) }}"
+          >
+            {% for page in seoPages %}
+              <option
+                value="{{ page.id }}"{% if page.id == selectedPageId %} selected{% endif %}
+                data-slug="{{ page.slug }}"
+                data-title="{{ page.title }}"
+              >
+                {{ page.title }} ({{ page.slug }})
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
       <h2>SEO</h2>
       <div class="uk-margin">
         <label class="uk-form-label" for="metaTitle">Meta Title</label>
@@ -74,6 +98,7 @@
         <button type="submit" class="uk-button uk-button-primary uk-margin-left">Speichern</button>
       </div>
     </form>
+    {% endif %}
   </div>
 {% endblock %}
 

--- a/tests/RoleAccessTest.php
+++ b/tests/RoleAccessTest.php
@@ -77,12 +77,23 @@ class RoleAccessTest extends TestCase
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
         $_SESSION['csrf_token'] = 'token';
+        $pdo = $this->getDatabase();
+        $pdo->exec("INSERT OR IGNORE INTO pages (id, slug, title, content) VALUES (1, 'landing', 'Landing', '')");
         $req = $this->createRequest('POST', '/admin/landingpage/seo', [
             'HTTP_X_CSRF_TOKEN' => 'token',
+            'HTTP_ACCEPT' => 'application/json',
         ]);
-        $req = $req->withParsedBody(['pageId' => 1, 'slug' => 'test']);
+        $req = $req->withParsedBody([
+            'pageId' => 1,
+            'slug' => 'test',
+            'meta_title' => 'Title',
+            'meta_description' => 'Description',
+        ]);
         $res = $app->handle($req);
-        $this->assertEquals(204, $res->getStatusCode());
+        $this->assertEquals(200, $res->getStatusCode());
+        $payload = json_decode((string) $res->getBody(), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('ok', $payload['status'] ?? null);
         session_destroy();
     }
 


### PR DESCRIPTION
## Summary
- allow selecting and editing SEO settings for different marketing pages in the admin UI
- extend backend services and controller to load/save configurations per page and return structured JSON responses
- adjust client-side form logic and tests to handle multiple marketing pages and seeded data in tests

## Testing
- `vendor/bin/phpunit tests/RoleAccessTest.php`
- `vendor/bin/phpcs src/Application/Seo/PageSeoConfigService.php src/Controller/Admin/LandingpageController.php src/Controller/AdminController.php src/Service/PageService.php tests/RoleAccessTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68d5a8c49cb0832baf2036498e051a63