### PR TITLE
Wrap calServer use case screenshots in card layout

### DIFF
--- a/migrations/20250926_update_calserver_page.sql
+++ b/migrations/20250926_update_calserver_page.sql
@@ -654,14 +654,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-ifm-ticketmanagement.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot des calServer-Ticketboards im ifm-Use-Case mit CAPA-Bewertung">
+                  </div>
                 </div>
               </div>
             </div>
@@ -691,14 +693,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-ksw-prozesskette.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot des calServer-Prozessflusses von Wareneingang bis Abrechnung im KSW-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -728,14 +732,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-systems-reporting.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Auftragssteuerung und Reporting-Widgets im Systems-Engineering-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -765,14 +771,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-teramess-dakks.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Zertifikatsverwaltung mit DAkkS-Historie im TERAMESS-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -802,14 +810,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-thermo-leihverwaltung.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Leihgeräte- und Geräteaktenübersicht im Thermo-Fisher-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -839,14 +849,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-zf-messwerte-sso.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Messwert-APIs und SSO-Konfiguration im ZF-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -876,14 +888,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-berlin-wartung.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Wartungs- und Projektplanung für Berliner Stadtwerke">
+                  </div>
                 </div>
               </div>
             </div>
@@ -913,14 +927,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-vde-auftragsboard.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot des calServer-Auftragsboards mit DMS-Integration im VDE-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>

--- a/migrations/20250927_update_calserver_visual_assets.sql
+++ b/migrations/20250927_update_calserver_visual_assets.sql
@@ -654,14 +654,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-ifm-ticketmanagement.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot des calServer-Ticketboards im ifm-Use-Case mit CAPA-Bewertung">
+                  </div>
                 </div>
               </div>
             </div>
@@ -691,14 +693,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-ksw-prozesskette.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot des calServer-Prozessflusses von Wareneingang bis Abrechnung im KSW-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -728,14 +732,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-systems-reporting.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Auftragssteuerung und Reporting-Widgets im Systems-Engineering-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -765,14 +771,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-teramess-dakks.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Zertifikatsverwaltung mit DAkkS-Historie im TERAMESS-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -802,14 +810,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-thermo-leihverwaltung.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Leihgeräte- und Geräteaktenübersicht im Thermo-Fisher-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -839,14 +849,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-zf-messwerte-sso.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Messwert-APIs und SSO-Konfiguration im ZF-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -876,14 +888,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-berlin-wartung.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Wartungs- und Projektplanung für Berliner Stadtwerke">
+                  </div>
                 </div>
               </div>
             </div>
@@ -913,14 +927,16 @@ VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-vde-auftragsboard.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot des calServer-Auftragsboards mit DMS-Integration im VDE-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>

--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1717,6 +1717,21 @@ body.qr-landing.calserver-theme .testimonial-card {
     min-height: 240px;
 }
 
+body.qr-landing.calserver-theme .usecase-card--visual {
+    padding: 0;
+    overflow: hidden;
+}
+
+body.qr-landing.calserver-theme .usecase-card--visual .usecase-visual {
+    margin: 0;
+}
+
+body.qr-landing.calserver-theme .usecase-card--visual .usecase-visual__image {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
 @media (max-width: 959px) {
     body.qr-landing.calserver-theme .quick-cta {
         padding: 20px;

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -997,14 +997,16 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-ifm-ticketmanagement.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot des calServer-Ticketboards im ifm-Use-Case mit CAPA-Bewertung">
+                  </div>
                 </div>
               </div>
             </div>
@@ -1034,14 +1036,16 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-ksw-prozesskette.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot des calServer-Prozessflusses von Wareneingang bis Abrechnung im KSW-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -1071,14 +1075,16 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-systems-reporting.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Auftragssteuerung und Reporting-Widgets im Systems-Engineering-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -1108,14 +1114,16 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-teramess-dakks.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Zertifikatsverwaltung mit DAkkS-Historie im TERAMESS-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -1145,14 +1153,16 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-thermo-leihverwaltung.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Leihgeräte- und Geräteaktenübersicht im Thermo-Fisher-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -1182,14 +1192,16 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-zf-messwerte-sso.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Messwert-APIs und SSO-Konfiguration im ZF-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>
@@ -1219,14 +1231,16 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-berlin-wartung.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot der calServer-Wartungs- und Projektplanung für Berliner Stadtwerke">
+                  </div>
                 </div>
               </div>
             </div>
@@ -1256,14 +1270,16 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
-                <div class="usecase-visual uk-margin-top">
-                  <img class="uk-border-rounded usecase-visual__image"
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
                        src="{{ basePath }}/uploads/calserver-usecase-vde-auftragsboard.webp"
                        width="960"
                        height="540"
                        loading="lazy"
                        decoding="async"
                        alt="Screenshot des calServer-Auftragsboards mit DMS-Integration im VDE-Use-Case">
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- wrap calServer use case screenshots in the same card markup as the adjacent key facts blocks across marketing page seed data
- add styling for the new visual cards so screenshots fill the card frame cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d84f31e0d8832b8884111bf611509f