### PR TITLE
Add admin marketing page creation endpoint and UI

### DIFF
--- a/public/js/trumbowyg-pages.js
+++ b/public/js/trumbowyg-pages.js
@@ -1,4 +1,4 @@
-/* global $, apiFetch, notify */
+/* global $, apiFetch, notify, UIkit */
 
 // Define custom UIkit templates for Trumbowyg
 const sanitize = str => {
@@ -11,6 +11,10 @@ const sanitize = str => {
   }
   return value;
 };
+const basePath = window.basePath || '';
+const formsInitialized = new WeakSet();
+let pageSelect = null;
+let currentSlug = '';
 $.extend(true, $.trumbowyg, {
   langs: { de: { template: 'Vorlage', variable: 'Variable' } },
   plugins: {
@@ -76,81 +80,288 @@ $.extend(true, $.trumbowyg, {
   }
 });
 
-export function initPageEditors() {
-  document.querySelectorAll('.page-form').forEach(form => {
-    const slug = form.dataset.slug;
-    const input = form.querySelector('input[name="content"]');
-    const editorEl = form.querySelector('.page-editor');
-    const initial = editorEl.dataset.content;
-    if (initial) {
-      editorEl.innerHTML = sanitize(initial);
-    }
-    $(editorEl).trumbowyg({
-      lang: 'de',
-      btns: [
-        ['viewHTML'],
-        ['formatting'],
-        ['bold', 'italic', 'underline'],
-        ['link'],
-        ['insertImage'],
-        ['unorderedList', 'orderedList'],
-        ['variable'],
-        ['template'],
-        ['fullscreen']
-      ],
-      plugins: { template: true, variable: true }
-    });
-    const saveBtn = form.querySelector('.save-page-btn');
-    saveBtn?.addEventListener('click', e => {
-      e.preventDefault();
-      const html = sanitize($(editorEl).trumbowyg('html'));
-      input.value = html;
-      apiFetch('/admin/pages/' + slug, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({ content: html })
-      }).then(r => {
-        if (!r.ok) throw new Error(r.statusText);
-        notify('Seite gespeichert', 'success');
-      }).catch(() => notify('Fehler beim Speichern', 'danger'));
-    });
+const labelForPage = page => {
+  if (page && typeof page.title === 'string' && page.title.trim() !== '') {
+    return page.title.trim();
+  }
+  const slug = typeof page.slug === 'string' ? page.slug : '';
+  return slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+};
+
+const initEditorForForm = form => {
+  if (!form || formsInitialized.has(form)) {
+    return;
+  }
+
+  const slug = form.dataset.slug || '';
+  const input = form.querySelector('input[name="content"]');
+  const editorEl = form.querySelector('.page-editor');
+  if (!slug || !input || !editorEl) {
+    return;
+  }
+
+  const initial = editorEl.dataset.content || input.value || '';
+  if (initial) {
+    editorEl.innerHTML = sanitize(initial);
+  }
+
+  $(editorEl).trumbowyg({
+    lang: 'de',
+    btns: [
+      ['viewHTML'],
+      ['formatting'],
+      ['bold', 'italic', 'underline'],
+      ['link'],
+      ['insertImage'],
+      ['unorderedList', 'orderedList'],
+      ['variable'],
+      ['template'],
+      ['fullscreen']
+    ],
+    plugins: { template: true, variable: true }
   });
+
+  const saveBtn = form.querySelector('.save-page-btn');
+  saveBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    const html = sanitize($(editorEl).trumbowyg('html'));
+    input.value = html;
+    apiFetch('/admin/pages/' + slug, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ content: html })
+    }).then(r => {
+      if (!r.ok) throw new Error(r.statusText);
+      notify('Seite gespeichert', 'success');
+    }).catch(() => notify('Fehler beim Speichern', 'danger'));
+  });
+
+  formsInitialized.add(form);
+};
+
+export function initPageEditors(scope = document) {
+  if (!scope) {
+    return;
+  }
+  if (scope instanceof HTMLElement && scope.classList.contains('page-form')) {
+    initEditorForForm(scope);
+    return;
+  }
+
+  const root = scope.querySelectorAll ? scope : document;
+  root.querySelectorAll('.page-form').forEach(initEditorForForm);
 }
 
-export function initPageSelection() {
-  const select = document.getElementById('pageContentSelect');
-  if (!select) {
-    return;
-  }
+const getForms = () => Array.from(document.querySelectorAll('.page-form'));
 
-  const forms = Array.from(document.querySelectorAll('.page-form'));
+const toggleForms = slug => {
+  const forms = getForms();
   if (!forms.length) {
+    currentSlug = '';
     return;
   }
 
-  const toggleForms = slug => {
-    let activeSlug = slug;
-    if (!forms.some(form => form.dataset.slug === activeSlug)) {
-      activeSlug = forms[0]?.dataset.slug || '';
-    }
-    forms.forEach(form => {
-      form.classList.toggle('uk-hidden', form.dataset.slug !== activeSlug);
-    });
-  };
+  let activeSlug = slug;
+  if (!forms.some(form => form.dataset.slug === activeSlug)) {
+    activeSlug = forms[0]?.dataset.slug || '';
+  }
 
-  let selected = select.dataset.selected || select.value;
-  if (!selected && select.options.length > 0) {
-    selected = select.options[0].value;
+  forms.forEach(form => {
+    form.classList.toggle('uk-hidden', form.dataset.slug !== activeSlug);
+  });
+
+  currentSlug = activeSlug;
+  if (pageSelect && activeSlug && pageSelect.value !== activeSlug) {
+    pageSelect.value = activeSlug;
+  }
+};
+
+export function initPageSelection() {
+  pageSelect = document.getElementById('pageContentSelect');
+  if (!pageSelect) {
+    return;
+  }
+
+  let selected = pageSelect.dataset.selected || pageSelect.value;
+  if (!selected && pageSelect.options.length > 0) {
+    selected = pageSelect.options[0].value;
   }
   if (selected) {
-    select.value = selected;
+    pageSelect.value = selected;
   }
   toggleForms(selected);
 
-  select.addEventListener('change', () => {
-    toggleForms(select.value);
+  pageSelect.addEventListener('change', () => {
+    toggleForms(pageSelect.value);
   });
 }
+
+const addPageOption = page => {
+  if (!pageSelect) {
+    return;
+  }
+  const slug = page.slug;
+  if (!slug) {
+    return;
+  }
+
+  const existing = Array.from(pageSelect.options).some(opt => opt.value === slug);
+  if (existing) {
+    pageSelect.value = slug;
+    return;
+  }
+
+  const option = document.createElement('option');
+  option.value = slug;
+  option.textContent = labelForPage(page);
+  pageSelect.appendChild(option);
+  pageSelect.value = slug;
+};
+
+const createPageForm = page => {
+  const container = document.getElementById('pageFormsContainer');
+  if (!container) {
+    return null;
+  }
+
+  const slug = page.slug;
+  const content = sanitize(page.content || '');
+  const form = document.createElement('form');
+  form.className = 'page-form uk-hidden';
+  form.dataset.slug = slug;
+
+  const input = document.createElement('input');
+  input.type = 'hidden';
+  input.name = 'content';
+  input.id = 'page_' + slug;
+  input.value = content;
+
+  const editor = document.createElement('div');
+  editor.className = 'page-editor';
+  editor.dataset.content = content;
+
+  const actions = document.createElement('div');
+  actions.className = 'uk-margin-top';
+
+  const saveBtn = document.createElement('button');
+  saveBtn.className = 'uk-button uk-button-primary save-page-btn';
+  saveBtn.type = 'submit';
+  saveBtn.textContent = 'Speichern';
+
+  const preview = document.createElement('a');
+  preview.className = 'uk-button uk-button-default preview-link';
+  preview.href = `${basePath}/${slug}`;
+  preview.target = '_blank';
+  preview.textContent = 'Vorschau';
+
+  actions.appendChild(saveBtn);
+  actions.appendChild(preview);
+
+  form.appendChild(input);
+  form.appendChild(editor);
+  form.appendChild(actions);
+
+  container.appendChild(form);
+  initPageEditors(form);
+
+  return form;
+};
+
+const refreshSelection = slug => {
+  if (slug) {
+    toggleForms(slug);
+  } else {
+    toggleForms(currentSlug);
+  }
+};
+
+const setupCreatePageForm = () => {
+  const form = document.getElementById('pageCreateForm');
+  if (!form || form.dataset.bound === '1') {
+    return;
+  }
+
+  const modalEl = document.getElementById('pageCreateModal');
+  const modal = modalEl && typeof UIkit !== 'undefined' ? UIkit.modal(modalEl) : null;
+  const messageEl = document.getElementById('pageCreateMessage');
+  const slugInput = document.getElementById('newPageSlug');
+  const titleInput = document.getElementById('newPageTitle');
+  const contentInput = document.getElementById('newPageContent');
+  const defaultContent = contentInput ? contentInput.value : '';
+
+  const clearMessage = () => {
+    if (!messageEl) return;
+    messageEl.hidden = true;
+    messageEl.textContent = '';
+    messageEl.className = 'uk-alert';
+  };
+
+  const showMessage = (text, status = 'danger') => {
+    if (!messageEl) return;
+    messageEl.textContent = text;
+    messageEl.className = `uk-alert uk-alert-${status}`;
+    messageEl.hidden = false;
+  };
+
+  form.addEventListener('submit', async event => {
+    event.preventDefault();
+    clearMessage();
+
+    const slug = (slugInput?.value || '').trim().toLowerCase();
+    const title = (titleInput?.value || '').trim();
+    const content = contentInput ? contentInput.value : '';
+
+    if (!slug || !title) {
+      showMessage('Slug und Titel werden benötigt.');
+      return;
+    }
+
+    try {
+      const response = await apiFetch('/admin/pages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify({ slug, title, content })
+      });
+
+      const payload = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        if (payload && payload.errors) {
+          const messages = Object.values(payload.errors).join(' ');
+          showMessage(messages || 'Fehler beim Anlegen der Seite.');
+        } else {
+          showMessage(payload.error || 'Fehler beim Anlegen der Seite.');
+        }
+        return;
+      }
+
+      const page = payload.page || payload;
+      if (!page || !page.slug) {
+        showMessage('Antwort konnte nicht verarbeitet werden.');
+        return;
+      }
+
+      addPageOption(page);
+      createPageForm(page);
+      refreshSelection(page.slug);
+      notify('Seite erstellt', 'success');
+      form.reset();
+      if (contentInput) {
+        contentInput.value = defaultContent;
+      }
+      if (modal) {
+        modal.hide();
+      }
+    } catch (error) {
+      showMessage(error?.message || 'Fehler beim Anlegen der Seite.');
+    }
+  });
+
+  form.dataset.bound = '1';
+};
 
 export function showPreview() {
   const editor = document.querySelector('.page-editor');
@@ -167,6 +378,7 @@ window.showPreview = showPreview;
 const initPagesModule = () => {
   initPageEditors();
   initPageSelection();
+  setupCreatePageForm();
 };
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', initPagesModule);

--- a/src/Controller/Admin/PageController.php
+++ b/src/Controller/Admin/PageController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use App\Service\PageService;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use RuntimeException;
 use Slim\Views\Twig;
 
 class PageController
@@ -64,6 +66,62 @@ class PageController
         return $response->withStatus(204);
     }
 
+    public function create(Request $request, Response $response): Response
+    {
+        $data = $this->parseRequestData($request);
+        if ($data === null) {
+            return $this->json($response, ['errors' => ['body' => 'Ungültige Anfrage.']], 400);
+        }
+
+        $slug = strtolower(trim((string) ($data['slug'] ?? '')));
+        $title = trim((string) ($data['title'] ?? ''));
+        $contentValue = $data['content'] ?? '';
+
+        $errors = [];
+
+        if ($slug === '') {
+            $errors['slug'] = 'Slug darf nicht leer sein.';
+        } elseif (!preg_match('/^[a-z0-9][a-z0-9\-]*$/', $slug)) {
+            $errors['slug'] = 'Slug darf nur Kleinbuchstaben, Zahlen und Bindestriche enthalten.';
+        } elseif (strlen($slug) > 100) {
+            $errors['slug'] = 'Slug darf maximal 100 Zeichen lang sein.';
+        }
+
+        if ($title === '') {
+            $errors['title'] = 'Titel darf nicht leer sein.';
+        } elseif (mb_strlen($title) > 150) {
+            $errors['title'] = 'Titel darf maximal 150 Zeichen lang sein.';
+        }
+
+        if (!is_scalar($contentValue) && $contentValue !== null) {
+            $errors['content'] = 'Inhalt muss eine Zeichenkette sein.';
+        }
+
+        if ($errors !== []) {
+            return $this->json($response, ['errors' => $errors], 422);
+        }
+
+        $content = (string) $contentValue;
+
+        try {
+            $page = $this->pageService->create($slug, $title, $content);
+        } catch (InvalidArgumentException $e) {
+            return $this->json($response, ['errors' => ['general' => $e->getMessage()]], 400);
+        } catch (RuntimeException $e) {
+            $status = stripos($e->getMessage(), 'existiert bereits') !== false ? 409 : 500;
+            return $this->json($response, ['error' => $e->getMessage()], $status);
+        }
+
+        if ($this->editableSlugs !== null) {
+            $slugValue = $page->getSlug();
+            if (!in_array($slugValue, $this->editableSlugs, true)) {
+                $this->editableSlugs[] = $slugValue;
+            }
+        }
+
+        return $this->json($response, ['page' => $page], 201);
+    }
+
     /**
      * Determine which page slugs can be edited via the admin area.
      *
@@ -87,5 +145,46 @@ class PageController
         $this->editableSlugs = array_keys($slugs);
 
         return $this->editableSlugs;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function parseRequestData(Request $request): ?array
+    {
+        $data = $request->getParsedBody();
+        if (is_array($data)) {
+            return $data;
+        }
+
+        $body = $request->getBody();
+        if ($body->isSeekable()) {
+            $body->rewind();
+        }
+        $raw = $body->getContents();
+        if ($body->isSeekable()) {
+            $body->rewind();
+        }
+
+        if ($raw === '') {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function json(Response $response, array $data, int $status): Response
+    {
+        $payload = json_encode($data, JSON_UNESCAPED_UNICODE);
+        if ($payload === false) {
+            $payload = json_encode(['error' => 'Encoding error'], JSON_UNESCAPED_UNICODE) ?: '{"error":"Encoding error"}';
+            $status = 500;
+        }
+        $response->getBody()->write($payload);
+
+        return $response
+            ->withStatus($status)
+            ->withHeader('Content-Type', 'application/json');
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -873,6 +873,11 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $controller->sample($request, $response);
     })->add(new RoleAuthMiddleware(Roles::ADMIN, Roles::CATALOG_EDITOR));
 
+    $app->post('/admin/pages', function (Request $request, Response $response) {
+        $controller = new PageController();
+        return $controller->create($request, $response);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN))->add(new CsrfMiddleware());
+
     $app->get('/admin/pages/{slug}', function (Request $request, Response $response, array $args) {
         $controller = new PageController();
         return $controller->edit($request, $response, $args);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1012,39 +1012,106 @@
                 {% if selectedSlug == '' and pages|length > 0 %}
                   {% set selectedSlug = (pages|first).slug %}
                 {% endif %}
-                <div class="uk-margin">
-                  <label class="uk-form-label" for="pageContentSelect">Marketing-Seite</label>
-                  <div class="uk-form-controls">
-                    <select
-                      id="pageContentSelect"
-                      class="uk-select"
-                      data-selected="{{ selectedSlug }}"
-                    >
-                      {% for page in pages %}
-                        {% set pageLabel = page.title is not empty ? page.title : page.slug|replace({'-': ' '})|title %}
-                        <option
-                          value="{{ page.slug }}"
-                          {% if page.slug == selectedSlug %}selected{% endif %}
-                        >{{ pageLabel }}</option>
-                      {% endfor %}
-                    </select>
+                <div class="uk-margin uk-flex uk-flex-middle uk-flex-between uk-flex-wrap" data-page-controls>
+                  <div class="uk-flex-1@m uk-margin-small-right@m">
+                    <label class="uk-form-label" for="pageContentSelect">Marketing-Seite</label>
+                    <div class="uk-form-controls">
+                      <select
+                        id="pageContentSelect"
+                        class="uk-select"
+                        data-selected="{{ selectedSlug }}"
+                      >
+                        {% for page in pages %}
+                          {% set pageLabel = page.title is not empty ? page.title : page.slug|replace({'-': ' '})|title %}
+                          <option
+                            value="{{ page.slug }}"
+                            {% if page.slug == selectedSlug %}selected{% endif %}
+                          >{{ pageLabel }}</option>
+                        {% endfor %}
+                      </select>
+                    </div>
+                  </div>
+                  <div class="uk-margin-small-top uk-margin-remove-top@m">
+                    <button
+                      type="button"
+                      class="uk-button uk-button-primary"
+                      id="pageCreateOpen"
+                      uk-toggle="target: #pageCreateModal"
+                    >Neue Seite</button>
                   </div>
                 </div>
-                {% for page in pages %}
-                <form class="page-form{% if page.slug != selectedSlug %} uk-hidden{% endif %}" data-slug="{{ page.slug }}">
-                  <input type="hidden" id="page_{{ page.slug }}" name="content" value="{{ page.content|e('html_attr') }}">
-                  <div class="page-editor" data-content="{{ page.content|e('html_attr') }}"></div>
-                  <div class="uk-margin-top">
-                    <button class="uk-button uk-button-primary save-page-btn">Speichern</button>
-                    <a
-                      class="uk-button uk-button-default preview-link"
-                      href="{{ basePath }}/{{ page.slug }}"
-                      target="_blank"
-                    >Vorschau</a>
-                  </div>
-                </form>
-                {% endfor %}
+                <div id="pageFormsContainer">
+                  {% for page in pages %}
+                  <form class="page-form{% if page.slug != selectedSlug %} uk-hidden{% endif %}" data-slug="{{ page.slug }}">
+                    <input type="hidden" id="page_{{ page.slug }}" name="content" value="{{ page.content|e('html_attr') }}">
+                    <div class="page-editor" data-content="{{ page.content|e('html_attr') }}"></div>
+                    <div class="uk-margin-top">
+                      <button class="uk-button uk-button-primary save-page-btn">Speichern</button>
+                      <a
+                        class="uk-button uk-button-default preview-link"
+                        href="{{ basePath }}/{{ page.slug }}"
+                        target="_blank"
+                      >Vorschau</a>
+                    </div>
+                  </form>
+                  {% endfor %}
+                </div>
               {% endif %}
+              <div id="pageCreateModal" class="uk-flex-top" uk-modal>
+                <div class="uk-modal-dialog uk-modal-body uk-margin-auto-vertical">
+                  <button class="uk-modal-close-default" type="button" uk-close></button>
+                  <h2 class="uk-modal-title">Neue Seite erstellen</h2>
+                  <div id="pageCreateMessage" class="uk-alert" hidden></div>
+                  <form id="pageCreateForm" class="uk-form-stacked">
+                    <div class="uk-margin">
+                      <label class="uk-form-label" for="newPageSlug">Slug</label>
+                      <div class="uk-form-controls">
+                        <input
+                          class="uk-input"
+                          id="newPageSlug"
+                          name="slug"
+                          type="text"
+                          maxlength="100"
+                          required
+                          pattern="[a-z0-9\-]+"
+                          placeholder="z. B. landing"
+                        >
+                        <small class="uk-text-meta">Nur Kleinbuchstaben, Zahlen und Bindestriche.</small>
+                      </div>
+                    </div>
+                    <div class="uk-margin">
+                      <label class="uk-form-label" for="newPageTitle">Titel</label>
+                      <div class="uk-form-controls">
+                        <input
+                          class="uk-input"
+                          id="newPageTitle"
+                          name="title"
+                          type="text"
+                          maxlength="150"
+                          required
+                          placeholder="Neue Marketing-Seite"
+                        >
+                      </div>
+                    </div>
+                    <div class="uk-margin">
+                      <label class="uk-form-label" for="newPageContent">Initiales HTML (optional)</label>
+                      <div class="uk-form-controls">
+                        <textarea
+                          class="uk-textarea"
+                          id="newPageContent"
+                          name="content"
+                          rows="6"
+                          placeholder="&lt;section class=&quot;uk-section&quot;&gt;...&lt;/section&gt;"
+                        ></textarea>
+                      </div>
+                    </div>
+                    <div class="uk-margin">
+                      <button type="button" class="uk-button uk-button-default uk-modal-close">Abbrechen</button>
+                      <button type="submit" class="uk-button uk-button-primary">Seite anlegen</button>
+                    </div>
+                  </form>
+                </div>
+              </div>
             </li>
           </ul>
         </div>
@@ -1499,6 +1566,7 @@
     </div>
   </div>
 {% endblock %}
+
 
 {% block scripts %}
   <script src="{{ basePath }}/js/custom-icons.js"></script>


### PR DESCRIPTION
## Summary
- add a PageService::create helper that validates input and inserts new pages with helpful errors
- expose a protected POST /admin/pages endpoint and controller action returning JSON for new pages
- extend the admin marketing tab UI and JavaScript to create pages via the new API and update the editor list
- cover the new behaviour with controller tests for success and validation failures

## Testing
- vendor/bin/phpunit tests/Controller/PageControllerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d70d7d1bb8832b97e244f86fa69ca5