### PR TITLE
Add global upload streaming endpoint and coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
             "node tests/test_team_name_suggestion.js",
             "node tests/test_catalog_prevent_repeat.js",
             "node tests/test_event_summary_switch.js",
-            "node tests/test_sticker_editor_save_events.js"
+            "node tests/test_sticker_editor_save_events.js",
+            "node tests/test_media_preview.js"
         ]
     }
 }

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -68,6 +68,8 @@ Alle Bilder werden über den `ImageUploadService` verarbeitet. Globale Dateien l
 
 Die Qualität entspricht den Konstanten in `ImageUploadService` und sorgt für einheitlich komprimierte Dateien.
 
+Globale Dateien lassen sich direkt über `/uploads/<dateiname>` abrufen, beispielsweise damit Vorschaubilder im Medienmanager korrekt geladen werden können.
+
 Über `/admin/media` steht eine Medienbibliothek bereit, die globale und eventbezogene Uploads kapselt. Die Oberfläche listet alle Dateien mit Größe und Änderungsdatum auf, erlaubt eine Volltextsuche sowie das seitenweise Durchblättern (20 Einträge pro Seite). Uploads werden serverseitig auf 5 MB und die Formate PNG/JPG/WEBP begrenzt; fehlerhafte Anfragen liefern strukturierte Antworten mit einem `error`-Feld und den gültigen `limits`. Die gleichen Informationen stehen nach erfolgreichen Aktionen zur Verfügung, etwa nach dem Hochladen (`message: uploaded`) oder beim Umbenennen (`message: renamed`).
 
 Alle XHR-Endpunkte (`/admin/media/files`, `/admin/media/upload`, `/admin/media/rename`, `/admin/media/delete`) sind per CSRF-Token und `RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR)` abgesichert. Die JSON-Antworten enthalten neben der Dateiliste zusätzliche Metadaten (`mime`, `size`, `modified`) sowie die Upload-Limits, damit Clients die Vorgaben unmittelbar in der Oberfläche anzeigen können. Pfad-Traversal wird serverseitig verhindert, indem Dateinamen strikt normalisiert und nur bekannte Verzeichnisse zugelassen werden.

--- a/src/Controller/GlobalMediaController.php
+++ b/src/Controller/GlobalMediaController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\ConfigService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class GlobalMediaController
+{
+    public function __construct(private ConfigService $config)
+    {
+    }
+
+    public function get(Request $request, Response $response): Response
+    {
+        $file = (string) $request->getAttribute('file');
+        $file = basename($file);
+        if ($file === '') {
+            return $response->withStatus(404);
+        }
+
+        $dir = $this->config->getGlobalUploadsDir();
+        $path = $dir . '/' . $file;
+        if (!is_file($path)) {
+            return $response->withStatus(404);
+        }
+
+        $mime = mime_content_type($path) ?: 'application/octet-stream';
+        $response->getBody()->write((string) file_get_contents($path));
+
+        return $response->withHeader('Content-Type', $mime);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -85,6 +85,7 @@ use App\Controller\AdminSubscriptionCheckoutController;
 use App\Controller\InvitationController;
 use App\Controller\CatalogStickerController;
 use App\Controller\EventImageController;
+use App\Controller\GlobalMediaController;
 use App\Service\ImageUploadService;
 use App\Service\MediaLibraryService;
 use Slim\Views\Twig;
@@ -146,6 +147,7 @@ require_once __DIR__ . '/Controller/AdminSubscriptionCheckoutController.php';
 require_once __DIR__ . '/Controller/InvitationController.php';
 require_once __DIR__ . '/Controller/CatalogStickerController.php';
 require_once __DIR__ . '/Controller/EventImageController.php';
+require_once __DIR__ . '/Controller/GlobalMediaController.php';
 
 use App\Infrastructure\Migrations\Migrator;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -272,6 +274,7 @@ return function (\Slim\App $app, TranslationService $translator) {
                 $imageUploadService
             ))
             ->withAttribute('eventImageController', new EventImageController($configService))
+            ->withAttribute('globalMediaController', new GlobalMediaController($configService))
             ->withAttribute('importController', $importController = new ImportController(
                 $catalogService,
                 $configService,
@@ -1265,6 +1268,11 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/admin/sticker-background', function (Request $request, Response $response) {
         return $request->getAttribute('catalogStickerController')->uploadBackground($request, $response);
     })->add(new RoleAuthMiddleware(...Roles::ALL));
+
+    $app->get('/uploads/{file}', function (Request $request, Response $response, array $args) {
+        $req = $request->withAttribute('file', $args['file']);
+        return $request->getAttribute('globalMediaController')->get($req, $response);
+    });
 
     $app->get('/events/{uid}/images/{file}', function (Request $request, Response $response, array $args) {
         $req = $request

--- a/tests/Controller/GlobalMediaControllerTest.php
+++ b/tests/Controller/GlobalMediaControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class GlobalMediaControllerTest extends TestCase
+{
+    public function testServesGlobalUpload(): void
+    {
+        $dir = __DIR__ . '/../../data/uploads';
+        $createdDir = false;
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+            $createdDir = true;
+        }
+        $file = $dir . '/sample.txt';
+        file_put_contents($file, 'demo');
+
+        putenv('MAIN_DOMAIN=localhost');
+        $_ENV['MAIN_DOMAIN'] = 'localhost';
+
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/uploads/sample.txt');
+        $request = $request->withUri(new \Slim\Psr7\Uri('http', 'localhost', 80, '/uploads/sample.txt'));
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('demo', (string) $response->getBody());
+        $this->assertSame('text/plain', $response->getHeaderLine('Content-Type'));
+
+        unlink($file);
+        if ($createdDir) {
+            rmdir($dir);
+        }
+
+        putenv('MAIN_DOMAIN');
+        unset($_ENV['MAIN_DOMAIN']);
+    }
+}

--- a/tests/test_media_preview.js
+++ b/tests/test_media_preview.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const code = fs.readFileSync('public/js/media-manager.js', 'utf8');
+const match = code.match(/function updatePreview\(file\) {\n([\s\S]*?)\n    }\n\n    function renderFiles/);
+if (!match) {
+  throw new Error('updatePreview function not found');
+}
+const updatePreviewCode = `function updatePreview(file) {\n${match[1]}\n}`;
+
+const previewImage = {
+  hidden: true,
+  src: '',
+  alt: ''
+};
+const previewPlaceholder = { hidden: false };
+const previewMeta = { hidden: true };
+const previewActions = { hidden: true };
+const previewName = { textContent: '' };
+const previewSize = { textContent: '' };
+const previewModified = { textContent: '' };
+const previewDownload = {
+  href: '#',
+  download: '',
+  setAttribute(attr, value) {
+    if (attr === 'download') {
+      this.download = value;
+    } else {
+      this[attr] = value;
+    }
+  },
+  removeAttribute(attr) {
+    if (attr === 'download') {
+      this.download = '';
+    }
+  }
+};
+
+const calls = [];
+const context = {
+  previewImage,
+  previewPlaceholder,
+  previewMeta,
+  previewActions,
+  previewName,
+  previewSize,
+  previewModified,
+  previewDownload,
+  translations: { preview: 'Preview' },
+  formatSize: (bytes) => `${bytes} B`,
+  formatDate: (value) => String(value),
+  withBase: (path) => {
+    calls.push(path);
+    return path;
+  },
+  console
+};
+
+vm.createContext(context);
+vm.runInContext(updatePreviewCode, context);
+
+context.updatePreview({
+  name: 'sample.png',
+  url: '/uploads/sample.png',
+  size: 2048,
+  modified: '2024-01-01T00:00:00Z'
+});
+
+assert.deepStrictEqual(calls, ['/uploads/sample.png']);
+assert.strictEqual(previewImage.hidden, false);
+assert.strictEqual(previewImage.src, '/uploads/sample.png');
+assert.strictEqual(previewImage.alt, 'Preview: sample.png');
+assert.strictEqual(previewPlaceholder.hidden, true);
+assert.strictEqual(previewMeta.hidden, false);
+assert.strictEqual(previewActions.hidden, false);
+assert.strictEqual(previewName.textContent, 'sample.png');
+assert.strictEqual(previewSize.textContent, '2048 B');
+assert.strictEqual(previewModified.textContent, '2024-01-01T00:00:00Z');
+assert.strictEqual(previewDownload.href, '/uploads/sample.png');
+assert.strictEqual(previewDownload.download, 'sample.png');
+
+context.updatePreview(null);
+
+assert.strictEqual(previewImage.hidden, true);
+assert.strictEqual(previewImage.src, '');
+assert.strictEqual(previewPlaceholder.hidden, false);
+assert.strictEqual(previewMeta.hidden, true);
+assert.strictEqual(previewActions.hidden, true);
+assert.strictEqual(previewDownload.href, '#');
+assert.strictEqual(previewDownload.download, '');
+
+console.log('ok');


### PR DESCRIPTION
## Summary
- add a GlobalMediaController to stream sanitized uploads from the shared directory
- expose the `/uploads/{file}` route and document the new public download endpoint
- extend automated coverage for global downloads and media previews

## Testing
- ./vendor/bin/phpunit tests/Controller/GlobalMediaControllerTest.php
- node tests/test_media_preview.js

------
https://chatgpt.com/codex/tasks/task_e_68d668d3f398832b80731c95ba4653ad