### PR TITLE
Render inline SVG flags in language selector

### DIFF
--- a/public/css/topbar.landing.css
+++ b/public/css/topbar.landing.css
@@ -36,3 +36,39 @@ body.qr-landing[data-theme="dark"].high-contrast{
   --topbar-btn-bg-hover: rgba(255,255,255,0.16);
   --topbar-focus-ring: rgba(140,200,255,0.8);
 }
+
+.lang-option{
+  display:flex;
+  align-items:center;
+  justify-content:flex-start;
+  gap:10px;
+  width:100%;
+  min-width:160px;
+  min-height:48px;
+  padding:0 12px;
+  height:auto;
+}
+.lang-option__icon{
+  flex-shrink:0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:24px;
+  height:16px;
+  border-radius:2px;
+  overflow:hidden;
+  box-shadow:0 0 0 1px color-mix(in oklab, var(--topbar-text) 25%, transparent);
+}
+.lang-option__svg{
+  display:block;
+  width:100%;
+  height:100%;
+}
+.lang-option__label{
+  flex:1;
+  text-align:left;
+}
+body.qr-landing.high-contrast .lang-option__icon,
+body.qr-landing[data-theme="dark"].high-contrast .lang-option__icon{
+  box-shadow:0 0 0 1px currentColor;
+}

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -102,12 +102,36 @@
                         <li>
                           <button class="uk-button uk-button-default git-btn lang-option"
                                   data-lang="de"
-                                  role="menuitem">{{ t('german') }}</button>
+                                  role="menuitem">
+                            <span class="lang-option__icon" aria-hidden="true">
+                              <svg class="lang-option__svg" viewBox="0 0 24 16" role="img" focusable="false">
+                                <rect width="24" height="16" fill="#ffce00" />
+                                <rect width="24" height="10.6667" fill="#dd0000" />
+                                <rect width="24" height="5.3333" fill="#000000" />
+                              </svg>
+                            </span>
+                            <span class="lang-option__label">{{ t('german') }}</span>
+                          </button>
                         </li>
                         <li>
                           <button class="uk-button uk-button-default git-btn lang-option"
                                   data-lang="en"
-                                  role="menuitem">{{ t('english') }}</button>
+                                  role="menuitem">
+                            <span class="lang-option__icon" aria-hidden="true">
+                              <svg class="lang-option__svg" viewBox="0 0 24 16" role="img" focusable="false">
+                                <rect width="24" height="16" fill="#012169" />
+                                <path fill="#ffffff" d="M0 0h3.2L24 13.6V16h-3.2L0 2.4z" />
+                                <path fill="#ffffff" d="M24 0h-3.2L0 13.6V16h3.2L24 2.4z" />
+                                <path fill="#c8102e" d="M0 0h1.6L24 12.8V16h-1.6L0 3.2z" />
+                                <path fill="#c8102e" d="M24 0h-1.6L0 12.8V16h1.6L24 3.2z" />
+                                <rect x="10" width="4" height="16" fill="#ffffff" />
+                                <rect y="6" width="24" height="4" fill="#ffffff" />
+                                <rect x="10.8" width="2.4" height="16" fill="#c8102e" />
+                                <rect y="6.8" width="24" height="2.4" fill="#c8102e" />
+                              </svg>
+                            </span>
+                            <span class="lang-option__label">{{ t('english') }}</span>
+                          </button>
                         </li>
                       </ul>
                     </div>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -76,10 +76,34 @@
                     <div id="languageDrop" class="uk-dropdown" hidden uk-dropdown="mode: click; pos: left-top; offset: 0">
                       <ul class="uk-nav uk-dropdown-nav" role="menu">
                         <li>
-                          <button class="uk-button uk-button-default git-btn lang-option" data-lang="de" role="menuitem">{{ t('german') }}</button>
+                          <button class="uk-button uk-button-default git-btn lang-option" data-lang="de" role="menuitem">
+                            <span class="lang-option__icon" aria-hidden="true">
+                              <svg class="lang-option__svg" viewBox="0 0 24 16" role="img" focusable="false">
+                                <rect width="24" height="16" fill="#ffce00" />
+                                <rect width="24" height="10.6667" fill="#dd0000" />
+                                <rect width="24" height="5.3333" fill="#000000" />
+                              </svg>
+                            </span>
+                            <span class="lang-option__label">{{ t('german') }}</span>
+                          </button>
                         </li>
                         <li>
-                          <button class="uk-button uk-button-default git-btn lang-option" data-lang="en" role="menuitem">{{ t('english') }}</button>
+                          <button class="uk-button uk-button-default git-btn lang-option" data-lang="en" role="menuitem">
+                            <span class="lang-option__icon" aria-hidden="true">
+                              <svg class="lang-option__svg" viewBox="0 0 24 16" role="img" focusable="false">
+                                <rect width="24" height="16" fill="#012169" />
+                                <path fill="#ffffff" d="M0 0h3.2L24 13.6V16h-3.2L0 2.4z" />
+                                <path fill="#ffffff" d="M24 0h-3.2L0 13.6V16h3.2L24 2.4z" />
+                                <path fill="#c8102e" d="M0 0h1.6L24 12.8V16h-1.6L0 3.2z" />
+                                <path fill="#c8102e" d="M24 0h-1.6L0 12.8V16h1.6L24 3.2z" />
+                                <rect x="10" width="4" height="16" fill="#ffffff" />
+                                <rect y="6" width="24" height="4" fill="#ffffff" />
+                                <rect x="10.8" width="2.4" height="16" fill="#c8102e" />
+                                <rect y="6.8" width="24" height="2.4" fill="#c8102e" />
+                              </svg>
+                            </span>
+                            <span class="lang-option__label">{{ t('english') }}</span>
+                          </button>
                         </li>
                       </ul>
                     </div>


### PR DESCRIPTION
## Summary
- render the German and English language flags inline within the marketing dropdown templates
- adjust the top bar language option styles for the embedded SVG markup and drop the separate asset files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9baa239a4832b8206140ee95017d4