### PR TITLE
Support domain-specific contact recipients

### DIFF
--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -29,7 +29,7 @@ class DomainStartPageService
      */
     public function getStartPage(string $host): ?string
     {
-        $config = $this->getDomainConfig($host);
+        $config = $this->getConfigForHost($host);
 
         if ($config === null) {
             return null;
@@ -38,6 +38,39 @@ class DomainStartPageService
         $startPage = (string) ($config['start_page'] ?? '');
 
         return $startPage === '' ? null : $startPage;
+    }
+
+    /**
+     * Determine the stored domain configuration for the given host.
+     *
+     * @return array{domain:string,start_page:string,email:?string}|null
+     */
+    public function getConfigForHost(string $host): ?array
+    {
+        $host = strtolower(trim($host));
+        if ($host === '') {
+            return null;
+        }
+
+        $candidates = [];
+        $normalizedHost = $this->normalizeDomain($host);
+        if ($normalizedHost !== '') {
+            $candidates[] = $normalizedHost;
+        }
+
+        $marketingHost = $this->normalizeDomain($host, stripAdmin: false);
+        if ($marketingHost !== '' && $marketingHost !== $normalizedHost) {
+            $candidates[] = $marketingHost;
+        }
+
+        foreach ($candidates as $candidate) {
+            $config = $this->getDomainConfig($candidate);
+            if ($config !== null) {
+                return $config;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Controller;
 
+use App\Service\DomainStartPageService;
 use App\Service\MailService;
 use Tests\TestCase;
 
@@ -84,6 +85,83 @@ class ContactControllerTest extends TestCase
         }
     }
 
+    public function testContactFormUsesDomainSpecificEmail(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        session_id('contactdomain');
+        session_start();
+        $_SESSION['csrf_token'] = 'token';
+        $_COOKIE[session_name()] = session_id();
+
+        $oldMainDomain = getenv('MAIN_DOMAIN');
+        $oldEnvMainDomain = $_ENV['MAIN_DOMAIN'] ?? null;
+        putenv('MAIN_DOMAIN=main.test');
+        $_ENV['MAIN_DOMAIN'] = 'main.test';
+
+        try {
+            $pdo = $this->getDatabase();
+            $domainService = new DomainStartPageService($pdo);
+            $domainService->saveDomainConfig('main.test', 'landing', 'contact@domain.test');
+
+            $mailer = new class extends MailService {
+                public array $args = [];
+                public function __construct()
+                {
+                }
+                public function sendContact(string $to, string $name, string $replyTo, string $message): void
+                {
+                    $this->args = [$to, $name, $replyTo, $message];
+                }
+            };
+
+            $body = json_encode([
+                'name' => 'Jane Doe',
+                'email' => 'jane@example.com',
+                'message' => 'Hi there',
+                'company' => '',
+            ], JSON_THROW_ON_ERROR);
+
+            $request = $this->createRequest(
+                'POST',
+                '/landing/contact',
+                [
+                    'Content-Type' => 'application/json',
+                    'X-CSRF-Token' => 'token',
+                ],
+                [session_name() => session_id()]
+            );
+            $request->getBody()->write($body);
+            $request->getBody()->rewind();
+            $request = $request
+                ->withUri($request->getUri()->withHost('main.test'))
+                ->withAttribute('mailService', $mailer);
+
+            $app = $this->getAppInstance();
+            $response = $app->handle($request);
+
+            $this->assertEquals(204, $response->getStatusCode());
+            $this->assertSame([
+                'contact@domain.test',
+                'Jane Doe',
+                'jane@example.com',
+                'Hi there',
+            ], $mailer->args);
+        } finally {
+            if ($oldMainDomain === false) {
+                putenv('MAIN_DOMAIN');
+            } else {
+                putenv('MAIN_DOMAIN=' . $oldMainDomain);
+            }
+            if ($oldEnvMainDomain === null) {
+                unset($_ENV['MAIN_DOMAIN']);
+            } else {
+                $_ENV['MAIN_DOMAIN'] = $oldEnvMainDomain;
+            }
+        }
+    }
+
     public function testContactFormHoneypotBlocksMail(): void
     {
         if (session_status() === PHP_SESSION_ACTIVE) {
@@ -138,6 +216,84 @@ class ContactControllerTest extends TestCase
 
             $this->assertEquals(204, $response->getStatusCode());
             $this->assertFalse($mailer->called, 'Honeypot submissions must not trigger mail delivery.');
+        } finally {
+            if ($oldMainDomain === false) {
+                putenv('MAIN_DOMAIN');
+            } else {
+                putenv('MAIN_DOMAIN=' . $oldMainDomain);
+            }
+            if ($oldEnvMainDomain === null) {
+                unset($_ENV['MAIN_DOMAIN']);
+            } else {
+                $_ENV['MAIN_DOMAIN'] = $oldEnvMainDomain;
+            }
+        }
+    }
+
+    public function testContactFormIgnoresInvalidDomainEmail(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        session_id('contactinvalid');
+        session_start();
+        $_SESSION['csrf_token'] = 'token';
+        $_COOKIE[session_name()] = session_id();
+
+        $oldMainDomain = getenv('MAIN_DOMAIN');
+        $oldEnvMainDomain = $_ENV['MAIN_DOMAIN'] ?? null;
+        putenv('MAIN_DOMAIN=main.test');
+        $_ENV['MAIN_DOMAIN'] = 'main.test';
+
+        try {
+            $pdo = $this->getDatabase();
+            $domainService = new DomainStartPageService($pdo);
+            $domainService->saveDomainConfig('main.test', 'landing', 'not-an-email');
+
+            $mailer = new class extends MailService {
+                public array $args = [];
+                public function __construct()
+                {
+                }
+                public function sendContact(string $to, string $name, string $replyTo, string $message): void
+                {
+                    $this->args = [$to, $name, $replyTo, $message];
+                }
+            };
+
+            $body = json_encode([
+                'name' => 'Invalid Email',
+                'email' => 'valid@example.com',
+                'message' => 'Please ignore',
+                'company' => '',
+            ], JSON_THROW_ON_ERROR);
+
+            $request = $this->createRequest(
+                'POST',
+                '/landing/contact',
+                [
+                    'Content-Type' => 'application/json',
+                    'X-CSRF-Token' => 'token',
+                ],
+                [session_name() => session_id()]
+            );
+            $request->getBody()->write($body);
+            $request->getBody()->rewind();
+            $request = $request
+                ->withUri($request->getUri()->withHost('main.test'))
+                ->withAttribute('mailService', $mailer);
+
+            $app = $this->getAppInstance();
+            $response = $app->handle($request);
+
+            $this->assertEquals(204, $response->getStatusCode());
+            $imprintEmail = $pdo->query("SELECT imprint_email FROM tenants WHERE subdomain = 'main'")?->fetchColumn();
+            $this->assertSame([
+                (string) $imprintEmail,
+                'Invalid Email',
+                'valid@example.com',
+                'Please ignore',
+            ], $mailer->args);
         } finally {
             if ($oldMainDomain === false) {
                 putenv('MAIN_DOMAIN');


### PR DESCRIPTION
## Summary
- add a DomainStartPageService helper to resolve start page/email config for the current host
- surface domain contact email data through DomainMiddleware and use it when choosing the contact recipient
- cover contact form delivery with domain-specific and fallback email scenarios

## Testing
- ./vendor/bin/phpunit --filter ContactControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68d66bb643cc832bbc6b18e85dd036d4