### PR TITLE
Align calServer CTA sections with highlight card styling

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -477,6 +477,67 @@ body.qr-landing.calserver-theme .calserver-highlight {
     box-shadow: var(--cs-highlight-shadow);
 }
 
+body.qr-landing.calserver-theme .calserver-highlight__intro {
+    max-width: 720px;
+    margin: 0 auto 42px;
+}
+
+body.qr-landing.calserver-theme .calserver-highlight__intro p {
+    color: color-mix(in oklab, rgba(255, 255, 255, 0.92) 92%, rgba(255, 255, 255, 0.62) 8%);
+}
+
+body.qr-landing.calserver-theme .calserver-highlight-card {
+    background: var(--cs-highlight-card-bg) !important;
+    border: 1px solid var(--cs-highlight-card-border) !important;
+    border-radius: 22px;
+    box-shadow: var(--cs-highlight-card-shadow);
+    padding: 32px 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    color: color-mix(in oklab, var(--qr-text) 88%, var(--qr-bg) 12%);
+}
+
+body.qr-landing.calserver-theme .calserver-highlight-card .uk-card-title {
+    color: color-mix(in oklab, var(--calserver-primary) 32%, var(--qr-text) 68%);
+    letter-spacing: -0.01em;
+}
+
+body.qr-landing.calserver-theme .calserver-highlight-card .uk-list-bullet > li::before {
+    border-color: color-mix(in oklab, var(--calserver-primary) 48%, transparent);
+}
+
+body.qr-landing.calserver-theme .calserver-highlight-card__actions {
+    margin-top: auto;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 18px;
+    align-items: center;
+}
+
+body.qr-landing.calserver-theme .calserver-highlight-card__actions .muted {
+    font-size: 0.85rem;
+}
+
+@media (max-width: 959px) {
+    body.qr-landing.calserver-theme .calserver-highlight-card {
+        padding: 28px;
+    }
+}
+
+@media (max-width: 639px) {
+    body.qr-landing.calserver-theme .calserver-highlight-card__actions {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+
+    body.qr-landing.calserver-theme .calserver-highlight-card__actions .uk-button {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
 body.qr-landing.calserver-theme .calserver-section-glow {
     position: relative;
     overflow: hidden;

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -1218,7 +1218,7 @@
           <li>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" uk-grid>
               <div class="anim">
-                <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
                   <h3 class="uk-card-title">Sofort startklar</h3>
                   <ul class="uk-list uk-list-bullet muted">
                     <li>Bereitstellung in wenigen Tagen</li>
@@ -1228,7 +1228,7 @@
                 </div>
               </div>
               <div class="anim">
-                <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
                   <h3 class="uk-card-title">Sicher &amp; skalierbar</h3>
                   <ul class="uk-list uk-list-bullet muted">
                     <li>Rechenzentrum in Deutschland</li>
@@ -1242,7 +1242,7 @@
           <li>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" uk-grid>
               <div class="anim">
-                <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
                   <h3 class="uk-card-title">Volle Kontrolle</h3>
                   <ul class="uk-list uk-list-bullet muted">
                     <li>Betrieb im eigenen Netzwerk</li>
@@ -1252,7 +1252,7 @@
                 </div>
               </div>
               <div class="anim">
-                <div class="uk-card uk-card-default uk-card-body uk-card-hover">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
                   <h3 class="uk-card-title">Individuelle Sicherheit</h3>
                   <ul class="uk-list uk-list-bullet muted">
                     <li>Anbindung an Ihr Identity-Management</li>
@@ -1362,18 +1362,54 @@
       </div>
     </section>
 
-    <section id="demo" class="uk-section uk-section-primary uk-light uk-text-center calserver-highlight calserver-section-glow">
+    <section id="demo" class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow">
       <div class="uk-container">
-        <h3 class="uk-heading-small uk-margin-small">Bereit, calServer live zu erleben?</h3>
-        <p>Jetzt testen oder Demo buchen – wir zeigen, wie Ihre Prozesse in calServer aussehen.</p>
-        <p class="uk-margin-medium-top">
-          <a class="uk-button uk-button-default uk-margin-small-right"
-             href="https://calendly.com/calhelp/calserver-vorstellung"
-             target="_blank"
-             rel="noopener">Demo buchen</a>
-          <a id="trial" class="uk-button uk-button-primary" href="#offer">Jetzt testen</a>
-        </p>
-        <p class="uk-text-small uk-margin-small">* Demo-Zugang und Testumgebung nach kurzer Abstimmung.</p>
+        <div class="calserver-highlight__intro uk-text-center">
+          <h2 class="uk-heading-small uk-margin-remove-bottom">Bereit, calServer live zu erleben?</h2>
+          <p class="uk-text-lead uk-margin-small-top">Jetzt testen oder Demo buchen – wir zeigen, wie Ihre Prozesse in calServer aussehen.</p>
+        </div>
+        <div class="uk-grid-large uk-child-width-1-1 uk-child-width-1-2@m uk-grid-match"
+             uk-grid
+             uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+              <div>
+                <h3 class="uk-card-title">Live-Demo buchen</h3>
+                <p class="muted">Wir führen Sie durch calServer, beantworten Fragen und zeigen passende Workflows.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Individuelle Präsentation mit Branchenfokus</li>
+                  <li>Direkter Austausch mit unseren Expert:innen</li>
+                  <li>Konkrete Empfehlungen für Ihren Einsatz</li>
+                </ul>
+              </div>
+              <div class="calserver-highlight-card__actions">
+                <a class="uk-button uk-button-primary"
+                   href="https://calendly.com/calhelp/calserver-vorstellung"
+                   target="_blank"
+                   rel="noopener">Demo buchen</a>
+                <span class="muted">ca. 45&nbsp;Minuten individuelles Gespräch</span>
+              </div>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+              <div>
+                <h3 class="uk-card-title">Testzugang sichern</h3>
+                <p class="muted">Starten Sie mit einer eigenen Umgebung und prüfen Sie calServer mit Ihren Prozessen.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Einrichtung nach kurzer Abstimmung</li>
+                  <li>Best Practices für den schnellen Einstieg</li>
+                  <li>Support-Team an Ihrer Seite</li>
+                </ul>
+              </div>
+              <div class="calserver-highlight-card__actions">
+                <a id="trial" class="uk-button uk-button-default" href="#offer">Jetzt testen</a>
+                <span class="muted">Zugang &amp; Demo-Umgebung inklusive</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p class="muted uk-text-small uk-text-center uk-margin-medium-top">* Demo-Zugang und Testumgebung nach kurzer Abstimmung.</p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- align the "Betriebsarten" cards and demo CTA section to share the same highlight card component
- restyled the demo section into matching cards with bullet points and CTA layout for consistent contrast in light/dark themes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5bbf35890832bb510f835cc7d33d2