### PR TITLE
Add rate limit stores and integrate Turnstile captcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,15 @@ Beispiele für DSNs:
 - Brevo API: `brevo+api://DEIN_API_KEY@default`
 - Mailchimp (Mandrill) API: `mailchimp+https://DEIN_MANDRILL_KEY@default`
 
+### Cloudflare Turnstile
+
+Die Marketing-Kontaktformulare lassen sich zusätzlich mit einem Cloudflare-Turnstile-Captcha schützen. Dafür müssen in der `.env` beide Schlüssel hinterlegt werden:
+
+- `TURNSTILE_SITE_KEY` – öffentlicher Schlüssel für das Frontend-Widget
+- `TURNSTILE_SECRET_KEY` – geheimer Schlüssel für die Server-Validierung
+
+Sind beide Werte gesetzt, blendet die Landingpage automatisch das Turnstile-Widget ein und der `ContactController` validiert eingehende Token serverseitig. Ohne Konfiguration bleibt das Formular wie bisher frei zugänglich.
+
 ### Passwort zurücksetzen
 Die API unterstützt ein zweistufiges Verfahren zum Zurücksetzen vergessener Passwörter:
 

--- a/content/landing.html
+++ b/content/landing.html
@@ -537,6 +537,10 @@
             <label class="uk-form-label" for="form-msg">Nachricht</label>
             <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
           </div>
+          <div class="uk-margin turnstile-field" data-turnstile-container>
+            <div class="turnstile-widget">{{ turnstile_widget }}</div>
+            <p class="uk-text-small turnstile-hint" data-turnstile-hint hidden>Bitte bestätigen Sie, dass Sie kein Roboter sind.</p>
+          </div>
           <div class="uk-margin">
             <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
           </div>

--- a/migrations/20250304_import_page_files.sql
+++ b/migrations/20250304_import_page_files.sql
@@ -537,6 +537,10 @@ INSERT INTO pages (slug, title, content) VALUES ('landing', 'Landing', '<!-- Soc
             <label class="uk-form-label" for="form-msg">Nachricht</label>
             <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
           </div>
+          <div class="uk-margin turnstile-field" data-turnstile-container>
+            <div class="turnstile-widget">{{ turnstile_widget }}</div>
+            <p class="uk-text-small turnstile-hint" data-turnstile-hint hidden>Bitte bestätigen Sie, dass Sie kein Roboter sind.</p>
+          </div>
           <div class="uk-margin">
             <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
           </div>

--- a/migrations/20250926_update_calserver_page.sql
+++ b/migrations/20250926_update_calserver_page.sql
@@ -1169,13 +1169,17 @@ VALUES (
                   <label class="uk-form-label" for="form-email">E-Mail</label>
                   <input class="uk-input" id="form-email" name="email" type="email" required>
                 </div>
-                <div class="uk-margin">
-                  <label class="uk-form-label" for="form-msg">Nachricht</label>
-                  <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
-                </div>
-                <div class="uk-margin">
-                  <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
-                </div>
+                  <div class="uk-margin">
+                    <label class="uk-form-label" for="form-msg">Nachricht</label>
+                    <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
+                  </div>
+                  <div class="uk-margin turnstile-field" data-turnstile-container>
+                    <div class="turnstile-widget">{{ turnstile_widget }}</div>
+                    <p class="uk-text-small turnstile-hint" data-turnstile-hint hidden>Bitte bestätigen Sie, dass Sie kein Roboter sind.</p>
+                  </div>
+                  <div class="uk-margin">
+                    <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
+                  </div>
                 <input type="text" name="company" autocomplete="off" tabindex="-1" class="uk-hidden" aria-hidden="true">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button class="btn btn-black uk-button uk-button-secondary uk-button-large uk-width-1-1" type="submit">Senden</button>

--- a/migrations/20250927_update_calserver_visual_assets.sql
+++ b/migrations/20250927_update_calserver_visual_assets.sql
@@ -1193,13 +1193,17 @@ VALUES (
                   <label class="uk-form-label" for="form-email">E-Mail</label>
                   <input class="uk-input" id="form-email" name="email" type="email" required>
                 </div>
-                <div class="uk-margin">
-                  <label class="uk-form-label" for="form-msg">Nachricht</label>
-                  <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
-                </div>
-                <div class="uk-margin">
-                  <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
-                </div>
+                  <div class="uk-margin">
+                    <label class="uk-form-label" for="form-msg">Nachricht</label>
+                    <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
+                  </div>
+                  <div class="uk-margin turnstile-field" data-turnstile-container>
+                    <div class="turnstile-widget">{{ turnstile_widget }}</div>
+                    <p class="uk-text-small turnstile-hint" data-turnstile-hint hidden>Bitte bestätigen Sie, dass Sie kein Roboter sind.</p>
+                  </div>
+                  <div class="uk-margin">
+                    <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
+                  </div>
                 <input type="text" name="company" autocomplete="off" tabindex="-1" class="uk-hidden" aria-hidden="true">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button class="btn btn-black uk-button uk-button-secondary uk-button-large uk-width-1-1" type="submit">Senden</button>

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -715,6 +715,22 @@ body.qr-landing:not([data-theme="dark"]) .contact-card span{
   box-shadow:0 0 0 3px var(--qr-ring);
   border-color: color-mix(in oklab, var(--qr-brand-600) 50%, transparent);
 }
+.qr-landing #contact-form .turnstile-field{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.qr-landing #contact-form .turnstile-hint{
+  margin:0;
+  color:var(--qr-muted);
+}
+body.qr-landing:not([data-theme="dark"]) #contact-form .turnstile-hint{
+  color:#333;
+}
+.qr-landing #contact-form.is-turnstile-disabled button[type="submit"]{
+  opacity:0.65;
+  cursor:not-allowed;
+}
 body.qr-landing:not(.high-contrast) #contact-form .uk-checkbox{
   appearance:none;
   width:20px; height:20px;

--- a/public/index.php
+++ b/public/index.php
@@ -25,10 +25,12 @@ if (is_readable($envFile)) {
 
 use Slim\Views\Twig;
 use Slim\Views\TwigMiddleware;
+use App\Application\Middleware\RateLimitMiddleware;
 use App\Application\Middleware\SessionMiddleware;
 use App\Application\Middleware\DomainMiddleware;
 use App\Application\Middleware\ProxyMiddleware;
 use App\Application\Middleware\UrlMiddleware;
+use App\Application\RateLimiting\RateLimitStoreFactory;
 use App\Twig\UikitExtension;
 use App\Twig\TranslationExtension;
 use App\Service\TranslationService;
@@ -66,6 +68,8 @@ $app->add(TwigMiddleware::create($app, $twig));
 $app->add(new UrlMiddleware($twig));
 $app->add(new DomainMiddleware());
 $app->add(new ProxyMiddleware());
+
+RateLimitMiddleware::setPersistentStore(RateLimitStoreFactory::createDefault());
 
 (require __DIR__ . '/../src/routes.php')($app, $translator);
 

--- a/sample.env
+++ b/sample.env
@@ -70,6 +70,10 @@ SMTP_ENCRYPTION=none # none|tls|ssl
 SMTP_FROM="support@quizrace.app"
 SMTP_FROM_NAME="QuizRace Support"
 
+# Cloudflare Turnstile Captcha (optional)
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+
 # Geheimnis zum Hashen von Passwort-Reset-Token
 PASSWORD_RESET_SECRET=changeme
 

--- a/src/Application/RateLimiting/ApcuRateLimitStore.php
+++ b/src/Application/RateLimiting/ApcuRateLimitStore.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\RateLimiting;
+
+use APCUIterator;
+use function apcu_delete;
+use function apcu_enabled;
+use function apcu_fetch;
+use function apcu_store;
+use function preg_quote;
+
+class ApcuRateLimitStore implements RateLimitStore
+{
+    private const PREFIX = 'rlm:';
+
+    /** @var array<string, true> */
+    private array $keys = [];
+
+    public static function isSupported(): bool
+    {
+        return function_exists('apcu_fetch')
+            && function_exists('apcu_store')
+            && function_exists('apcu_delete')
+            && (!function_exists('apcu_enabled') || apcu_enabled());
+    }
+
+    public function increment(string $key, int $windowSeconds): int
+    {
+        $namespacedKey = self::PREFIX . $key;
+        $now = time();
+
+        $entry = apcu_fetch($namespacedKey, $success);
+        if (!$success || !is_array($entry) || $this->isExpired($entry, $now, $windowSeconds)) {
+            $entry = ['count' => 0, 'start' => $now];
+        }
+
+        $count = (int) ($entry['count'] ?? 0) + 1;
+        $start = (int) ($entry['start'] ?? $now);
+
+        apcu_store($namespacedKey, ['count' => $count, 'start' => $start], $windowSeconds);
+        $this->keys[$namespacedKey] = true;
+
+        return $count;
+    }
+
+    public function reset(): void
+    {
+        if (!self::isSupported()) {
+            return;
+        }
+
+        if (class_exists(APCUIterator::class)) {
+            /** @var iterable<array{key:string}> $iterator */
+            $iterator = new APCUIterator('/^' . preg_quote(self::PREFIX, '/') . '/');
+            foreach ($iterator as $item) {
+                apcu_delete($item['key']);
+            }
+        } else {
+            foreach (array_keys($this->keys) as $key) {
+                apcu_delete($key);
+            }
+        }
+
+        $this->keys = [];
+    }
+
+    /**
+     * @param array<string, int> $entry
+     */
+    private function isExpired(array $entry, int $now, int $windowSeconds): bool
+    {
+        $start = (int) ($entry['start'] ?? 0);
+
+        return $start === 0 || ($now - $start) > $windowSeconds;
+    }
+}

--- a/src/Application/RateLimiting/FilesystemRateLimitStore.php
+++ b/src/Application/RateLimiting/FilesystemRateLimitStore.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\RateLimiting;
+
+class FilesystemRateLimitStore implements RateLimitStore
+{
+    private string $directory;
+
+    public function __construct(?string $directory = null)
+    {
+        $directory = $directory ?? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rate_limit';
+        $this->directory = rtrim($directory, DIRECTORY_SEPARATOR);
+    }
+
+    public function increment(string $key, int $windowSeconds): int
+    {
+        $path = $this->pathFor($key);
+        $now = time();
+        $entry = $this->read($path, $now, $windowSeconds);
+
+        $count = (int) ($entry['count'] ?? 0) + 1;
+        $start = (int) ($entry['start'] ?? $now);
+
+        $this->write($path, ['count' => $count, 'start' => $start]);
+
+        return $count;
+    }
+
+    public function reset(): void
+    {
+        if (!is_dir($this->directory)) {
+            return;
+        }
+
+        $pattern = $this->directory . DIRECTORY_SEPARATOR . 'rlm_*.json';
+        $files = glob($pattern) ?: [];
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
+    }
+
+    /**
+     * @return array{count:int,start:int}
+     */
+    private function read(string $path, int $now, int $windowSeconds): array
+    {
+        if (is_file($path)) {
+            $contents = file_get_contents($path);
+            if ($contents !== false) {
+                $decoded = json_decode($contents, true);
+                if (is_array($decoded)) {
+                    $start = (int) ($decoded['start'] ?? 0);
+                    if ($start !== 0 && ($now - $start) <= $windowSeconds) {
+                        return [
+                            'count' => (int) ($decoded['count'] ?? 0),
+                            'start' => $start,
+                        ];
+                    }
+                }
+            }
+        }
+
+        return ['count' => 0, 'start' => $now];
+    }
+
+    /**
+     * @param array{count:int,start:int} $data
+     */
+    private function write(string $path, array $data): void
+    {
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0777, true);
+        }
+
+        file_put_contents($path, json_encode($data), LOCK_EX);
+    }
+
+    private function pathFor(string $key): string
+    {
+        return $this->directory . DIRECTORY_SEPARATOR . 'rlm_' . $key . '.json';
+    }
+}

--- a/src/Application/RateLimiting/RateLimitStore.php
+++ b/src/Application/RateLimiting/RateLimitStore.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\RateLimiting;
+
+interface RateLimitStore
+{
+    /**
+     * Increment the counter for the given key and return the current total within the window.
+     */
+    public function increment(string $key, int $windowSeconds): int;
+
+    /**
+     * Remove all persisted counters for this store.
+     */
+    public function reset(): void;
+}

--- a/src/Application/RateLimiting/RateLimitStoreFactory.php
+++ b/src/Application/RateLimiting/RateLimitStoreFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\RateLimiting;
+
+final class RateLimitStoreFactory
+{
+    public static function createDefault(?string $directory = null): RateLimitStore
+    {
+        if (ApcuRateLimitStore::isSupported()) {
+            return new ApcuRateLimitStore();
+        }
+
+        return new FilesystemRateLimitStore($directory);
+    }
+}

--- a/src/Service/TurnstileConfig.php
+++ b/src/Service/TurnstileConfig.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class TurnstileConfig
+{
+    private ?string $siteKey;
+    private ?string $secretKey;
+    private bool $enabled;
+
+    public function __construct(?string $siteKey, ?string $secretKey, bool $enabled = true)
+    {
+        $siteKey = $this->normalize($siteKey);
+        $secretKey = $this->normalize($secretKey);
+        $this->enabled = $enabled;
+        $this->siteKey = $siteKey;
+        $this->secretKey = $secretKey;
+    }
+
+    public static function fromEnv(): self
+    {
+        $siteKey = getenv('TURNSTILE_SITE_KEY') ?: null;
+        $secretKey = getenv('TURNSTILE_SECRET_KEY') ?: null;
+
+        return new self($siteKey, $secretKey);
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled && $this->siteKey !== null && $this->secretKey !== null;
+    }
+
+    public function getSiteKey(): ?string
+    {
+        return $this->siteKey;
+    }
+
+    public function getSecretKey(): ?string
+    {
+        return $this->secretKey;
+    }
+
+    private function normalize(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        return $value;
+    }
+}

--- a/src/Service/TurnstileVerificationService.php
+++ b/src/Service/TurnstileVerificationService.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Throwable;
+
+class TurnstileVerificationService
+{
+    private ClientInterface $httpClient;
+    private TurnstileConfig $config;
+    private LoggerInterface $logger;
+
+    public function __construct(
+        TurnstileConfig $config,
+        ?ClientInterface $httpClient = null,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->config = $config;
+        $this->httpClient = $httpClient ?? new Client([
+            'timeout' => 5,
+        ]);
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function verify(?string $token, ?string $ip = null): bool
+    {
+        if (!$this->config->isEnabled()) {
+            return true;
+        }
+
+        $token = is_string($token) ? trim($token) : '';
+        if ($token === '') {
+            return false;
+        }
+
+        $secret = $this->config->getSecretKey();
+        if ($secret === null) {
+            return false;
+        }
+
+        try {
+            $response = $this->httpClient->request(
+                'POST',
+                'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+                [
+                    'headers' => [
+                        'Accept' => 'application/json',
+                    ],
+                    'form_params' => array_filter(
+                        [
+                            'secret' => $secret,
+                            'response' => $token,
+                            'remoteip' => $ip !== null ? trim($ip) : null,
+                        ],
+                        static fn ($value): bool => $value !== null && $value !== ''
+                    ),
+                ]
+            );
+        } catch (Throwable $e) {
+            $this->logger->warning('Turnstile verification request failed: ' . $e->getMessage());
+
+            return false;
+        }
+
+        $payload = (string) $response->getBody();
+        $data = json_decode($payload, true);
+        if (!is_array($data)) {
+            $this->logger->warning('Turnstile verification returned unexpected payload.', ['body' => $payload]);
+
+            return false;
+        }
+
+        return (bool) ($data['success'] ?? false);
+    }
+}

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -300,6 +300,9 @@
 {% endblock %}
 
 {% block scripts %}
+  {% if turnstileSiteKey %}
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
+  {% endif %}
   <script src="{{ basePath }}/js/custom-icons.js" defer></script>
   <script src="{{ basePath }}/js/storage.js"></script>
   <script>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -202,6 +202,9 @@
 {% endblock %}
 
 {% block scripts %}
+  {% if turnstileSiteKey %}
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
+  {% endif %}
   <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/app.js"></script>
   <script src="{{ basePath }}/js/landing.js" defer></script>

--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -7,6 +7,8 @@ namespace Tests\Controller;
 use App\Application\Middleware\RateLimitMiddleware;
 use App\Service\DomainStartPageService;
 use App\Service\MailService;
+use App\Service\TurnstileConfig;
+use App\Service\TurnstileVerificationService;
 use Tests\TestCase;
 
 class ContactControllerTest extends TestCase
@@ -24,6 +26,9 @@ class ContactControllerTest extends TestCase
         session_start();
         $_SESSION['csrf_token'] = 'token';
         $_COOKIE[session_name()] = session_id();
+        putenv('TURNSTILE_SITE_KEY');
+        putenv('TURNSTILE_SECRET_KEY');
+        unset($_ENV['TURNSTILE_SITE_KEY'], $_ENV['TURNSTILE_SECRET_KEY']);
 
         $oldMainDomain = getenv('MAIN_DOMAIN');
         $oldEnvMainDomain = $_ENV['MAIN_DOMAIN'] ?? null;
@@ -140,6 +145,179 @@ class ContactControllerTest extends TestCase
         ];
     }
 
+    public function testContactFormRequiresCaptchaWhenConfigured(): void
+    {
+        RateLimitMiddleware::resetPersistentStorage();
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        session_id('contactcaptcha');
+        session_start();
+        $_SESSION['csrf_token'] = 'token';
+        $_COOKIE[session_name()] = session_id();
+
+        putenv('TURNSTILE_SITE_KEY=site-key');
+        putenv('TURNSTILE_SECRET_KEY=secret-key');
+        $_ENV['TURNSTILE_SITE_KEY'] = 'site-key';
+        $_ENV['TURNSTILE_SECRET_KEY'] = 'secret-key';
+
+        $body = json_encode([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'message' => 'Hello',
+            'company' => '',
+        ], JSON_THROW_ON_ERROR);
+
+        $request = $this->createRequest(
+            'POST',
+            '/landing/contact',
+            [
+                'Content-Type' => 'application/json',
+                'X-CSRF-Token' => 'token',
+            ],
+            [session_name() => session_id()]
+        );
+        $request->getBody()->write($body);
+        $request->getBody()->rewind();
+
+        $app = $this->getAppInstance();
+        $response = $app->handle($request);
+
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testContactFormRejectsWhenCaptchaFails(): void
+    {
+        RateLimitMiddleware::resetPersistentStorage();
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        session_id('contactcaptcha2');
+        session_start();
+        $_SESSION['csrf_token'] = 'token';
+        $_COOKIE[session_name()] = session_id();
+
+        $config = new TurnstileConfig('site', 'secret');
+        $verifier = new class($config) extends TurnstileVerificationService {
+            public function __construct(TurnstileConfig $config)
+            {
+                parent::__construct($config);
+            }
+
+            public function verify(?string $token, ?string $ip = null): bool
+            {
+                return false;
+            }
+        };
+
+        $body = json_encode([
+            'name' => 'Jane Doe',
+            'email' => 'jane@example.com',
+            'message' => 'Test',
+            'company' => '',
+            'cf-turnstile-response' => 'token-value',
+        ], JSON_THROW_ON_ERROR);
+
+        $request = $this->createRequest(
+            'POST',
+            '/landing/contact',
+            [
+                'Content-Type' => 'application/json',
+                'X-CSRF-Token' => 'token',
+            ],
+            [session_name() => session_id()]
+        );
+        $request->getBody()->write($body);
+        $request->getBody()->rewind();
+        $request = $request
+            ->withAttribute('turnstileConfig', $config)
+            ->withAttribute('turnstileVerifier', $verifier);
+
+        $app = $this->getAppInstance();
+        $response = $app->handle($request);
+
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testContactFormAcceptsWithValidCaptcha(): void
+    {
+        RateLimitMiddleware::resetPersistentStorage();
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
+        session_id('contactcaptcha3');
+        session_start();
+        $_SESSION['csrf_token'] = 'token';
+        $_COOKIE[session_name()] = session_id();
+
+        $config = new TurnstileConfig('site', 'secret');
+        $verifier = new class($config) extends TurnstileVerificationService {
+            public array $calls = [];
+
+            public function __construct(TurnstileConfig $config)
+            {
+                parent::__construct($config);
+            }
+
+            public function verify(?string $token, ?string $ip = null): bool
+            {
+                $this->calls[] = [$token, $ip];
+
+                return true;
+            }
+        };
+
+        $mailer = new class extends MailService {
+            public array $sent = [];
+            public function __construct()
+            {
+            }
+            public function sendContact(
+                string $to,
+                string $name,
+                string $replyTo,
+                string $message,
+                ?array $templateData = null,
+                ?string $fromEmail = null,
+                ?array $smtpOverride = null
+            ): void {
+                $this->sent[] = [$to, $name, $replyTo, $message];
+            }
+        };
+
+        $body = json_encode([
+            'name' => 'Jane Roe',
+            'email' => 'jane@example.com',
+            'message' => 'Valid',
+            'company' => '',
+            'cf-turnstile-response' => 'token-value',
+        ], JSON_THROW_ON_ERROR);
+
+        $request = $this->createRequest(
+            'POST',
+            '/landing/contact',
+            [
+                'Content-Type' => 'application/json',
+                'X-CSRF-Token' => 'token',
+            ],
+            [session_name() => session_id()]
+        );
+        $request->getBody()->write($body);
+        $request->getBody()->rewind();
+        $request = $request
+            ->withAttribute('turnstileConfig', $config)
+            ->withAttribute('turnstileVerifier', $verifier)
+            ->withAttribute('mailService', $mailer);
+
+        $app = $this->getAppInstance();
+        $response = $app->handle($request);
+
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertCount(1, $verifier->calls);
+        $this->assertSame('token-value', $verifier->calls[0][0]);
+        $this->assertNotEmpty($mailer->sent);
+    }
+
     public function testContactFormUsesDomainSpecificEmail(): void
     {
         RateLimitMiddleware::resetPersistentStorage();
@@ -150,6 +328,9 @@ class ContactControllerTest extends TestCase
         session_start();
         $_SESSION['csrf_token'] = 'token';
         $_COOKIE[session_name()] = session_id();
+        putenv('TURNSTILE_SITE_KEY');
+        putenv('TURNSTILE_SECRET_KEY');
+        unset($_ENV['TURNSTILE_SITE_KEY'], $_ENV['TURNSTILE_SECRET_KEY']);
 
         $oldMainDomain = getenv('MAIN_DOMAIN');
         $oldEnvMainDomain = $_ENV['MAIN_DOMAIN'] ?? null;
@@ -399,6 +580,7 @@ class ContactControllerTest extends TestCase
 
     public function testContactFormIgnoresInvalidDomainEmail(): void
     {
+        RateLimitMiddleware::resetPersistentStorage();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
         }
@@ -406,6 +588,9 @@ class ContactControllerTest extends TestCase
         session_start();
         $_SESSION['csrf_token'] = 'token';
         $_COOKIE[session_name()] = session_id();
+        putenv('TURNSTILE_SITE_KEY');
+        putenv('TURNSTILE_SECRET_KEY');
+        unset($_ENV['TURNSTILE_SITE_KEY'], $_ENV['TURNSTILE_SECRET_KEY']);
 
         $oldMainDomain = getenv('MAIN_DOMAIN');
         $oldEnvMainDomain = $_ENV['MAIN_DOMAIN'] ?? null;

--- a/tests/Controller/LandingControllerTest.php
+++ b/tests/Controller/LandingControllerTest.php
@@ -105,6 +105,38 @@ HTML;
         unset($_ENV['SMTP_HOST'], $_ENV['SMTP_USER'], $_ENV['SMTP_PASS']);
     }
 
+    public function testLandingPageIncludesTurnstileWidgetWhenConfigured(): void
+    {
+        putenv('SMTP_HOST=localhost');
+        putenv('SMTP_USER=user@example.org');
+        putenv('SMTP_PASS=secret');
+        $_ENV['SMTP_HOST'] = 'localhost';
+        $_ENV['SMTP_USER'] = 'user@example.org';
+        $_ENV['SMTP_PASS'] = 'secret';
+
+        putenv('TURNSTILE_SITE_KEY=site-key');
+        putenv('TURNSTILE_SECRET_KEY=secret-key');
+        $_ENV['TURNSTILE_SITE_KEY'] = 'site-key';
+        $_ENV['TURNSTILE_SECRET_KEY'] = 'secret-key';
+
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/landing');
+        $response = $app->handle($request);
+        $body = (string) $response->getBody();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('cf-turnstile', $body);
+        $this->assertStringContainsString('https://challenges.cloudflare.com/turnstile', $body);
+
+        putenv('SMTP_HOST');
+        putenv('SMTP_USER');
+        putenv('SMTP_PASS');
+        unset($_ENV['SMTP_HOST'], $_ENV['SMTP_USER'], $_ENV['SMTP_PASS']);
+        putenv('TURNSTILE_SITE_KEY');
+        putenv('TURNSTILE_SECRET_KEY');
+        unset($_ENV['TURNSTILE_SITE_KEY'], $_ENV['TURNSTILE_SECRET_KEY']);
+    }
+
     public function testLandingPageContainsFaqLink(): void
     {
         $app = $this->getAppInstance();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -176,6 +176,18 @@ class TestCase extends PHPUnit_TestCase
             putenv('MARKETING_DOMAINS');
             unset($_ENV['MARKETING_DOMAINS']);
         }
+        if (getenv('TURNSTILE_SITE_KEY') !== false) {
+            putenv('TURNSTILE_SITE_KEY');
+        }
+        if (array_key_exists('TURNSTILE_SITE_KEY', $_ENV)) {
+            unset($_ENV['TURNSTILE_SITE_KEY']);
+        }
+        if (getenv('TURNSTILE_SECRET_KEY') !== false) {
+            putenv('TURNSTILE_SECRET_KEY');
+        }
+        if (array_key_exists('TURNSTILE_SECRET_KEY', $_ENV)) {
+            unset($_ENV['TURNSTILE_SECRET_KEY']);
+        }
         $this->pdo = null;
         parent::tearDown();
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,3 +18,9 @@ if (getenv('MARKETING_DOMAINS') === false) {
     putenv('MARKETING_DOMAINS');
     unset($_ENV['MARKETING_DOMAINS']);
 }
+
+$rateLimitDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rate_limit_tests_' . getmypid();
+\App\Application\Middleware\RateLimitMiddleware::setPersistentStore(
+    new \App\Application\RateLimiting\FilesystemRateLimitStore($rateLimitDir)
+);
+\App\Application\Middleware\RateLimitMiddleware::resetPersistentStorage();


### PR DESCRIPTION
## Summary
- add persistent rate limit store abstractions with APCu/filesystem implementations and update the middleware/runtime configuration
- integrate Cloudflare Turnstile configuration/verification, apply captcha enforcement to marketing controllers/templates, and adjust front-end assets
- document the new captcha environment variables and extend PHPUnit coverage for the captcha and persistent rate limiting flows

## Testing
- `./vendor/bin/phpunit --filter ContactControllerTest`
- `./vendor/bin/phpunit --filter RateLimitMiddlewareTest`


------
https://chatgpt.com/codex/tasks/task_e_68da3395f494832b92696d2cbe62aaac