### PR TITLE
Refine calServer video placeholder copy and layout

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -368,17 +368,25 @@ body.qr-landing.calserver-theme .calserver-hero-video__embed iframe {
 }
 
 body.qr-landing.calserver-theme .calserver-hero-video__preview {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 84px;
-    height: 84px;
-    border-radius: 50%;
+    display: grid;
+    gap: 6px;
+    justify-items: center;
+    padding: 18px 24px;
+    width: 100%;
+    border-radius: 16px;
     background: rgba(255, 255, 255, 0.08);
 }
 
-body.qr-landing.calserver-theme .calserver-hero-video__preview .uk-icon {
-    color: rgba(255, 255, 255, 0.9);
+body.qr-landing.calserver-theme .calserver-hero-video__preview-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    color: rgba(255, 255, 255, 0.94);
+}
+
+body.qr-landing.calserver-theme .calserver-hero-video__preview-subtitle {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.72);
 }
 
 body.qr-landing.calserver-theme .calserver-hero-video__hint,
@@ -496,11 +504,14 @@ body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-vide
 body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__preview,
 body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__preview {
     background: currentColor;
+    color: var(--qr-bg);
 }
 
-body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__preview .uk-icon,
-body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__preview .uk-icon {
-    color: var(--qr-bg);
+body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__preview-title,
+body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__preview-title,
+body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__preview-subtitle,
+body.qr-landing.calserver-theme[data-theme="high-contrast"] .calserver-hero-video__preview-subtitle {
+    color: inherit;
 }
 
 body.qr-landing.calserver-theme.high-contrast .calserver-hero-video__meta-text,

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -184,19 +184,20 @@
                      data-video-params="rel=0&playlist=ovHo2SF84u0&loop=1">
                   <div class="calserver-hero-video__placeholder" role="group" aria-label="YouTube Video">
                     <div class="calserver-hero-video__preview" aria-hidden="true">
-                      <span class="uk-icon" data-uk-icon="icon: play-circle; ratio: 2"></span>
+                      <span class="calserver-hero-video__preview-title">Video-Vorschau</span>
+                      <span class="calserver-hero-video__preview-subtitle">calServer Vorstellung auf YouTube</span>
                     </div>
                     <p class="calserver-hero-video__hint">
-                      Mit Klick auf „YouTube laden“ stimmst du zu, dass Inhalte von YouTube geladen werden.
-                      Dabei können personenbezogene Daten übertragen werden.
+                      Lade die Vorstellung direkt hier. Mit deinem Klick erlaubst du, dass YouTube-Inhalte nachgeladen
+                      werden. Dabei können personenbezogene Daten durch Google verarbeitet werden.
                     </p>
                     <button class="uk-button uk-button-primary calserver-hero-video__consent-button"
                             type="button"
                             data-calserver-video-consent>
-                      YouTube laden
+                      Video laden
                     </button>
                     <p class="calserver-hero-video__privacy-note">
-                      Du kannst deine Einwilligung jederzeit über deine Browser-Einstellungen widerrufen.
+                      Du kannst deine Einwilligung jederzeit in deinen Browser-Einstellungen widerrufen.
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove the play icon from the calServer hero video placeholder and replace it with a textual preview header
- rewrite the consent hint and CTA copy to sound friendlier while keeping the privacy notice clear
- update the placeholder styling, including high-contrast mode, for the new text-based layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8619cd818832b8a96a5f4782011f8