### PR TITLE
Fix spacing in Stripe webhook test

### DIFF
--- a/tests/Controller/StripeWebhookControllerTest.php
+++ b/tests/Controller/StripeWebhookControllerTest.php
@@ -32,7 +32,7 @@ class StripeWebhookControllerTest extends TestCase
     public function testCheckoutSessionCompletedCreatesTenantFromOnboardingData(): void
     {
         putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
-        $pdo = new class('sqlite::memory:') extends \PDO {
+        $pdo = new class ('sqlite::memory:') extends \PDO {
             public function __construct(string $dsn)
             {
                 parent::__construct($dsn);


### PR DESCRIPTION
## Summary
- add required spacing before the anonymous class constructor call in the Stripe webhook controller test

## Testing
- vendor/bin/phpcs *(fails: existing style errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6962c02e8832baafd814f682dc5e1