### PR TITLE
Ensure calServer module buttons fit mobile viewport

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1586,6 +1586,8 @@ body.qr-landing.calserver-theme .calserver-modules-nav__link {
     flex-direction: column;
     gap: 6px;
     width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
     padding: 18px 20px;
     border-radius: 18px;
     background: color-mix(in oklab, var(--calserver-primary) 10%, transparent);
@@ -1715,6 +1717,7 @@ body.qr-landing.calserver-theme .calserver-module-figure .uk-list {
         padding-bottom: 0;
         margin-bottom: 0;
         gap: 12px;
+        width: 100%;
     }
 
     body.qr-landing.calserver-theme .calserver-modules-nav > li {


### PR DESCRIPTION
## Summary
- prevent the calServer module navigation buttons from exceeding the viewport width by forcing border-box sizing
- ensure the mobile module navigation spans the available width so the buttons stay centered on small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da4f10efe0832b935303358da4b8c9