### PR TITLE
Add marketing contact endpoint for calserver

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -454,6 +454,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     $app->post('/landing/contact', ContactController::class)
         ->add(new RateLimitMiddleware(3, 3600))
         ->add(new CsrfMiddleware());
+    $app->post('/calserver/contact', ContactController::class)
+        ->add(new RateLimitMiddleware(3, 3600))
+        ->add(new CsrfMiddleware());
     $app->get('/onboarding', OnboardingController::class);
     $app->post('/onboarding/email', function (Request $request, Response $response) {
         return $request->getAttribute('onboardingEmailController')->request($request, $response);


### PR DESCRIPTION
## Summary
- expose a POST /calserver/contact endpoint that mirrors the landing contact form protections
- share the existing contact form test across both marketing contact endpoints
- ensure contact tests accommodate the extended MailService signature

## Testing
- ./vendor/bin/phpunit tests/Controller/ContactControllerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d99e12422c832b85cc4dc150f5f687