### PR TITLE
Fix phpstan domain configuration warnings

### DIFF
--- a/src/Application/Middleware/DomainMiddleware.php
+++ b/src/Application/Middleware/DomainMiddleware.php
@@ -83,9 +83,9 @@ class DomainMiddleware implements MiddlewareInterface
             $service = new DomainStartPageService($pdo);
             $config = $service->getConfigForHost($originalHost);
             if ($config !== null) {
-                $startPage = (string) ($config['start_page'] ?? '');
-                if ($startPage === '') {
-                    $startPage = null;
+                $startPageValue = trim($config['start_page']);
+                if ($startPageValue !== '') {
+                    $startPage = $startPageValue;
                 }
 
                 $email = $config['email'] ?? null;

--- a/src/Controller/Admin/DomainContactTemplateController.php
+++ b/src/Controller/Admin/DomainContactTemplateController.php
@@ -124,7 +124,7 @@ class DomainContactTemplateController
         $marketing = getenv('MARKETING_DOMAINS') ?: '';
         $known = $this->domains->determineDomains($mainDomain, (string) $marketing);
         foreach ($known as $entry) {
-            if (($entry['normalized'] ?? '') === $normalized) {
+            if ($entry['normalized'] === $normalized) {
                 return true;
             }
         }

--- a/src/Controller/Admin/DomainStartPageController.php
+++ b/src/Controller/Admin/DomainStartPageController.php
@@ -63,14 +63,14 @@ class DomainStartPageController
                     'domain' => $domain,
                     'normalized' => $domain,
                     'type' => 'custom',
-                    'start_page' => $config['start_page'] ?? null,
-                    'email' => $config['email'] ?? null,
+                    'start_page' => $config['start_page'],
+                    'email' => $config['email'],
                 ];
                 continue;
             }
 
-            $combined[$domain]['start_page'] = $config['start_page'] ?? null;
-            $combined[$domain]['email'] = $config['email'] ?? null;
+            $combined[$domain]['start_page'] = $config['start_page'];
+            $combined[$domain]['email'] = $config['email'];
         }
 
         $ordered = [];
@@ -105,7 +105,7 @@ class DomainStartPageController
                 'normalized' => $item['normalized'],
                 'type' => $item['type'],
                 'start_page' => $startPage,
-                'email' => $item['email'] ?? null,
+                'email' => $item['email'],
             ];
         }
 

--- a/src/Controller/Admin/LandingpageController.php
+++ b/src/Controller/Admin/LandingpageController.php
@@ -186,7 +186,7 @@ class LandingpageController
         $mappings = $this->domainService->getAllMappings();
         $domainsBySlug = [];
         foreach ($mappings as $domain => $config) {
-            $slug = $config['start_page'] ?? '';
+            $slug = trim($config['start_page']);
             if ($slug === '') {
                 continue;
             }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -319,7 +319,7 @@ class AdminController
         $mappings = $domainService->getAllMappings();
         $domainsBySlug = [];
         foreach ($mappings as $domain => $config) {
-            $slug = $config['start_page'] ?? '';
+            $slug = trim($config['start_page']);
             if ($slug === '') {
                 continue;
             }

--- a/src/Controller/Marketing/ContactController.php
+++ b/src/Controller/Marketing/ContactController.php
@@ -80,7 +80,7 @@ class ContactController
         $host = strtolower($request->getUri()->getHost());
         $domainConfig = $domainService->getDomainConfig($host);
         $domainEmail = null;
-        if ($domainConfig !== null && array_key_exists('email', $domainConfig) && $domainConfig['email'] !== null) {
+        if ($domainConfig !== null && $domainConfig['email'] !== null) {
             $domainEmail = trim((string) $domainConfig['email']);
             if ($domainEmail === '') {
                 $domainEmail = null;

--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -57,7 +57,7 @@ class MarketingPageController
         $view = Twig::fromRequest($request);
         $template = sprintf('marketing/%s.twig', $slug);
         $loader = $view->getEnvironment()->getLoader();
-        if (method_exists($loader, 'exists') && !$loader->exists($template)) {
+        if (!$loader->exists($template)) {
             return $response->withStatus(404);
         }
 

--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -75,7 +75,7 @@ class DomainStartPageService
             return null;
         }
 
-        $startPage = (string) ($config['start_page'] ?? '');
+        $startPage = trim($config['start_page']);
 
         return $startPage === '' ? null : $startPage;
     }

--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -105,7 +105,7 @@ class EventService
 
         foreach ($events as $idx => $event) {
             $uid = $event['uid'] ?? bin2hex(random_bytes(16));
-            $rawName = (string) ($event['name'] ?? '');
+            $rawName = (string) $event['name'];
             $name = trim($rawName);
             $isDraft = !empty($event['draft'])
                 || str_starts_with($rawName, '__draft__')

--- a/src/Service/MediaLibraryService.php
+++ b/src/Service/MediaLibraryService.php
@@ -81,7 +81,7 @@ class MediaLibraryService
     /**
      * Upload a file for the requested scope.
      *
-     * @param array{name?:string}|null $options
+     * @param array{name?:string,tags?:list<string>,folder?:string|null}|null $options
      */
     public function uploadFile(
         string $scope,

--- a/src/Service/PageService.php
+++ b/src/Service/PageService.php
@@ -66,12 +66,7 @@ class PageService
             throw new RuntimeException('Die Seite konnte nicht angelegt werden.', 0, $exception);
         }
 
-        $page = $this->findBySlug($normalizedSlug);
-        if ($page === null) {
-            throw new RuntimeException('Die neu angelegte Seite konnte nicht geladen werden.');
-        }
-
-        return $page;
+        return $this->loadCreatedPage($normalizedSlug);
     }
 
     /**
@@ -144,5 +139,15 @@ class PageService
         }
 
         return new Page((int) $row['id'], $pageSlug, $title, (string) ($row['content'] ?? ''));
+    }
+
+    private function loadCreatedPage(string $slug): Page
+    {
+        $page = $this->findBySlug($slug);
+        if ($page === null) {
+            throw new RuntimeException('Die neu angelegte Seite konnte nicht geladen werden.');
+        }
+
+        return $page;
     }
 }


### PR DESCRIPTION
## Summary
- stop treating mandatory domain configuration fields as optional throughout middleware, services, and controllers
- simplify marketing page rendering checks and document optional media upload metadata to satisfy static analysis
- load newly created pages via a dedicated helper to clarify post-insert lookups

## Testing
- `./vendor/bin/phpstan --no-progress --memory-limit=512M`

------
https://chatgpt.com/codex/tasks/task_e_68d72a3a3858832b815e2d47763cb8a6