### PR TITLE
Add glow background effect to calServer demo section

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -470,18 +470,26 @@ body.qr-landing.calserver-theme .pricing-card--featured li {
 }
 
 body.qr-landing.calserver-theme .calserver-highlight {
-    position: relative;
     padding: 32px 0 28px;
     background: var(--cs-highlight-bg);
     border-top: 1px solid var(--cs-highlight-border-top);
     border-bottom: 1px solid var(--cs-highlight-border-bottom);
-    overflow: hidden;
     box-shadow: var(--cs-highlight-shadow);
+}
+
+body.qr-landing.calserver-theme .calserver-section-glow {
+    position: relative;
+    overflow: hidden;
     z-index: 0;
 }
 
-body.qr-landing.calserver-theme .calserver-highlight::before,
-body.qr-landing.calserver-theme .calserver-highlight::after {
+body.qr-landing.calserver-theme .calserver-section-glow > * {
+    position: relative;
+    z-index: 1;
+}
+
+body.qr-landing.calserver-theme .calserver-section-glow::before,
+body.qr-landing.calserver-theme .calserver-section-glow::after {
     content: "";
     position: absolute;
     top: 0;
@@ -496,11 +504,11 @@ body.qr-landing.calserver-theme .calserver-highlight::after {
     z-index: 0;
 }
 
-body.qr-landing.calserver-theme .calserver-highlight::before {
+body.qr-landing.calserver-theme .calserver-section-glow::before {
     left: 0;
 }
 
-body.qr-landing.calserver-theme .calserver-highlight::after {
+body.qr-landing.calserver-theme .calserver-section-glow::after {
     right: 0;
     transform: scaleX(-1);
 }

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -206,7 +206,7 @@
       </div>
     </section>
 
-    <section class="calserver-highlight" aria-label="calServer in Zahlen">
+    <section class="calserver-highlight calserver-section-glow" aria-label="calServer in Zahlen">
       <div class="uk-container">
         <div class="calserver-stats-strip" role="list">
           <div class="calserver-stats-strip__item" role="listitem">
@@ -1206,7 +1206,7 @@
       </div>
     </section>
 
-    <section id="modes" class="uk-section uk-section-primary uk-light">
+    <section id="modes" class="uk-section uk-section-primary uk-light calserver-section-glow">
       <div class="uk-container">
         <h2 class="uk-heading-line uk-light"><span>Betriebsarten, die zu Ihnen passen</span></h2>
         <ul class="uk-subnav uk-subnav-pill uk-margin" uk-switcher>
@@ -1362,7 +1362,7 @@
       </div>
     </section>
 
-    <section id="demo" class="uk-section uk-section-primary uk-light uk-text-center">
+    <section id="demo" class="uk-section uk-section-primary uk-light uk-text-center calserver-section-glow">
       <div class="uk-container">
         <h3 class="uk-heading-small uk-margin-small">Bereit, calServer live zu erleben?</h3>
         <p>Jetzt testen oder Demo buchen – wir zeigen, wie Ihre Prozesse in calServer aussehen.</p>


### PR DESCRIPTION
## Summary
- extract the hero stats glow effect into a reusable calserver-section-glow helper
- apply the shared glow background to the "Bereit, calServer live zu erleben?" CTA block and keep it on the stats highlight
- extend the glow helper to the "Betriebsarten, die zu Ihnen passen" section for consistent styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5adf6c598832ba9d44bace309a548