### PR TITLE
Apply landing page styling to admin landing content editor

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -827,6 +827,16 @@ body.admin-page {
   background: #fff;
 }
 
+.page-editor.landing-editor {
+  background: var(--qr-bg);
+  color: var(--qr-text);
+  border-color: var(--qr-border);
+}
+
+.page-editor.landing-editor a {
+  color: var(--qr-link);
+}
+
 /* Prevent huge heights from UIkit's height-viewport plugin inside the editor */
 .page-editor [uk-height-viewport] {
   min-height: auto !important;

--- a/public/js/trumbowyg-pages.js
+++ b/public/js/trumbowyg-pages.js
@@ -76,14 +76,202 @@ $.extend(true, $.trumbowyg, {
   }
 });
 
+const LANDING_STYLE_FILES = [
+  '/css/landing.css',
+  '/css/onboarding.css',
+  '/css/topbar.landing.css'
+];
+
+let landingStylesPromise;
+
+function ensureLandingEditorStyles() {
+  if (document.getElementById('landing-editor-styles')) {
+    return Promise.resolve();
+  }
+  if (landingStylesPromise) {
+    return landingStylesPromise;
+  }
+  const base = window.basePath || '';
+  const requests = LANDING_STYLE_FILES.map(path => {
+    const url = base.replace(/\/$/, '') + path;
+    return fetch(url).then(resp => (resp.ok ? resp.text() : '')).catch(() => '');
+  });
+  landingStylesPromise = Promise.all(requests).then(chunks => {
+    const scoped = chunks
+      .map(chunk => scopeLandingCss(chunk, '.landing-editor'))
+      .filter(Boolean)
+      .join('\n');
+    if (scoped) {
+      const styleEl = document.createElement('style');
+      styleEl.id = 'landing-editor-styles';
+      styleEl.textContent = scoped;
+      document.head.appendChild(styleEl);
+    }
+    if (!document.getElementById('landing-editor-font')) {
+      const fontLink = document.createElement('link');
+      fontLink.id = 'landing-editor-font';
+      fontLink.rel = 'stylesheet';
+      fontLink.href = 'https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap';
+      document.head.appendChild(fontLink);
+    }
+  }).catch(err => {
+    if (window.console && typeof window.console.warn === 'function') {
+      window.console.warn('Failed to load landing editor styles', err);
+    }
+  });
+  return landingStylesPromise;
+}
+
+function scopeLandingCss(css, scopeSelector) {
+  if (!css) {
+    return '';
+  }
+  let parser;
+  try {
+    parser = document.createElement('style');
+    parser.textContent = css;
+    document.head.appendChild(parser);
+    const sheet = parser.sheet;
+    if (!sheet || !sheet.cssRules) {
+      parser.remove();
+      return css;
+    }
+
+    const styleRuleType = window.CSSRule?.STYLE_RULE ?? 1;
+    const mediaRuleType = window.CSSRule?.MEDIA_RULE ?? 4;
+    const supportsRuleType = window.CSSRule?.SUPPORTS_RULE ?? 12;
+    const keyframesRuleType = window.CSSRule?.KEYFRAMES_RULE ?? 7;
+
+    const toArray = list => {
+      try {
+        return Array.from(list);
+      } catch (err) {
+        const arr = [];
+        for (let i = 0; i < list.length; i += 1) {
+          arr.push(list[i]);
+        }
+        return arr;
+      }
+    };
+
+    const processRuleList = ruleList => {
+      const rules = [];
+      toArray(ruleList).forEach(rule => {
+        if (rule.type === styleRuleType) {
+          const selectors = prefixSelectorList(rule.selectorText, scopeSelector);
+          if (selectors) {
+            rules.push(`${selectors} { ${rule.style.cssText} }`);
+          }
+        } else if (rule.type === mediaRuleType) {
+          const inner = processRuleList(rule.cssRules);
+          if (inner.length) {
+            rules.push(`@media ${rule.conditionText} { ${inner.join(' ')} }`);
+          }
+        } else if (rule.type === supportsRuleType) {
+          const innerSupports = processRuleList(rule.cssRules);
+          if (innerSupports.length) {
+            rules.push(`@supports ${rule.conditionText} { ${innerSupports.join(' ')} }`);
+          }
+        } else if (rule.type === keyframesRuleType) {
+          rules.push(rule.cssText);
+        } else {
+          rules.push(rule.cssText);
+        }
+      });
+      return rules;
+    };
+
+    const scoped = processRuleList(sheet.cssRules).join('\n');
+    parser.remove();
+    return scoped;
+  } catch (error) {
+    if (parser && parser.parentNode) {
+      parser.parentNode.removeChild(parser);
+    }
+    if (window.console && typeof window.console.warn === 'function') {
+      window.console.warn('Failed to scope landing CSS', error);
+    }
+    return css;
+  }
+}
+
+function prefixSelectorList(selectorText, scopeSelector) {
+  if (!selectorText) {
+    return '';
+  }
+  return selectorText
+    .split(',')
+    .map(sel => prefixSingleSelector(sel, scopeSelector))
+    .filter(Boolean)
+    .join(', ');
+}
+
+function prefixSingleSelector(selector, scopeSelector) {
+  let trimmed = selector.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (trimmed.startsWith(scopeSelector)) {
+    return trimmed;
+  }
+  if (trimmed.startsWith(':root')) {
+    const remainder = trimmed.slice(':root'.length);
+    return combineSelector(scopeSelector, remainder);
+  }
+  if (/^body\b/i.test(trimmed)) {
+    trimmed = trimmed.replace(/^body\b/i, '');
+  }
+  if (/^html\b/i.test(trimmed)) {
+    trimmed = trimmed.replace(/^html\b/i, '');
+  }
+  if (/^\.qr-landing\b/.test(trimmed)) {
+    trimmed = trimmed.replace(/^\.qr-landing\b/, '');
+  }
+  return combineSelector(scopeSelector, trimmed);
+}
+
+function combineSelector(scopeSelector, remainder) {
+  const hadLeadingSpace = /^\s/.test(remainder);
+  const clean = remainder.trim();
+  if (!clean) {
+    return scopeSelector;
+  }
+  if (/^[>+~]/.test(clean)) {
+    return `${scopeSelector} ${clean}`;
+  }
+  if (hadLeadingSpace) {
+    return `${scopeSelector} ${clean}`;
+  }
+  if (/^[.:#\[]/.test(clean)) {
+    return `${scopeSelector}${clean}`;
+  }
+  return `${scopeSelector} ${clean}`;
+}
+
+function applyLandingStyling(element) {
+  if (!element) {
+    return;
+  }
+  ensureLandingEditorStyles();
+  element.classList.add('landing-editor');
+  if (!element.hasAttribute('data-theme')) {
+    element.setAttribute('data-theme', 'dark');
+  }
+  element.classList.add('dark-mode');
+}
+
 export function initPageEditors() {
   document.querySelectorAll('.page-form').forEach(form => {
     const slug = form.dataset.slug;
     const input = form.querySelector('input[name="content"]');
     const editorEl = form.querySelector('.page-editor');
+    const isLandingPage = form.dataset.landing === 'true';
     const initial = editorEl.dataset.content;
     if (initial) {
       editorEl.innerHTML = sanitize(initial);
+    }
+    if (isLandingPage) {
+      applyLandingStyling(editorEl);
     }
     $(editorEl).trumbowyg({
       lang: 'de',
@@ -157,7 +345,15 @@ export function showPreview() {
   if (!editor) return;
   const html = sanitize($(editor).trumbowyg('html'));
   const target = document.getElementById('preview-content');
-  if (target) target.innerHTML = html;
+  if (target) {
+    target.innerHTML = html;
+    if (editor.classList.contains('landing-editor')) {
+      applyLandingStyling(target);
+    } else {
+      target.classList.remove('landing-editor', 'dark-mode');
+      target.removeAttribute('data-theme');
+    }
+  }
   if (window.UIkit) {
     window.UIkit.modal('#preview-modal').show();
   }

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1012,6 +1012,7 @@
                 {% if selectedSlug == '' and pages|length > 0 %}
                   {% set selectedSlug = (pages|first).slug %}
                 {% endif %}
+                {% set excludedLandingSlugs = ['impressum', 'datenschutz', 'faq', 'lizenz'] %}
                 <div class="uk-margin">
                   <label class="uk-form-label" for="pageContentSelect">Marketing-Seite</label>
                   <div class="uk-form-controls">
@@ -1031,7 +1032,11 @@
                   </div>
                 </div>
                 {% for page in pages %}
-                <form class="page-form{% if page.slug != selectedSlug %} uk-hidden{% endif %}" data-slug="{{ page.slug }}">
+                <form
+                  class="page-form{% if page.slug != selectedSlug %} uk-hidden{% endif %}"
+                  data-slug="{{ page.slug }}"
+                  data-landing="{{ page.slug not in excludedLandingSlugs ? 'true' : 'false' }}"
+                >
                   <input type="hidden" id="page_{{ page.slug }}" name="content" value="{{ page.content|e('html_attr') }}">
                   <div class="page-editor" data-content="{{ page.content|e('html_attr') }}"></div>
                   <div class="uk-margin-top">

--- a/templates/admin/pages/edit.twig
+++ b/templates/admin/pages/edit.twig
@@ -15,10 +15,17 @@
 
 {% block body_class %}uk-background-muted uk-padding{% endblock %}
 
+{% set excludedLandingSlugs = ['impressum', 'datenschutz', 'faq', 'lizenz'] %}
+
 {% block body %}
   <div class="uk-container uk-container-expand">
     <h1 class="uk-heading-bullet">Seite bearbeiten: {{ slug }}</h1>
-    <form method="post" class="uk-form-stacked page-form" data-slug="{{ slug }}">
+    <form
+      method="post"
+      class="uk-form-stacked page-form"
+      data-slug="{{ slug }}"
+      data-landing="{{ slug not in excludedLandingSlugs ? 'true' : 'false' }}"
+    >
       <input type="hidden" id="pageContent" name="content" value="{{ content|e('html_attr') }}">
       <div class="page-editor" data-content="{{ content|e('html_attr') }}"></div>
       <div class="uk-margin-top">


### PR DESCRIPTION
## Summary
- scope the marketing landing CSS to a dedicated `.landing-editor` wrapper and load it dynamically for landing content editors
- mark landing-content forms in the admin so only marketing pages receive the scoped styling
- align the admin editor preview and base styles with the landing page design tokens for accurate editing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d70bb54ca0832bbe0ef1d9b52aea62