### PR TITLE
Improve calserver demo CTA button contrast in light mode

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -647,6 +647,75 @@ body.qr-landing.calserver-theme .calserver-highlight-card__actions .muted {
     font-size: 0.85rem;
 }
 
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-primary,
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-primary {
+    background: color-mix(in oklab, var(--calserver-primary) 88%, #103b99 12%);
+    border-color: color-mix(in oklab, var(--calserver-primary) 68%, rgba(15, 23, 42, 0.24));
+    color: #ffffff;
+    box-shadow: 0 18px 36px -24px
+        color-mix(in oklab, var(--calserver-primary) 68%, rgba(15, 23, 42, 0.7));
+}
+
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-primary:hover,
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-primary:hover {
+    background: color-mix(in oklab, var(--calserver-primary) 78%, #0a2d86 22%);
+    border-color: color-mix(in oklab, var(--calserver-primary) 72%, rgba(15, 23, 42, 0.34));
+}
+
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-primary:focus-visible,
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-primary:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--calserver-primary) 75%, #8ab3ff 25%);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--calserver-primary) 54%, rgba(15, 23, 42, 0.18));
+}
+
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-default,
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-default {
+    background: #ffffff;
+    color: color-mix(in oklab, var(--calserver-primary) 82%, #071440 18%);
+    border-color: color-mix(in oklab, var(--calserver-primary) 32%, rgba(15, 23, 42, 0.08));
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--calserver-primary) 26%, rgba(15, 23, 42, 0.16)) inset,
+        0 14px 28px -24px rgba(15, 23, 42, 0.32);
+}
+
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-default:hover,
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-default:hover {
+    background: color-mix(in oklab, #ffffff 86%, var(--calserver-primary) 14%);
+    color: color-mix(in oklab, var(--calserver-primary) 88%, #041233 12%);
+    border-color: color-mix(in oklab, var(--calserver-primary) 46%, rgba(15, 23, 42, 0.16));
+}
+
+body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-default:focus-visible,
+body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast)
+    .calserver-highlight-card__actions
+    .uk-button-default:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--calserver-primary) 62%, #9bbdff 38%);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--calserver-primary) 32%, rgba(15, 23, 42, 0.22));
+}
+
 @media (max-width: 959px) {
     body.qr-landing.calserver-theme .calserver-highlight-card {
         padding: 28px;


### PR DESCRIPTION
## Summary
- add dedicated light-mode styles for calServer demo CTA buttons to increase contrast and focus visibility
- enhance hover and focus treatments to ensure the primary and default buttons remain legible on tinted card backgrounds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5e4114b6c832b933952b8b7a2889e