### PR TITLE
Fix UTF-8 parsing for landing page media alt text

### DIFF
--- a/src/Service/LandingMediaReferenceService.php
+++ b/src/Service/LandingMediaReferenceService.php
@@ -306,7 +306,7 @@ class LandingMediaReferenceService
         $previous = libxml_use_internal_errors(true);
 
         $document = new DOMDocument();
-        $html = '<!DOCTYPE html><html><body>' . $content . '</body></html>';
+        $html = '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>' . $content . '</body></html>';
         if ($document->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD)) {
             foreach ($document->getElementsByTagName('img') as $image) {
                 $src = $image->getAttribute('src');


### PR DESCRIPTION
## Summary
- ensure DOMDocument parses landing page markup with UTF-8 encoding metadata
- prevent umlaut characters from being misdecoded when collecting image alt texts

## Testing
- composer test *(fails: vendor/bin/phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d860ddf70c832bb5ec09d8fe6b198d