### PR TITLE
Align trust story timeline markup with list semantics

### DIFF
--- a/migrations/20250926_update_calserver_page.sql
+++ b/migrations/20250926_update_calserver_page.sql
@@ -124,8 +124,8 @@ VALUES (
         </div>
 
         
-        <div class="trust-story trust-story--timeline" role="list" aria-label="So begleitet calServer dein Team">
-                                              <article class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-devices" aria-describedby="trust-step-devices-description">
+        <ul class="trust-story trust-story--timeline" role="list" aria-label="So begleitet calServer dein Team">
+                                              <li class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-devices" aria-describedby="trust-step-devices-description">
               <div class="trust-story__marker" aria-hidden="true">
                 <span class="trust-story__connector trust-story__connector--before"></span>
                 <span class="trust-story__badge" data-step-index="1">
@@ -140,8 +140,8 @@ VALUES (
                   Importiere Bestandslisten oder starte direkt im Browser. calServer sammelt Stammdaten, Dokumente und Verantwortlichkeiten an einem Ort, damit nichts verloren geht.
                 </p>
               </div>
-            </article>
-                                              <article class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-deadlines" aria-describedby="trust-step-deadlines-description">
+            </li>
+                                              <li class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-deadlines" aria-describedby="trust-step-deadlines-description">
               <div class="trust-story__marker" aria-hidden="true">
                 <span class="trust-story__connector trust-story__connector--before"></span>
                 <span class="trust-story__badge" data-step-index="2">
@@ -156,8 +156,8 @@ VALUES (
                   Erinnerungen, Eskalationspfade und mobile Checklisten halten dein Team auf Kurs. Jede Person sieht sofort, welche Prüfaufträge heute wichtig sind.
                 </p>
               </div>
-            </article>
-                                              <article class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-audit" aria-describedby="trust-step-audit-description">
+            </li>
+                                              <li class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-audit" aria-describedby="trust-step-audit-description">
               <div class="trust-story__marker" aria-hidden="true">
                 <span class="trust-story__connector trust-story__connector--before"></span>
                 <span class="trust-story__badge" data-step-index="3">
@@ -172,8 +172,8 @@ VALUES (
                   Nachweise, Zertifikate und Gerätehistorien liegen revisionssicher bereit. Mit Hosting in Deutschland und täglichen Backups bist du auf Kontrollen vorbereitet.
                 </p>
               </div>
-            </article>
-                  </div>
+            </li>
+                  </ul>
 
         <div class="trust-story__closing uk-grid uk-grid-large uk-flex-middle" uk-grid>
           <div class="uk-width-1-1 uk-width-expand@m">

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -465,8 +465,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
         </div>
 
         
-        <div class="trust-story trust-story--timeline" role="list" aria-label="So begleitet calServer dein Team">
-                                              <article class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-devices" aria-describedby="trust-step-devices-description">
+        <ul class="trust-story trust-story--timeline" role="list" aria-label="So begleitet calServer dein Team">
+                                              <li class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-devices" aria-describedby="trust-step-devices-description">
               <div class="trust-story__marker" aria-hidden="true">
                 <span class="trust-story__connector trust-story__connector--before"></span>
                 <span class="trust-story__badge" data-step-index="1">
@@ -481,8 +481,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                   Importiere Bestandslisten oder starte direkt im Browser. calServer sammelt Stammdaten, Dokumente und Verantwortlichkeiten an einem Ort, damit nichts verloren geht.
                 </p>
               </div>
-            </article>
-                                              <article class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-deadlines" aria-describedby="trust-step-deadlines-description">
+            </li>
+                                              <li class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-deadlines" aria-describedby="trust-step-deadlines-description">
               <div class="trust-story__marker" aria-hidden="true">
                 <span class="trust-story__connector trust-story__connector--before"></span>
                 <span class="trust-story__badge" data-step-index="2">
@@ -497,8 +497,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                   Erinnerungen, Eskalationspfade und mobile Checklisten halten dein Team auf Kurs. Jede Person sieht sofort, welche Prüfaufträge heute wichtig sind.
                 </p>
               </div>
-            </article>
-                                              <article class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-audit" aria-describedby="trust-step-audit-description">
+            </li>
+                                              <li class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-audit" aria-describedby="trust-step-audit-description">
               <div class="trust-story__marker" aria-hidden="true">
                 <span class="trust-story__connector trust-story__connector--before"></span>
                 <span class="trust-story__badge" data-step-index="3">
@@ -513,8 +513,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                   Nachweise, Zertifikate und Gerätehistorien liegen revisionssicher bereit. Mit Hosting in Deutschland und täglichen Backups bist du auf Kontrollen vorbereitet.
                 </p>
               </div>
-            </article>
-                  </div>
+            </li>
+                  </ul>
 
         <div class="trust-story__closing uk-grid uk-grid-large uk-flex-middle" uk-grid>
           <div class="uk-width-1-1 uk-width-expand@m">


### PR DESCRIPTION
## Summary
- replace the trust story timeline step markup with semantic list items in the calServer page content
- update both the migration and SQLite schema to wrap the steps in an unordered list for consistent structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e6aa6e70832b8bdd6af49997a5db