### PR TITLE
Enable admin page editing based on stored slugs

### DIFF
--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -4,14 +4,33 @@ declare(strict_types=1);
 
 namespace Tests\Controller;
 
+use PDO;
 use Tests\TestCase;
 
 class PageControllerTest extends TestCase
 {
-    public function testEditAndUpdate(): void
+    /**
+     * @dataProvider editableSlugProvider
+     */
+    public function testEditPageIsAccessible(string $slug, string $title): void
     {
         $pdo = $this->getDatabase();
-        $pdo->exec("INSERT INTO pages(slug, content) VALUES('landing','<p>old</p>')");
+        $this->seedPage($pdo, $slug, $title, '<p>content</p>');
+
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+
+        $response = $app->handle($this->createRequest('GET', '/admin/pages/' . $slug));
+        $this->assertSame(200, $response->getStatusCode());
+
+        session_destroy();
+    }
+
+    public function testUpdatePersistsContent(): void
+    {
+        $pdo = $this->getDatabase();
+        $this->seedPage($pdo, 'landing', 'Landing', '<p>old</p>');
 
         $app = $this->getAppInstance();
         session_start();
@@ -19,14 +38,14 @@ class PageControllerTest extends TestCase
         $_SESSION['csrf_token'] = 'token';
 
         $response = $app->handle($this->createRequest('GET', '/admin/pages/landing'));
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
 
-        $req = $this->createRequest('POST', '/admin/pages/landing', [
+        $request = $this->createRequest('POST', '/admin/pages/landing', [
             'HTTP_X_CSRF_TOKEN' => 'token',
-        ]);
-        $req = $req->withParsedBody(['content' => '<p>new</p>']);
-        $res = $app->handle($req);
-        $this->assertEquals(204, $res->getStatusCode());
+        ])->withParsedBody(['content' => '<p>new</p>']);
+        $result = $app->handle($request);
+        $this->assertSame(204, $result->getStatusCode());
+
         $content = $pdo->query("SELECT content FROM pages WHERE slug='landing'")->fetchColumn();
         $this->assertSame('<p>new</p>', $content);
 
@@ -38,8 +57,31 @@ class PageControllerTest extends TestCase
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
-        $res = $app->handle($this->createRequest('GET', '/admin/pages/unknown'));
-        $this->assertEquals(404, $res->getStatusCode());
+
+        $response = $app->handle($this->createRequest('GET', '/admin/pages/unknown'));
+        $this->assertSame(404, $response->getStatusCode());
+
         session_destroy();
+    }
+
+    /**
+     * @return array<int, array{0:string,1:string}>
+     */
+    public function editableSlugProvider(): array
+    {
+        return [
+            ['landing', 'Landing'],
+            ['calserver', 'calServer'],
+            ['lizenz', 'Lizenz'],
+        ];
+    }
+
+    private function seedPage(PDO $pdo, string $slug, string $title, string $content): void
+    {
+        $stmt = $pdo->prepare('DELETE FROM pages WHERE slug = ?');
+        $stmt->execute([$slug]);
+
+        $stmt = $pdo->prepare('INSERT INTO pages (slug, title, content) VALUES (?, ?, ?)');
+        $stmt->execute([$slug, $title, $content]);
     }
 }


### PR DESCRIPTION
## Summary
- derive editable admin page slugs from the PageService so new landing pages such as calserver and lizenz are supported
- reuse the dynamically built slug list in both edit() and update() to keep 404 handling consistent
- extend controller tests to cover calserver, lizenz and unknown slugs

## Testing
- ./vendor/bin/phpunit tests/Controller/PageControllerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d681d8acd8832b8d07ec125dd43a20