### PR TITLE
Fix event creation flow to prompt required fields

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -2174,7 +2174,14 @@ document.addEventListener('DOMContentLoaded', function () {
     list.push(item);
     eventManager.render(list);
     highlightCurrentEvent();
-    saveEvents();
+    const nameCell = eventsListEl?.querySelector(`tr[data-id="${item.id}"] td[data-key="name"]`);
+    const nameCard = eventsCardsEl?.querySelector(`.qr-cell[data-id="${item.id}"][data-key="name"]`);
+    const target = nameCell || nameCard;
+    if (target && eventEditor) {
+      requestAnimationFrame(() => {
+        eventEditor.open(target);
+      });
+    }
   });
 
 


### PR DESCRIPTION
## Summary
- stop auto-saving a new event with empty required fields so it stays visible for editing
- automatically open the event edit modal when creating a new event to capture the mandatory data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5bf0bfed8832b802d9ea4325742a1