### PR TITLE
Adjust calserver use case layout classes

### DIFF
--- a/migrations/20250926_update_calserver_page.sql
+++ b/migrations/20250926_update_calserver_page.sql
@@ -630,8 +630,8 @@ VALUES (
         <ul class="uk-switcher uk-margin-large-top"
             data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .usecase-story, .usecase-highlight; delay: 100; repeat: true">
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">ifm – Störungsbearbeitung &amp; Verbesserungen über zwei Standorte</h3>
                 <p class="uk-text-lead">calServer steuert die interne Kalibrier- und Störungsbearbeitung über zwei Standorte hinweg.</p>
@@ -667,8 +667,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">KSW – End-to-End vom Wareneingang bis zur Rechnung</h3>
                 <p class="uk-text-lead">calServer bildet den gesamten Ablauf von Wareneingang über Labor bis zur Abrechnung ab.</p>
@@ -704,8 +704,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">Systems Engineering – Auftragsbearbeitung als Herzstück</h3>
                 <p class="uk-text-lead">calServer macht die Auftragsbearbeitung zum steuernden Zentrum des Labors.</p>
@@ -741,8 +741,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">TERAMESS – DAkkS-konforme Zertifikate in der Cloud</h3>
                 <p class="uk-text-lead">calServer CLOUD bündelt DAkkS-konforme Zertifikate, Geräteakten und Prüfberichte.</p>
@@ -778,8 +778,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">Thermo Fisher Scientific – EMEA Labore</h3>
                 <p class="uk-text-lead">calServer orchestriert EMEA-weit Leihgeräte, Geräteakten und ISO-/DAkkS-konforme Zertifikate auf einer Plattform.</p>
@@ -815,8 +815,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Industrielabor</span>
                 <h3 class="uk-h2">ZF – API-Messwerte auf Kubernetes mit SSO</h3>
                 <p class="uk-text-lead">calServer verbindet skalierbare Messwert-APIs auf Kubernetes mit SSO und Geräteakten-Management.</p>
@@ -852,8 +852,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Assetmanagement</span>
                 <h3 class="uk-h2">Berliner Stadtwerke – Projekte &amp; Wartung für erneuerbare Anlagen</h3>
                 <p class="uk-text-lead">calServer steuert Projekte, Wartungspläne und Einsätze für regenerative Energieanlagen der Stadt Berlin.</p>
@@ -889,8 +889,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Qualitätsmanagement</span>
                 <h3 class="uk-h2">VDE – Agile Auftragssteuerung &amp; Intranet</h3>
                 <p class="uk-text-lead">calServer bündelt agile Auftragssteuerung und Dokumentenflüsse für Prüf- und Zertifizierungsprozesse.</p>

--- a/migrations/20250927_update_calserver_visual_assets.sql
+++ b/migrations/20250927_update_calserver_visual_assets.sql
@@ -630,8 +630,8 @@ VALUES (
         <ul class="uk-switcher uk-margin-large-top"
             data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .usecase-story, .usecase-highlight; delay: 100; repeat: true">
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">ifm – Störungsbearbeitung &amp; Verbesserungen über zwei Standorte</h3>
                 <p class="uk-text-lead">calServer steuert die interne Kalibrier- und Störungsbearbeitung über zwei Standorte hinweg.</p>
@@ -667,8 +667,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">KSW – End-to-End vom Wareneingang bis zur Rechnung</h3>
                 <p class="uk-text-lead">calServer bildet den gesamten Ablauf von Wareneingang über Labor bis zur Abrechnung ab.</p>
@@ -704,8 +704,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">Systems Engineering – Auftragsbearbeitung als Herzstück</h3>
                 <p class="uk-text-lead">calServer macht die Auftragsbearbeitung zum steuernden Zentrum des Labors.</p>
@@ -741,8 +741,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">TERAMESS – DAkkS-konforme Zertifikate in der Cloud</h3>
                 <p class="uk-text-lead">calServer CLOUD bündelt DAkkS-konforme Zertifikate, Geräteakten und Prüfberichte.</p>
@@ -778,8 +778,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">Thermo Fisher Scientific – EMEA Labore</h3>
                 <p class="uk-text-lead">calServer orchestriert EMEA-weit Leihgeräte, Geräteakten und ISO-/DAkkS-konforme Zertifikate auf einer Plattform.</p>
@@ -815,8 +815,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Industrielabor</span>
                 <h3 class="uk-h2">ZF – API-Messwerte auf Kubernetes mit SSO</h3>
                 <p class="uk-text-lead">calServer verbindet skalierbare Messwert-APIs auf Kubernetes mit SSO und Geräteakten-Management.</p>
@@ -852,8 +852,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Assetmanagement</span>
                 <h3 class="uk-h2">Berliner Stadtwerke – Projekte &amp; Wartung für erneuerbare Anlagen</h3>
                 <p class="uk-text-lead">calServer steuert Projekte, Wartungspläne und Einsätze für regenerative Energieanlagen der Stadt Berlin.</p>
@@ -889,8 +889,8 @@ VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Qualitätsmanagement</span>
                 <h3 class="uk-h2">VDE – Agile Auftragssteuerung &amp; Intranet</h3>
                 <p class="uk-text-lead">calServer bündelt agile Auftragssteuerung und Dokumentenflüsse für Prüf- und Zertifizierungsprozesse.</p>

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -973,8 +973,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
         <ul class="uk-switcher uk-margin-large-top"
             data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .usecase-story, .usecase-highlight; delay: 100; repeat: true">
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">ifm – Störungsbearbeitung &amp; Verbesserungen über zwei Standorte</h3>
                 <p class="uk-text-lead">calServer steuert die interne Kalibrier- und Störungsbearbeitung über zwei Standorte hinweg.</p>
@@ -1010,8 +1010,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">KSW – End-to-End vom Wareneingang bis zur Rechnung</h3>
                 <p class="uk-text-lead">calServer bildet den gesamten Ablauf von Wareneingang über Labor bis zur Abrechnung ab.</p>
@@ -1047,8 +1047,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">Systems Engineering – Auftragsbearbeitung als Herzstück</h3>
                 <p class="uk-text-lead">calServer macht die Auftragsbearbeitung zum steuernden Zentrum des Labors.</p>
@@ -1084,8 +1084,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">TERAMESS – DAkkS-konforme Zertifikate in der Cloud</h3>
                 <p class="uk-text-lead">calServer CLOUD bündelt DAkkS-konforme Zertifikate, Geräteakten und Prüfberichte.</p>
@@ -1121,8 +1121,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
                 <h3 class="uk-h2">Thermo Fisher Scientific – EMEA Labore</h3>
                 <p class="uk-text-lead">calServer orchestriert EMEA-weit Leihgeräte, Geräteakten und ISO-/DAkkS-konforme Zertifikate auf einer Plattform.</p>
@@ -1158,8 +1158,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Industrielabor</span>
                 <h3 class="uk-h2">ZF – API-Messwerte auf Kubernetes mit SSO</h3>
                 <p class="uk-text-lead">calServer verbindet skalierbare Messwert-APIs auf Kubernetes mit SSO und Geräteakten-Management.</p>
@@ -1195,8 +1195,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Assetmanagement</span>
                 <h3 class="uk-h2">Berliner Stadtwerke – Projekte &amp; Wartung für erneuerbare Anlagen</h3>
                 <p class="uk-text-lead">calServer steuert Projekte, Wartungspläne und Einsätze für regenerative Energieanlagen der Stadt Berlin.</p>
@@ -1232,8 +1232,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </div>
           </li>
           <li>
-            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-              <div class="usecase-story">
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
                 <span class="pill pill--badge uk-margin-small-bottom">Qualitätsmanagement</span>
                 <h3 class="uk-h2">VDE – Agile Auftragssteuerung &amp; Intranet</h3>
                 <p class="uk-text-lead">calServer bündelt agile Auftragssteuerung und Dokumentenflüsse für Prüf- und Zertifizierungsprozesse.</p>


### PR DESCRIPTION
## Summary
- align the calServer use case grid rows to the top to keep text and key facts level
- mark use case stories as first column scrollspy elements to match desired styling
- keep default SQLite schema in sync with the updated class names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8501dbcfc832b889e492a637733f5