### PR TITLE
Fix calServer asset links and alt text

### DIFF
--- a/content/landing.html
+++ b/content/landing.html
@@ -385,7 +385,7 @@
         <div class="uk-card uk-card-quizrace uk-card-body">
           <picture>
             <source srcset="{{ basePath }}/uploads/landing/quizrace-shot.avif" type="image/avif">
-            <img src="{{ basePath }}/uploads/landing/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="QuizRace Editor">
+            <img src="{{ basePath }}/uploads/landing/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="Bildschirmfoto des QuizRace-Dashboards mit Live-Ranking und Aufgabenliste">
           </picture>
         </div>
       </div>

--- a/migrations/20250304_import_page_files.sql
+++ b/migrations/20250304_import_page_files.sql
@@ -385,7 +385,7 @@ INSERT INTO pages (slug, title, content) VALUES ('landing', 'Landing', '<!-- Soc
         <div class="uk-card uk-card-quizrace uk-card-body">
           <picture>
             <source srcset="{{ basePath }}/uploads/landing/quizrace-shot.avif" type="image/avif">
-            <img src="{{ basePath }}/uploads/landing/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="QuizRace Editor">
+            <img src="{{ basePath }}/uploads/landing/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="Bildschirmfoto des QuizRace-Dashboards mit Live-Ranking und Aufgabenliste">
           </picture>
         </div>
       </div>

--- a/migrations/20250927_update_calserver_visual_assets.sql
+++ b/migrations/20250927_update_calserver_visual_assets.sql
@@ -651,7 +651,7 @@ VALUES (
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-ifm-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-ifm-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -693,7 +693,7 @@ VALUES (
                     <li>DMS &amp; Reporting integriert</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-ksw-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-ksw-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -735,7 +735,7 @@ VALUES (
                     <li>Versionierung &amp; Nachvollziehbarkeit (DMS)</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-systems-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-systems-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -777,7 +777,7 @@ VALUES (
                     <li>Serienexports &amp; Auswertungen</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-teramess-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-teramess-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -819,7 +819,7 @@ VALUES (
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-thermo-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-thermo-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -861,7 +861,7 @@ VALUES (
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-zf-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-zf-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -903,7 +903,7 @@ VALUES (
                     <li>Dashboards für Verfügbarkeit &amp; Performance</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-berlin-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-berlin-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -945,7 +945,7 @@ VALUES (
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-vde-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-vde-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -994,7 +994,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-ifm-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-ifm-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -1036,7 +1036,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>DMS &amp; Reporting integriert</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-ksw-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-ksw-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -1078,7 +1078,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Versionierung &amp; Nachvollziehbarkeit (DMS)</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-systems-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-systems-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -1120,7 +1120,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Serienexports &amp; Auswertungen</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-teramess-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-teramess-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -1162,7 +1162,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-thermo-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-thermo-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -1204,7 +1204,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-zf-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-zf-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -1246,7 +1246,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Dashboards für Verfügbarkeit &amp; Performance</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-berlin-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-berlin-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
@@ -1288,7 +1288,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
                   </ul>
                   <a class="uk-button uk-button-text uk-margin-top"
-                    href="{{ basePath }}/ipload/calserver-usecase-vde-highlights.pdf"
+                    href="{{ basePath }}/uploads/calserver-usecase-vde-highlights.pdf"
                     target="_blank"
                     rel="noopener">
                     <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -134,7 +134,7 @@
             <div class="qr-mockup uk-card qr-card">
               <picture>
                 <source srcset="{{ basePath }}/uploads/landing/quizrace-shot.avif" type="image/avif">
-                <img src="{{ basePath }}/uploads/landing/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="QuizRace Screenshot">
+                <img src="{{ basePath }}/uploads/landing/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="Bildschirmfoto des QuizRace-Dashboards mit Live-Ranking und Aufgabenliste">
               </picture>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- point calServer use case PDF downloads to the uploads directory in migrations and schema
- describe the landing page mockup image with a clearer alt text across templates and seeded content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d872e48538832b89c8006458de3798