### PR TITLE
Simplify admin landing page management

### DIFF
--- a/public/js/trumbowyg-pages.js
+++ b/public/js/trumbowyg-pages.js
@@ -115,6 +115,41 @@ export function initPageEditors() {
   });
 }
 
+export function initPageSelection() {
+  const select = document.getElementById('pageContentSelect');
+  if (!select) {
+    return;
+  }
+
+  const forms = Array.from(document.querySelectorAll('.page-form'));
+  if (!forms.length) {
+    return;
+  }
+
+  const toggleForms = slug => {
+    let activeSlug = slug;
+    if (!forms.some(form => form.dataset.slug === activeSlug)) {
+      activeSlug = forms[0]?.dataset.slug || '';
+    }
+    forms.forEach(form => {
+      form.classList.toggle('uk-hidden', form.dataset.slug !== activeSlug);
+    });
+  };
+
+  let selected = select.dataset.selected || select.value;
+  if (!selected && select.options.length > 0) {
+    selected = select.options[0].value;
+  }
+  if (selected) {
+    select.value = selected;
+  }
+  toggleForms(selected);
+
+  select.addEventListener('change', () => {
+    toggleForms(select.value);
+  });
+}
+
 export function showPreview() {
   const editor = document.querySelector('.page-editor');
   if (!editor) return;
@@ -127,8 +162,12 @@ export function showPreview() {
 }
 
 window.showPreview = showPreview;
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initPageEditors);
-} else {
+const initPagesModule = () => {
   initPageEditors();
+  initPageSelection();
+};
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initPagesModule);
+} else {
+  initPagesModule();
 }

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -30,6 +30,7 @@ return [
     'tab_statistics' => 'Statistik',
     'tab_pages' => 'Seiten',
     'tab_landingpage_seo' => 'Landingpage SEO',
+    'tab_landingpage_content' => 'Landingpage Inhalte',
     'tab_management' => 'Administration',
     'tab_logs' => 'Logs',
     'tab_tenants' => 'Subdomains',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -30,6 +30,7 @@ return [
     'tab_statistics' => 'Statistics',
     'tab_pages' => 'Pages',
     'tab_landingpage_seo' => 'Landing Page SEO',
+    'tab_landingpage_content' => 'Landing Page Content',
     'tab_management' => 'Management',
     'tab_logs' => 'Logs',
     'tab_tenants' => 'Subdomains',

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -215,6 +215,11 @@ class AdminController
             ? $seoPages[$selectedSeoPage->getId()]['config']
             : [];
 
+        $selectedPageSlug = $selectedSeoPage?->getSlug() ?? '';
+        if ($selectedPageSlug === '') {
+            $selectedPageSlug = $pages[0]['slug'] ?? '';
+        }
+
         $mediaService = new MediaLibraryService($configSvc, new ImageUploadService());
         $mediaLimits = $mediaService->getLimits();
 
@@ -237,6 +242,7 @@ class AdminController
               'seo_config' => $seoConfig,
               'seo_pages' => array_values($seoPages),
               'selectedSeoPageId' => $selectedSeoPage?->getId(),
+              'selectedPageSlug' => $selectedPageSlug,
               'domainType' => $request->getAttribute('domainType'),
               'tenant' => $tenant,
               'stripe_configured' => StripeService::isConfigured()['ok'],

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -913,10 +913,7 @@
           <h2 class="uk-heading-bullet">{{ t('heading_pages') }}</h2>
           <ul id="pageTabs" class="uk-tab" uk-tab="connect: #pageSwitcher">
             <li class="uk-active"><a href="#">{{ t('tab_landingpage_seo') }}</a></li>
-            {% for page in pages %}
-              {% set pageLabel = page.title is not empty ? page.title : page.slug|replace({'-': ' '})|title %}
-              <li data-slug="{{ page.slug }}"><a href="#">{{ pageLabel }}</a></li>
-            {% endfor %}
+            <li><a href="#">{{ t('tab_landingpage_content') }}</a></li>
           </ul>
           <ul id="pageSwitcher" class="uk-switcher uk-margin">
             <li>
@@ -1007,18 +1004,48 @@
               </form>
               {% endif %}
             </li>
-            {% for page in pages %}
             <li>
-              <form class="page-form" data-slug="{{ page.slug }}">
-                <input type="hidden" id="page_{{ page.slug }}" name="content" value="{{ page.content|e('html_attr') }}">
-                <div class="page-editor" data-content="{{ page.content|e('html_attr') }}"></div>
-                <div class="uk-margin-top">
-                  <button class="uk-button uk-button-primary save-page-btn">Speichern</button>
-                  <a class="uk-button uk-button-default preview-link" href="{{ basePath }}/{{ page.slug }}" target="_blank">Vorschau</a>
+              {% if pages|default([]) is empty %}
+                <div class="uk-alert uk-alert-warning">Keine Marketing-Seiten gefunden.</div>
+              {% else %}
+                {% set selectedSlug = selectedPageSlug|default('') %}
+                {% if selectedSlug == '' and pages|length > 0 %}
+                  {% set selectedSlug = (pages|first).slug %}
+                {% endif %}
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="pageContentSelect">Marketing-Seite</label>
+                  <div class="uk-form-controls">
+                    <select
+                      id="pageContentSelect"
+                      class="uk-select"
+                      data-selected="{{ selectedSlug }}"
+                    >
+                      {% for page in pages %}
+                        {% set pageLabel = page.title is not empty ? page.title : page.slug|replace({'-': ' '})|title %}
+                        <option
+                          value="{{ page.slug }}"
+                          {% if page.slug == selectedSlug %}selected{% endif %}
+                        >{{ pageLabel }}</option>
+                      {% endfor %}
+                    </select>
+                  </div>
                 </div>
-              </form>
+                {% for page in pages %}
+                <form class="page-form{% if page.slug != selectedSlug %} uk-hidden{% endif %}" data-slug="{{ page.slug }}">
+                  <input type="hidden" id="page_{{ page.slug }}" name="content" value="{{ page.content|e('html_attr') }}">
+                  <div class="page-editor" data-content="{{ page.content|e('html_attr') }}"></div>
+                  <div class="uk-margin-top">
+                    <button class="uk-button uk-button-primary save-page-btn">Speichern</button>
+                    <a
+                      class="uk-button uk-button-default preview-link"
+                      href="{{ basePath }}/{{ page.slug }}"
+                      target="_blank"
+                    >Vorschau</a>
+                  </div>
+                </form>
+                {% endfor %}
+              {% endif %}
             </li>
-            {% endfor %}
           </ul>
         </div>
       </li>


### PR DESCRIPTION
## Summary
- replace the per-landing-page tabs in the admin view with a single content tab and dropdown selector
- provide the selected landing page slug from the controller and add matching translation strings
- update the page editor script to toggle the visible form based on the dropdown choice

## Testing
- composer test *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6924e8a38832bad890b0b2cbbf63d