### PR TITLE
Adjust calServer module overlay layering

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1579,6 +1579,8 @@ body.qr-landing.calserver-theme .calserver-modules-nav {
     padding: 0;
     list-style: none;
     border-bottom: none;
+    position: relative;
+    z-index: 2;
 }
 
 body.qr-landing.calserver-theme .calserver-modules-nav__link {
@@ -1642,6 +1644,7 @@ body.qr-landing.calserver-theme .calserver-module-figure {
     display: flex;
     flex-direction: column;
     height: 100%;
+    z-index: 0;
 }
 
 body.qr-landing.calserver-theme .calserver-module-figure::before {
@@ -1653,7 +1656,7 @@ body.qr-landing.calserver-theme .calserver-module-figure::before {
     border: 1px solid var(--qr-card-border);
     box-shadow: 0 22px 48px -28px rgba(15, 23, 42, 0.35);
     pointer-events: none;
-    z-index: -1;
+    z-index: 0;
 }
 
 body.qr-landing.calserver-theme .calserver-module-figure img,
@@ -1677,8 +1680,9 @@ body.qr-landing.calserver-theme .calserver-module-figure figcaption {
     flex-direction: column;
     gap: 14px;
     background: var(--qr-card);
+    border: 1px solid color-mix(in oklab, var(--calserver-primary) 22%, var(--qr-card-border) 78%);
     border-top: 1px solid color-mix(in oklab, var(--calserver-primary) 28%, rgba(15, 23, 42, 0.32));
-    box-shadow: 0 -18px 32px -28px rgba(15, 23, 42, 0.55) inset;
+    border-radius: 0 0 22px 22px;
 }
 
 body.qr-landing.calserver-theme .calserver-module-figure h3 {


### PR DESCRIPTION
## Summary
- keep the calServer module figure overlay behind the screenshot and copy while leaving the navigation buttons above it by tuning the stacking order
- swap the drop shadow on the module description panel for the standard border treatment used elsewhere on the page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da51091040832b9deed23a43a027b0