### PR TITLE
Add calServer marketing page to SEO admin options

### DIFF
--- a/migrations/20250319_add_calserver_page.sql
+++ b/migrations/20250319_add_calserver_page.sql
@@ -1,0 +1,7 @@
+INSERT INTO pages (slug, title, content)
+VALUES (
+    'calserver',
+    'calServer',
+    '<!-- Placeholder content for calServer marketing page -->'
+)
+ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
## Summary
- add a migration that seeds the `pages` table with a calServer entry so the SEO admin dropdown lists it alongside other marketing pages

## Testing
- vendor/bin/phpunit tests/Controller/CalserverControllerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d5b885e3e8832b920b1bb1a1c67b52