### PR TITLE
Fix calServer CTA button text color in light mode

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -59,6 +59,14 @@ body.qr-landing:not(.dark-mode){
   --color-primary: var(--qr-landing-primary);
 }
 
+body.qr-landing:not(.dark-mode):not(.high-contrast):not([data-theme="dark"]) .uk-button-primary{
+  color:#ffffff!important;
+}
+
+body.qr-landing:not(.dark-mode):not(.high-contrast):not([data-theme="dark"]) .uk-button-primary [data-uk-icon]{
+  color:inherit;
+}
+
 body.qr-landing.high-contrast{
   --qr-bg:#ffffff;
   --qr-fg:#000000;


### PR DESCRIPTION
## Summary
- ensure primary buttons on the calServer landing render white text in light mode to match the design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da420c8508832b89c6d29d83c09d6a