### PR TITLE
Ensure calServer cookie trigger icon stays white

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1818,6 +1818,9 @@ body.qr-landing.calserver-theme .usecase-card--visual .usecase-visual__image {
 .calserver-cookie-trigger svg {
     width: 1.45rem;
     height: 1.45rem;
+    color: inherit;
+    stroke: currentColor;
+    fill: none;
 }
 
 .calserver-cookie-trigger:hover,


### PR DESCRIPTION
## Summary
- ensure the calServer cookie consent trigger icon inherits the trigger color
- explicitly set the fingerprint icon stroke to use the inherited color in all modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da60837090832ba80cdf4162c5823a