### PR TITLE
Adjust calserver SEO defaults

### DIFF
--- a/public/js/seo-form.js
+++ b/public/js/seo-form.js
@@ -264,32 +264,32 @@ export function initSeoForm() {
       metaTitle: 'calServer – Kalibrier- & Prüfmittelmanagement',
       metaDescription:
         'calServer digitalisiert Kalibrier- und Prüfmittelverwaltung: Geräteakten, Terminplanung und Workflows in einer Plattform – Hosting & Support in Deutschland.',
-      slug: '/',
-      canonical: `${ctx.baseUrl}/`,
+      slug: '/calserver',
+      canonical: `${ctx.baseUrl}/calserver`,
       robots: 'index, follow',
       ogTitle: 'calServer – Plattform für Kalibrier- & Prüfmittelteams',
       ogDescription:
         'Überwachen Sie Prüfmittel, Kalibrierfristen, Serviceaufträge und Dokumentation zentral. calServer liefert Workflows, Erinnerungen und Hosting in Deutschland.',
-      ogImage: `${ctx.baseUrl}/uploads/module-placeholder.svg`,
+      ogImage: `${ctx.baseUrl}/uploads/calserver-module-device-management.webp`,
       schema: `{
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "calServer",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Web",
-  "url": "${ctx.baseUrl}/",
+  "url": "${ctx.baseUrl}/calserver",
   "description": "calServer digitalisiert Kalibrier- und Prüfmittelverwaltung für Teams – inklusive Geräteakten, Terminplanung, Workflows und Dokumentation.",
   "provider": {
     "@type": "Organization",
     "name": "calServer",
-    "url": "${ctx.baseUrl}/"
+    "url": "${ctx.baseUrl}/calserver"
   },
   "sameAs": [
     "https://calserver.de",
     "https://calserver.com"
   ]
 }`,
-      hreflang: `<link rel="alternate" href="${ctx.baseUrl}/" hreflang="de" />\n<link rel="alternate" href="${ctx.baseUrl}/en/" hreflang="en" />`,
+      hreflang: `<link rel="alternate" href="${ctx.baseUrl}/calserver" hreflang="de" />\n<link rel="alternate" href="${ctx.baseUrl}/en/calserver" hreflang="en" />`,
       domain: ctx.domain
     })
   };


### PR DESCRIPTION
## Summary
- set the calserver example defaults to use the /calserver slug and canonical URL
- point the calserver OG image and structured data to the new screenshot asset and path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d84c2d8f68832b9502159f684144c7