### PR TITLE
Allow marketing contact forms to define submission endpoint

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -522,7 +522,9 @@
     <p class="uk-text-lead uk-text-center" uk-scrollspy="cls: uk-animation-fade; delay: 150">Ob Testzugang, Angebot oder individuelle Beratung – wir melden uns garantiert persönlich zurück.</p>
     <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
       <div>
-        <form id="contact-form" class="uk-form-stacked uk-width-large uk-margin-auto">
+        <form id="contact-form"
+              class="uk-form-stacked uk-width-large uk-margin-auto"
+              data-contact-endpoint="{{ basePath }}/landing/contact">
           <div class="uk-margin">
             <label class="uk-form-label" for="form-name">Ihr Name</label>
             <input class="uk-input" id="form-name" name="name" type="text" required>

--- a/migrations/20250304_import_page_files.sql
+++ b/migrations/20250304_import_page_files.sql
@@ -522,7 +522,9 @@ INSERT INTO pages (slug, title, content) VALUES ('landing', 'Landing', '<!-- Soc
     <p class="uk-text-lead uk-text-center" uk-scrollspy="cls: uk-animation-fade; delay: 150">Ob Testzugang, Angebot oder individuelle Beratung – wir melden uns garantiert persönlich zurück.</p>
     <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" uk-grid uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
       <div>
-        <form id="contact-form" class="uk-form-stacked uk-width-large uk-margin-auto">
+        <form id="contact-form"
+              class="uk-form-stacked uk-width-large uk-margin-auto"
+              data-contact-endpoint="{{ basePath }}/landing/contact">
           <div class="uk-margin">
             <label class="uk-form-label" for="form-name">Ihr Name</label>
             <input class="uk-input" id="form-name" name="name" type="text" required>

--- a/migrations/20250926_update_calserver_page.sql
+++ b/migrations/20250926_update_calserver_page.sql
@@ -1110,7 +1110,9 @@ VALUES (
         <p class="uk-text-lead uk-text-center" data-uk-scrollspy="cls: uk-animation-fade; delay: 150">Ob Testzugang, Angebot oder individuelle Beratung – wir melden uns garantiert persönlich zurück.</p>
         <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" data-uk-grid data-uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
           <div>
-                          <form id="contact-form" class="uk-form-stacked uk-width-large uk-margin-auto">
+                          <form id="contact-form"
+                                class="uk-form-stacked uk-width-large uk-margin-auto"
+                                data-contact-endpoint="{{ basePath }}/calserver/contact">
                 <div class="uk-margin">
                   <label class="uk-form-label" for="form-name">Ihr Name</label>
                   <input class="uk-input" id="form-name" name="name" type="text" required>

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -33,6 +33,35 @@ document.addEventListener('DOMContentLoaded', () => {
   const msg = document.getElementById('contact-modal-message');
   if (!form || !modal || !msg) return;
 
+  const basePath = (window.basePath || '').replace(/\/+$/, '');
+  const defaultEndpoint = `${basePath}/landing/contact`;
+
+  const resolveEndpoint = (value) => {
+    if (!value) {
+      return defaultEndpoint;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      return defaultEndpoint;
+    }
+
+    if (/^(https?:)?\/\//i.test(trimmed)) {
+      return trimmed;
+    }
+
+    if (basePath !== '' && trimmed.startsWith(`${basePath}/`)) {
+      return trimmed;
+    }
+
+    if (trimmed.startsWith('/')) {
+      return basePath === '' ? trimmed : `${basePath}${trimmed}`;
+    }
+
+    const prefix = basePath === '' ? '/' : `${basePath}/`;
+    return `${prefix}${trimmed.replace(/^\/+/, '')}`;
+  };
+
   form.addEventListener('submit', (e) => {
     e.preventDefault();
 
@@ -41,7 +70,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (hp && hp.value.trim() !== '') return;
 
     const data = new URLSearchParams(new FormData(form));
-    fetch(`${window.basePath}/landing/contact`, {
+    const endpoint = resolveEndpoint(form.dataset.contactEndpoint);
+    fetch(endpoint, {
       method: 'POST',
       headers: {'Content-Type': 'application/x-www-form-urlencoded'},
       credentials: 'same-origin',

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -1453,7 +1453,9 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
         <p class="uk-text-lead uk-text-center" data-uk-scrollspy="cls: uk-animation-fade; delay: 150">Ob Testzugang, Angebot oder individuelle Beratung – wir melden uns garantiert persönlich zurück.</p>
         <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" data-uk-grid data-uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
           <div>
-                          <form id="contact-form" class="uk-form-stacked uk-width-large uk-margin-auto">
+                          <form id="contact-form"
+                                class="uk-form-stacked uk-width-large uk-margin-auto"
+                                data-contact-endpoint="{{ basePath }}/calserver/contact">
                 <div class="uk-margin">
                   <label class="uk-form-label" for="form-name">Ihr Name</label>
                   <input class="uk-input" id="form-name" name="name" type="text" required>

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -288,6 +288,10 @@
           anchor.textContent = email;
         }
       });
+      var contactForm = document.getElementById('contact-form');
+      if (contactForm && !contactForm.hasAttribute('data-contact-endpoint')) {
+        contactForm.setAttribute('data-contact-endpoint', '{{ basePath }}/calserver/contact');
+      }
     });
   </script>
   <script src="{{ basePath }}/js/app.js"></script>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -192,6 +192,10 @@
           anchor.textContent = email;
         }
       });
+      var contactForm = document.getElementById('contact-form');
+      if (contactForm && !contactForm.hasAttribute('data-contact-endpoint')) {
+        contactForm.setAttribute('data-contact-endpoint', '{{ basePath }}/landing/contact');
+      }
     });
   </script>
 {% endblock %}

--- a/tests/Controller/LandingControllerTest.php
+++ b/tests/Controller/LandingControllerTest.php
@@ -16,7 +16,7 @@ class LandingControllerTest extends TestCase
             $stmt = $pdo->prepare('INSERT INTO pages(slug,title,content) VALUES(?,?,?)');
             $content = <<<'HTML'
 <p>Landing <a href="/faq">FAQ</a></p>
-<form id="contact-form"><input type="text" name="name"></form>
+<form id="contact-form" data-contact-endpoint="/landing/contact"><input type="text" name="name"></form>
 HTML;
             $stmt->execute(['landing', 'Landing', $content]);
         } catch (\PDOException $e) {
@@ -97,6 +97,7 @@ HTML;
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringContainsString('id="contact-form"', $body);
+        $this->assertStringContainsString('data-contact-endpoint="/landing/contact"', $body);
 
         putenv('SMTP_HOST');
         putenv('SMTP_USER');


### PR DESCRIPTION
## Summary
- read the marketing contact form endpoint from a configurable data attribute with sensible fallbacks
- add `data-contact-endpoint` to the landing and calServer marketing templates and seeded HTML content
- update the landing controller test to cover the configured contact endpoint attribute

## Testing
- vendor/bin/phpunit tests/Controller/LandingControllerTest.php *(fails: vendor/bin/phpunit not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d724c811f8832b9b3ec19fb98fb72d