### PR TITLE
Update calServer PDF highlights to use Media Manager placeholders

### DIFF
--- a/migrations/20250927_update_calserver_visual_assets.sql
+++ b/migrations/20250927_update_calserver_visual_assets.sql
@@ -650,7 +650,10 @@ VALUES (
                     <li>Tickets + Chancen-/Risiken-Bewertung</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-ifm-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -689,7 +692,10 @@ VALUES (
                     <li>Auftragsbearbeitung als Taktgeber</li>
                     <li>DMS &amp; Reporting integriert</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-ksw-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -728,7 +734,10 @@ VALUES (
                     <li>Reports direkt aus den Prozessdaten</li>
                     <li>Versionierung &amp; Nachvollziehbarkeit (DMS)</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-systems-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -767,7 +776,10 @@ VALUES (
                     <li>DAkkS-konforme Prüfhistorie</li>
                     <li>Serienexports &amp; Auswertungen</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-teramess-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -806,7 +818,10 @@ VALUES (
                     <li>Revisionssicheres DMS für Zertifikate &amp; Historie</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-thermo-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -845,7 +860,10 @@ VALUES (
                     <li>SSO für schnellen, sicheren Zugang</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-zf-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -884,7 +902,10 @@ VALUES (
                     <li>Geplante &amp; ungeplante Wartung aus einem System</li>
                     <li>Dashboards für Verfügbarkeit &amp; Performance</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-berlin-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -923,7 +944,10 @@ VALUES (
                     <li>Audit-Trails &amp; versionierte Freigaben</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-vde-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -993,7 +993,10 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Tickets + Chancen-/Risiken-Bewertung</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-ifm-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -1032,7 +1035,10 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Auftragsbearbeitung als Taktgeber</li>
                     <li>DMS &amp; Reporting integriert</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-ksw-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -1071,7 +1077,10 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Reports direkt aus den Prozessdaten</li>
                     <li>Versionierung &amp; Nachvollziehbarkeit (DMS)</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-systems-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -1110,7 +1119,10 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>DAkkS-konforme Prüfhistorie</li>
                     <li>Serienexports &amp; Auswertungen</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-teramess-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -1149,7 +1161,10 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Revisionssicheres DMS für Zertifikate &amp; Historie</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-thermo-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -1188,7 +1203,10 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>SSO für schnellen, sicheren Zugang</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-zf-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -1227,7 +1245,10 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Geplante &amp; ungeplante Wartung aus einem System</li>
                     <li>Dashboards für Verfügbarkeit &amp; Performance</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-berlin-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>
@@ -1266,7 +1287,10 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Audit-Trails &amp; versionierte Freigaben</li>
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
-                                    <a class="uk-button uk-button-text uk-margin-top" href="#">
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/ipload/calserver-usecase-vde-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
                   </a>
                 </div>


### PR DESCRIPTION
## Summary
- point the calServer use case PDF CTA buttons to Media Manager placeholder URLs
- keep the placeholder file names descriptive for each use case across both seeded SQL definitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8609ec1f0832ba495c1d8260b0a88