### PR TITLE
Link FAQ contact prompt to on-page form

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -1357,7 +1357,7 @@
         </ul>
         <div class="uk-margin-top">
           <span class="muted">Noch nicht fündig geworden?</span>
-          <a class="uk-margin-small-left" href="{{ basePath }}/kontakt">Weitere Fragen → Kontakt</a>
+          <a class="uk-margin-small-left" href="#contact-form">Weitere Fragen → Kontakt</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- point the calServer FAQ contact link to the page's own contact form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5bc810758832b9c37ef6bcc98cad3