### PR TITLE
Enhance contact form rate limiting

### DIFF
--- a/src/Application/Middleware/RateLimitMiddleware.php
+++ b/src/Application/Middleware/RateLimitMiddleware.php
@@ -10,13 +10,16 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Slim\Psr7\Response as SlimResponse;
 
-/**
- * Simple session-based rate limiter.
- */
 class RateLimitMiddleware implements MiddlewareInterface
 {
+    private const APCU_PREFIX = 'rlm:';
+    private const FILE_PREFIX = 'rlm_';
+
     private int $maxRequests;
     private int $windowSeconds;
+    private static ?string $storageDir = null;
+    /** @var array<string, true> */
+    private static array $apcuKeys = [];
 
     public function __construct(int $maxRequests = 5, int $windowSeconds = 60)
     {
@@ -29,6 +32,10 @@ class RateLimitMiddleware implements MiddlewareInterface
      */
     public function process(Request $request, RequestHandler $handler): Response
     {
+        if (!isset($_SESSION) || !is_array($_SESSION)) {
+            $_SESSION = [];
+        }
+
         $key = 'rate:' . $request->getUri()->getPath();
         $entry = $_SESSION[$key] ?? ['count' => 0, 'start' => time()];
 
@@ -40,9 +47,166 @@ class RateLimitMiddleware implements MiddlewareInterface
         $_SESSION[$key] = $entry;
 
         if ($entry['count'] > $this->maxRequests) {
-            return (new SlimResponse())->withStatus(429);
+            return $this->tooManyRequestsResponse();
+        }
+
+        $persistentCount = $this->incrementPersistentCounter($request);
+        if ($persistentCount > $this->maxRequests) {
+            return $this->tooManyRequestsResponse();
         }
 
         return $handler->handle($request);
+    }
+
+    /**
+     * Clear all persistent counters. Intended for use in tests.
+     */
+    public static function resetPersistentStorage(): void
+    {
+        if (self::apcuAvailable()) {
+            if (class_exists('\\APCUIterator')) {
+                /** @var iterable<array{key:string}> $iterator */
+                $iterator = new \APCUIterator('/^' . preg_quote(self::APCU_PREFIX, '/') . '/');
+                foreach ($iterator as $item) {
+                    apcu_delete($item['key']);
+                }
+            } else {
+                foreach (array_keys(self::$apcuKeys) as $key) {
+                    apcu_delete($key);
+                }
+            }
+            self::$apcuKeys = [];
+        }
+
+        $dir = self::$storageDir ?? (sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rate_limit');
+        if (is_dir($dir)) {
+            $files = glob($dir . DIRECTORY_SEPARATOR . self::FILE_PREFIX . '*.json');
+            if (is_array($files)) {
+                foreach ($files as $file) {
+                    if (is_file($file)) {
+                        @unlink($file);
+                    }
+                }
+            }
+        }
+    }
+
+    private function tooManyRequestsResponse(): Response
+    {
+        $response = new SlimResponse(429);
+
+        return $response->withHeader('Retry-After', (string) $this->windowSeconds);
+    }
+
+    private function incrementPersistentCounter(Request $request): int
+    {
+        $now = time();
+        $hash = $this->fingerprintRequest($request);
+
+        if (self::apcuAvailable()) {
+            $key = self::APCU_PREFIX . $hash;
+            $entry = apcu_fetch($key, $success);
+            if (!$success || !is_array($entry) || $this->isExpiredEntry($entry, $now)) {
+                $entry = ['count' => 0, 'start' => $now];
+            }
+
+            $entry['count'] = (int) ($entry['count'] ?? 0) + 1;
+            $entry['start'] = (int) ($entry['start'] ?? $now);
+            apcu_store($key, $entry, $this->windowSeconds);
+            self::$apcuKeys[$key] = true;
+
+            return (int) $entry['count'];
+        }
+
+        $path = $this->getFilePath($hash);
+        $entry = $this->readFileEntry($path, $now);
+        $entry['count'] = (int) ($entry['count'] ?? 0) + 1;
+        $entry['start'] = (int) ($entry['start'] ?? $now);
+        $this->writeFileEntry($path, $entry);
+
+        return (int) $entry['count'];
+    }
+
+    /**
+     * @param array<string, int> $entry
+     */
+    private function isExpiredEntry(array $entry, int $now): bool
+    {
+        if (!isset($entry['start'])) {
+            return true;
+        }
+
+        return ($now - (int) $entry['start']) > $this->windowSeconds;
+    }
+
+    private function fingerprintRequest(Request $request): string
+    {
+        $serverParams = $request->getServerParams();
+        $ip = (string) ($serverParams['REMOTE_ADDR'] ?? 'unknown');
+        $ua = $request->getHeaderLine('User-Agent');
+        if ($ua === '') {
+            $ua = (string) ($serverParams['HTTP_USER_AGENT'] ?? '');
+        }
+        $ua = trim($ua);
+        if ($ua === '') {
+            $ua = 'no-ua';
+        }
+
+        $path = strtolower($request->getUri()->getPath());
+
+        return hash('sha256', $path . '|' . $ip . '|' . $ua);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function readFileEntry(string $path, int $now): array
+    {
+        if (is_file($path)) {
+            $contents = file_get_contents($path);
+            if ($contents !== false) {
+                $data = json_decode($contents, true);
+                if (is_array($data) && !$this->isExpiredEntry($data, $now)) {
+                    return [
+                        'count' => (int) ($data['count'] ?? 0),
+                        'start' => (int) ($data['start'] ?? $now),
+                    ];
+                }
+            }
+        }
+
+        return ['count' => 0, 'start' => $now];
+    }
+
+    /**
+     * @param array<string, int> $entry
+     */
+    private function writeFileEntry(string $path, array $entry): void
+    {
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0777, true);
+        }
+
+        file_put_contents($path, json_encode($entry), LOCK_EX);
+    }
+
+    private function getFilePath(string $hash): string
+    {
+        $dir = self::$storageDir;
+        if ($dir === null) {
+            $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rate_limit';
+            self::$storageDir = $dir;
+        }
+
+        return rtrim($dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . self::FILE_PREFIX . $hash . '.json';
+    }
+
+    private static function apcuAvailable(): bool
+    {
+        return function_exists('apcu_fetch')
+            && function_exists('apcu_store')
+            && function_exists('apcu_delete')
+            && (!function_exists('apcu_enabled') || apcu_enabled());
     }
 }

--- a/tests/Application/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/Application/Middleware/RateLimitMiddlewareTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Middleware;
+
+use App\Application\Middleware\RateLimitMiddleware;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+class RateLimitMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RateLimitMiddleware::resetPersistentStorage();
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        RateLimitMiddleware::resetPersistentStorage();
+        $_SESSION = [];
+        parent::tearDown();
+    }
+
+    public function testPersistentLimitBlocksAcrossSessions(): void
+    {
+        $middleware = new RateLimitMiddleware(2, 3600);
+        $factory = new ServerRequestFactory();
+        $request = $factory->createServerRequest(
+            'POST',
+            'https://example.com/landing/contact',
+            [
+                'REMOTE_ADDR' => '203.0.113.5',
+                'HTTP_USER_AGENT' => 'phpunit-bot',
+            ]
+        );
+
+        $handler = new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $factory = new ResponseFactory();
+
+                return $factory->createResponse(204);
+            }
+        };
+
+        for ($i = 0; $i < 2; $i++) {
+            $_SESSION = [];
+            $response = $middleware->process($request, $handler);
+            $this->assertSame(204, $response->getStatusCode());
+        }
+
+        $_SESSION = [];
+        $response = $middleware->process($request, $handler);
+        $this->assertSame(429, $response->getStatusCode());
+        $this->assertSame('3600', $response->getHeaderLine('Retry-After'));
+    }
+}

--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Controller;
 
+use App\Application\Middleware\RateLimitMiddleware;
 use App\Service\DomainStartPageService;
 use App\Service\MailService;
 use Tests\TestCase;
@@ -15,6 +16,7 @@ class ContactControllerTest extends TestCase
      */
     public function testContactFormSendsMail(string $route): void
     {
+        RateLimitMiddleware::resetPersistentStorage();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
         }
@@ -138,6 +140,7 @@ class ContactControllerTest extends TestCase
 
     public function testContactFormUsesDomainSpecificEmail(): void
     {
+        RateLimitMiddleware::resetPersistentStorage();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
         }

--- a/tests/SessionDependentMiddlewareTest.php
+++ b/tests/SessionDependentMiddlewareTest.php
@@ -64,6 +64,7 @@ class SessionDependentMiddlewareTest extends TestCase
 
     public function testRateLimitMiddlewareUsesSession(): void
     {
+        RateLimitMiddleware::resetPersistentStorage();
         $app = AppFactory::create();
         $app->add(new SessionMiddleware());
         $app->get('/limited', fn (Request $request, Response $response): Response => $response)


### PR DESCRIPTION
## Summary
- extend the rate limiter to track attempts per IP/User-Agent in APCu or a filesystem fallback and expose a reset helper
- add unit coverage for the persistent limiter and ensure existing contact/controller tests reset limiter state between runs
- keep the marketing contact tests green with the tougher limiter configuration

## Testing
- `./vendor/bin/phpunit tests/Application/Middleware/RateLimitMiddlewareTest.php tests/Controller/ContactControllerTest.php tests/SessionDependentMiddlewareTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68d99cbdfbdc832bb95d3ec87f738c53