### PR TITLE
Fix page editor HTML sanitization fallback

### DIFF
--- a/public/js/trumbowyg-pages.js
+++ b/public/js/trumbowyg-pages.js
@@ -2,12 +2,14 @@
 
 // Define custom UIkit templates for Trumbowyg
 const sanitize = str => {
-  if (window.DOMPurify) {
-    return window.DOMPurify.sanitize(str);
+  const value = typeof str === 'string' ? str : String(str ?? '');
+  if (window.DOMPurify && typeof window.DOMPurify.sanitize === 'function') {
+    return window.DOMPurify.sanitize(value);
   }
-  const div = document.createElement('div');
-  div.textContent = str;
-  return div.innerHTML;
+  if (window.console && typeof window.console.warn === 'function') {
+    window.console.warn('DOMPurify not available, skipping HTML sanitization for page editor content.');
+  }
+  return value;
 };
 $.extend(true, $.trumbowyg, {
   langs: { de: { template: 'Vorlage', variable: 'Variable' } },


### PR DESCRIPTION
## Summary
- keep legal page editors from mangling HTML when DOMPurify fails to load
- warn in the console when sanitization is skipped so administrators know DOMPurify is missing

## Testing
- composer test *(fails: vendor/bin/phpunit not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d696e03104832b86b72c6b80fc95e7