### PR TITLE
Ensure landing topbar language options override git button sizing

### DIFF
--- a/public/css/topbar.landing.css
+++ b/public/css/topbar.landing.css
@@ -71,6 +71,13 @@ body.qr-landing.calserver-theme:not([data-theme="dark"]):not(.dark-mode):not(.hi
   padding:0 12px;
   height:auto;
 }
+.qr-landing .qr-topbar .lang-option.git-btn{
+  width:100%;
+  min-width:160px;
+  min-height:48px;
+  padding:0 12px;
+  height:auto;
+}
 .lang-option__icon{
   flex-shrink:0;
   display:inline-flex;


### PR DESCRIPTION
## Summary
- add a more specific selector so language option buttons keep their intended dimensions within the landing topbar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da69f5268c832ba2139aa1b0f28222