### PR TITLE
Exclude JavaScript tests from PHPCS ruleset

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,4 +20,5 @@
     <!-- Paths to check -->
     <file>src</file>
     <file>tests</file>
+    <exclude-pattern>tests/.*\.js$</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Summary
- update the PHPCS ruleset to exclude JavaScript test files from linting

## Testing
- vendor/bin/phpcs

------
https://chatgpt.com/codex/tasks/task_e_68d696282268832b9f7b0bc69d014f39