### PR TITLE
Normalize base path handling for marketing assets

### DIFF
--- a/src/Controller/DatenschutzController.php
+++ b/src/Controller/DatenschutzController.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\PageService;
+use App\Service\PageVariableService;
+use App\Support\BasePathHelper;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Views\Twig;
 use Slim\Routing\RouteContext;
-use App\Service\PageVariableService;
+use Slim\Views\Twig;
 
 /**
  * Renders the privacy policy page.
@@ -23,7 +24,7 @@ class DatenschutzController
         if ($html === null) {
             return $response->withStatus(404);
         }
-        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $basePath = BasePathHelper::normalize(RouteContext::fromRequest($request)->getBasePath());
         $html = str_replace('{{ basePath }}', $basePath, $html);
         $html = PageVariableService::apply($html);
 

--- a/src/Controller/FaqController.php
+++ b/src/Controller/FaqController.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\PageService;
+use App\Support\BasePathHelper;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Views\Twig;
 use Slim\Routing\RouteContext;
+use Slim\Views\Twig;
 
 /**
  * Displays the frequently asked questions.
@@ -25,7 +26,7 @@ class FaqController
         if ($html === null) {
             return $response->withStatus(404);
         }
-        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $basePath = BasePathHelper::normalize(RouteContext::fromRequest($request)->getBasePath());
         $html = str_replace('{{ basePath }}', $basePath, $html);
 
         $view = Twig::fromRequest($request);

--- a/src/Controller/ImpressumController.php
+++ b/src/Controller/ImpressumController.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\PageService;
+use App\Service\PageVariableService;
+use App\Support\BasePathHelper;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Views\Twig;
 use Slim\Routing\RouteContext;
-use App\Service\PageVariableService;
+use Slim\Views\Twig;
 
 /**
  * Displays the legal notice page.
@@ -23,7 +24,7 @@ class ImpressumController
         if ($html === null) {
             return $response->withStatus(404);
         }
-        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $basePath = BasePathHelper::normalize(RouteContext::fromRequest($request)->getBasePath());
         $html = str_replace('{{ basePath }}', $basePath, $html);
         $html = PageVariableService::apply($html);
 

--- a/src/Controller/LizenzController.php
+++ b/src/Controller/LizenzController.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Service\PageService;
+use App\Support\BasePathHelper;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Views\Twig;
 use Slim\Routing\RouteContext;
+use Slim\Views\Twig;
 
 /**
  * Shows the open-source license information.
@@ -22,7 +23,7 @@ class LizenzController
         if ($html === null) {
             return $response->withStatus(404);
         }
-        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $basePath = BasePathHelper::normalize(RouteContext::fromRequest($request)->getBasePath());
         $html = str_replace('{{ basePath }}', $basePath, $html);
 
         $view = Twig::fromRequest($request);

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Domain\Roles;
-use App\Service\UserService;
-use App\Service\SessionService;
 use App\Infrastructure\Database;
+use App\Service\SessionService;
+use App\Service\UserService;
 use App\Service\VersionService;
+use App\Support\BasePathHelper;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
@@ -118,7 +119,7 @@ class LoginController
             } else {
                 $target = '/help';
             }
-            $basePath = RouteContext::fromRequest($request)->getBasePath();
+            $basePath = BasePathHelper::normalize(RouteContext::fromRequest($request)->getBasePath());
             return $response->withHeader('Location', $basePath . $target)->withStatus(302);
         }
 

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Support\BasePathHelper;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteContext;
@@ -36,7 +37,7 @@ class LogoutController
             true
         );
 
-        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $basePath = BasePathHelper::normalize(RouteContext::fromRequest($request)->getBasePath());
         return $response->withHeader('Location', $basePath . '/login')->withStatus(302);
     }
 }

--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -7,6 +7,7 @@ namespace App\Controller\Marketing;
 use App\Application\Seo\PageSeoConfigService;
 use App\Service\MailService;
 use App\Service\PageService;
+use App\Support\BasePathHelper;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteContext;
@@ -39,7 +40,7 @@ class MarketingPageController
         }
 
         $html = $page->getContent();
-        $basePath = RouteContext::fromRequest($request)->getBasePath();
+        $basePath = BasePathHelper::normalize(RouteContext::fromRequest($request)->getBasePath());
         $html = str_replace('{{ basePath }}', $basePath, $html);
 
         $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));

--- a/src/Support/BasePathHelper.php
+++ b/src/Support/BasePathHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class BasePathHelper
+{
+    private function __construct()
+    {
+    }
+
+    public static function normalize(?string $basePath): string
+    {
+        if ($basePath === null) {
+            return '';
+        }
+
+        $basePath = trim($basePath);
+        if ($basePath === '' || $basePath === '/') {
+            return '';
+        }
+
+        $normalized = '/' . trim($basePath, '/');
+        $normalized = preg_replace('#/+#', '/', $normalized) ?: '/';
+
+        if ($normalized === '/' || $normalized === '') {
+            return '';
+        }
+
+        return rtrim($normalized, '/');
+    }
+}

--- a/tests/Support/BasePathHelperTest.php
+++ b/tests/Support/BasePathHelperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use App\Support\BasePathHelper;
+use PHPUnit\Framework\TestCase;
+
+class BasePathHelperTest extends TestCase
+{
+    /**
+     * @dataProvider provideBasePaths
+     */
+    public function testNormalize(?string $input, string $expected): void
+    {
+        self::assertSame($expected, BasePathHelper::normalize($input));
+    }
+
+    /**
+     * @return iterable<string, array{?string, string}>
+     */
+    public static function provideBasePaths(): iterable
+    {
+        yield 'null' => [null, ''];
+        yield 'empty string' => ['', ''];
+        yield 'single slash' => ['/', ''];
+        yield 'already normalized rootless' => ['sub', '/sub'];
+        yield 'leading slash kept' => ['/admin', '/admin'];
+        yield 'trailing slash trimmed' => ['/admin/', '/admin'];
+        yield 'whitespace trimmed' => ['  /app ', '/app'];
+        yield 'double slashes collapsed' => ['//nested//path//', '/nested/path'];
+    }
+}


### PR DESCRIPTION
## Summary
- add a BasePathHelper to normalize application base paths before they are injected into stored marketing markup
- update marketing and static page controllers to use the helper so uploaded assets resolve correctly even when the base path resolves to a single slash
- cover the helper with unit tests to document the normalization edge cases

## Testing
- ./vendor/bin/phpunit tests/Support/BasePathHelperTest.php tests/Controller/CalserverControllerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d79b16b710832b9d0ca0009465ccd9