### PR TITLE
Add hamburger toggle to collapse admin sidebar

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -299,6 +299,12 @@ body.uk-padding {
 /* Admin sidebar navigation */
 .qr-sidebar { min-height: calc(100vh - 56px); }
 .qr-sidebar-card { height: 100%; overflow-y: auto; }
+.admin-page.sidebar-collapsed #adminSidebar {
+  display: none !important;
+}
+.admin-page.sidebar-collapsed .qr-sidebar-card {
+  display: none;
+}
 .qr-nav-text { margin-left: 8px; }
 .uk-nav-default > li.uk-active > a {
   background: var(--uk-background-muted, #f8f8f8);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4,6 +4,9 @@ document.addEventListener('DOMContentLoaded', function () {
   const accessibilityToggles = document.querySelectorAll('.accessibility-toggle');
   const configMenuToggle = document.getElementById('configMenuToggle');
   const configMenu = document.getElementById('menuDrop');
+  const sidebarToggle = document.getElementById('sidebarToggle');
+  const adminSidebar = document.getElementById('adminSidebar');
+  const sidebarHasItems = adminSidebar && adminSidebar.querySelector('li');
   const offcanvasToggle = document.getElementById('offcanvas-toggle');
   const offcanvas = document.getElementById('qr-offcanvas');
   const offcanvasHasItems = offcanvas && offcanvas.querySelector('li');
@@ -16,6 +19,31 @@ document.addEventListener('DOMContentLoaded', function () {
 
   if (offcanvasToggle && !offcanvasHasItems) {
     offcanvasToggle.hidden = true;
+  }
+
+  if (sidebarToggle) {
+    if (!sidebarHasItems) {
+      sidebarToggle.hidden = true;
+    } else {
+      const collapsedKey = (typeof STORAGE_KEYS !== 'undefined' && STORAGE_KEYS.ADMIN_SIDEBAR)
+        ? STORAGE_KEYS.ADMIN_SIDEBAR
+        : 'adminSidebarCollapsed';
+      const setCollapsedState = (collapsed) => {
+        document.body.classList.toggle('sidebar-collapsed', collapsed);
+        sidebarToggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        sidebarToggle.setAttribute('aria-pressed', collapsed ? 'true' : 'false');
+      };
+      const storedSidebar = (typeof getStored === 'function') ? getStored(collapsedKey) : null;
+      const initialCollapsed = storedSidebar === 'true' || storedSidebar === '1';
+      setCollapsedState(initialCollapsed);
+      sidebarToggle.addEventListener('click', () => {
+        const collapsed = !document.body.classList.contains('sidebar-collapsed');
+        setCollapsedState(collapsed);
+        if (typeof setStored === 'function') {
+          setStored(collapsedKey, collapsed ? '1' : '0');
+        }
+      });
+    }
   }
 
   if (teamNameBtn) {

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -17,7 +17,8 @@
     BARRIER_FREE: 'barrierFree',
     QR_THEME: 'qr-theme',
     QR_CONTRAST: 'qr-contrast',
-    TENANT_COLUMNS: 'tenantColumns'
+    TENANT_COLUMNS: 'tenantColumns',
+    ADMIN_SIDEBAR: 'adminSidebarCollapsed'
   };
 
   const eventScoped = new Set([

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -32,6 +32,17 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
+      <button
+        id="sidebarToggle"
+        type="button"
+        class="uk-navbar-toggle uk-visible@m uk-margin-small-right git-btn"
+        aria-controls="adminSidebar"
+        aria-expanded="true"
+        aria-pressed="false"
+        aria-label="{{ t('menu') }}"
+      >
+        <span uk-navbar-toggle-icon></span>
+      </button>
       <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">
         QuizRace Admin
         <div class="uk-text-meta uk-text-small">v{{ version }}</div>
@@ -65,7 +76,7 @@
     </div>
   {% endif %}
   <div class="uk-grid-collapse" uk-grid>
-    <aside class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
+    <aside id="adminSidebar" class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
       <div class="uk-card qr-card uk-card-body qr-sidebar-card">
         {% include 'admin/_nav.twig' %}
       </div>

--- a/templates/admin/logs.twig
+++ b/templates/admin/logs.twig
@@ -14,9 +14,17 @@
 {% block body %}
   {% embed 'topbar.twig' %}
     {% block left %}
-      <a class="uk-navbar-toggle git-btn" uk-toggle="target: #qr-offcanvas" aria-label="{{ t('menu') }}">
+      <button
+        id="sidebarToggle"
+        type="button"
+        class="uk-navbar-toggle uk-visible@m uk-margin-small-right git-btn"
+        aria-controls="adminSidebar"
+        aria-expanded="true"
+        aria-pressed="false"
+        aria-label="{{ t('menu') }}"
+      >
         <span uk-navbar-toggle-icon></span>
-      </a>
+      </button>
       <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">
         QuizRace Admin
       </a>
@@ -37,7 +45,7 @@
     {% endblock %}
   {% endembed %}
   <div class="uk-grid-collapse" uk-grid>
-    <aside class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
+    <aside id="adminSidebar" class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
       <div class="uk-card qr-card uk-card-body qr-sidebar-card">
         {% include 'admin/_nav.twig' %}
       </div>


### PR DESCRIPTION
## Summary
- add a hamburger toggle to the admin top bar so the sidebar can be collapsed on larger screens
- hide the sidebar with new CSS and persist the toggle state in storage for a consistent experience
- reuse the toggle on the admin logs view and fall back gracefully when no sidebar items are present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d79de2a878832ba315f05931ac6a84