### PR TITLE
Sanitize template HTML in admin editor

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -195,12 +195,28 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     return window.jQuery(element);
   };
+  const sanitizeTemplateHtml = value => {
+    if (typeof value !== 'string' || value === '') {
+      return '';
+    }
+    if (window.DOMPurify && typeof window.DOMPurify.sanitize === 'function') {
+      return window.DOMPurify.sanitize(value, {
+        FORBID_TAGS: ['style', 'link', 'meta', 'html', 'head', 'body', 'base']
+      });
+    }
+    return value
+      .replace(/<style[\s\S]*?<\/style>/gi, '')
+      .replace(/<\/?(?:html|head|body)[^>]*>/gi, '')
+      .replace(/<link[^>]*>/gi, '')
+      .replace(/<meta[^>]*>/gi, '');
+  };
   const setTemplateFieldValue = (element, value) => {
     if (!element) return;
     if (element.dataset.templateEditor === 'html') {
       const editor = ensureTemplateEditor(element);
       if (editor) {
-        editor.trumbowyg('html', typeof value === 'string' ? value : '');
+        const sanitized = sanitizeTemplateHtml(value);
+        editor.trumbowyg('html', sanitized);
         return;
       }
     }


### PR DESCRIPTION
## Summary
- sanitize template HTML with DOMPurify before rendering it in the admin editor
- filter out global style-related tags to avoid leaking template styles into the admin UI

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d72a5111e4832b84ac86b70aded91b