### PR TITLE
Make domain start page options dynamic

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -32,6 +32,7 @@ use App\Service\NginxService;
 use App\Service\SettingsService;
 use App\Service\DomainStartPageService;
 use App\Service\DomainContactTemplateService;
+use App\Service\PageService;
 use App\Service\TranslationService;
 use App\Service\PasswordResetService;
 use App\Service\PasswordPolicy;
@@ -253,7 +254,10 @@ return function (\Slim\App $app, TranslationService $translator) {
             )
             ->withAttribute('userController', new UserController($userService))
             ->withAttribute('settingsController', new SettingsController($settingsService))
-            ->withAttribute('domainStartPageController', new DomainStartPageController($domainStartPageService, $settingsService))
+            ->withAttribute(
+                'domainStartPageController',
+                new DomainStartPageController($domainStartPageService, $settingsService, new PageService($pdo))
+            )
             ->withAttribute(
                 'domainContactTemplateController',
                 new DomainContactTemplateController($domainContactTemplateService, $domainStartPageService)

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1556,12 +1556,7 @@
     window.baseUrl = '{{ baseUrl }}';
     window.mainDomain = '{{ main_domain }}';
     window.domainType = '{{ domainType }}';
-    window.domainStartPageOptions = {{ {
-      'help': t('option_help_page'),
-      'events': t('option_events_page'),
-      'landing': t('option_landing_page'),
-      'calserver': t('option_calserver_page')
-    }|json_encode|raw }};
+    window.domainStartPageOptions = {{ domain_start_page_options|default({})|json_encode|raw }};
     window.domainStartPageTypeLabels = {{ {
       'main': t('label_domain_type_main'),
       'marketing': t('label_domain_type_marketing'),

--- a/tests/Controller/DomainStartPageControllerTest.php
+++ b/tests/Controller/DomainStartPageControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Service\DomainStartPageService;
+use App\Service\PageService;
+use Tests\TestCase;
+
+class DomainStartPageControllerTest extends TestCase
+{
+    public function testCanSaveNewMarketingPageAsStartPage(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        session_id('domainstartpage');
+        session_start();
+        $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
+        $_COOKIE[session_name()] = session_id();
+
+        $previousMainDomain = getenv('MAIN_DOMAIN');
+        $previousEnvMainDomain = $_ENV['MAIN_DOMAIN'] ?? null;
+        putenv('MAIN_DOMAIN=example.com');
+        $_ENV['MAIN_DOMAIN'] = 'example.com';
+
+        try {
+            $pdo = $this->getDatabase();
+            $pageService = new PageService($pdo);
+            $pageService->create('fresh-marketing', 'Fresh Marketing', '<p>Landing</p>');
+
+            $request = $this->createRequest('POST', '/admin/domain-start-pages', [
+                'Content-Type' => 'application/json',
+            ]);
+            $payload = json_encode([
+                'domain' => 'example.com',
+                'start_page' => 'fresh-marketing',
+                'email' => '',
+            ], JSON_THROW_ON_ERROR);
+            $request->getBody()->write($payload);
+            $request->getBody()->rewind();
+
+            $app = $this->getAppInstance();
+            $response = $app->handle($request);
+
+            $this->assertSame(200, $response->getStatusCode());
+
+            $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            $this->assertSame('ok', $data['status'] ?? null);
+            $this->assertSame('fresh-marketing', $data['config']['start_page'] ?? null);
+            $this->assertArrayHasKey('fresh-marketing', $data['options'] ?? []);
+
+            $service = new DomainStartPageService($pdo);
+            $config = $service->getDomainConfig('example.com');
+            $this->assertNotNull($config);
+            $this->assertSame('fresh-marketing', $config['start_page']);
+
+            $settingsValue = $pdo->query("SELECT value FROM settings WHERE key = 'home_page'")?->fetchColumn();
+            $this->assertSame('fresh-marketing', $settingsValue);
+        } finally {
+            if ($previousMainDomain === false) {
+                putenv('MAIN_DOMAIN');
+            } else {
+                putenv('MAIN_DOMAIN=' . $previousMainDomain);
+            }
+            if ($previousEnvMainDomain === null) {
+                unset($_ENV['MAIN_DOMAIN']);
+            } else {
+                $_ENV['MAIN_DOMAIN'] = $previousEnvMainDomain;
+            }
+            session_destroy();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- build the domain start page options dynamically from marketing pages and expose localized labels through the API
- update the admin controller, template, and JavaScript to consume the provided option map and refresh it when new slugs appear
- add a controller test that saves a freshly created marketing page as the start page

## Testing
- vendor/bin/phpunit --filter DomainStartPageControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68d716b9e018832b8f560d609a3b7a35