### PR TITLE
Ensure calServer cookie banner colors override landing styles

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1953,9 +1953,9 @@ body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .calserve
         160deg,
         color-mix(in oklab, var(--calserver-primary) 28%, rgba(10, 16, 28, 0.95)) 0%,
         color-mix(in oklab, var(--calserver-primary) 18%, rgba(6, 10, 22, 0.96)) 100%
-    );
-    border: 1px solid color-mix(in oklab, var(--calserver-primary) 48%, rgba(255, 255, 255, 0.18));
-    color: color-mix(in oklab, #ffffff 92%, rgba(255, 255, 255, 0.08));
+    ) !important;
+    border: 1px solid color-mix(in oklab, var(--calserver-primary) 48%, rgba(255, 255, 255, 0.18)) !important;
+    color: color-mix(in oklab, #ffffff 92%, rgba(255, 255, 255, 0.08)) !important;
 }
 
 body.qr-landing.calserver-theme:not(.dark-mode):not(.high-contrast) .calserver-cookie-banner,
@@ -1964,9 +1964,9 @@ body.qr-landing.calserver-theme[data-theme="light"]:not(.high-contrast) .calserv
         160deg,
         color-mix(in oklab, var(--calserver-primary) 12%, #ffffff 88%) 0%,
         color-mix(in oklab, var(--calserver-primary) 8%, #f5f7fb 92%) 100%
-    );
-    border: 1px solid color-mix(in oklab, var(--calserver-primary) 26%, rgba(15, 23, 42, 0.1));
-    color: color-mix(in oklab, #0b1532 88%, var(--calserver-primary) 12%);
+    ) !important;
+    border: 1px solid color-mix(in oklab, var(--calserver-primary) 26%, rgba(15, 23, 42, 0.1)) !important;
+    color: color-mix(in oklab, #0b1532 88%, var(--calserver-primary) 12%) !important;
 }
 
 body.qr-landing.calserver-theme.high-contrast .calserver-cookie-banner,


### PR DESCRIPTION
## Summary
- enforce the calServer cookie banner gradients and text colors with !important overrides
- keep dark and light theme banner styling aligned with the intended palette despite landing styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da716984c8832bbcf73fef8b582827