### PR TITLE
Restrict CodeSniffer to PHP files

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,9 @@
     <!-- use colors in output -->
     <arg name="colors"/>
 
+    <!-- restrict to PHP files -->
+    <arg name="extensions" value="php"/>
+
     <!-- inherit rules from: -->
     <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>


### PR DESCRIPTION
## Summary
- configure phpcs.xml to limit linting to PHP file extensions so JavaScript tests are skipped

## Testing
- vendor/bin/phpcs

------
https://chatgpt.com/codex/tasks/task_e_68d6961c147c832bbb1054416a98f638