### PR TITLE
Fix highlight headings contrast in light mode

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -486,6 +486,34 @@ body.qr-landing.calserver-theme .calserver-highlight__intro p {
     color: color-mix(in oklab, rgba(255, 255, 255, 0.92) 92%, rgba(255, 255, 255, 0.62) 8%);
 }
 
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast)
+    .calserver-highlight__intro
+    p,
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast)
+    .calserver-highlight__intro
+    p {
+    color: color-mix(in oklab, var(--qr-text) 92%, var(--qr-bg) 8%);
+}
+
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast) .calserver-highlight.uk-light,
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast) .calserver-highlight.uk-light {
+    color: var(--qr-text);
+}
+
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast)
+    .calserver-highlight.uk-light
+    :is(h1, h2, h3, h4, h5, h6, .uk-heading-small, .uk-heading-medium, .uk-heading-large, .uk-heading-xlarge,
+        .uk-heading-line > span, .uk-text-lead) {
+    color: inherit;
+}
+
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast)
+    .calserver-highlight.uk-light
+    :is(h1, h2, h3, h4, h5, h6, .uk-heading-small, .uk-heading-medium, .uk-heading-large, .uk-heading-xlarge,
+        .uk-heading-line > span, .uk-text-lead) {
+    color: inherit;
+}
+
 body.qr-landing.calserver-theme .calserver-highlight-card {
     background: var(--cs-highlight-card-bg) !important;
     border: 1px solid var(--cs-highlight-card-border) !important;


### PR DESCRIPTION
## Summary
- ensure highlight sections that use the `uk-light` helper inherit the standard text color in light mode
- align intro paragraph styling in light mode with the regular text palette so copy stays legible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5be7588c4832ba53d9d244415e3b6