### PR TITLE
Improve Trumbowyg toolbar contrast in dark mode

### DIFF
--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -256,14 +256,31 @@ body .trumbowyg-button-pane {
 
 body .trumbowyg-button-pane button {
   color: #f5f5f5;
+  background-color: #323232;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  opacity: 1;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
-body .trumbowyg-button-pane button svg {
+body .trumbowyg-button-pane button svg,
+body .trumbowyg-button-pane button svg * {
   fill: #f5f5f5;
+  stroke: #f5f5f5;
+  opacity: 1;
 }
 
 body .trumbowyg-button-pane button:hover {
   background-color: #333;
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+body .trumbowyg-button-pane button:focus,
+body .trumbowyg-button-pane button:focus-visible,
+body .trumbowyg-button-pane button.trumbowyg-active {
+  outline: 2px solid var(--accent-color, #1e87f0);
+  outline-offset: 2px;
+  background-color: #383838;
+  border-color: rgba(30, 135, 240, 0.45);
 }
 
 /* Styles fuer QR-Scan-Popup im Dunkelmodus */
@@ -595,14 +612,31 @@ body[data-theme="dark"] .trumbowyg-button-pane {
 
 body[data-theme="dark"] .trumbowyg-button-pane button {
   color: #f5f5f5;
+  background-color: #323232;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  opacity: 1;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
-body[data-theme="dark"] .trumbowyg-button-pane button svg {
+body[data-theme="dark"] .trumbowyg-button-pane button svg,
+body[data-theme="dark"] .trumbowyg-button-pane button svg * {
   fill: #f5f5f5;
+  stroke: #f5f5f5;
+  opacity: 1;
 }
 
 body[data-theme="dark"] .trumbowyg-button-pane button:hover {
   background-color: #333;
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+body[data-theme="dark"] .trumbowyg-button-pane button:focus,
+body[data-theme="dark"] .trumbowyg-button-pane button:focus-visible,
+body[data-theme="dark"] .trumbowyg-button-pane button.trumbowyg-active {
+  outline: 2px solid var(--accent-color, #1e87f0);
+  outline-offset: 2px;
+  background-color: #383838;
+  border-color: rgba(30, 135, 240, 0.45);
 }
 
 /* Styles fuer QR-Scan-Popup im Dunkelmodus */


### PR DESCRIPTION
## Summary
- brighten Trumbowyg toolbar buttons in dark mode with higher icon contrast and default opacity
- add subtle background and focus styling so buttons remain distinct without changing the hover color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d72fa438fc832b9965e3bb36f1f922