### PR TITLE
Fix cookie trigger icon color inheritance

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1823,6 +1823,10 @@ body.qr-landing.calserver-theme .usecase-card--visual .usecase-visual__image {
     fill: none;
 }
 
+.calserver-cookie-trigger .uk-icon {
+    color: inherit !important;
+}
+
 .calserver-cookie-trigger:hover,
 .calserver-cookie-trigger:focus-visible {
     background: color-mix(in oklab, var(--calserver-primary) 30%, rgba(8, 13, 24, 0.9));


### PR DESCRIPTION
## Summary
- ensure the cookie trigger's uk-icon inherits the button color so the glyph remains visible across themes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da84a210cc832b8ddeadc246f15eb6