### PR TITLE
Fix domain service initialization in admin controller

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -153,6 +153,7 @@ class AdminController
         }
 
         $marketingPages = $this->filterMarketingPages($allPages);
+        $domainService = new DomainStartPageService($pdo);
         $translator = $request->getAttribute('translator');
         $translationService = $translator instanceof TranslationService ? $translator : null;
         $domainStartPageOptions = $domainService->getStartPageOptions($pageSvc);
@@ -219,7 +220,6 @@ class AdminController
             ?: $uri->getHost();
 
         $seoSvc = new PageSeoConfigService($pdo);
-        $domainService = new DomainStartPageService($pdo);
         $selectedSeoSlug = isset($params['seoPage']) ? (string) $params['seoPage'] : '';
         $selectedSeoPage = $this->selectSeoPage($marketingPages, $selectedSeoSlug);
         $seoPages = $this->buildSeoPageData(


### PR DESCRIPTION
## Summary
- instantiate `DomainStartPageService` before using it in the admin controller
- reuse the same instance for later SEO-related logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d71b8e43dc832b98eebd30855a8d6b