### PR TITLE
Adjust calServer module screenshot styling

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1635,15 +1635,30 @@ body.qr-landing.calserver-theme .calserver-modules-switcher > li {
 }
 
 body.qr-landing.calserver-theme .calserver-module-figure {
+    position: relative;
     margin: 0;
-    background: var(--qr-card);
-    border: 1px solid var(--qr-card-border);
     border-radius: 22px;
-    overflow: hidden;
-    box-shadow: 0 22px 48px -28px rgba(15, 23, 42, 0.35);
     display: flex;
     flex-direction: column;
     height: 100%;
+}
+
+body.qr-landing.calserver-theme .calserver-module-figure::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--qr-card);
+    border: 1px solid var(--qr-card-border);
+    box-shadow: 0 22px 48px -28px rgba(15, 23, 42, 0.35);
+    pointer-events: none;
+    z-index: 0;
+}
+
+body.qr-landing.calserver-theme .calserver-module-figure img,
+body.qr-landing.calserver-theme .calserver-module-figure figcaption {
+    position: relative;
+    z-index: 1;
 }
 
 body.qr-landing.calserver-theme .calserver-module-figure img {
@@ -1651,6 +1666,8 @@ body.qr-landing.calserver-theme .calserver-module-figure img {
     width: 100%;
     height: auto;
     object-fit: cover;
+    border-radius: 0;
+    box-shadow: 0 18px 32px -24px rgba(15, 23, 42, 0.45);
 }
 
 body.qr-landing.calserver-theme .calserver-module-figure figcaption {
@@ -1658,6 +1675,9 @@ body.qr-landing.calserver-theme .calserver-module-figure figcaption {
     display: flex;
     flex-direction: column;
     gap: 14px;
+    background: var(--qr-card);
+    border-top: 1px solid color-mix(in oklab, var(--calserver-primary) 28%, rgba(15, 23, 42, 0.32));
+    box-shadow: 0 -18px 32px -28px rgba(15, 23, 42, 0.55) inset;
 }
 
 body.qr-landing.calserver-theme .calserver-module-figure h3 {


### PR DESCRIPTION
## Summary
- rework the calServer module card styling so screenshots keep square corners while the card retains its rounded background and shadow
- add a subtle drop shadow and border to separate the screenshots from the descriptive copy beneath them

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9ba2bbd3c832bb70debed6bf9377c