### PR TITLE
Add follow-up migration for calServer marketing visuals

### DIFF
--- a/migrations/20250927_update_calserver_visual_assets.sql
+++ b/migrations/20250927_update_calserver_visual_assets.sql
@@ -1,351 +1,8 @@
--- SQLite schema for tests
--- This script sets up the database schema in a SQLite-compatible way
-
-CREATE TABLE IF NOT EXISTS migrations (
-    version TEXT PRIMARY KEY
-);
-
--- Events
-CREATE TABLE IF NOT EXISTS events (
-    uid TEXT PRIMARY KEY,
-    slug TEXT UNIQUE NOT NULL,
-    name TEXT NOT NULL,
-    start_date TEXT DEFAULT CURRENT_TIMESTAMP,
-    end_date TEXT DEFAULT CURRENT_TIMESTAMP,
-    description TEXT,
-    published BOOLEAN NOT NULL DEFAULT FALSE,
-    sort_order INTEGER NOT NULL DEFAULT 0
-);
-
--- Players
-CREATE TABLE IF NOT EXISTS players (
-    event_uid TEXT NOT NULL,
-    player_name TEXT NOT NULL,
-    player_uid TEXT NOT NULL,
-    PRIMARY KEY (event_uid, player_uid)
-);
-
--- Config
-CREATE TABLE IF NOT EXISTS config (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    displayErrorDetails BOOLEAN,
-    QRUser BOOLEAN,
-    logoPath TEXT,
-    pageTitle TEXT,
-    backgroundColor TEXT,
-    buttonColor TEXT,
-    CheckAnswerButton TEXT,
-    QRRestrict BOOLEAN,
-    randomNames BOOLEAN DEFAULT TRUE,
-    competitionMode BOOLEAN,
-    teamResults BOOLEAN,
-    photoUpload BOOLEAN,
-    puzzleWordEnabled BOOLEAN,
-    puzzleWord TEXT,
-    puzzleFeedback TEXT,
-    collectPlayerUid BOOLEAN,
-    inviteText TEXT,
-    qrremember BOOLEAN DEFAULT FALSE,
-    event_uid TEXT,
-    qrLabelLine1 TEXT,
-    qrLabelLine2 TEXT,
-    qrLogoPath TEXT,
-    qrLogoWidth INTEGER,
-    qrRoundMode TEXT,
-    qrLogoPunchout BOOLEAN,
-    qrRounded BOOLEAN,
-    qrColorTeam TEXT,
-    qrColorCatalog TEXT,
-    qrColorEvent TEXT,
-    stickerTemplate TEXT,
-    stickerPrintHeader BOOLEAN,
-    stickerPrintSubheader BOOLEAN,
-    stickerPrintCatalog BOOLEAN,
-    stickerPrintDesc BOOLEAN,
-    stickerQrColor TEXT,
-    stickerQrSizePct NUMERIC(6,2),
-    stickerDescTop REAL,
-    stickerDescLeft REAL,
-    stickerQrTop REAL,
-    stickerQrLeft REAL,
-    stickerHeaderFontSize INTEGER,
-    stickerSubheaderFontSize INTEGER,
-    stickerCatalogFontSize INTEGER,
-    stickerDescFontSize INTEGER,
-    stickerTextColor TEXT,
-    stickerDescWidth REAL,
-    stickerDescHeight REAL,
-    stickerBgPath TEXT,
-    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
-);
-
--- Settings
-CREATE TABLE IF NOT EXISTS settings (
-    key TEXT PRIMARY KEY,
-    value TEXT
-);
-INSERT OR IGNORE INTO settings(key, value) VALUES('home_page', 'help');
-INSERT OR IGNORE INTO settings(key, value) VALUES('registration_enabled', '0');
-
--- Domain start pages
-CREATE TABLE IF NOT EXISTS domain_start_pages (
-    domain TEXT PRIMARY KEY,
-    start_page TEXT NOT NULL,
-    email TEXT,
-    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-
--- Domain contact templates
-CREATE TABLE IF NOT EXISTS domain_contact_templates (
-    domain TEXT PRIMARY KEY,
-    sender_name TEXT,
-    recipient_html TEXT,
-    recipient_text TEXT,
-    sender_html TEXT,
-    sender_text TEXT,
-    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-
--- Teams
-CREATE TABLE IF NOT EXISTS teams (
-    sort_order INTEGER NOT NULL,
-    name TEXT NOT NULL,
-    uid TEXT PRIMARY KEY,
-    event_uid TEXT,
-    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE,
-    UNIQUE(event_uid, sort_order)
-);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_team_name ON teams(name);
-
--- Results
-CREATE TABLE IF NOT EXISTS results (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL,
-    catalog TEXT NOT NULL,
-    attempt INTEGER NOT NULL,
-    correct INTEGER NOT NULL,
-    answer_text TEXT,
-    consent BOOLEAN,
-    total INTEGER NOT NULL,
-    time INTEGER NOT NULL,
-    puzzleTime INTEGER,
-    photo TEXT,
-    event_uid TEXT,
-    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS idx_results_catalog ON results(catalog);
-CREATE INDEX IF NOT EXISTS idx_results_name ON results(name);
-
--- Question results
-CREATE TABLE IF NOT EXISTS question_results (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL,
-    catalog TEXT NOT NULL,
-    question_id INTEGER NOT NULL,
-    attempt INTEGER NOT NULL,
-    correct INTEGER NOT NULL,
-    answer_text TEXT,
-    photo TEXT,
-    consent BOOLEAN,
-    event_uid TEXT,
-    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS idx_qresults_catalog ON question_results(catalog);
-CREATE INDEX IF NOT EXISTS idx_qresults_name ON question_results(name);
-CREATE INDEX IF NOT EXISTS idx_qresults_question ON question_results(question_id);
-
--- Catalogs
-CREATE TABLE IF NOT EXISTS catalogs (
-    uid TEXT PRIMARY KEY,
-    sort_order INTEGER NOT NULL,
-    slug TEXT UNIQUE NOT NULL,
-    file TEXT NOT NULL,
-    name TEXT NOT NULL,
-    description TEXT,
-    raetsel_buchstabe TEXT,
-    comment TEXT,
-    design_path TEXT,
-    event_uid TEXT,
-    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE,
-    UNIQUE(event_uid, sort_order)
-);
-
--- Questions
-CREATE TABLE IF NOT EXISTS questions (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    catalog_uid TEXT NOT NULL,
-    sort_order INTEGER,
-    type TEXT NOT NULL,
-    prompt TEXT NOT NULL,
-    options TEXT DEFAULT '{}',
-    answers TEXT DEFAULT '[]',
-    terms TEXT DEFAULT '{}',
-    items TEXT DEFAULT '{}',
-    cards TEXT DEFAULT '[]',
-    right_label TEXT,
-    left_label TEXT,
-    FOREIGN KEY (catalog_uid) REFERENCES catalogs(uid) ON DELETE CASCADE,
-    UNIQUE(catalog_uid, sort_order)
-);
-CREATE INDEX IF NOT EXISTS idx_questions_catalog ON questions(catalog_uid);
-
--- Photo consents
-CREATE TABLE IF NOT EXISTS photo_consents (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    team TEXT NOT NULL,
-    time INTEGER NOT NULL,
-    event_uid TEXT,
-    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS idx_photo_consents_team ON photo_consents(team);
-
--- Summary photos
-CREATE TABLE IF NOT EXISTS summary_photos (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL,
-    path TEXT NOT NULL,
-    time INTEGER NOT NULL,
-    event_uid TEXT,
-    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS idx_summary_photos_name ON summary_photos(name);
-
--- Users
-CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    username TEXT UNIQUE NOT NULL,
-    password TEXT NOT NULL,
-    email TEXT UNIQUE,
-    active BOOLEAN NOT NULL DEFAULT TRUE,
-    role TEXT NOT NULL DEFAULT 'catalog-editor',
-    position INTEGER NOT NULL DEFAULT 0
-);
-
--- User sessions
-CREATE TABLE IF NOT EXISTS user_sessions (
-    user_id INTEGER NOT NULL,
-    session_id TEXT PRIMARY KEY,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-
--- Password resets
-CREATE TABLE IF NOT EXISTS password_resets (
-    user_id INTEGER NOT NULL,
-    token_hash TEXT NOT NULL UNIQUE,
-    expires_at TEXT NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
-
--- Tenants
-CREATE TABLE IF NOT EXISTS tenants (
-    uid TEXT PRIMARY KEY,
-    subdomain TEXT UNIQUE NOT NULL,
-    plan TEXT,
-    billing_info TEXT,
-    stripe_customer_id TEXT,
-    stripe_subscription_id TEXT,
-    stripe_price_id TEXT,
-    stripe_status TEXT,
-    stripe_current_period_end TEXT,
-    stripe_cancel_at_period_end BOOLEAN,
-    imprint_name TEXT,
-    imprint_street TEXT,
-    imprint_zip TEXT,
-    imprint_city TEXT,
-    imprint_email TEXT,
-    custom_limits TEXT,
-    plan_started_at TEXT,
-    plan_expires_at TEXT,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-
--- Active event
-CREATE TABLE IF NOT EXISTS active_event (
-    event_uid TEXT PRIMARY KEY,
-    FOREIGN KEY (event_uid) REFERENCES events(uid) ON DELETE CASCADE
-);
-
--- Audit log
-CREATE TABLE IF NOT EXISTS audit_logs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    action TEXT NOT NULL,
-    context TEXT DEFAULT '{}' NOT NULL,
-    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-CREATE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs(action);
-
--- Email confirmations
-CREATE TABLE IF NOT EXISTS email_confirmations (
-    email TEXT NOT NULL,
-    token TEXT NOT NULL,
-    confirmed INTEGER NOT NULL DEFAULT 0,
-    expires_at TEXT NOT NULL,
-    UNIQUE(token),
-    UNIQUE(email)
-);
-
--- Invitations
-CREATE TABLE IF NOT EXISTS invitations (
-    email TEXT NOT NULL,
-    token TEXT NOT NULL,
-    expires_at TEXT NOT NULL,
-    UNIQUE(token),
-    UNIQUE(email)
-);
-
--- Pages
-CREATE TABLE IF NOT EXISTS pages (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    slug TEXT UNIQUE NOT NULL,
-    title TEXT NOT NULL,
-    content TEXT NOT NULL,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-
--- Page SEO config
-CREATE TABLE IF NOT EXISTS page_seo_config (
-    page_id INTEGER PRIMARY KEY REFERENCES pages(id) ON DELETE CASCADE,
-    domain TEXT,
-    meta_title TEXT,
-    meta_description TEXT,
-    slug TEXT NOT NULL,
-    canonical_url TEXT,
-    robots_meta TEXT,
-    og_title TEXT,
-    og_description TEXT,
-    og_image TEXT,
-    favicon_path TEXT,
-    schema_json TEXT,
-    hreflang TEXT,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_page_seo_config_domain_slug
-    ON page_seo_config(COALESCE(domain, ''), slug);
-
-CREATE TABLE IF NOT EXISTS page_seo_config_history (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    page_id INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
-    domain TEXT,
-    meta_title TEXT,
-    meta_description TEXT,
-    slug TEXT,
-    canonical_url TEXT,
-    robots_meta TEXT,
-    og_title TEXT,
-    og_description TEXT,
-    og_image TEXT,
-    favicon_path TEXT,
-    schema_json TEXT,
-    hreflang TEXT,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-
-INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
+INSERT INTO pages (slug, title, content)
+VALUES (
     'calserver',
     'calServer',
-    '<section class="calserver-highlight calserver-section-glow" aria-label="calServer in Zahlen">
+    $$<section class="calserver-highlight calserver-section-glow" aria-label="calServer in Zahlen">
       <div class="uk-container">
         <div class="calserver-stats-strip" role="list">
           <div class="calserver-stats-strip__item" role="listitem">
@@ -709,17 +366,17 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
              aria-label="Nächste Funktion"></a>
         </div>
         <script>
-          document.addEventListener(''DOMContentLoaded'', () => {
-            const sliderElement = document.getElementById(''feature-slider'');
-            const navElement = document.getElementById(''feature-nav'');
-            if (!sliderElement || !navElement || typeof UIkit === ''undefined'') {
+          document.addEventListener('DOMContentLoaded', () => {
+            const sliderElement = document.getElementById('feature-slider');
+            const navElement = document.getElementById('feature-nav');
+            if (!sliderElement || !navElement || typeof UIkit === 'undefined') {
               return;
             }
 
             const slider = UIkit.slider(sliderElement);
-            const pills = Array.from(navElement.querySelectorAll(''li''));
-            const slides = Array.from(sliderElement.querySelectorAll(''.feature-slider__item''));
-            const itemsContainer = sliderElement.querySelector(''.uk-slider-items'');
+            const pills = Array.from(navElement.querySelectorAll('li'));
+            const slides = Array.from(sliderElement.querySelectorAll('.feature-slider__item'));
+            const itemsContainer = sliderElement.querySelector('.uk-slider-items');
             if (!itemsContainer) {
               return;
             }
@@ -732,7 +389,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 return;
               }
 
-              const viewportElement = sliderElement.querySelector(''.uk-slider-container'') || sliderElement;
+              const viewportElement = sliderElement.querySelector('.uk-slider-container') || sliderElement;
               const viewportRect = viewportElement.getBoundingClientRect();
               const midpoint = viewportRect.left + viewportRect.width / 2;
 
@@ -740,7 +397,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
               let minDistance = Number.POSITIVE_INFINITY;
 
               slideElements.forEach((item) => {
-                const card = item.querySelector(''.feature-card'');
+                const card = item.querySelector('.feature-card');
                 if (!card) {
                   return;
                 }
@@ -756,18 +413,18 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
               });
 
               slideElements.forEach((item) => {
-                item.classList.remove(''is-center'');
-                const card = item.querySelector(''.feature-card'');
+                item.classList.remove('is-center');
+                const card = item.querySelector('.feature-card');
                 if (card) {
-                  card.classList.remove(''feature-card--focus'');
+                  card.classList.remove('feature-card--focus');
                 }
               });
 
               if (nearest) {
-                nearest.classList.add(''is-center'');
-                const focusCard = nearest.querySelector(''.feature-card'');
+                nearest.classList.add('is-center');
+                const focusCard = nearest.querySelector('.feature-card');
                 if (focusCard) {
-                  focusCard.classList.add(''feature-card--focus'');
+                  focusCard.classList.add('feature-card--focus');
                 }
               }
             };
@@ -775,39 +432,39 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             const setActive = (index) => {
               pills.forEach((li, i) => {
                 const isActive = i === index;
-                li.classList.toggle(''uk-active'', isActive);
+                li.classList.toggle('uk-active', isActive);
 
-                const link = li.querySelector(''.feature-nav__pill'');
+                const link = li.querySelector('.feature-nav__pill');
                 if (!link) {
                   return;
                 }
 
-                link.classList.toggle(''is-active'', isActive);
+                link.classList.toggle('is-active', isActive);
                 if (isActive) {
-                  link.setAttribute(''aria-current'', ''true'');
+                  link.setAttribute('aria-current', 'true');
                 } else {
-                  link.removeAttribute(''aria-current'');
+                  link.removeAttribute('aria-current');
                 }
               });
             };
 
             const setCurrent = (index) => {
-              slides.forEach((slide, i) => slide.classList.toggle(''uk-current'', i === index));
+              slides.forEach((slide, i) => slide.classList.toggle('uk-current', i === index));
             };
 
             pills.forEach((li) => {
-              const link = li.querySelector(''a[data-target]'');
+              const link = li.querySelector('a[data-target]');
               if (!link) {
                 return;
               }
 
               const targetId = link.dataset.target;
               const targetIndex = indexById.get(targetId);
-              if (typeof targetIndex === ''undefined'') {
+              if (typeof targetIndex === 'undefined') {
                 return;
               }
 
-              link.addEventListener(''click'', (event) => {
+              link.addEventListener('click', (event) => {
                 event.preventDefault();
                 slider.show(targetIndex);
                 setActive(targetIndex);
@@ -816,17 +473,17 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
               });
             });
 
-            UIkit.util.on(sliderElement, ''itemshown'', () => {
+            UIkit.util.on(sliderElement, 'itemshown', () => {
               setActive(slider.index);
               setCurrent(slider.index);
               applyFocusToCenter();
             });
 
-            const initialIndex = typeof slider.index === ''number'' ? slider.index : 0;
+            const initialIndex = typeof slider.index === 'number' ? slider.index : 0;
             setActive(initialIndex);
             setCurrent(initialIndex);
             applyFocusToCenter();
-            window.addEventListener(''resize'', applyFocusToCenter);
+            window.addEventListener('resize', applyFocusToCenter);
           });
         </script>
       </div>
@@ -1540,5 +1197,9 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
         <button class="uk-button uk-button-primary uk-modal-close" type="button">OK</button>
       </div>
     </div>
-'
-);
+    $$
+)
+ON CONFLICT (slug) DO UPDATE
+SET title = EXCLUDED.title,
+    content = EXCLUDED.content,
+    updated_at = CURRENT_TIMESTAMP;


### PR DESCRIPTION
## Summary
- restore the 20250926 migration so previous deployments retain the original placeholder assets
- add a 20250927 migration that updates the calServer page to reference the descriptive WEBP screenshots and alt text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d79f8990a4832ba283bd1a393c326c