### PR TITLE
Fix mobile padding for calserver module buttons

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1732,6 +1732,7 @@ body.qr-landing.calserver-theme .calserver-module-figure .uk-list {
 
     body.qr-landing.calserver-theme .calserver-modules-nav__link {
         padding: 16px;
+        padding-inline-start: 0;
     }
 
     body.qr-landing.calserver-theme .calserver-module-figure figcaption {


### PR DESCRIPTION
## Summary
- remove the left padding from calserver module buttons on small screens to align them flush with the container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da96a7901c832bb7f8c807e7e20520