### PR TITLE
Hide dotfiles from media library listings

### DIFF
--- a/src/Service/MediaLibraryService.php
+++ b/src/Service/MediaLibraryService.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;
+use function str_starts_with;
 
 /**
  * Provides listing and file management for admin media uploads.
@@ -56,6 +57,9 @@ class MediaLibraryService
 
         while (($entry = readdir($handle)) !== false) {
             if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            if (str_starts_with($entry, '.')) {
                 continue;
             }
             if ($entry === self::METADATA_FILE) {


### PR DESCRIPTION
## Summary
- skip dotfiles when reading media directories so placeholders like .gitkeep no longer appear in the admin media manager

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8560862b0832bbe3f8e501b7c8c90