### PR TITLE
Update calServer placeholder image paths

### DIFF
--- a/migrations/20250926_update_calserver_page.sql
+++ b/migrations/20250926_update_calserver_page.sql
@@ -531,7 +531,7 @@ VALUES (
             <ul id="calserver-modules-switcher" class="uk-switcher calserver-modules-switcher">
                               <li>
                   <figure id="module-device-management" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver/modules/module-placeholder.svg"
+                    <img src="{{ basePath }}/uploads/module-placeholder.svg"
                          width="1200"
                          height="675"
                          loading="lazy"
@@ -550,7 +550,7 @@ VALUES (
                 </li>
                               <li>
                   <figure id="module-calendar-resources" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver/modules/module-placeholder.svg"
+                    <img src="{{ basePath }}/uploads/module-placeholder.svg"
                          width="1200"
                          height="675"
                          loading="lazy"
@@ -569,7 +569,7 @@ VALUES (
                 </li>
                               <li>
                   <figure id="module-order-ticketing" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver/modules/module-placeholder.svg"
+                    <img src="{{ basePath }}/uploads/module-placeholder.svg"
                          width="1200"
                          height="675"
                          loading="lazy"
@@ -588,7 +588,7 @@ VALUES (
                 </li>
                               <li>
                   <figure id="module-self-service" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver/modules/module-placeholder.svg"
+                    <img src="{{ basePath }}/uploads/module-placeholder.svg"
                          width="1200"
                          height="675"
                          loading="lazy"

--- a/public/js/seo-form.js
+++ b/public/js/seo-form.js
@@ -270,7 +270,7 @@ export function initSeoForm() {
       ogTitle: 'calServer – Plattform für Kalibrier- & Prüfmittelteams',
       ogDescription:
         'Überwachen Sie Prüfmittel, Kalibrierfristen, Serviceaufträge und Dokumentation zentral. calServer liefert Workflows, Erinnerungen und Hosting in Deutschland.',
-      ogImage: `${ctx.baseUrl}/uploads/calserver/modules/module-placeholder.svg`,
+      ogImage: `${ctx.baseUrl}/uploads/module-placeholder.svg`,
       schema: `{
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -874,7 +874,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             <ul id="calserver-modules-switcher" class="uk-switcher calserver-modules-switcher">
                               <li>
                   <figure id="module-device-management" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver/modules/module-placeholder.svg"
+                    <img src="{{ basePath }}/uploads/module-placeholder.svg"
                          width="1200"
                          height="675"
                          loading="lazy"
@@ -893,7 +893,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 </li>
                               <li>
                   <figure id="module-calendar-resources" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver/modules/module-placeholder.svg"
+                    <img src="{{ basePath }}/uploads/module-placeholder.svg"
                          width="1200"
                          height="675"
                          loading="lazy"
@@ -912,7 +912,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 </li>
                               <li>
                   <figure id="module-order-ticketing" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver/modules/module-placeholder.svg"
+                    <img src="{{ basePath }}/uploads/module-placeholder.svg"
                          width="1200"
                          height="675"
                          loading="lazy"
@@ -931,7 +931,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 </li>
                               <li>
                   <figure id="module-self-service" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver/modules/module-placeholder.svg"
+                    <img src="{{ basePath }}/uploads/module-placeholder.svg"
                          width="1200"
                          height="675"
                          loading="lazy"


### PR DESCRIPTION
## Summary
- point the calServer module figures to the shared `/uploads/module-placeholder.svg` asset
- keep the seeded SQLite schema and SEO form defaults in sync with the new placeholder location

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d72f9d1138832b80a8bc53e4d2cf7f