### PR TITLE
Load DOMPurify for page editor

### DIFF
--- a/templates/admin/pages/edit.twig
+++ b/templates/admin/pages/edit.twig
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/ui/trumbowyg.min.css">
   <script src="https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/trumbowyg@2/dist/trumbowyg.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
   <script type="module" src="{{ basePath }}/js/trumbowyg-pages.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- load DOMPurify on the admin page editor so rich text content is sanitized without being escaped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c455e934832b93a1b710d040dca6