### PR TITLE
Add admin page creation workflow

### DIFF
--- a/public/js/seo-form.js
+++ b/public/js/seo-form.js
@@ -39,6 +39,19 @@ export function initSeoForm() {
   const pageConfigs = {};
   const pageMeta = {};
 
+  const buildOptionLabel = (slug, title) => {
+    const trimmedTitle = (title || '').trim();
+    if (trimmedTitle) {
+      return `${trimmedTitle} (${slug})`;
+    }
+    const fallback = (slug || '')
+      .split('-')
+      .filter(Boolean)
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
+    return `${fallback || slug} (${slug})`;
+  };
+
   const faviconInput = form.querySelector('#faviconPath');
   const mediaButton = form.querySelector('#faviconSelectButton');
   const mediaModalEl = document.getElementById('seoMediaModal');
@@ -424,6 +437,51 @@ export function initSeoForm() {
       }
     });
   }
+
+  document.addEventListener('marketing-page:created', event => {
+    const detail = event.detail || {};
+    const pageIdRaw = detail.id;
+    const slug = (detail.slug || '').trim();
+    if (pageIdRaw == null || slug === '') {
+      return;
+    }
+    const id = String(pageIdRaw);
+    const title = detail.title || '';
+
+    if (pageSelect) {
+      const hasOption = Array.from(pageSelect.options).some(option => option.value === id);
+      if (!hasOption) {
+        const option = document.createElement('option');
+        option.value = id;
+        option.dataset.slug = slug;
+        option.dataset.title = title;
+        option.textContent = buildOptionLabel(slug, title);
+        pageSelect.append(option);
+      }
+    }
+
+    pageConfigs[id] = {
+      pageId: detail.id,
+      metaTitle: '',
+      metaDescription: '',
+      slug,
+      domain: '',
+      canonicalUrl: '',
+      robotsMeta: '',
+      ogTitle: '',
+      ogDescription: '',
+      ogImage: '',
+      faviconPath: '',
+      schemaJson: '',
+      hreflang: ''
+    };
+
+    pageMeta[id] = {
+      slug,
+      title: title || '',
+      domains: []
+    };
+  });
 
   const importBtn = form.querySelector('.import-seo-example');
   if (importBtn) {

--- a/src/routes.php
+++ b/src/routes.php
@@ -883,6 +883,11 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $controller->update($request, $response, $args);
     })->add(new RoleAuthMiddleware(Roles::ADMIN))->add(new CsrfMiddleware());
 
+    $app->post('/admin/pages', function (Request $request, Response $response) {
+        $controller = new PageController();
+        return $controller->create($request, $response);
+    })->add(new RoleAuthMiddleware(Roles::ADMIN))->add(new CsrfMiddleware());
+
     $app->get('/admin/landingpage/seo', function (Request $request, Response $response) {
         if ($request->getAttribute('domainType') !== 'main') {
             return $response->withStatus(404);

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1013,42 +1013,84 @@
                   {% set selectedSlug = (pages|first).slug %}
                 {% endif %}
                 {% set excludedLandingSlugs = ['impressum', 'datenschutz', 'faq', 'lizenz'] %}
-                <div class="uk-margin">
-                  <label class="uk-form-label" for="pageContentSelect">Marketing-Seite</label>
-                  <div class="uk-form-controls">
-                    <select
-                      id="pageContentSelect"
-                      class="uk-select"
-                      data-selected="{{ selectedSlug }}"
-                    >
-                      {% for page in pages %}
-                        {% set pageLabel = page.title is not empty ? page.title : page.slug|replace({'-': ' '})|title %}
-                        <option
-                          value="{{ page.slug }}"
-                          {% if page.slug == selectedSlug %}selected{% endif %}
-                        >{{ pageLabel }}</option>
-                      {% endfor %}
-                    </select>
+                <div class="uk-flex uk-flex-middle uk-margin-small-bottom uk-flex-wrap">
+                  <div class="uk-width-1-1 uk-width-expand@m uk-margin-small-bottom">
+                    <label class="uk-form-label" for="pageContentSelect">Marketing-Seite</label>
+                    <div class="uk-form-controls">
+                      <select
+                        id="pageContentSelect"
+                        class="uk-select"
+                        data-selected="{{ selectedSlug }}"
+                        data-excluded-landing="{{ excludedLandingSlugs|join(',') }}"
+                      >
+                        {% for page in pages %}
+                          {% set pageLabel = page.title is not empty ? page.title : page.slug|replace({'-': ' '})|title %}
+                          <option
+                            value="{{ page.slug }}"
+                            {% if page.slug == selectedSlug %}selected{% endif %}
+                          >{{ pageLabel }}</option>
+                        {% endfor %}
+                      </select>
+                    </div>
+                  </div>
+                  <div class="uk-margin-small-left">
+                    <button
+                      class="uk-button uk-button-default"
+                      type="button"
+                      uk-toggle="target: #createPageModal"
+                    >Neue Seite</button>
                   </div>
                 </div>
-                {% for page in pages %}
-                <form
-                  class="page-form{% if page.slug != selectedSlug %} uk-hidden{% endif %}"
-                  data-slug="{{ page.slug }}"
-                  data-landing="{{ page.slug not in excludedLandingSlugs ? 'true' : 'false' }}"
-                >
-                  <input type="hidden" id="page_{{ page.slug }}" name="content" value="{{ page.content|e('html_attr') }}">
-                  <div class="page-editor" data-content="{{ page.content|e('html_attr') }}"></div>
-                  <div class="uk-margin-top">
-                    <button class="uk-button uk-button-primary save-page-btn">Speichern</button>
-                    <a
-                      class="uk-button uk-button-default preview-link"
-                      href="{{ basePath }}/{{ page.slug }}"
-                      target="_blank"
-                    >Vorschau</a>
+                <div id="pageFormsContainer">
+                  {% for page in pages %}
+                  <form
+                    class="page-form{% if page.slug != selectedSlug %} uk-hidden{% endif %}"
+                    data-slug="{{ page.slug }}"
+                    data-landing="{{ page.slug not in excludedLandingSlugs ? 'true' : 'false' }}"
+                  >
+                    <input type="hidden" id="page_{{ page.slug }}" name="content" value="{{ page.content|e('html_attr') }}">
+                    <div class="page-editor" data-content="{{ page.content|e('html_attr') }}"></div>
+                    <div class="uk-margin-top">
+                      <button class="uk-button uk-button-primary save-page-btn">Speichern</button>
+                      <a
+                        class="uk-button uk-button-default preview-link"
+                        href="{{ basePath }}/{{ page.slug }}"
+                        target="_blank"
+                      >Vorschau</a>
+                    </div>
+                  </form>
+                  {% endfor %}
+                </div>
+                <div id="createPageModal" uk-modal>
+                  <div class="uk-modal-dialog uk-modal-body">
+                    <h2 class="uk-modal-title">Neue Seite anlegen</h2>
+                    <form id="createPageForm" class="uk-form-stacked">
+                      <div id="createPageFeedback" class="uk-alert uk-alert-danger" hidden></div>
+                      <div class="uk-margin">
+                        <label class="uk-form-label" for="newPageSlug">Slug</label>
+                        <div class="uk-form-controls">
+                          <input class="uk-input" id="newPageSlug" name="slug" type="text" required maxlength="100" placeholder="z. B. neue-landingpage">
+                        </div>
+                      </div>
+                      <div class="uk-margin">
+                        <label class="uk-form-label" for="newPageTitle">Titel</label>
+                        <div class="uk-form-controls">
+                          <input class="uk-input" id="newPageTitle" name="title" type="text" required placeholder="Seitentitel">
+                        </div>
+                      </div>
+                      <div class="uk-margin">
+                        <label class="uk-form-label" for="newPageContent">Initiales HTML (optional)</label>
+                        <div class="uk-form-controls">
+                          <textarea class="uk-textarea" id="newPageContent" name="content" rows="6" placeholder="&lt;section class=&quot;uk-section&quot;&gt;...&lt;/section&gt;"></textarea>
+                        </div>
+                      </div>
+                      <div class="uk-flex uk-flex-right">
+                        <button type="submit" class="uk-button uk-button-primary">Seite erstellen</button>
+                        <button type="button" class="uk-button uk-button-default uk-margin-small-left uk-modal-close">Abbrechen</button>
+                      </div>
+                    </form>
                   </div>
-                </form>
-                {% endfor %}
+                </div>
               {% endif %}
             </li>
           </ul>

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Controller;
 
 use PDO;
+use Slim\Psr7\Factory\StreamFactory;
 use Tests\TestCase;
 
 class PageControllerTest extends TestCase
@@ -60,6 +61,114 @@ class PageControllerTest extends TestCase
 
         $response = $app->handle($this->createRequest('GET', '/admin/pages/unknown'));
         $this->assertSame(404, $response->getStatusCode());
+
+        session_destroy();
+    }
+
+    public function testCreatePageSuccess(): void
+    {
+        $pdo = $this->getDatabase();
+        $pdo->exec("DELETE FROM pages WHERE slug = 'neue-seite'");
+
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $_SESSION['csrf_token'] = 'token';
+
+        $stream = (new StreamFactory())->createStream(json_encode([
+            'slug' => 'Neue-Seite',
+            'title' => 'Neue Seite',
+            'content' => '<p>Hallo Welt</p>',
+        ], JSON_THROW_ON_ERROR));
+
+        $request = $this->createRequest('POST', '/admin/pages', [
+            'HTTP_X_CSRF_TOKEN' => 'token',
+        ])->withHeader('Content-Type', 'application/json')
+            ->withBody($stream);
+
+        $response = $app->handle($request);
+        $this->assertSame(201, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('neue-seite', $payload['page']['slug'] ?? null);
+        $this->assertSame('Neue Seite', $payload['page']['title'] ?? null);
+
+        $row = $pdo->query("SELECT slug, title, content FROM pages WHERE slug = 'neue-seite'")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertNotFalse($row);
+        $this->assertSame('neue-seite', $row['slug']);
+        $this->assertSame('Neue Seite', $row['title']);
+        $this->assertSame('<p>Hallo Welt</p>', $row['content']);
+
+        session_destroy();
+    }
+
+    public function testCreatePageValidationError(): void
+    {
+        $pdo = $this->getDatabase();
+        $pdo->exec("DELETE FROM pages WHERE slug = 'invalid'");
+
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $_SESSION['csrf_token'] = 'token';
+
+        $stream = (new StreamFactory())->createStream(json_encode([
+            'slug' => 'Invalid Slug',
+            'title' => '',
+            'content' => '',
+        ], JSON_THROW_ON_ERROR));
+
+        $request = $this->createRequest('POST', '/admin/pages', [
+            'HTTP_X_CSRF_TOKEN' => 'token',
+        ])->withHeader('Content-Type', 'application/json')
+            ->withBody($stream);
+
+        $response = $app->handle($request);
+        $this->assertSame(422, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($payload);
+        $this->assertArrayHasKey('error', $payload);
+
+        $count = (int) $pdo->query("SELECT COUNT(*) FROM pages WHERE slug = 'invalid'")->fetchColumn();
+        $this->assertSame(0, $count);
+
+        session_destroy();
+    }
+
+    public function testCreatePageConflict(): void
+    {
+        $pdo = $this->getDatabase();
+        $this->seedPage($pdo, 'konflikt', 'Konflikt', '<p>Alt</p>');
+
+        $app = $this->getAppInstance();
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $_SESSION['csrf_token'] = 'token';
+
+        $stream = (new StreamFactory())->createStream(json_encode([
+            'slug' => 'konflikt',
+            'title' => 'Neuer Titel',
+            'content' => '<p>Neu</p>',
+        ], JSON_THROW_ON_ERROR));
+
+        $request = $this->createRequest('POST', '/admin/pages', [
+            'HTTP_X_CSRF_TOKEN' => 'token',
+        ])->withHeader('Content-Type', 'application/json')
+            ->withBody($stream);
+
+        $response = $app->handle($request);
+        $this->assertSame(409, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getBody(), true);
+        $this->assertIsArray($payload);
+        $this->assertArrayHasKey('error', $payload);
+
+        $row = $pdo->query("SELECT content FROM pages WHERE slug = 'konflikt'")
+            ->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('<p>Alt</p>', $row['content']);
 
         session_destroy();
     }


### PR DESCRIPTION
## Summary
- add a PageService::create helper that validates slugs/titles and raises helpful errors on conflicts
- expose a CSRF-protected POST /admin/pages endpoint with controller and UI wiring for creating marketing pages
- update the marketing editor, SEO tooling, and controller tests to cover page creation success and validation failures

## Testing
- ./vendor/bin/phpunit --filter PageControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68d711183e34832bb668b02f911b98a9