### PR TITLE
Align media manager refresh button with search input

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1025,4 +1025,15 @@ body.admin-page {
   margin-bottom: 0.25rem;
 }
 
+@media (min-width: 960px) {
+  .media-refresh-container {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  .media-refresh-container [data-media-refresh] {
+    margin-top: auto;
+  }
+}
+
 

--- a/templates/admin/media.twig
+++ b/templates/admin/media.twig
@@ -88,7 +88,7 @@
                 >
               </div>
             </div>
-            <div class="uk-width-1-1 uk-width-auto@m uk-flex uk-flex-right@m uk-flex-bottom">
+            <div class="uk-width-1-1 uk-width-auto@m uk-flex uk-flex-right@m uk-flex-bottom media-refresh-container">
               <button type="button" class="uk-button uk-button-default uk-button-small uk-width-1-1 uk-width-auto@m" data-media-refresh>
                 <span class="uk-margin-small-right" uk-icon="refresh" aria-hidden="true"></span>
                 {{ t('button_media_refresh') }}


### PR DESCRIPTION
## Summary
- add a dedicated container class to the media manager refresh button so it can be aligned with the search input
- apply responsive styling that stacks the refresh button container and pushes the button to the bottom on wider screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d79d21c424832b815e9512502f3b6e