### PR TITLE
Add consent-gated video placeholder for calServer landing

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -334,12 +334,74 @@ body.qr-landing.calserver-theme .calserver-hero-video__frame::before {
     padding-top: 56.25%;
 }
 
-body.qr-landing.calserver-theme .calserver-hero-video__frame iframe {
+body.qr-landing.calserver-theme .calserver-hero-video__embed {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 24px 28px;
+    text-align: center;
+    background: linear-gradient(
+            144deg,
+            color-mix(in oklab, var(--calserver-primary) 28%, rgba(0, 10, 32, 0.86)) 0%,
+            color-mix(in oklab, var(--calserver-primary) 52%, rgba(1, 5, 18, 0.82)) 100%
+        );
+    color: rgba(255, 255, 255, 0.94);
+}
+
+body.qr-landing.calserver-theme .calserver-hero-video__embed.is-loaded {
+    display: block;
+    padding: 0;
+    background: transparent;
+}
+
+body.qr-landing.calserver-theme .calserver-hero-video__frame iframe,
+body.qr-landing.calserver-theme .calserver-hero-video__embed iframe {
     position: absolute;
     inset: 0;
     width: 100%;
     height: 100%;
     border: 0;
+}
+
+body.qr-landing.calserver-theme .calserver-hero-video__preview {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 84px;
+    height: 84px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+body.qr-landing.calserver-theme .calserver-hero-video__preview .uk-icon {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+body.qr-landing.calserver-theme .calserver-hero-video__hint,
+body.qr-landing.calserver-theme .calserver-hero-video__privacy-note,
+body.qr-landing.calserver-theme .calserver-hero-video__noscript-note {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.86);
+}
+
+body.qr-landing.calserver-theme .calserver-hero-video__hint {
+    max-width: 420px;
+}
+
+body.qr-landing.calserver-theme .calserver-hero-video__privacy-note {
+    font-size: 0.78rem;
+    opacity: 0.9;
+}
+
+body.qr-landing.calserver-theme .calserver-hero-video__noscript-note a {
+    color: inherit;
+    text-decoration: underline;
 }
 
 body.qr-landing.calserver-theme .calserver-hero-video__meta {
@@ -414,6 +476,31 @@ body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-vide
     background: var(--qr-card);
     border-color: currentColor;
     box-shadow: none;
+}
+
+body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__embed,
+body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__embed {
+    background: var(--qr-card);
+    color: currentColor;
+}
+
+body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__hint,
+body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__hint,
+body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__privacy-note,
+body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__privacy-note,
+body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__noscript-note,
+body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__noscript-note {
+    color: currentColor;
+}
+
+body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__preview,
+body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__preview {
+    background: currentColor;
+}
+
+body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__preview .uk-icon,
+body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__preview .uk-icon {
+    color: var(--qr-bg);
 }
 
 body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__meta-text,

--- a/public/js/calserver.js
+++ b/public/js/calserver.js
@@ -1,0 +1,105 @@
+(function () {
+  const CONSENT_KEY = 'calserverVideoConsent';
+  const ALLOW_ATTR = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+
+  function readConsent() {
+    try {
+      if (typeof getStored === 'function') {
+        return getStored(CONSENT_KEY) === '1';
+      }
+    } catch (error) {
+      /* empty */
+    }
+
+    try {
+      if (typeof localStorage !== 'undefined') {
+        return localStorage.getItem(CONSENT_KEY) === '1';
+      }
+    } catch (error) {
+      /* empty */
+    }
+
+    return false;
+  }
+
+  function storeConsent() {
+    try {
+      if (typeof setStored === 'function') {
+        setStored(CONSENT_KEY, '1');
+        return;
+      }
+    } catch (error) {
+      /* empty */
+    }
+
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(CONSENT_KEY, '1');
+      }
+    } catch (error) {
+      /* empty */
+    }
+  }
+
+  function buildSrc(element) {
+    const videoId = element.getAttribute('data-video-id');
+    if (!videoId) {
+      return null;
+    }
+
+    const params = element.getAttribute('data-video-params') || '';
+    const normalizedParams = params ? (params.startsWith('?') ? params : `?${params}`) : '';
+    return `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}${normalizedParams}`;
+  }
+
+  function injectIframe(container) {
+    if (!container || container.dataset.state === 'loaded') {
+      return;
+    }
+
+    const src = buildSrc(container);
+    if (!src) {
+      return;
+    }
+
+    const iframe = document.createElement('iframe');
+    iframe.src = src;
+    iframe.title = container.getAttribute('data-video-title') || '';
+    iframe.loading = 'lazy';
+    iframe.setAttribute('allow', ALLOW_ATTR);
+    iframe.setAttribute('allowfullscreen', 'true');
+
+    container.innerHTML = '';
+    container.appendChild(iframe);
+    container.dataset.state = 'loaded';
+    container.classList.add('is-loaded');
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const containers = document.querySelectorAll('[data-calserver-video]');
+    if (!containers.length) {
+      return;
+    }
+
+    if (readConsent()) {
+      containers.forEach(injectIframe);
+      return;
+    }
+
+    containers.forEach(function (container) {
+      const consentButton = container.querySelector('[data-calserver-video-consent]');
+      if (!consentButton) {
+        return;
+      }
+
+      consentButton.addEventListener('click', function () {
+        if (container.dataset.state === 'loaded') {
+          return;
+        }
+
+        storeConsent();
+        injectIframe(container);
+      });
+    });
+  });
+})();

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -177,11 +177,37 @@
             <div class="calserver-hero-video">
               <span class="pill pill--accent calserver-hero-video__badge">Live-Vorschau</span>
               <div class="calserver-hero-video__frame">
-                <iframe src="https://www.youtube-nocookie.com/embed/ovHo2SF84u0?rel=0&playlist=ovHo2SF84u0&loop=1"
-                        title="calServer Vorstellung"
-                        loading="lazy"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        allowfullscreen></iframe>
+                <div class="calserver-hero-video__embed"
+                     data-calserver-video
+                     data-video-id="ovHo2SF84u0"
+                     data-video-title="calServer Vorstellung"
+                     data-video-params="rel=0&playlist=ovHo2SF84u0&loop=1">
+                  <div class="calserver-hero-video__placeholder" role="group" aria-label="YouTube Video">
+                    <div class="calserver-hero-video__preview" aria-hidden="true">
+                      <span class="uk-icon" uk-icon="icon: play-circle; ratio: 2"></span>
+                    </div>
+                    <p class="calserver-hero-video__hint">
+                      Mit Klick auf „YouTube laden“ stimmst du zu, dass Inhalte von YouTube geladen werden.
+                      Dabei können personenbezogene Daten übertragen werden.
+                    </p>
+                    <button class="uk-button uk-button-primary calserver-hero-video__consent-button"
+                            type="button"
+                            data-calserver-video-consent>
+                      YouTube laden
+                    </button>
+                    <p class="calserver-hero-video__privacy-note">
+                      Du kannst deine Einwilligung jederzeit über deine Browser-Einstellungen widerrufen.
+                    </p>
+                  </div>
+                </div>
+                <noscript>
+                  <p class="calserver-hero-video__noscript-note">
+                    JavaScript ist deaktiviert. Öffne das Video direkt auf
+                    <a href="https://www.youtube.com/watch?v=ovHo2SF84u0" target="_blank" rel="noopener">
+                      YouTube
+                    </a>.
+                  </p>
+                </noscript>
               </div>
               <div class="calserver-hero-video__meta">
                 <div class="calserver-hero-video__meta-text">
@@ -1535,5 +1561,6 @@
     });
   </script>
   <script src="{{ basePath }}/js/app.js"></script>
+  <script src="{{ basePath }}/js/calserver.js" defer></script>
   <script src="{{ basePath }}/js/landing.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace the always-on YouTube iframe on the calServer landing page with a consent placeholder
- add client-side script that remembers consent and loads the video on demand
- extend calServer styles to render the placeholder and maintain accessibility in high contrast mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d681d3f2e8832b945c9b53218a69a8