### PR TITLE
Adjust config menu toggle border radius

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -69,6 +69,9 @@ body:not(.dark-mode) .topbar .uk-navbar-nav>li>a{
   box-sizing:border-box;cursor:pointer;
   transition:background .12s,border-color .12s,box-shadow .12s;
 }
+.config-menu #configMenuToggle.git-btn{
+  border-radius:0 0 6px 6px;
+}
 .git-btn:hover{
   background:var(--topbar-btn-bg-hover);
   border-color:var(--topbar-btn-border-hover);


### PR DESCRIPTION
## Summary
- square off the config menu toggle button's top corners while keeping the bottom radius to match the fixed positioning

## Testing
- not run (css change)


------
https://chatgpt.com/codex/tasks/task_e_68d67148e38c832bbe9ffcf8bb5783f0