### PR TITLE
Add favicon configuration support to marketing pages

### DIFF
--- a/migrations/20250330_add_favicon_path_to_page_seo_config.sql
+++ b/migrations/20250330_add_favicon_path_to_page_seo_config.sql
@@ -1,0 +1,2 @@
+ALTER TABLE page_seo_config ADD COLUMN IF NOT EXISTS favicon_path TEXT;
+ALTER TABLE page_seo_config_history ADD COLUMN IF NOT EXISTS favicon_path TEXT;

--- a/src/Application/Seo/SeoValidator.php
+++ b/src/Application/Seo/SeoValidator.php
@@ -57,6 +57,11 @@ class SeoValidator
             $errors['domain'] = 'Invalid domain';
         }
 
+        $favicon = $data['faviconPath'] ?? null;
+        if ($favicon !== null && $favicon !== '' && mb_strlen((string) $favicon) > 255) {
+            $errors['faviconPath'] = 'Favicon path too long';
+        }
+
         return $errors;
     }
 }

--- a/src/Controller/Admin/LandingpageController.php
+++ b/src/Controller/Admin/LandingpageController.php
@@ -94,6 +94,7 @@ class LandingpageController
             'schemaJson' => $data['schemaJson'] ?? $data['schema'] ?? null,
             'hreflang' => $data['hreflang'] ?? null,
             'domain' => $normalizedDomain !== '' ? $normalizedDomain : null,
+            'faviconPath' => $data['faviconPath'] ?? $data['favicon_path'] ?? null,
         ];
 
         $errors = $this->seoService->validate($payload);
@@ -101,6 +102,10 @@ class LandingpageController
             $response->getBody()->write(json_encode(['errors' => $errors]));
             return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
         }
+
+        $payload['faviconPath'] = $this->seoService->normalizeFaviconPath(
+            isset($payload['faviconPath']) ? (string) $payload['faviconPath'] : null
+        );
 
         $page = $this->pageService->findById($payload['pageId']);
         if ($page === null || in_array($page->getSlug(), self::EXCLUDED_SLUGS, true)) {
@@ -119,7 +124,8 @@ class LandingpageController
             $payload['ogImage'],
             $payload['schemaJson'],
             $payload['hreflang'],
-            $payload['domain']
+            $payload['domain'],
+            $payload['faviconPath']
         );
 
         $this->seoService->save($config);

--- a/src/Controller/Marketing/LandingController.php
+++ b/src/Controller/Marketing/LandingController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Marketing;
 
+use App\Application\Seo\PageSeoConfigService;
 use App\Service\MailService;
 use App\Service\PageService;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -16,13 +17,22 @@ use Slim\Views\Twig;
  */
 class LandingController
 {
+    private PageService $pages;
+    private PageSeoConfigService $seo;
+
+    public function __construct(?PageService $pages = null, ?PageSeoConfigService $seo = null)
+    {
+        $this->pages = $pages ?? new PageService();
+        $this->seo = $seo ?? new PageSeoConfigService();
+    }
+
     public function __invoke(Request $request, Response $response): Response
     {
-        $service = new PageService();
-        $html = $service->get('landing');
-        if ($html === null) {
+        $page = $this->pages->findBySlug('landing');
+        if ($page === null) {
             return $response->withStatus(404);
         }
+        $html = $page->getContent();
         $basePath = RouteContext::fromRequest($request)->getBasePath();
         $html = str_replace('{{ basePath }}', $basePath, $html);
 
@@ -39,8 +49,10 @@ class LandingController
         }
 
         $view = Twig::fromRequest($request);
+        $config = $this->seo->load($page->getId());
         return $view->render($response, 'marketing/landing.twig', [
             'content' => $html,
+            'pageFavicon' => $config?->getFaviconPath(),
         ]);
     }
 }

--- a/src/Domain/PageSeoConfig.php
+++ b/src/Domain/PageSeoConfig.php
@@ -35,6 +35,8 @@ class PageSeoConfig implements JsonSerializable
 
     private ?string $hreflang;
 
+    private ?string $faviconPath;
+
     /** @var Page|null */
     private $page;
 
@@ -50,7 +52,8 @@ class PageSeoConfig implements JsonSerializable
         ?string $ogImage = null,
         ?string $schemaJson = null,
         ?string $hreflang = null,
-        ?string $domain = null
+        ?string $domain = null,
+        ?string $faviconPath = null
     ) {
         $this->pageId = $pageId;
         $this->slug = $slug;
@@ -64,6 +67,7 @@ class PageSeoConfig implements JsonSerializable
         $this->ogImage = $ogImage;
         $this->schemaJson = $schemaJson;
         $this->hreflang = $hreflang;
+        $this->faviconPath = $faviconPath;
     }
 
     public function getPageId(): int
@@ -126,6 +130,11 @@ class PageSeoConfig implements JsonSerializable
         return $this->hreflang;
     }
 
+    public function getFaviconPath(): ?string
+    {
+        return $this->faviconPath;
+    }
+
     /**
      * @return Page|null
      */
@@ -156,6 +165,7 @@ class PageSeoConfig implements JsonSerializable
             'ogTitle' => $this->ogTitle,
             'ogDescription' => $this->ogDescription,
             'ogImage' => $this->ogImage,
+            'faviconPath' => $this->faviconPath,
             'schemaJson' => $this->schemaJson,
             'hreflang' => $this->hreflang,
         ];

--- a/src/Service/PageService.php
+++ b/src/Service/PageService.php
@@ -22,10 +22,8 @@ class PageService
 
     public function get(string $slug): ?string
     {
-        $stmt = $this->pdo->prepare('SELECT content FROM pages WHERE slug = ?');
-        $stmt->execute([$slug]);
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $row !== false ? (string) ($row['content'] ?? '') : null;
+        $page = $this->findBySlug($slug);
+        return $page?->getContent();
     }
 
     public function save(string $slug, string $content): void
@@ -81,5 +79,28 @@ class PageService
         }
 
         return new Page((int) $row['id'], $slug, $title, (string) ($row['content'] ?? ''));
+    }
+
+    public function findBySlug(string $slug): ?Page
+    {
+        $normalized = trim($slug);
+        if ($normalized === '') {
+            return null;
+        }
+
+        $stmt = $this->pdo->prepare('SELECT id, slug, title, content FROM pages WHERE slug = ?');
+        $stmt->execute([$normalized]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+
+        $pageSlug = isset($row['slug']) ? (string) $row['slug'] : '';
+        $title = isset($row['title']) ? (string) $row['title'] : '';
+        if ($pageSlug === '' || $title === '') {
+            return null;
+        }
+
+        return new Page((int) $row['id'], $pageSlug, $title, (string) ($row['content'] ?? ''));
     }
 }

--- a/templates/admin/landingpage/edit.html.twig
+++ b/templates/admin/landingpage/edit.html.twig
@@ -69,6 +69,14 @@
         </div>
       </div>
       <div class="uk-margin">
+        <label class="uk-form-label" for="faviconPath">Favicon</label>
+        <div class="uk-form-controls uk-flex uk-flex-middle uk-flex-wrap" style="gap:8px;">
+          <input class="uk-input uk-flex-auto" id="faviconPath" name="favicon_path" type="text" placeholder="/uploads/favicon.svg" value="{{ config.faviconPath|default('') }}">
+          <button type="button" class="uk-button uk-button-default" id="faviconSelectButton">Aus Medien wählen</button>
+        </div>
+        <small class="uk-text-meta">Optionaler relativer Pfad oder HTTPS-URL.</small>
+      </div>
+      <div class="uk-margin">
         <label class="uk-form-label" for="robots">Robots</label>
         <div class="uk-form-controls">
           <input class="uk-input" id="robots" name="robots" type="text" placeholder="index, follow" value="{{ config.robotsMeta|default('') }}">
@@ -99,6 +107,19 @@
         <button type="submit" class="uk-button uk-button-primary uk-margin-left">Speichern</button>
       </div>
     </form>
+    <div id="seoMediaModal" class="uk-modal" uk-modal>
+      <div class="uk-modal-dialog uk-modal-body">
+        <button class="uk-modal-close-default" type="button" uk-close></button>
+        <h2 class="uk-modal-title">Favicon auswählen</h2>
+        <div class="uk-margin-small">
+          <input class="uk-input" type="search" placeholder="Suchen..." data-role="media-search">
+        </div>
+        <div class="uk-overflow-auto" style="max-height: 320px;">
+          <ul class="uk-list uk-list-divider" data-role="media-list"></ul>
+        </div>
+        <p class="uk-text-meta" data-role="media-empty" hidden>Keine Medien gefunden.</p>
+      </div>
+    </div>
     {% endif %}
   </div>
 {% endblock %}

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -37,7 +37,24 @@
     ]
   }
   </script>
-  <link rel="icon" href="{{ basePath }}/favicon.svg" type="image/svg+xml">
+  {% set rawFavicon = pageFavicon is defined and pageFavicon ? pageFavicon : '/favicon.svg' %}
+  {% set faviconSource = rawFavicon starts with 'http' ? rawFavicon : basePath ~ rawFavicon %}
+  {% set faviconExt = (rawFavicon|split('?')|first|split('#')|first|split('.')|last|lower) %}
+  {% set faviconType = 'image/svg+xml' %}
+  {% if faviconExt in ['png'] %}
+    {% set faviconType = 'image/png' %}
+  {% elseif faviconExt in ['ico', 'cur'] %}
+    {% set faviconType = 'image/x-icon' %}
+  {% elseif faviconExt in ['jpg', 'jpeg'] %}
+    {% set faviconType = 'image/jpeg' %}
+  {% elseif faviconExt == 'gif' %}
+    {% set faviconType = 'image/gif' %}
+  {% elseif faviconExt == 'webp' %}
+    {% set faviconType = 'image/webp' %}
+  {% elseif faviconExt == 'svg' %}
+    {% set faviconType = 'image/svg+xml' %}
+  {% endif %}
+  <link rel="icon" href="{{ faviconSource }}" type="{{ faviconType }}">
   <link rel="stylesheet" href="{{ basePath }}/css/uikit.min.css">
   <link rel="stylesheet" href="{{ basePath }}/css/variables.css">
   <link rel="stylesheet" href="{{ basePath }}/css/table.css">


### PR DESCRIPTION
## Summary
- add a migration and domain/service changes so page SEO configs persist a favicon path alongside existing metadata
- extend the admin landing page SEO form and JavaScript to let admins pick a favicon from the media library and submit it
- surface the configured favicon on marketing pages and layout with a slug-based page lookup and graceful fallback
- cover the new favicon behaviour with updated PageSeoConfigService tests

## Testing
- ./vendor/bin/phpunit tests/Service/PageSeoConfigServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d705a40c08832b966c8717e28075de