### PR TITLE
Add configurable SEO metadata for marketing pages

### DIFF
--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -3,18 +3,59 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-  <title>{% block title %}QuizRace – Das interaktive Team-Quiz für Events{% endblock %}</title>
-  <meta name="description" content="QuizRace macht Ihr Event einzigartig: QR-Code-Stationen, Live-Ranking & Rätselspaß – datensicher, flexibel, ohne App-Download.">
-  <meta name="robots" content="index, follow">
-  <link rel="canonical" href="{{ canonicalUrl }}">
-  <meta property="og:title" content="QuizRace – Das interaktive Team-Quiz für Events">
-  <meta property="og:description" content="Gestalten Sie in Minuten ein Event-Quiz mit QR-Code-Stationen, Live-Ranking & Rätselwort. DSGVO-konform, ohne App-Download.">
-  <meta property="og:image" content="{{ baseUrl ~ (config.ogImagePath ?? '/uploads/seo/social-preview.jpg') }}">
-    <meta property="og:url" content="{{ canonicalUrl }}">
+  {% set defaultTitle = 'QuizRace – Das interaktive Team-Quiz für Events' %}
+  {% set effectiveTitle = metaTitle|default(defaultTitle) %}
+  <title>{% block title %}{{ effectiveTitle }}{% endblock %}</title>
+  {% set defaultDescription = 'QuizRace macht Ihr Event einzigartig: QR-Code-Stationen, Live-Ranking & Rätselspaß – datensicher, flexibel, ohne App-Download.' %}
+  {% set effectiveDescription = metaDescription|default(defaultDescription) %}
+  <meta name="description" content="{{ effectiveDescription }}">
+  {% set effectiveRobots = robotsMeta|default('index, follow') %}
+  <meta name="robots" content="{{ effectiveRobots }}">
+  {% set effectiveCanonical = canonicalUrl|default('') %}
+  {% if effectiveCanonical %}
+  <link rel="canonical" href="{{ effectiveCanonical }}">
+  {% endif %}
+  {% set effectiveOgTitle = ogTitle|default(effectiveTitle) %}
+  <meta property="og:title" content="{{ effectiveOgTitle }}">
+  {% set effectiveOgDescription = ogDescription|default(effectiveDescription) %}
+  <meta property="og:description" content="{{ effectiveOgDescription }}">
+  {% set defaultOgImage = baseUrl ~ (config.ogImagePath ?? '/uploads/seo/social-preview.jpg') %}
+  {% if ogImage is defined and ogImage %}
+    {% if ogImage matches '/^https?:\\/\\//i' %}
+      {% set effectiveOgImage = ogImage %}
+    {% else %}
+      {% set effectiveOgImage = baseUrl ~ ogImage %}
+    {% endif %}
+  {% else %}
+    {% set effectiveOgImage = defaultOgImage %}
+  {% endif %}
+  <meta property="og:image" content="{{ effectiveOgImage }}">
+    {% if effectiveCanonical %}
+    <meta property="og:url" content="{{ effectiveCanonical }}">
+    {% endif %}
     <meta property="og:type" content="website">
     <meta property="og:locale" content="de_DE">
     <meta name="twitter:card" content="summary_large_image">
+  {% if hreflangLinks is defined and hreflangLinks is not empty %}
+    {% for link in hreflangLinks %}
+      <link rel="alternate" href="{{ link.href }}" hreflang="{{ link.hreflang }}">
+    {% endfor %}
+  {% elseif hreflang is defined and hreflang and effectiveCanonical %}
+    {% set hreflangCodes = hreflang|split(',') %}
+    {% for code in hreflangCodes %}
+      {% set trimmedCode = code|trim %}
+      {% if trimmedCode %}
+      <link rel="alternate" href="{{ effectiveCanonical }}" hreflang="{{ trimmedCode }}">
+      {% endif %}
+    {% endfor %}
+  {% else %}
   <link rel="alternate" href="https://quizrace.app/" hreflang="de">
+  {% endif %}
+  {% if schemaJson is defined and schemaJson %}
+  <script type="application/ld+json">
+  {{ schemaJson|raw }}
+  </script>
+  {% else %}
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -37,6 +78,7 @@
     ]
   }
   </script>
+  {% endif %}
   {% set rawFavicon = pageFavicon is defined and pageFavicon ? pageFavicon : '/favicon.svg' %}
   {% set faviconSource = rawFavicon starts with 'http' ? rawFavicon : basePath ~ rawFavicon %}
   {% set faviconExt = (rawFavicon|split('?')|first|split('#')|first|split('.')|last|lower) %}

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -9,7 +9,7 @@
     { 'href': '#faq', 'label': 'FAQ', 'icon': 'question' }
 ] %}
 
-{% block title %}calServer – Kalibrier- und Inventarverwaltung für Teams{% endblock %}
+{% block title %}{{ metaTitle|default('calServer – Kalibrier- und Inventarverwaltung für Teams') }}{% endblock %}
 
 {% block head %}
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap"

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -8,7 +8,7 @@
   { 'href': '#contact-us', 'label': 'Kontakt', 'icon': 'mail' }
 ] %}
 
-{% block title %}QuizRace – Das interaktive Team-Quiz für Events{% endblock %}
+{% block title %}{{ metaTitle|default('QuizRace – Das interaktive Team-Quiz für Events') }}{% endblock %}
 
 {% block head %}
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- pass the marketing page SEO configuration fields through the controller to Twig, including normalized hreflang data
- make the base layout consume optional SEO values for title, meta tags, Open Graph data, canonical links, hreflang, and JSON-LD
- let the marketing landing templates respect configurable meta titles instead of hard-coded strings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d99c58ed3c832b884dc6cec5d760d4