### PR TITLE
Fix Calserver footer text contrast

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -225,6 +225,9 @@ body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast) .uk-card
 
 body.qr-landing.calserver-theme:not(.high-contrast) .site-footer,
 body.qr-landing.calserver-theme:not(.high-contrast) .site-footer a,
+body.qr-landing.calserver-theme:not(.high-contrast) .footer-section,
+body.qr-landing.calserver-theme:not(.high-contrast) .footer-section p,
+body.qr-landing.calserver-theme:not(.high-contrast) .footer-section li,
 body.qr-landing.calserver-theme:not(.high-contrast) .footer-section strong {
     color: #ffffff;
 }


### PR DESCRIPTION
## Summary
- ensure all footer text elements on the calServer landing page inherit the white color used on the dark background

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d99d594008832b85415de3c94876b1