### PR TITLE
Accept 2xx responses when finalizing onboarding

### DIFF
--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -563,7 +563,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             tText = await tRes.text();
           }
         } catch (_) {}
-        if (!tRes.ok || !tData || tData.queued !== true) {
+        if (!tRes.ok || (tData && tData.error)) {
           mark('create', false);
           let msg = '';
           if (!tRes.ok) {
@@ -581,7 +581,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 msg = (tData && tData.error) || tText || 'Mandant anlegen fehlgeschlagen';
             }
           } else {
-            msg = (tData && tData.error) || 'Mandant anlegen fehlgeschlagen';
+            msg = tData && tData.error ? tData.error : 'Mandant anlegen fehlgeschlagen';
           }
           throw new Error(msg);
         }

--- a/tests/test_onboarding_flow.js
+++ b/tests/test_onboarding_flow.js
@@ -45,7 +45,7 @@ function createCtx(map) {
 async function successScenario() {
   const ctx = createCtx({
     '/onboarding/checkout/sess': () => Promise.resolve({ ok: true, json: () => Promise.resolve({ paid: true, plan: 'basic' }) }),
-    '/tenants': () => Promise.resolve({ ok: true, status: 201, headers: { get: () => 'application/json' }, json: () => Promise.resolve({ queued: true }) }),
+    '/tenants': () => Promise.resolve({ ok: true, status: 201, headers: { get: () => 'application/json' }, json: () => Promise.resolve({ created: true }) }),
     '/api/tenants/tenant/onboard': () => Promise.resolve({ ok: true, headers: { get: () => 'application/json' }, json: () => Promise.resolve({}), text: () => Promise.resolve('') }),
     'https://tenant.example.com/healthz': () => Promise.resolve({ ok: true, headers: { get: () => 'application/json' }, json: () => Promise.resolve({ status: 'ok' }) }),
     '/tenant-welcome': () => Promise.resolve({ ok: true }),
@@ -59,7 +59,7 @@ async function successScenario() {
 async function failureScenario() {
   const ctx = createCtx({
     '/onboarding/checkout/sess': () => Promise.resolve({ ok: true, json: () => Promise.resolve({ paid: true, plan: 'basic' }) }),
-    '/tenants': () => Promise.resolve({ ok: true, status: 201, headers: { get: () => 'application/json' }, json: () => Promise.resolve({ queued: true }) }),
+    '/tenants': () => Promise.resolve({ ok: true, status: 201, headers: { get: () => 'application/json' }, json: () => Promise.resolve({ created: true }) }),
     '/api/tenants/tenant/onboard': () => Promise.resolve({ ok: false, status: 500, headers: { get: () => 'text/plain' }, text: () => Promise.resolve('fail') })
   });
   const fn = vm.runInNewContext('(' + finalizeCode + ')', ctx);


### PR DESCRIPTION
## Summary
- treat any successful 2xx response from the tenant creation endpoint as a completed onboarding step
- update onboarding flow tests to reflect the relaxed success criteria

## Testing
- node tests/test_onboarding_flow.js
- node tests/test_onboarding_plan.js

------
https://chatgpt.com/codex/tasks/task_e_68d9b70d3d0c832ba6381c8cd5c3d17a