### PR TITLE
Add PDF links to missing landing assets

### DIFF
--- a/public/js/media-manager.js
+++ b/public/js/media-manager.js
@@ -145,6 +145,7 @@ ready(() => {
       landingMissingHeading: 'Missing landing assets',
       landingMissingEmpty: 'All landing assets available.',
       landingPrefill: 'Prefill upload',
+      landingOpenPdf: 'Open PDF',
       landingUsage: 'Landing pages',
       landingPreview: 'Landing references',
       landingMarkup: 'Landing content',
@@ -918,6 +919,7 @@ ready(() => {
           meta.className = 'uk-text-meta';
           const slugTitle = entry.title || entry.slug || '';
           const type = typeof entry.type === 'string' ? entry.type.toLowerCase() : '';
+          const extension = typeof entry.extension === 'string' ? entry.extension.toLowerCase() : '';
           const typeLabel = type === 'seo'
             ? (translations.landingSeo || fallbackTranslations.landingSeo)
             : (translations.landingMarkup || fallbackTranslations.landingMarkup);
@@ -935,6 +937,19 @@ ready(() => {
           button.dataset.extension = entry.extension || '';
           button.textContent = translations.landingPrefill || fallbackTranslations.landingPrefill;
           actions.appendChild(button);
+          if (extension === 'pdf') {
+            const path = typeof entry.path === 'string' ? entry.path.trim() : '';
+            if (path) {
+              const urlPath = path.startsWith('/') ? path : `/${path}`;
+              const link = document.createElement('a');
+              link.href = withBase(urlPath);
+              link.target = '_blank';
+              link.rel = 'noopener';
+              link.className = 'uk-button uk-button-default uk-button-xsmall uk-margin-small-left';
+              link.textContent = translations.landingOpenPdf || fallbackTranslations.landingOpenPdf;
+              actions.appendChild(link);
+            }
+          }
           item.appendChild(actions);
           landingMissingList.appendChild(item);
         });

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -169,6 +169,7 @@ return [
     'column_media_modified' => 'Geändert',
     'heading_media_landing_missing' => 'Fehlende Landing-Assets',
     'button_media_landing_prefill' => 'Upload vorausfüllen',
+    'button_media_landing_open_pdf' => 'PDF öffnen',
     'label_media_landing_references' => 'Landingpages',
     'label_media_landing_preview' => 'Landing-Verweise',
     'tooltip_media_landing_markup' => 'In Landingpage-Inhalten verwendet',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -170,6 +170,7 @@ return [
     'column_media_modified' => 'Modified',
     'heading_media_landing_missing' => 'Missing landing assets',
     'button_media_landing_prefill' => 'Prefill upload',
+    'button_media_landing_open_pdf' => 'Open PDF',
     'label_media_landing_references' => 'Landing pages',
     'label_media_landing_preview' => 'Landing references',
     'tooltip_media_landing_markup' => 'Referenced in landing page content',

--- a/templates/admin/media.twig
+++ b/templates/admin/media.twig
@@ -49,6 +49,7 @@
   'landingMissingHeading': t('heading_media_landing_missing'),
   'landingMissingEmpty': t('text_media_landing_missing'),
   'landingPrefill': t('button_media_landing_prefill'),
+  'landingOpenPdf': t('button_media_landing_open_pdf'),
   'landingUsage': t('label_media_landing_references'),
   'landingPreview': t('label_media_landing_preview'),
   'landingMarkup': t('tooltip_media_landing_markup'),


### PR DESCRIPTION
## Summary
- add translations and template wiring for a new "Open PDF" action in the missing landing assets card
- render a PDF link button next to the upload prefill action when a missing asset expects a PDF file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d85cadfa80832ba5c9122b24e3d6eb