### PR TITLE
Fix redundant base path normalization check

### DIFF
--- a/src/Support/BasePathHelper.php
+++ b/src/Support/BasePathHelper.php
@@ -24,7 +24,7 @@ final class BasePathHelper
         $normalized = '/' . trim($basePath, '/');
         $normalized = preg_replace('#/+#', '/', $normalized) ?: '/';
 
-        if ($normalized === '/' || $normalized === '') {
+        if ($normalized === '/') {
             return '';
         }
 


### PR DESCRIPTION
## Summary
- remove the redundant empty-string comparison when normalizing base paths

## Testing
- vendor/bin/phpstan --no-progress --memory-limit=512M

------
https://chatgpt.com/codex/tasks/task_e_68d81a04b718832b8287be80faa2d5ba