### PR TITLE
Add ProvenExpert trust seal to calServer page

### DIFF
--- a/migrations/20250930_add_calserver_proseal_widget.sql
+++ b/migrations/20250930_add_calserver_proseal_widget.sql
@@ -1,0 +1,2383 @@
+INSERT INTO pages (slug, title, content)
+VALUES (
+    'calserver',
+    'calServer',
+    $$<section class="calserver-highlight calserver-section-glow" aria-label="calServer in Zahlen">
+      <div class="uk-container">
+        <div class="calserver-stats-strip" role="list">
+          <div class="calserver-stats-strip__item" role="listitem">
+            <div class="calserver-stats-strip__header">
+              <span class="calserver-stats-strip__value"
+                    data-counter-target="1668"
+                    data-counter-duration="1600"
+                    data-counter-start="0">
+                1.668
+              </span>
+              <div class="calserver-stats-strip__title-group">
+                <span class="calserver-stats-strip__title">umgesetzte Kund:innen-Wünsche</span>
+                <span class="calserver-stats-strip__label">Stand: 23.09.2025</span>
+              </div>
+              <span class="calserver-stats-strip__tooltip"
+                    data-uk-icon="icon: info"
+                    data-uk-tooltip="title: „Priorisierte Kundenanforderungen, ausgeliefert und abgenommen.“; pos: bottom"
+                    aria-label="Priorisierte Kundenanforderungen, ausgeliefert und abgenommen."
+                    tabindex="0"></span>
+            </div>
+            <p class="calserver-stats-strip__benefit">Durch Community driven Engineering kundennahe Entwicklung.</p>
+          </div>
+          <div class="calserver-stats-strip__item" role="listitem">
+            <div class="calserver-stats-strip__header">
+              <span class="calserver-stats-strip__value"
+                    data-counter-target="99.9"
+                    data-counter-duration="1800"
+                    data-counter-decimals="1"
+                    data-counter-suffix=" %"
+                    data-counter-start="0">
+                99,9 %
+              </span>
+              <div class="calserver-stats-strip__title-group">
+                <span class="calserver-stats-strip__title">Systemverfügbarkeit</span>
+                <span class="calserver-stats-strip__label">Stand: 23.09.2025</span>
+              </div>
+              <span class="calserver-stats-strip__tooltip"
+                    data-uk-icon="icon: info"
+                    data-uk-tooltip="title: „Zeitanteil, in dem der Service erreichbar war.“; pos: bottom"
+                    aria-label="Zeitanteil, in dem der Service erreichbar war."
+                    tabindex="0"></span>
+            </div>
+            <p class="calserver-stats-strip__benefit">Sichere, planbare Abläufe im Alltag.</p>
+          </div>
+          <div class="calserver-stats-strip__item" role="listitem">
+            <div class="calserver-stats-strip__header">
+              <span class="calserver-stats-strip__value"
+                    data-counter-target="15"
+                    data-counter-duration="1400"
+                    data-counter-prefix="&gt; "
+                    data-counter-start="0">
+                &gt; 15
+              </span>
+              <div class="calserver-stats-strip__title-group">
+                <span class="calserver-stats-strip__title">Jahre am Markt</span>
+                <span class="calserver-stats-strip__label">Stand: 23.09.2025</span>
+              </div>
+              <span class="calserver-stats-strip__tooltip"
+                    data-uk-icon="icon: info"
+                    data-uk-tooltip="title: „calServer wird seit über 15 Jahren produktiv eingesetzt.“; pos: bottom"
+                    aria-label="calServer wird seit über 15 Jahren produktiv eingesetzt."
+                    tabindex="0"></span>
+            </div>
+            <p class="calserver-stats-strip__benefit">Erfahrung, Stabilität und gereifte Prozesse.</p>
+          </div>
+        </div>
+
+        <div class="calserver-logo-marquee"
+             aria-label="calServer Leistungsversprechen">
+          <div class="calserver-logo-marquee__track" role="list">
+            <div class="calserver-logo-marquee__item" role="listitem">
+              Hosting in Deutschland
+            </div>
+            <div class="calserver-logo-marquee__item" role="listitem">
+              DSGVO-konform
+            </div>
+            <div class="calserver-logo-marquee__item" role="listitem">
+              Software Made in Germany
+            </div>
+            <div class="calserver-logo-marquee__item" role="listitem">
+              REST-API &amp; Webhooks
+            </div>
+            <div class="calserver-logo-marquee__item" role="listitem">
+              Autom. Backups und weitere keys
+            </div>
+
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              Hosting in Deutschland
+            </div>
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              DSGVO-konform
+            </div>
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              Software Made in Germany
+            </div>
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              REST-API &amp; Webhooks
+            </div>
+            <div class="calserver-logo-marquee__item" role="listitem" aria-hidden="true">
+              Autom. Backups und weitere keys
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <div class="section-divider"></div>
+
+    <section id="trust" class="uk-section uk-section-muted">
+      <div class="uk-container">
+        <div class="uk-grid-large uk-flex-middle" data-uk-grid>
+          <div class="uk-width-1-1 uk-width-2-3@m">
+            <h2 class="uk-heading-line uk-margin-remove-bottom"><span>So fühlt sich calServer im Alltag an</span></h2>
+          </div>
+          <div class="uk-width-1-1 uk-width-1-3@m">
+            <p class="trust-story__lead">
+              Vom ersten Login bis zur entspannten Audit-Vorbereitung: calServer nimmt dir Schritt für Schritt den Druck aus der Kalibrier- und Inventarverwaltung.
+            </p>
+          </div>
+        </div>
+
+        
+        <ul class="trust-story trust-story--timeline" role="list" aria-label="So begleitet calServer dein Team">
+                                              <li class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-devices" aria-describedby="trust-step-devices-description">
+              <div class="trust-story__marker" aria-hidden="true">
+                <span class="trust-story__connector trust-story__connector--before"></span>
+                <span class="trust-story__badge" data-step-index="1">
+                                      <span class="trust-story__badge-icon" aria-hidden="true" data-uk-icon="icon: database"></span>
+                                    <span class="trust-story__sr">Schritt 1</span>
+                </span>
+                <span class="trust-story__connector trust-story__connector--after"></span>
+              </div>
+              <div class="trust-story__content">
+                <h3 id="trust-step-devices" class="trust-story__title">Alle Geräte auf einen Blick</h3>
+                <p id="trust-step-devices-description" class="trust-story__text">
+                  Importiere Bestandslisten oder starte direkt im Browser. calServer sammelt Stammdaten, Dokumente und Verantwortlichkeiten an einem Ort, damit nichts verloren geht.
+                </p>
+              </div>
+            </li>
+                                              <li class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-deadlines" aria-describedby="trust-step-deadlines-description">
+              <div class="trust-story__marker" aria-hidden="true">
+                <span class="trust-story__connector trust-story__connector--before"></span>
+                <span class="trust-story__badge" data-step-index="2">
+                                      <span class="trust-story__badge-icon" aria-hidden="true" data-uk-icon="icon: bell"></span>
+                                    <span class="trust-story__sr">Schritt 2</span>
+                </span>
+                <span class="trust-story__connector trust-story__connector--after"></span>
+              </div>
+              <div class="trust-story__content">
+                <h3 id="trust-step-deadlines" class="trust-story__title">Fristen melden sich von selbst</h3>
+                <p id="trust-step-deadlines-description" class="trust-story__text">
+                  Erinnerungen, Eskalationspfade und mobile Checklisten halten dein Team auf Kurs. Jede Person sieht sofort, welche Prüfaufträge heute wichtig sind.
+                </p>
+              </div>
+            </li>
+                                              <li class="trust-story__step" role="listitem" tabindex="0" aria-labelledby="trust-step-audit" aria-describedby="trust-step-audit-description">
+              <div class="trust-story__marker" aria-hidden="true">
+                <span class="trust-story__connector trust-story__connector--before"></span>
+                <span class="trust-story__badge" data-step-index="3">
+                                      <span class="trust-story__badge-icon" aria-hidden="true" data-uk-icon="icon: shield"></span>
+                                    <span class="trust-story__sr">Schritt 3</span>
+                </span>
+                <span class="trust-story__connector trust-story__connector--after"></span>
+              </div>
+              <div class="trust-story__content">
+                <h3 id="trust-step-audit" class="trust-story__title">Auditbereit – jederzeit</h3>
+                <p id="trust-step-audit-description" class="trust-story__text">
+                  Nachweise, Zertifikate und Gerätehistorien liegen revisionssicher bereit. Mit Hosting in Deutschland und täglichen Backups bist du auf Kontrollen vorbereitet.
+                </p>
+              </div>
+            </li>
+                  </ul>
+
+        <div class="trust-story__closing uk-grid uk-grid-large uk-flex-middle" data-uk-grid>
+          <div class="uk-width-1-1 uk-width-expand@m">
+            <h3 class="trust-story__closing-title">Beruhigende Sicherheit für dein Team</h3>
+            <p class="trust-story__closing-text">
+              DSGVO-konform, zuverlässig betreut und flexibel erweiterbar – calServer wächst mit deinen Abläufen und sorgt dafür, dass Termine, Rollen und Geräte harmonisch zusammenspielen.
+            </p>
+          </div>
+          <div class="uk-width-1-1 uk-width-auto@m">
+            <div class="trust-story__cta-group">
+              <a class="uk-button uk-button-primary cta-main" href="#trial">
+                <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Jetzt testen
+              </a>
+              <a class="btn btn-transparent" href="https://calendly.com/calhelp/calserver-vorstellung" target="_blank" rel="noopener">
+                <span class="uk-margin-small-right" data-uk-icon="icon: calendar"></span>Demo buchen
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="features" class="uk-section uk-section-default uk-section-large">
+      <div class="uk-container">
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+          <h2 class="uk-heading-line"><span>Funktionen, die den Alltag erleichtern</span></h2>
+          <span class="muted">Scroll &amp; entdecke die wichtigsten Bereiche</span>
+        </div>
+        <div class="uk-margin-large-top">
+          <div class="uk-text-center uk-margin-medium-bottom">
+            <h3 class="uk-heading-bullet">Funktionen im Fokus</h3>
+            <p class="muted">Wähle die Bereiche, die dein Team täglich nutzt – und spring direkt zur passenden
+              Funktionskarte.</p>
+          </div>
+          <nav class="feature-nav" aria-label="Funktionsnavigation">
+            <ul id="feature-nav" class="feature-nav__list">
+              <li><a class="feature-nav__pill" href="#" data-target="feature-inventare-intervalle">Inventare &amp; Intervalle</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-kalibrierscheine">Kalibrierscheine digitalisieren</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-email-abrufe">E-Mail-Abrufe &amp; Erinnerungen</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-geraeteverwaltung">Geräteverwaltung</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-kalibrier-reparatur">Kalibrier- &amp; Reparaturverwaltung</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-auftragsbearbeitung">Auftragsbearbeitung</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-leihverwaltung">Leihverwaltung</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-dokumentationen">Dokumentationen &amp; Wiki</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-dms">Dateimanagement (DMS)</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-meldungen">Meldungen &amp; Tickets</a></li>
+              <li><a class="feature-nav__pill" href="#" data-target="feature-cloud">Moderne Cloud-Basis</a></li>
+            </ul>
+          </nav>
+        </div>
+        <div id="feature-slider"
+             class="uk-position-relative uk-visible-toggle feature-slider"
+             tabindex="-1"
+             data-uk-slider="center: true; autoplay: true; autoplay-interval: 4200; finite: false">
+          <div class="uk-slider-container">
+            <ul class="uk-slider-items uk-child-width-1-1@s uk-child-width-1-2@m uk-child-width-1-3@l feature-slider__list"
+                data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .feature-slider__item; delay: 75; repeat: true">
+              <li class="feature-slider__item" id="feature-inventare-intervalle">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Inventare &amp; Intervalle</h3>
+                  <p>Fälligkeiten kommen zu dir – Erinnerungen, Abrufe und Planungsübersichten sorgen für Ruhe.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Automatische Erinnerungslogik</li>
+                    <li>Klare Statusfarben</li>
+                    <li>Planungs-Dashboards</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-kalibrierscheine">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Kalibrierscheine digitalisieren</h3>
+                  <p>Einfach hochladen, alles Weitere erledigt die Zuordnung mit Versionierung &amp; Vorschau.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Intelligente Dateinamen-Erkennung</li>
+                    <li>Versionen &amp; Freigaben</li>
+                    <li>Teilen per Link</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-email-abrufe">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">E-Mail-Abrufe &amp; Erinnerungen</h3>
+                  <p>Persönlich und planbar – Serien mit System statt Einzelmails.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Vorlagen &amp; Platzhalter</li>
+                    <li>Zeitpläne je Zielgruppe</li>
+                    <li>Versandprotokoll</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-geraeteverwaltung">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Geräteverwaltung</h3>
+                  <p>Ob 100 oder 100.000 Geräte – Suche, Filter und Gruppen bleiben schnell.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Schnellsuche &amp; Filter</li>
+                    <li>Sets &amp; Zubehör</li>
+                    <li>Exporte (CSV/PDF)</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-kalibrier-reparatur">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Kalibrier- &amp; Reparaturverwaltung</h3>
+                  <p>Von Messwerten bis Bericht – ohne Medienbrüche, mit revisionssicheren Freigaben.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Messwerte erfassen/importieren</li>
+                    <li>Bearbeitbare Übersichten</li>
+                    <li>Berichte direkt erzeugen</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-auftragsbearbeitung">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Auftragsbearbeitung</h3>
+                  <p>Ein Flow für alles: Angebot → Auftrag → Rechnung – mit eigenem Briefpapier.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Sammel- &amp; Teilrechnungen</li>
+                    <li>Preislisten &amp; Nummernkreise</li>
+                    <li>Automatische Status</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-leihverwaltung">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Leihverwaltung</h3>
+                  <p>Reservieren statt Telefonkette – Kalender auf, Gerät rein, fertig.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Drag-and-Drop Kalender</li>
+                    <li>Zubehör-Sets</li>
+                    <li>Rückgabe-Erinnerungen</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-dokumentationen">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Dokumentationen &amp; Wiki</h3>
+                  <p>Wissen bleibt im Team – gepflegt, versioniert und durchsuchbar.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Editor mit Inhaltsverzeichnis</li>
+                    <li>Versionen &amp; Berechtigungen</li>
+                    <li>Interne Verlinkungen</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-dms">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Dateimanagement (DMS)</h3>
+                  <p>„Nur speichern, nicht sortieren“ – Zuordnung läuft im Hintergrund.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Auto-Zuordnung</li>
+                    <li>Versionierung</li>
+                    <li>PDF-Viewer</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-meldungen">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Meldungen &amp; Tickets</h3>
+                  <p>Alles an einem Ort: Anliegen, Verlauf, Benachrichtigungen.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Zentrales Ticketing</li>
+                    <li>Teilnehmerwechsel</li>
+                    <li>Benachrichtigungsketten</li>
+                  </ul>
+                </article>
+              </li>
+              <li class="feature-slider__item" id="feature-cloud">
+                <article class="feature-card">
+                  <h3 class="uk-card-title feature-card__title">Moderne Cloud-Basis</h3>
+                  <p>Schnell, stabil und updatefreundlich – ohne großen Admin-Aufwand.</p>
+                  <ul class="uk-list uk-list-bullet">
+                    <li>Skalierbare Umgebung</li>
+                    <li>Regelmäßige Updates</li>
+                    <li>Tägliche Backups</li>
+                  </ul>
+                </article>
+              </li>
+            </ul>
+          </div>
+          <a class="uk-position-center-left uk-position-small uk-hidden-hover"
+             href="#"
+             data-uk-slidenav-previous
+             data-uk-slider-item="previous"
+             aria-label="Vorherige Funktion"></a>
+          <a class="uk-position-center-right uk-position-small uk-hidden-hover"
+             href="#"
+             data-uk-slidenav-next
+             data-uk-slider-item="next"
+             aria-label="Nächste Funktion"></a>
+        </div>
+        <script>
+          document.addEventListener('DOMContentLoaded', () => {
+            const sliderElement = document.getElementById('feature-slider');
+            const navElement = document.getElementById('feature-nav');
+            if (!sliderElement || !navElement || typeof UIkit === 'undefined') {
+              return;
+            }
+
+            const slider = UIkit.slider(sliderElement);
+            const pills = Array.from(navElement.querySelectorAll('li'));
+            const slides = Array.from(sliderElement.querySelectorAll('.feature-slider__item'));
+            const itemsContainer = sliderElement.querySelector('.uk-slider-items');
+            if (!itemsContainer) {
+              return;
+            }
+
+            const indexById = new Map(slides.map((slide, index) => [slide.id, index]));
+
+            const applyFocusToCenter = () => {
+              const slideElements = Array.from(itemsContainer.children);
+              if (!slideElements.length) {
+                return;
+              }
+
+              const viewportElement = sliderElement.querySelector('.uk-slider-container') || sliderElement;
+              const viewportRect = viewportElement.getBoundingClientRect();
+              const midpoint = viewportRect.left + viewportRect.width / 2;
+
+              let nearest = null;
+              let minDistance = Number.POSITIVE_INFINITY;
+
+              slideElements.forEach((item) => {
+                const card = item.querySelector('.feature-card');
+                if (!card) {
+                  return;
+                }
+
+                const rect = item.getBoundingClientRect();
+                const centerX = rect.left + rect.width / 2;
+                const distance = Math.abs(centerX - midpoint);
+
+                if (distance < minDistance) {
+                  minDistance = distance;
+                  nearest = item;
+                }
+              });
+
+              slideElements.forEach((item) => {
+                item.classList.remove('is-center');
+                const card = item.querySelector('.feature-card');
+                if (card) {
+                  card.classList.remove('feature-card--focus');
+                }
+              });
+
+              if (nearest) {
+                nearest.classList.add('is-center');
+                const focusCard = nearest.querySelector('.feature-card');
+                if (focusCard) {
+                  focusCard.classList.add('feature-card--focus');
+                }
+              }
+            };
+
+            const setActive = (index) => {
+              pills.forEach((li, i) => {
+                const isActive = i === index;
+                li.classList.toggle('uk-active', isActive);
+
+                const link = li.querySelector('.feature-nav__pill');
+                if (!link) {
+                  return;
+                }
+
+                link.classList.toggle('is-active', isActive);
+                if (isActive) {
+                  link.setAttribute('aria-current', 'true');
+                } else {
+                  link.removeAttribute('aria-current');
+                }
+              });
+            };
+
+            const setCurrent = (index) => {
+              slides.forEach((slide, i) => slide.classList.toggle('uk-current', i === index));
+            };
+
+            pills.forEach((li) => {
+              const link = li.querySelector('a[data-target]');
+              if (!link) {
+                return;
+              }
+
+              const targetId = link.dataset.target;
+              const targetIndex = indexById.get(targetId);
+              if (typeof targetIndex === 'undefined') {
+                return;
+              }
+
+              link.addEventListener('click', (event) => {
+                event.preventDefault();
+                slider.show(targetIndex);
+                setActive(targetIndex);
+                setCurrent(targetIndex);
+                applyFocusToCenter();
+              });
+            });
+
+            UIkit.util.on(sliderElement, 'itemshown', () => {
+              setActive(slider.index);
+              setCurrent(slider.index);
+              applyFocusToCenter();
+            });
+
+            const initialIndex = typeof slider.index === 'number' ? slider.index : 0;
+            setActive(initialIndex);
+            setCurrent(initialIndex);
+            applyFocusToCenter();
+            window.addEventListener('resize', applyFocusToCenter);
+          });
+        </script>
+      </div>
+    </section>
+
+    <hr class="uk-divider-icon">
+
+            <section id="modules" class="uk-section uk-section-muted">
+      <div class="uk-container">
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+          <h2 class="uk-heading-line"><span>Module, die den Unterschied machen</span></h2>
+          <span class="muted">Individuell kombinierbar – ohne versteckte Kosten</span>
+        </div>
+        <div class="calserver-modules-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > *; delay: 100; repeat: true">
+          <div>
+            <ul class="uk-tab calserver-modules-nav"
+                data-uk-switcher="connect: #calserver-modules-switcher; animation: uk-animation-fade">
+                              <li>
+                  <a class="calserver-modules-nav__link" href="#module-device-management">
+                    <span class="calserver-modules-nav__title">Geräteverwaltung & Historie</span>
+                    <span class="calserver-modules-nav__desc">Geräteakten, Anhänge und Historie in einer Oberfläche – inklusive Messwerten.</span>
+                  </a>
+                </li>
+                              <li>
+                  <a class="calserver-modules-nav__link" href="#module-calendar-resources">
+                    <span class="calserver-modules-nav__title">Kalender & Ressourcen</span>
+                    <span class="calserver-modules-nav__desc">Planung von Terminen, Leihgeräten und Personal in einer Ansicht.</span>
+                  </a>
+                </li>
+                              <li>
+                  <a class="calserver-modules-nav__link" href="#module-order-ticketing">
+                    <span class="calserver-modules-nav__title">Auftrags- & Ticketverwaltung</span>
+                    <span class="calserver-modules-nav__desc">Vom Auftrag bis zur Rechnung – mit klaren Status, Workflows und Dokumenten.</span>
+                  </a>
+                </li>
+                              <li>
+                  <a class="calserver-modules-nav__link" href="#module-self-service">
+                    <span class="calserver-modules-nav__title">Self-Service & Extranet</span>
+                    <span class="calserver-modules-nav__desc">Stellen Sie Kunden & Partnern Geräteinfos, Zertifikate und Formulare bereit.</span>
+                  </a>
+                </li>
+                          </ul>
+          </div>
+          <div>
+            <ul id="calserver-modules-switcher" class="uk-switcher calserver-modules-switcher">
+                              <li>
+                  <figure id="module-device-management" class="calserver-module-figure">
+                    <img src="{{ basePath }}/uploads/calserver-module-device-management.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
+                    <figcaption>
+                      <h3 class="uk-h3">Geräteverwaltung & Historie</h3>
+                      <p class="muted">Geräteakten, Anhänge und Historie in einer Oberfläche – inklusive Messwerten.</p>
+                                              <ul class="uk-list uk-list-bullet muted">
+                                                      <li>Geräte- & Standortverwaltung</li>
+                                                      <li>Versionierte Dokumente & Bilder</li>
+                                                      <li>Messwerte direkt verknüpfen</li>
+                                                  </ul>
+                                          </figcaption>
+                  </figure>
+                </li>
+                              <li>
+                  <figure id="module-calendar-resources" class="calserver-module-figure">
+                    <img src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
+                    <figcaption>
+                      <h3 class="uk-h3">Kalender & Ressourcen</h3>
+                      <p class="muted">Planung von Terminen, Leihgeräten und Personal in einer Ansicht.</p>
+                                              <ul class="uk-list uk-list-bullet muted">
+                                                      <li>Gantt & Kalender</li>
+                                                      <li>Verfügbarkeits-Check in Echtzeit</li>
+                                                      <li>Outlook/iCal-Integration</li>
+                                                  </ul>
+                                          </figcaption>
+                  </figure>
+                </li>
+                              <li>
+                  <figure id="module-order-ticketing" class="calserver-module-figure">
+                    <img src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
+                    <figcaption>
+                      <h3 class="uk-h3">Auftrags- & Ticketverwaltung</h3>
+                      <p class="muted">Vom Auftrag bis zur Rechnung – mit klaren Status, Workflows und Dokumenten.</p>
+                                              <ul class="uk-list uk-list-bullet muted">
+                                                      <li>Service & Ticketsystem</li>
+                                                      <li>Angebote, Aufträge, Rechnungen</li>
+                                                      <li>Eskalationen & SLAs</li>
+                                                  </ul>
+                                          </figcaption>
+                  </figure>
+                </li>
+                              <li>
+                  <figure id="module-self-service" class="calserver-module-figure">
+                    <img src="{{ basePath }}/uploads/calserver-module-self-service.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
+                    <figcaption>
+                      <h3 class="uk-h3">Self-Service & Extranet</h3>
+                      <p class="muted">Stellen Sie Kunden & Partnern Geräteinfos, Zertifikate und Formulare bereit.</p>
+                                              <ul class="uk-list uk-list-bullet muted">
+                                                      <li>Kundenportale</li>
+                                                      <li>Dokumente & Zertifikate</li>
+                                                      <li>Individuelle Rechte</li>
+                                                  </ul>
+                                          </figcaption>
+                  </figure>
+                </li>
+                          </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="usecases" class="uk-section uk-section-default">
+      <div class="uk-container">
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+          <h2 class="uk-heading-line"><span>Anwendungsfälle aus der Praxis</span></h2>
+          <span class="muted">Vom Labor bis zum Außendienst</span>
+        </div>
+        <ul class="uk-subnav uk-subnav-pill uk-margin-large-top usecase-tabs" data-uk-switcher="animation: uk-animation-fade">
+          <li><a href="#">ifm electronic (2 Standorte)</a></li>
+          <li><a href="#">KSW Kalibrierservice GmbH</a></li>
+          <li><a href="#">Systems Engineering GmbH</a></li>
+          <li><a href="#">TERAMESS (DAkkS-Labor)</a></li>
+          <li><a href="#">Thermo Fisher Scientific (EMEA)</a></li>
+          <li><a href="#">ZF Friedrichshafen</a></li>
+          <li><a href="#">Berliner Stadtwerke</a></li>
+          <li><a href="#">VDE Deutschland</a></li>
+        </ul>
+        <ul class="uk-switcher uk-margin-large-top"
+            data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .usecase-story, .usecase-highlight; delay: 100; repeat: true">
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
+                <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
+                <h3 class="uk-h2">ifm – Störungsbearbeitung &amp; Verbesserungen über zwei Standorte</h3>
+                <p class="uk-text-lead">calServer steuert die interne Kalibrier- und Störungsbearbeitung über zwei Standorte hinweg.</p>
+                <p>Fehlermeldungen werden im Ticketmanagement strukturiert aufgenommen, priorisiert und nachverfolgt; gleichzeitig dient es der Chancen-/Risiken-Betrachtung für kontinuierliche Verbesserungen. Die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL hält Geräte- und Kalibrierdaten standortübergreifend konsistent.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Ticketmanagement für Störungen &amp; CAPA-nahe Auswertungen</li>
+                  <li>Standortübergreifende Geräteakten &amp; Zertifikate im DMS</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Zwei Standorte, konsistente Datenbasis</li>
+                    <li>Tickets + Chancen-/Risiken-Bewertung</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
+                  </ul>
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/uploads/calserver-usecase-ifm-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
+                    <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
+                       src="{{ basePath }}/uploads/calserver-usecase-ifm-ticketmanagement.webp"
+                       width="960"
+                       height="540"
+                       loading="lazy"
+                       decoding="async"
+                       alt="Screenshot des calServer-Ticketboards im ifm-Use-Case mit CAPA-Bewertung">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
+                <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
+                <h3 class="uk-h2">KSW – End-to-End vom Wareneingang bis zur Rechnung</h3>
+                <p class="uk-text-lead">calServer bildet den gesamten Ablauf von Wareneingang über Labor bis zur Abrechnung ab.</p>
+                <p>Laborbegleitscheine, Geräteakten und Zertifikate liegen zentral vor; Auftragsbearbeitung, Status und Kommunikation greifen ineinander — revisionssicher, schnell, transparent.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Auftragsbearbeitung mit SLAs, Eskalation &amp; Serienmails</li>
+                  <li>DMS für Zertifikate, Berichte und Historie</li>
+                  <li>Durchgängige Übergabe an Abrechnung &amp; Reporting</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Wareneingang → Labor → Rechnung</li>
+                    <li>Auftragsbearbeitung als Taktgeber</li>
+                    <li>DMS &amp; Reporting integriert</li>
+                  </ul>
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/uploads/calserver-usecase-ksw-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
+                    <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
+                       src="{{ basePath }}/uploads/calserver-usecase-ksw-prozesskette.webp"
+                       width="960"
+                       height="540"
+                       loading="lazy"
+                       decoding="async"
+                       alt="Screenshot des calServer-Prozessflusses von Wareneingang bis Abrechnung im KSW-Use-Case">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
+                <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
+                <h3 class="uk-h2">Systems Engineering – Auftragsbearbeitung als Herzstück</h3>
+                <p class="uk-text-lead">calServer macht die Auftragsbearbeitung zum steuernden Zentrum des Labors.</p>
+                <p>Interne Aufgaben werden klar priorisiert, Reportings kommen direkt aus dem System und bleiben dank Versionierung nachvollziehbar — für verlässliche Termine und klare Zuständigkeiten.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Aufgaben-/Rollensteuerung mit Status &amp; Checklisten</li>
+                  <li>Eigene Reports aus Auftrags- und Gerätedaten</li>
+                  <li>DMS &amp; Historie für Audit- und Nachweispflichten</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Klarer Status- &amp; Rollenfluss</li>
+                    <li>Reports direkt aus den Prozessdaten</li>
+                    <li>Versionierung &amp; Nachvollziehbarkeit (DMS)</li>
+                  </ul>
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/uploads/calserver-usecase-systems-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
+                    <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
+                       src="{{ basePath }}/uploads/calserver-usecase-systems-reporting.webp"
+                       width="960"
+                       height="540"
+                       loading="lazy"
+                       decoding="async"
+                       alt="Screenshot der calServer-Auftragssteuerung und Reporting-Widgets im Systems-Engineering-Use-Case">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
+                <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
+                <h3 class="uk-h2">TERAMESS – DAkkS-konforme Zertifikate in der Cloud</h3>
+                <p class="uk-text-lead">calServer CLOUD bündelt DAkkS-konforme Zertifikate, Geräteakten und Prüfberichte.</p>
+                <p>Zertifikate werden revisionssicher abgelegt; Wiederhol- und Folgemessungen bleiben transparent nachvollziehbar. Kommunikation und Dokumente laufen in klaren, prüffesten Bahnen.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Revisionssichere Ablage mit Versionierung</li>
+                  <li>Strukturierte Prüf- &amp; Messhistorie</li>
+                  <li>Auswertungen &amp; Serienexports für Kund:innenkommunikation</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Revisionssicheres DMS in der Cloud</li>
+                    <li>DAkkS-konforme Prüfhistorie</li>
+                    <li>Serienexports &amp; Auswertungen</li>
+                  </ul>
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/uploads/calserver-usecase-teramess-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
+                    <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
+                       src="{{ basePath }}/uploads/calserver-usecase-teramess-dakks.webp"
+                       width="960"
+                       height="540"
+                       loading="lazy"
+                       decoding="async"
+                       alt="Screenshot der calServer-Zertifikatsverwaltung mit DAkkS-Historie im TERAMESS-Use-Case">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
+                <span class="pill pill--badge uk-margin-small-bottom">Kalibrierlabor</span>
+                <h3 class="uk-h2">Thermo Fisher Scientific – EMEA Labore</h3>
+                <p class="uk-text-lead">calServer orchestriert EMEA-weit Leihgeräte, Geräteakten und ISO-/DAkkS-konforme Zertifikate auf einer Plattform.</p>
+                <p>Mehrere Labore arbeiten in einem konsistenten Workflow: Leihverwaltung, Prüffristen und Zertifikate werden zentral gesteuert, während Aufträge und Rückgaben standortübergreifend nachvollziehbar bleiben. Die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL hält Stammdaten, Kalibrierläufe und Ergebnisse automatisch aktuell.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Zentrale Leihverwaltung mit Termin- &amp; Rückgabe-Erinnerungen</li>
+                  <li>Revisionssicheres DMS für Zertifikate &amp; Historie</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>EMEA-weit einheitliche Leihverwaltung &amp; Geräteakten</li>
+                    <li>Revisionssicheres DMS für Zertifikate &amp; Historie</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
+                  </ul>
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/uploads/calserver-usecase-thermo-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
+                    <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
+                       src="{{ basePath }}/uploads/calserver-usecase-thermo-leihverwaltung.webp"
+                       width="960"
+                       height="540"
+                       loading="lazy"
+                       decoding="async"
+                       alt="Screenshot der calServer-Leihgeräte- und Geräteaktenübersicht im Thermo-Fisher-Use-Case">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
+                <span class="pill pill--badge uk-margin-small-bottom">Industrielabor</span>
+                <h3 class="uk-h2">ZF – API-Messwerte auf Kubernetes mit SSO</h3>
+                <p class="uk-text-lead">calServer verbindet skalierbare Messwert-APIs auf Kubernetes mit SSO und Geräteakten-Management.</p>
+                <p>Messwerte fließen über Microservices automatisiert ein; Geräte, Zertifikate und Auswertungen bleiben im Zugriff der berechtigten Teams. Single Sign-On vereinfacht den Zugang, die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL stellt durchgehend konsistente Kalibrierdaten sicher.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>API-Ingestion von Messwerten (Microservices/Kubernetes)</li>
+                  <li>SSO (z. B. EntraID/Google) für nahtlosen Zugriff</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Microservices auf Kubernetes</li>
+                    <li>SSO für schnellen, sicheren Zugang</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
+                  </ul>
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/uploads/calserver-usecase-zf-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
+                    <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
+                       src="{{ basePath }}/uploads/calserver-usecase-zf-messwerte-sso.webp"
+                       width="960"
+                       height="540"
+                       loading="lazy"
+                       decoding="async"
+                       alt="Screenshot der calServer-Messwert-APIs und SSO-Konfiguration im ZF-Use-Case">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
+                <span class="pill pill--badge uk-margin-small-bottom">Assetmanagement</span>
+                <h3 class="uk-h2">Berliner Stadtwerke – Projekte &amp; Wartung für erneuerbare Anlagen</h3>
+                <p class="uk-text-lead">calServer steuert Projekte, Wartungspläne und Einsätze für regenerative Energieanlagen der Stadt Berlin.</p>
+                <p>Vom Maßnahmenplan bis zur Einsatzplanung: Teams behalten Verfügbarkeit, Leistung und Kosten im Blick. Checklisten, Offline-Fähigkeit und Eskalationslogik sichern die fristgerechte Abarbeitung. (Ohne MET/CAL/MET/TEAM – Fokus auf Projekt- &amp; Wartungssteuerung.)</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Projekt- &amp; Maßnahmensteuerung inkl. Einsatzplanung</li>
+                  <li>Geplante/ungeplante Wartung mit Checklisten &amp; Offline-Modus</li>
+                  <li>Dashboards für Verfügbarkeit, Leistung &amp; Kosten/Nutzen</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Stadtweite EE-Anlagen im Überblick</li>
+                    <li>Geplante &amp; ungeplante Wartung aus einem System</li>
+                    <li>Dashboards für Verfügbarkeit &amp; Performance</li>
+                  </ul>
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/uploads/calserver-usecase-berlin-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
+                    <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
+                       src="{{ basePath }}/uploads/calserver-usecase-berlin-wartung.webp"
+                       width="960"
+                       height="540"
+                       loading="lazy"
+                       decoding="async"
+                       alt="Screenshot der calServer-Wartungs- und Projektplanung für Berliner Stadtwerke">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid>
+              <div class="usecase-story uk-first-column uk-scrollspy-inview">
+                <span class="pill pill--badge uk-margin-small-bottom">Qualitätsmanagement</span>
+                <h3 class="uk-h2">VDE – Agile Auftragssteuerung &amp; Intranet</h3>
+                <p class="uk-text-lead">calServer bündelt agile Auftragssteuerung und Dokumentenflüsse für Prüf- und Zertifizierungsprozesse.</p>
+                <p>Teams planen, priorisieren und dokumentieren Vorgänge auf einem anpassbaren Board; Freigaben sind versioniert, nachvollziehbar und auditfest. Rollen und Vorlagen verteilen Informationen zielgerichtet. Die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL sorgt für konsistente Mess- und Auftragsdaten.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Agiles Auftragsboard mit SLAs, Eskalationen und Vorlagen</li>
+                  <li>Revisionssichere DMS-Ablage inkl. Freigabe-Workflow</li>
+                  <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
+                </ul>
+              </div>
+              <div class="usecase-highlight">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+                  <h4 class="uk-heading-bullet">Key Facts</h4>
+                  <ul class="uk-list uk-list-divider">
+                    <li>Agiles Auftragsboard (SLAs, Eskalationslogik)</li>
+                    <li>Audit-Trails &amp; versionierte Freigaben</li>
+                    <li>Bidirektionale Synchronisation mit Fluke MET/TEAM &amp; MET/CAL</li>
+                  </ul>
+                  <a class="uk-button uk-button-text uk-margin-top"
+                    href="{{ basePath }}/uploads/calserver-usecase-vde-highlights.pdf"
+                    target="_blank"
+                    rel="noopener">
+                    <span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>HIGHLIGHTS ALS PDF
+                  </a>
+                </div>
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+                  <div class="usecase-visual">
+                    <img class="uk-border-rounded usecase-visual__image"
+                       src="{{ basePath }}/uploads/calserver-usecase-vde-auftragsboard.webp"
+                       width="960"
+                       height="540"
+                       loading="lazy"
+                       decoding="async"
+                       alt="Screenshot des calServer-Auftragsboards mit DMS-Integration im VDE-Use-Case">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="modes" class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow">
+      <div class="uk-container">
+        <h2 class="uk-heading-line uk-light"><span>Betriebsarten, die zu Ihnen passen</span></h2>
+        <ul class="uk-subnav uk-subnav-pill uk-margin" data-uk-switcher>
+          <li><a href="#">Cloud</a></li>
+          <li><a href="#">On-Premise</a></li>
+        </ul>
+        <ul class="uk-switcher uk-margin"
+            data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
+              <div class="anim">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+                  <h3 class="uk-card-title">Sofort startklar</h3>
+                  <ul class="uk-list uk-list-bullet muted">
+                    <li>Bereitstellung in wenigen Tagen</li>
+                    <li>Automatisierte Updates &amp; Monitoring</li>
+                    <li>Backup-Strategie inklusive</li>
+                  </ul>
+                </div>
+              </div>
+              <div class="anim">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+                  <h3 class="uk-card-title">Sicher &amp; skalierbar</h3>
+                  <ul class="uk-list uk-list-bullet muted">
+                    <li>Rechenzentrum in Deutschland</li>
+                    <li>ISO 27001 zertifizierte Infrastruktur</li>
+                    <li>Flexible Nutzer:innenzahlen</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
+              <div class="anim">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+                  <h3 class="uk-card-title">Volle Kontrolle</h3>
+                  <ul class="uk-list uk-list-bullet muted">
+                    <li>Betrieb im eigenen Netzwerk</li>
+                    <li>Unterstützung bei Installation &amp; Updates</li>
+                    <li>Integration in bestehende Systeme</li>
+                  </ul>
+                </div>
+              </div>
+              <div class="anim">
+                <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+                  <h3 class="uk-card-title">Individuelle Sicherheit</h3>
+                  <ul class="uk-list uk-list-bullet muted">
+                    <li>Anbindung an Ihr Identity-Management</li>
+                    <li>Flexible Backup- und Wartungsfenster</li>
+                    <li>Support per SLA vereinbar</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="pricing" class="uk-section uk-section-default">
+      <div class="uk-container">
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+          <h2 class="uk-heading-line"><span>Preise, die Klarheit schaffen</span></h2>
+          <span class="muted">Ehrlich, transparent, ohne versteckte Kosten.</span>
+        </div>
+        <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-large uk-grid-match"
+             data-uk-grid
+             data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
+              <h3>Standard</h3>
+              <p class="muted">Die solide Basis für kleine Teams.</p>
+              <p class="uk-text-large uk-text-bold">ab 250 €/Monat</p>
+              <ul class="uk-list uk-list-bullet uk-text-left muted">
+                <li>Bis 2 Mandanten</li>
+                <li>Alle Kernmodule inklusive</li>
+                <li>E-Mail-Support innerhalb von 24 h</li>
+              </ul>
+              <a class="uk-button uk-button-default" href="#offer">Unverbindliches Angebot</a>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-primary uk-card-primary--highlight uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative">
+              <span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Empfohlen</span>
+              <h3>Performance</h3>
+              <p>Für größere Teams mit mehr Tempo.</p>
+              <p class="uk-text-large uk-text-bold">auf Anfrage</p>
+              <ul class="uk-list uk-list-bullet uk-text-left">
+                <li>Unbegrenzte Nutzer:innen</li>
+                <li>Erweiterte Automatisierungen</li>
+                <li>Priorisierter Support &amp; SLA</li>
+              </ul>
+              <a class="uk-button uk-button-default" href="#offer">Beratung anfragen</a>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
+              <h3>Enterprise</h3>
+              <p class="muted">Individuell zugeschnitten auf Ihre Prozesse.</p>
+              <p class="uk-text-large uk-text-bold">individuell</p>
+              <ul class="uk-list uk-list-bullet uk-text-left muted">
+                <li>Eigene Mandanten-Strukturen</li>
+                <li>On-Premise oder Hybrid</li>
+                <li>Integrationen &amp; Projektbegleitung</li>
+              </ul>
+              <a class="uk-button uk-button-default" href="#offer">Angebot anfordern</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="uk-section uk-section-muted">
+      <div class="uk-container">
+        <h2 class="uk-heading-line"><span>Häufige Fragen</span></h2>
+        <ul data-uk-accordion>
+          <li>
+            <a class="uk-accordion-title" href="#">Wie schnell bin ich mit der Cloud-Version startklar?</a>
+            <div class="uk-accordion-content">
+              <p>In der Regel innerhalb weniger Tage – wir begleiten den Kick-off persönlich.</p>
+            </div>
+          </li>
+          <li>
+            <a class="uk-accordion-title" href="#">Kann ich zwischen Cloud und On-Premise wechseln?</a>
+            <div class="uk-accordion-content">
+              <p>Ja, ein Wechsel ist jederzeit möglich. Wir unterstützen bei Migration und Datenübernahme.</p>
+            </div>
+          </li>
+          <li>
+            <a class="uk-accordion-title" href="#">Welche Datenimporte sind möglich?</a>
+            <div class="uk-accordion-content">
+              <p>Excel/CSV-Importe, API-Schnittstellen sowie individuelle Integrationen.</p>
+            </div>
+          </li>
+          <li>
+            <a class="uk-accordion-title" href="#">Wie funktioniert der Support?</a>
+            <div class="uk-accordion-content">
+              <p>Support per E-Mail, Telefon oder Ticketsystem – je nach Paket sogar mit SLA.</p>
+            </div>
+          </li>
+          <li>
+            <a class="uk-accordion-title" href="#">Was passiert mit meinen Daten nach dem Test?</a>
+            <div class="uk-accordion-content">
+              <p>Nach Testende entscheiden Sie: weiter nutzen, exportieren oder löschen lassen – ganz transparent.</p>
+            </div>
+          </li>
+        </ul>
+        <div class="uk-margin-top">
+          <span class="muted">Noch nicht fündig geworden?</span>
+          <a class="uk-margin-small-left" href="#contact-form">Weitere Fragen → Kontakt</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="demo" class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow">
+      <div class="uk-container">
+        <div class="calserver-highlight__intro uk-text-center">
+          <h2 class="uk-heading-small uk-margin-remove-bottom">Bereit, calServer live zu erleben?</h2>
+          <p class="uk-text-lead uk-margin-small-top">Jetzt testen oder Demo buchen – wir zeigen, wie Ihre Prozesse in calServer aussehen.</p>
+        </div>
+        <div class="uk-grid-large uk-child-width-1-1 uk-child-width-1-2@m uk-grid-match"
+             data-uk-grid
+             data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+              <div>
+                <h3 class="uk-card-title">Live-Demo buchen</h3>
+                <p class="muted">Wir führen Sie durch calServer, beantworten Fragen und zeigen passende Workflows.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Individuelle Präsentation mit Branchenfokus</li>
+                  <li>Direkter Austausch mit unseren Expert:innen</li>
+                  <li>Konkrete Empfehlungen für Ihren Einsatz</li>
+                </ul>
+              </div>
+              <div class="calserver-highlight-card__actions">
+                <a class="uk-button uk-button-primary"
+                   href="https://calendly.com/calhelp/calserver-vorstellung"
+                   target="_blank"
+                   rel="noopener">Demo buchen</a>
+                <span class="muted">ca. 45&nbsp;Minuten individuelles Gespräch</span>
+              </div>
+            </div>
+          </div>
+          <div class="anim">
+            <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+              <div>
+                <h3 class="uk-card-title">Testzugang sichern</h3>
+                <p class="muted">Starten Sie mit einer eigenen Umgebung und prüfen Sie calServer mit Ihren Prozessen.</p>
+                <ul class="uk-list uk-list-bullet muted">
+                  <li>Einrichtung nach kurzer Abstimmung</li>
+                  <li>Best Practices für den schnellen Einstieg</li>
+                  <li>Support-Team an Ihrer Seite</li>
+                </ul>
+              </div>
+              <div class="calserver-highlight-card__actions">
+                <a id="trial" class="uk-button uk-button-default" href="#offer">Jetzt testen</a>
+                <span class="muted">Zugang &amp; Demo-Umgebung inklusive</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p class="muted uk-text-small uk-text-center uk-margin-medium-top">* Demo-Zugang und Testumgebung nach kurzer Abstimmung.</p>
+      </div>
+    </section>
+
+    <section id="contact-us" class="uk-section">
+      <div class="uk-container">
+        <h2 class="uk-heading-medium uk-text-center" data-uk-scrollspy="cls: uk-animation-slide-top-small">Noch Fragen? Wir sind für Sie da.</h2>
+        <p class="uk-text-lead uk-text-center" data-uk-scrollspy="cls: uk-animation-fade; delay: 150">Ob Testzugang, Angebot oder individuelle Beratung – wir melden uns garantiert persönlich zurück.</p>
+        <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" data-uk-grid data-uk-scrollspy="target: > div; cls: uk-animation-slide-right-small; delay: 150">
+          <div>
+                          <form id="contact-form"
+                                class="uk-form-stacked uk-width-large uk-margin-auto"
+                                data-contact-endpoint="{{ basePath }}/calserver/contact">
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="form-name">Ihr Name</label>
+                  <input class="uk-input" id="form-name" name="name" type="text" required>
+                </div>
+                <div class="uk-margin">
+                  <label class="uk-form-label" for="form-email">E-Mail</label>
+                  <input class="uk-input" id="form-email" name="email" type="email" required>
+                </div>
+                  <div class="uk-margin">
+                    <label class="uk-form-label" for="form-msg">Nachricht</label>
+                    <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
+                  </div>
+                  <div class="uk-margin turnstile-field" data-turnstile-container>
+                    <div class="turnstile-widget">{{ turnstile_widget }}</div>
+                    <p class="uk-text-small turnstile-hint" data-turnstile-hint hidden>Bitte bestätigen Sie, dass Sie kein Roboter sind.</p>
+                  </div>
+                  <div class="uk-margin">
+                    <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
+                  </div>
+                <input type="text" name="company" autocomplete="off" tabindex="-1" class="uk-hidden" aria-hidden="true">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <button class="btn btn-black uk-button uk-button-secondary uk-button-large uk-width-1-1" type="submit">Senden</button>
+              </form>
+                      </div>
+          <div>
+            <div class="uk-grid uk-child-width-1-1 uk-grid-small">
+              <div><div class="uk-form-label" aria-hidden="true">&nbsp;</div></div>
+              <div>
+                <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
+                  <p class="uk-margin-small-bottom uk-text-large">E-Mail</p>
+                  <a
+                    class="uk-text-lead uk-link-reset js-email-link"
+                    data-user="office"
+                    data-domain="calhelp.de"
+                    href="#"
+                  >office [at] calhelp.de</a>
+                </div>
+              </div>
+              <div>
+                <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
+                  <p class="uk-margin-small-bottom uk-text-large">Telefon</p>
+                  <a href="tel:+4933203609080" class="uk-text-lead uk-link-reset">+49 33203 609080</a>
+                </div>
+              </div>
+              <div>
+                <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
+                  <p class="uk-margin-small-bottom uk-text-large">Kundenstimmen</p>
+                  <div
+                    class="calserver-proseal"
+                    data-calserver-proseal
+                    data-widget-id="1503aa9a-ae86-41d0-8ce9-05ed6f0a4856"
+                    data-widget-language="de-DE">
+                    <div class="calserver-proseal__placeholder" data-calserver-proseal-placeholder>
+                      <p class="uk-text-small uk-margin-small-bottom">Bewertungen werden geladen, sobald du Marketing-Cookies erlaubst.</p>
+                      <button class="uk-button uk-button-primary uk-button-small" type="button" data-calserver-proseal-consent>Bewertungen anzeigen</button>
+                      <p class="uk-text-meta uk-margin-small-top">Du kannst deine Auswahl jederzeit in den Cookie-Einstellungen ändern.</p>
+                      <p class="uk-text-meta uk-margin-small-top calserver-proseal__error" data-calserver-proseal-error hidden>Bewertungen konnten nicht geladen werden. Bitte versuche es später erneut.</p>
+                    </div>
+                    <div class="calserver-proseal__embed" id="proSealWidget" data-proseal-target hidden></div>
+                    <noscript>
+                      <p class="uk-text-small uk-margin-small-top">
+                        <a class="uk-link-muted" href="https://www.provenexpert.com/calhelp/?utm_source=seals&amp;utm_campaign=embedded-proseal&amp;utm_medium=profile&amp;utm_content=1503aa9a-ae86-41d0-8ce9-05ed6f0a4856" rel="noopener" target="_blank">Kundenbewertungen auf ProvenExpert ansehen</a>
+                      </p>
+                    </noscript>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div id="contact-modal" data-uk-modal>
+      <div class="uk-modal-dialog uk-modal-body">
+        <p id="contact-modal-message" aria-live="polite"></p>
+        <button class="uk-button uk-button-primary uk-modal-close" type="button">OK</button>
+      </div>
+    </div>
+    $$
+)
+ON CONFLICT (slug) DO UPDATE
+SET title = EXCLUDED.title,
+    content = EXCLUDED.content,
+    updated_at = CURRENT_TIMESTAMP;
+
+INSERT INTO pages (slug, title, content)
+VALUES (
+    'calserver-en',
+    'calServer',
+    $$
+<section aria-label="calServer in numbers" class="calserver-highlight calserver-section-glow">
+<div class="uk-container">
+<div class="calserver-stats-strip" role="list">
+<div class="calserver-stats-strip__item" role="listitem">
+<div class="calserver-stats-strip__header">
+<span class="calserver-stats-strip__value" data-counter-duration="1600" data-counter-start="0" data-counter-target="1668">
+                1,668
+              </span>
+<div class="calserver-stats-strip__title-group">
+<span class="calserver-stats-strip__title">Implemented customer wishes</span>
+<span class="calserver-stats-strip__label">As of 23 Sep 2025</span>
+</div>
+<span aria-label="Prioritized customer requirements, delivered and accepted." class="calserver-stats-strip__tooltip" data-uk-icon="icon: info" data-uk-tooltip='title: "Prioritized customer requirements, delivered and accepted."; pos: bottom' tabindex="0"></span>
+</div>
+<p class="calserver-stats-strip__benefit">Customer-centric development through community-driven engineering.</p>
+</div>
+<div class="calserver-stats-strip__item" role="listitem">
+<div class="calserver-stats-strip__header">
+<span class="calserver-stats-strip__value" data-counter-decimals="1" data-counter-duration="1800" data-counter-start="0" data-counter-suffix=" %" data-counter-target="99.9">
+                99.9 %
+              </span>
+<div class="calserver-stats-strip__title-group">
+<span class="calserver-stats-strip__title">System availability</span>
+<span class="calserver-stats-strip__label">As of 23 Sep 2025</span>
+</div>
+<span aria-label="Time part in which the service was accessible." class="calserver-stats-strip__tooltip" data-uk-icon="icon: info" data-uk-tooltip='title: "Time part in which the service was accessible."; pos: bottom' tabindex="0"></span>
+</div>
+<p class="calserver-stats-strip__benefit">Reliable, predictable daily routines.</p>
+</div>
+<div class="calserver-stats-strip__item" role="listitem">
+<div class="calserver-stats-strip__header">
+<span class="calserver-stats-strip__value" data-counter-duration="1400" data-counter-prefix="&gt; " data-counter-start="0" data-counter-target="15">
+                &gt; 15
+              </span>
+<div class="calserver-stats-strip__title-group">
+<span class="calserver-stats-strip__title">Years on the market</span>
+<span class="calserver-stats-strip__label">As of 23 Sep 2025</span>
+</div>
+<span aria-label="calServer has been used productively for over 15 years." class="calserver-stats-strip__tooltip" data-uk-icon="icon: info" data-uk-tooltip='title: "calServer has been used productively for over 15 years."; pos: bottom' tabindex="0"></span>
+</div>
+<p class="calserver-stats-strip__benefit">Experience, stability and mature processes.</p>
+</div>
+</div>
+<div aria-label="calServer value promise" class="calserver-logo-marquee">
+<div class="calserver-logo-marquee__track" role="list">
+<div class="calserver-logo-marquee__item" role="listitem">
+              Hosting in Germany
+            </div>
+<div class="calserver-logo-marquee__item" role="listitem">
+              GDPR-compliant
+            </div>
+<div class="calserver-logo-marquee__item" role="listitem">
+              Software made in Germany
+            </div>
+<div class="calserver-logo-marquee__item" role="listitem">
+              REST API &amp; webhooks
+            </div>
+<div class="calserver-logo-marquee__item" role="listitem">
+              Automatic backups &amp; more
+            </div>
+<div aria-hidden="true" class="calserver-logo-marquee__item" role="listitem">
+              Hosting in Germany
+            </div>
+<div aria-hidden="true" class="calserver-logo-marquee__item" role="listitem">
+              GDPR-compliant
+            </div>
+<div aria-hidden="true" class="calserver-logo-marquee__item" role="listitem">
+              Software made in Germany
+            </div>
+<div aria-hidden="true" class="calserver-logo-marquee__item" role="listitem">
+              REST API &amp; webhooks
+            </div>
+<div aria-hidden="true" class="calserver-logo-marquee__item" role="listitem">
+              Automatic backups &amp; more
+            </div>
+</div>
+</div>
+</div>
+</section>
+<div class="section-divider"></div>
+<section class="uk-section uk-section-muted" id="trust">
+<div class="uk-container">
+<div class="uk-grid-large uk-flex-middle" data-uk-grid="">
+<div class="uk-width-1-1 uk-width-2-3@m">
+<h2 class="uk-heading-line uk-margin-remove-bottom"><span>This is what calServer feels like in daily operations</span></h2>
+</div>
+<div class="uk-width-1-1 uk-width-1-3@m">
+<p class="trust-story__lead">
+              From the first login to relaxed audit prep, calServer steadily relieves pressure on calibration and inventory management.
+            </p>
+</div>
+</div>
+<ul aria-label="So calServer accompanies your team" class="trust-story trust-story--timeline" role="list">
+<li aria-describedby="trust-step-devices-description" aria-labelledby="trust-step-devices" class="trust-story__step" role="listitem" tabindex="0">
+<div aria-hidden="true" class="trust-story__marker">
+<span class="trust-story__connector trust-story__connector--before"></span>
+<span class="trust-story__badge" data-step-index="1">
+<span aria-hidden="true" class="trust-story__badge-icon" data-uk-icon="icon: database"></span>
+<span class="trust-story__sr">Step 1</span>
+</span>
+<span class="trust-story__connector trust-story__connector--after"></span>
+</div>
+<div class="trust-story__content">
+<h3 class="trust-story__title" id="trust-step-devices">All devices at a glance</h3>
+<p class="trust-story__text" id="trust-step-devices-description">
+                  Import inventories or start directly in the browser. calServer collects master data, documents and responsibilities in one place so nothing gets lost.
+                </p>
+</div>
+</li>
+<li aria-describedby="trust-step-deadlines-description" aria-labelledby="trust-step-deadlines" class="trust-story__step" role="listitem" tabindex="0">
+<div aria-hidden="true" class="trust-story__marker">
+<span class="trust-story__connector trust-story__connector--before"></span>
+<span class="trust-story__badge" data-step-index="2">
+<span aria-hidden="true" class="trust-story__badge-icon" data-uk-icon="icon: bell"></span>
+<span class="trust-story__sr">Step 2</span>
+</span>
+<span class="trust-story__connector trust-story__connector--after"></span>
+</div>
+<div class="trust-story__content">
+<h3 class="trust-story__title" id="trust-step-deadlines">Deadlines take care of themselves</h3>
+<p class="trust-story__text" id="trust-step-deadlines-description">
+                  Reminders, escalation paths and mobile checklists keep your team on track. Everyone immediately sees which calibration jobs matter today.
+                </p>
+</div>
+</li>
+<li aria-describedby="trust-step-audit-description" aria-labelledby="trust-step-audit" class="trust-story__step" role="listitem" tabindex="0">
+<div aria-hidden="true" class="trust-story__marker">
+<span class="trust-story__connector trust-story__connector--before"></span>
+<span class="trust-story__badge" data-step-index="3">
+<span aria-hidden="true" class="trust-story__badge-icon" data-uk-icon="icon: shield"></span>
+<span class="trust-story__sr">Step 3</span>
+</span>
+<span class="trust-story__connector trust-story__connector--after"></span>
+</div>
+<div class="trust-story__content">
+<h3 class="trust-story__title" id="trust-step-audit">Audit-ready at any time</h3>
+<p class="trust-story__text" id="trust-step-audit-description">
+                  Evidence, certificates and instrument history are audit-ready. Hosting in Germany and daily backups keep you prepared for inspections.
+                </p>
+</div>
+</li>
+</ul>
+<div class="trust-story__closing uk-grid uk-grid-large uk-flex-middle" data-uk-grid="">
+<div class="uk-width-1-1 uk-width-expand@m">
+<h3 class="trust-story__closing-title">Reassuring security for your team</h3>
+<p class="trust-story__closing-text">
+              GDPR-compliant, reliably managed and flexibly expandable — calServer grows with your workflows and keeps schedules, roles and instruments working in sync.
+            </p>
+</div>
+<div class="uk-width-1-1 uk-width-auto@m">
+<div class="trust-story__cta-group">
+<a class="uk-button uk-button-primary cta-main" href="#trial">
+<span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Test now
+              </a>
+<a class="btn btn-transparent" href="https://calendly.com/calhelp/calserver-vorstellung" rel="noopener" target="_blank">
+<span class="uk-margin-small-right" data-uk-icon="icon: calendar"></span>Book demo
+              </a>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section class="uk-section uk-section-default uk-section-large" id="features">
+<div class="uk-container">
+<div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+<h2 class="uk-heading-line"><span>Functions that make everyday work easier</span></h2>
+<span class="muted">Scroll &amp; discover the key areas</span>
+</div>
+<div class="uk-margin-large-top">
+<div class="uk-text-center uk-margin-medium-bottom">
+<h3 class="uk-heading-bullet">Features in focus</h3>
+<p class="muted">Pick the areas your team uses every day — and jump straight to the right feature card.</p>
+</div>
+<nav aria-label="Functional navigation" class="feature-nav">
+<ul class="feature-nav__list" id="feature-nav">
+<li><a class="feature-nav__pill" data-target="feature-inventare-intervalle" href="#">Inventories &amp; intervals</a></li>
+<li><a class="feature-nav__pill" data-target="feature-kalibrierscheine" href="#">Digitize calibration certificates</a></li>
+<li><a class="feature-nav__pill" data-target="feature-email-abrufe" href="#">Email follow-ups &amp; reminders</a></li>
+<li><a class="feature-nav__pill" data-target="feature-geraeteverwaltung" href="#">Device management</a></li>
+<li><a class="feature-nav__pill" data-target="feature-kalibrier-reparatur" href="#">Calibration &amp; repair management</a></li>
+<li><a class="feature-nav__pill" data-target="feature-auftragsbearbeitung" href="#">Order processing</a></li>
+<li><a class="feature-nav__pill" data-target="feature-leihverwaltung" href="#">Loan management</a></li>
+<li><a class="feature-nav__pill" data-target="feature-dokumentationen" href="#">Documentation &amp; wiki</a></li>
+<li><a class="feature-nav__pill" data-target="feature-dms" href="#">File management (DMS)</a></li>
+<li><a class="feature-nav__pill" data-target="feature-meldungen" href="#">Alerts &amp; tickets</a></li>
+<li><a class="feature-nav__pill" data-target="feature-cloud" href="#">Modern cloud foundation</a></li>
+</ul>
+</nav>
+</div>
+<div class="uk-position-relative uk-visible-toggle feature-slider" data-uk-slider="center: true; autoplay: true; autoplay-interval: 4200; finite: false" id="feature-slider" tabindex="-1">
+<div class="uk-slider-container">
+<ul class="uk-slider-items uk-child-width-1-1@s uk-child-width-1-2@m uk-child-width-1-3@l feature-slider__list" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .feature-slider__item; delay: 75; repeat: true">
+<li class="feature-slider__item" id="feature-inventare-intervalle">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Inventories &amp; intervals</h3>
+<p>Due dates come to you — reminders, follow-ups and planning overviews create calm.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Automated reminder logic</li>
+<li>Clear status colors</li>
+<li>Planning dashboards</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-kalibrierscheine">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Digitize calibration certificates</h3>
+<p>Just upload — automatic mapping takes care of versioning &amp; previews.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Intelligent filename detection</li>
+<li>Versions &amp; approvals</li>
+<li>Share via link</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-email-abrufe">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Email follow-ups &amp; reminders</h3>
+<p>Personal and predictable — automated series replace one-off emails.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Templates &amp; placeholders</li>
+<li>Schedules per audience</li>
+<li>Delivery log</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-geraeteverwaltung">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Device management</h3>
+<p>Whether 100 or 100,000 instruments — searches, filters and group views stay fast.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Quick search &amp; filters</li>
+<li>Sets &amp; accessories</li>
+<li>Exports (CSV/PDF)</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-kalibrier-reparatur">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Calibration &amp; repair management</h3>
+<p>From measurements to reports — no media breaks, with audit-proof approvals.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Capture or import measured values</li>
+<li>Editable overviews</li>
+<li>Generate reports instantly</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-auftragsbearbeitung">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Order processing</h3>
+<p>One flow for everything: quote → order → invoice — complete with your letterhead.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Batch &amp; partial invoices</li>
+<li>Price lists &amp; numbering schemes</li>
+<li>Automatic status updates</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-leihverwaltung">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Loan management</h3>
+<p>Reserve instead of phone chains — open the calendar, drop the device in, done.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Drag-and-drop calendar</li>
+<li>Accessory bundles</li>
+<li>Return reminders</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-dokumentationen">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Documentation &amp; wiki</h3>
+<p>Knowledge stays within the team — curated, versioned and searchable.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Editor with table of contents</li>
+<li>Versions &amp; permissions</li>
+<li>Internal links</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-dms">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">File management (DMS)</h3>
+<p>“Just store, no sorting” — assignment runs in the background.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Automatic assignment</li>
+<li>Versioning</li>
+<li>PDF viewer</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-meldungen">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Alerts &amp; tickets</h3>
+<p>Everything in one place: requests, history, notifications.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Central ticketing</li>
+<li>Change tracking</li>
+<li>Notification chains</li>
+</ul>
+</article>
+</li>
+<li class="feature-slider__item" id="feature-cloud">
+<article class="feature-card">
+<h3 class="uk-card-title feature-card__title">Modern cloud foundation</h3>
+<p>Fast, stable and update-friendly — without heavy admin.</p>
+<ul class="uk-list uk-list-bullet">
+<li>Scalable environment</li>
+<li>Regular updates</li>
+<li>Daily backups</li>
+</ul>
+</article>
+</li>
+</ul>
+</div>
+<a aria-label="Previous function" class="uk-position-center-left uk-position-small uk-hidden-hover" data-uk-slidenav-previous="" data-uk-slider-item="previous" href="#"></a>
+<a aria-label="Next function" class="uk-position-center-right uk-position-small uk-hidden-hover" data-uk-slidenav-next="" data-uk-slider-item="next" href="#"></a>
+</div>
+<script>
+          document.addEventListener('DOMContentLoaded', () => {
+            const sliderElement = document.getElementById('feature-slider');
+            const navElement = document.getElementById('feature-nav');
+            if (!sliderElement || !navElement || typeof UIkit === 'undefined') {
+              return;
+            }
+
+            const slider = UIkit.slider(sliderElement);
+            const pills = Array.from(navElement.querySelectorAll('li'));
+            const slides = Array.from(sliderElement.querySelectorAll('.feature-slider__item'));
+            const itemsContainer = sliderElement.querySelector('.uk-slider-items');
+            if (!itemsContainer) {
+              return;
+            }
+
+            const indexById = new Map(slides.map((slide, index) => [slide.id, index]));
+
+            const applyFocusToCenter = () => {
+              const slideElements = Array.from(itemsContainer.children);
+              if (!slideElements.length) {
+                return;
+              }
+
+              const viewportElement = sliderElement.querySelector('.uk-slider-container') || sliderElement;
+              const viewportRect = viewportElement.getBoundingClientRect();
+              const midpoint = viewportRect.left + viewportRect.width / 2;
+
+              let nearest = null;
+              let minDistance = Number.POSITIVE_INFINITY;
+
+              slideElements.forEach((item) => {
+                const card = item.querySelector('.feature-card');
+                if (!card) {
+                  return;
+                }
+
+                const rect = item.getBoundingClientRect();
+                const centerX = rect.left + rect.width / 2;
+                const distance = Math.abs(centerX - midpoint);
+
+                if (distance < minDistance) {
+                  minDistance = distance;
+                  nearest = item;
+                }
+              });
+
+              slideElements.forEach((item) => {
+                item.classList.remove('is-center');
+                const card = item.querySelector('.feature-card');
+                if (card) {
+                  card.classList.remove('feature-card--focus');
+                }
+              });
+
+              if (nearest) {
+                nearest.classList.add('is-center');
+                const focusCard = nearest.querySelector('.feature-card');
+                if (focusCard) {
+                  focusCard.classList.add('feature-card--focus');
+                }
+              }
+            };
+
+            const setActive = (index) => {
+              pills.forEach((li, i) => {
+                const isActive = i === index;
+                li.classList.toggle('uk-active', isActive);
+
+                const link = li.querySelector('.feature-nav__pill');
+                if (!link) {
+                  return;
+                }
+
+                link.classList.toggle('is-active', isActive);
+                if (isActive) {
+                  link.setAttribute('aria-current', 'true');
+                } else {
+                  link.removeAttribute('aria-current');
+                }
+              });
+            };
+
+            const setCurrent = (index) => {
+              slides.forEach((slide, i) => slide.classList.toggle('uk-current', i === index));
+            };
+
+            pills.forEach((li) => {
+              const link = li.querySelector('a[data-target]');
+              if (!link) {
+                return;
+              }
+
+              const targetId = link.dataset.target;
+              const targetIndex = indexById.get(targetId);
+              if (typeof targetIndex === 'undefined') {
+                return;
+              }
+
+              link.addEventListener('click', (event) => {
+                event.preventDefault();
+                slider.show(targetIndex);
+                setActive(targetIndex);
+                setCurrent(targetIndex);
+                applyFocusToCenter();
+              });
+            });
+
+            UIkit.util.on(sliderElement, 'itemshown', () => {
+              setActive(slider.index);
+              setCurrent(slider.index);
+              applyFocusToCenter();
+            });
+
+            const initialIndex = typeof slider.index === 'number' ? slider.index : 0;
+            setActive(initialIndex);
+            setCurrent(initialIndex);
+            applyFocusToCenter();
+            window.addEventListener('resize', applyFocusToCenter);
+          });
+        </script>
+</div>
+</section>
+<hr class="uk-divider-icon"/>
+<section class="uk-section uk-section-muted" id="modules">
+<div class="uk-container">
+<div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+<h2 class="uk-heading-line"><span>Modules that make the difference</span></h2>
+<span class="muted">Can be combined individually - without hidden costs</span>
+</div>
+<div class="calserver-modules-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: &gt; *; delay: 100; repeat: true">
+<div>
+<ul class="uk-tab calserver-modules-nav" data-uk-switcher="connect: #calserver-modules-switcher; animation: uk-animation-fade">
+<li>
+<a class="calserver-modules-nav__link" href="#module-device-management">
+<span class="calserver-modules-nav__title">Device management &amp; history</span>
+<span class="calserver-modules-nav__desc">Device files, attachments and history in one interface — including measurement values.</span>
+</a>
+</li>
+<li>
+<a class="calserver-modules-nav__link" href="#module-calendar-resources">
+<span class="calserver-modules-nav__title">Calendar &amp; resources</span>
+<span class="calserver-modules-nav__desc">Plan appointments, loan devices and staff in a single view.</span>
+</a>
+</li>
+<li>
+<a class="calserver-modules-nav__link" href="#module-order-ticketing">
+<span class="calserver-modules-nav__title">Order &amp; ticket management</span>
+<span class="calserver-modules-nav__desc">From order to invoice — with clear statuses, workflows and documents.</span>
+</a>
+</li>
+<li>
+<a class="calserver-modules-nav__link" href="#module-self-service">
+<span class="calserver-modules-nav__title">Self-service &amp; extranet</span>
+<span class="calserver-modules-nav__desc">Provide customers &amp; partners with instrument details, certificates and forms.</span>
+</a>
+</li>
+</ul>
+</div>
+<div>
+<ul class="uk-switcher calserver-modules-switcher" id="calserver-modules-switcher">
+<li>
+<figure class="calserver-module-figure" id="module-device-management">
+<img alt="Screenshot of the calServer device management with device files, history and measured values" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-device-management.webp" width="1200"/>
+<figcaption>
+<h3 class="uk-h3">Device management &amp; history</h3>
+<p class="muted">Device files, attachments and history in one interface — including measurement values.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Device &amp; location management</li>
+<li>Versioned documents &amp; images</li>
+<li>Link measurement values directly</li>
+</ul>
+</figcaption>
+</figure>
+</li>
+<li>
+<figure class="calserver-module-figure" id="module-calendar-resources">
+<img alt="Screenshot of the calServer calendar with resource and scheduling" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp" width="1200"/>
+<figcaption>
+<h3 class="uk-h3">Calendar &amp; resources</h3>
+<p class="muted">Plan appointments, loan devices and staff in a single view.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Gantt &amp; calendar</li>
+<li>Availability check in real time</li>
+<li>Outlook/ical integration</li>
+</ul>
+</figcaption>
+</figure>
+</li>
+<li>
+<figure class="calserver-module-figure" id="module-order-ticketing">
+<img alt="Screenshot of the calServer mandate and ticket management with workflow status" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp" width="1200"/>
+<figcaption>
+<h3 class="uk-h3">Order &amp; ticket management</h3>
+<p class="muted">From order to invoice — with clear statuses, workflows and documents.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Service &amp; ticket system</li>
+<li>Offers, orders, invoices</li>
+<li>Escalations &amp; SLAs</li>
+</ul>
+</figcaption>
+</figure>
+</li>
+<li>
+<figure class="calserver-module-figure" id="module-self-service">
+<img alt="Screenshot of the calServer self-service portal with customer view and certificates" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-self-service.webp" width="1200"/>
+<figcaption>
+<h3 class="uk-h3">Self-service &amp; extranet</h3>
+<p class="muted">Provide customers &amp; partners with instrument details, certificates and forms.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Customer portals</li>
+<li>Documents &amp; certificates</li>
+<li>Individual rights</li>
+</ul>
+</figcaption>
+</figure>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</section>
+<section class="uk-section uk-section-default" id="usecases">
+<div class="uk-container">
+<div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+<h2 class="uk-heading-line"><span>Application cases from practice</span></h2>
+<span class="muted">From the laboratory to the field</span>
+</div>
+<ul class="uk-subnav uk-subnav-pill uk-margin-large-top usecase-tabs" data-uk-switcher="animation: uk-animation-fade">
+<li><a href="#">ifm electronic (2 locations)</a></li>
+<li><a href="#">KSW Kalibrierservice GmbH</a></li>
+<li><a href="#">Systems Engineering GmbH</a></li>
+<li><a href="#">Teramess (Dakks-Labor)</a></li>
+<li><a href="#">Thermo Fisher Scientific (EMEA)</a></li>
+<li><a href="#">ZF Friedrichshafen</a></li>
+<li><a href="#">Berlin Stadtwerke</a></li>
+<li><a href="#">VDE Germany</a></li>
+</ul>
+<ul class="uk-switcher uk-margin-large-top" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .usecase-story, .usecase-highlight; delay: 100; repeat: true">
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid="">
+<div class="usecase-story uk-first-column uk-scrollspy-inview">
+<span class="pill pill--badge uk-margin-small-bottom">Calibration laboratory</span>
+<h3 class="uk-h2">ifm – incident handling &amp; improvements across two sites</h3>
+<p class="uk-text-lead">calServer coordinates internal calibration and incident handling across two sites.</p>
+<p>Tickets capture faults in a structured, prioritised and traceable way while doubling as a risk/opportunity log for continuous improvement. Bidirectional sync with Fluke MET/TEAM and MET/CAL keeps device and calibration data consistent across locations.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Ticket management for incidents &amp; CAPA-focused analytics</li>
+<li>Cross-site device records &amp; certificates in the DMS</li>
+<li>Bidirectional MET/TEAM &amp; MET/CAL synchronisation</li>
+</ul>
+</div>
+<div class="usecase-highlight">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+<h4 class="uk-heading-bullet">Key facts</h4>
+<ul class="uk-list uk-list-divider">
+<li>Two locations, consistent database</li>
+<li>Tickets + opportunities/risks rating</li>
+<li>Bidirectional sync with Fluke MET/TEAM &amp; MET/CAL</li>
+</ul>
+<a class="uk-button uk-button-text uk-margin-top" href="#">
+<span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>Highlights as PDF
+                  </a>
+</div>
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+<div class="usecase-visual">
+<img alt="Screenshot of the calServer ticket board in the IFM-UNE case with a capa rating" class="uk-border-rounded usecase-visual__image" decoding="async" height="540" loading="lazy" src="{{ basePath }}/uploads/calserver-usecase-ifm-ticketmanagement.webp" width="960"/>
+</div>
+</div>
+</div>
+</div>
+</li>
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid="">
+<div class="usecase-story uk-first-column uk-scrollspy-inview">
+<span class="pill pill--badge uk-margin-small-bottom">Calibration laboratory</span>
+<h3 class="uk-h2">KSW – end-to-end from goods receipt to invoicing</h3>
+<p class="uk-text-lead">calServer covers the entire flow from goods receipt through the lab to invoicing.</p>
+<p>Job travellers, device files and certificates live in one place; order processing, statuses and communication stay in sync — reliable, fast and transparent.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Order processing with SLAs, escalations &amp; email sequences</li>
+<li>DMS for certificates, reports and history</li>
+<li>Seamless handover to billing &amp; reporting</li>
+</ul>
+</div>
+<div class="usecase-highlight">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+<h4 class="uk-heading-bullet">Key facts</h4>
+<ul class="uk-list uk-list-divider">
+<li>Input → laboratory → invoice</li>
+<li>Order processing running like clockwork</li>
+<li>Integrated DMS &amp; reporting</li>
+</ul>
+<a class="uk-button uk-button-text uk-margin-top" href="#">
+<span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>Highlights as PDF
+                  </a>
+</div>
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+<div class="usecase-visual">
+<img alt="Screenshot of the calServer process flow from goods receipt to billing in the KSW-Use-Case" class="uk-border-rounded usecase-visual__image" decoding="async" height="540" loading="lazy" src="{{ basePath }}/uploads/calserver-usecase-ksw-prozesskette.webp" width="960"/>
+</div>
+</div>
+</div>
+</div>
+</li>
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid="">
+<div class="usecase-story uk-first-column uk-scrollspy-inview">
+<span class="pill pill--badge uk-margin-small-bottom">Calibration laboratory</span>
+<h3 class="uk-h2">Systems Engineering – order processing as the heartbeat</h3>
+<p class="uk-text-lead">calServer makes order processing the heartbeat of the laboratory.</p>
+<p>Internal tasks stay clearly prioritised, reports come straight from the system and remain traceable thanks to versioning — ensuring reliable schedules and clear responsibilities.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Task/role control with statuses &amp; checklists</li>
+<li>Own reports from order and device data</li>
+<li>DMS &amp; history for audit and compliance duties</li>
+</ul>
+</div>
+<div class="usecase-highlight">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+<h4 class="uk-heading-bullet">Key facts</h4>
+<ul class="uk-list uk-list-divider">
+<li>Clear status &amp; role flow</li>
+<li>Reports directly from the process data</li>
+<li>Version &amp; understandability (DMS)</li>
+</ul>
+<a class="uk-button uk-button-text uk-margin-top" href="#">
+<span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>Highlights as PDF
+                  </a>
+</div>
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+<div class="usecase-visual">
+<img alt="Screenshot of the calServer mandate and reporting widgets in the system engineering use" class="uk-border-rounded usecase-visual__image" decoding="async" height="540" loading="lazy" src="{{ basePath }}/uploads/calserver-usecase-systems-reporting.webp" width="960"/>
+</div>
+</div>
+</div>
+</div>
+</li>
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid="">
+<div class="usecase-story uk-first-column uk-scrollspy-inview">
+<span class="pill pill--badge uk-margin-small-bottom">Calibration laboratory</span>
+<h3 class="uk-h2">Teramess – DAkkS-compliant certificates in the cloud</h3>
+<p class="uk-text-lead">calServer Cloud consolidates DAkkS-compliant certificates, device files and test reports.</p>
+<p>Certificates are stored with version history; repeat and follow-up calibrations stay transparently traceable. Communication and documents run in defined, auditable lanes.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Audit-proof filing with versioning</li>
+<li>Structured inspection &amp; measurement history</li>
+<li>Analyses &amp; bulk exports for customer communication</li>
+</ul>
+</div>
+<div class="usecase-highlight">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+<h4 class="uk-heading-bullet">Key facts</h4>
+<ul class="uk-list uk-list-divider">
+<li>Audit-proof DMS in the cloud</li>
+<li>DAkkS-compliant test history</li>
+<li>Bulk exports &amp; analytics</li>
+</ul>
+<a class="uk-button uk-button-text uk-margin-top" href="#">
+<span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>Highlights as PDF
+                  </a>
+</div>
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+<div class="usecase-visual">
+<img alt="Screenshot of the calServer certificate management with DAKKKS history in the teramess-use-case" class="uk-border-rounded usecase-visual__image" decoding="async" height="540" loading="lazy" src="{{ basePath }}/uploads/calserver-usecase-teramess-dakks.webp" width="960"/>
+</div>
+</div>
+</div>
+</div>
+</li>
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid="">
+<div class="usecase-story uk-first-column uk-scrollspy-inview">
+<span class="pill pill--badge uk-margin-small-bottom">Calibration laboratory</span>
+<h3 class="uk-h2">Thermo Fisher Scientific – EMEA lab</h3>
+<p class="uk-text-lead">calServer orchestrates EMEA-wide loan devices, device records and ISO/DAkkS-compliant certificates on one platform.</p>
+<p>Multiple laboratories operate within one consistent workflow: loan management, test jobs and certificates are controlled centrally, while orders and returns remain transparent across locations. Bidirectional sync with Fluke MET/TEAM and MET/CAL automatically maintains master data, calibration runs and results.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Central loan management with appointment &amp; return reminders</li>
+<li>Audit-proof DMS for certificates &amp; history</li>
+<li>Bidirectional MET/TEAM &amp; MET/CAL synchronisation</li>
+</ul>
+</div>
+<div class="usecase-highlight">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+<h4 class="uk-heading-bullet">Key facts</h4>
+<ul class="uk-list uk-list-divider">
+<li>Unified loan management &amp; device records across EMEA</li>
+<li>Audit-proof DMS for certificates &amp; history</li>
+<li>Bidirectional sync with Fluke MET/TEAM &amp; MET/CAL</li>
+</ul>
+<a class="uk-button uk-button-text uk-margin-top" href="#">
+<span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>Highlights as PDF
+                  </a>
+</div>
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+<div class="usecase-visual">
+<img alt="Screenshot of the calServer loan and device file overview in the thermo-fisher-us-case" class="uk-border-rounded usecase-visual__image" decoding="async" height="540" loading="lazy" src="{{ basePath }}/uploads/calserver-usecase-thermo-leihverwaltung.webp" width="960"/>
+</div>
+</div>
+</div>
+</div>
+</li>
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid="">
+<div class="usecase-story uk-first-column uk-scrollspy-inview">
+<span class="pill pill--badge uk-margin-small-bottom">Industrial laboratory</span>
+<h3 class="uk-h2">ZF – API-driven measurement data on Kubernetes with SSO</h3>
+<p class="uk-text-lead">calServer combines scalable measurement APIs on Kubernetes with SSO and device record management.</p>
+<p>Measurement values flow automatically via microservices; devices, certificates and evaluations remain accessible to authorised teams. Single sign-on simplifies access, while bidirectional sync with Fluke MET/TEAM and MET/CAL keeps calibration data consistent.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>API ingestion of measurement data (microservices/Kubernetes)</li>
+<li>SSO (e.g. Entra ID/Google) for seamless access</li>
+<li>Bidirectional MET/TEAM &amp; MET/CAL synchronisation</li>
+</ul>
+</div>
+<div class="usecase-highlight">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+<h4 class="uk-heading-bullet">Key facts</h4>
+<ul class="uk-list uk-list-divider">
+<li>Microservices on Kubernetes</li>
+<li>SSO for fast, safe access</li>
+<li>Bidirectional sync with Fluke MET/TEAM &amp; MET/CAL</li>
+</ul>
+<a class="uk-button uk-button-text uk-margin-top" href="#">
+<span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>Highlights as PDF
+                  </a>
+</div>
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+<div class="usecase-visual">
+<img alt="Screenshot of the calServer Messwert-APIS and SSO configuration in the ZF-UNE-CASE" class="uk-border-rounded usecase-visual__image" decoding="async" height="540" loading="lazy" src="{{ basePath }}/uploads/calserver-usecase-zf-messwerte-sso.webp" width="960"/>
+</div>
+</div>
+</div>
+</div>
+</li>
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid="">
+<div class="usecase-story uk-first-column uk-scrollspy-inview">
+<span class="pill pill--badge uk-margin-small-bottom">Asset management</span>
+<h3 class="uk-h2">Berliner Stadtwerke – projects &amp; maintenance for renewable assets</h3>
+<p class="uk-text-lead">calServer manages projects, maintenance plans and operations for renewable energy assets at Berliner Stadtwerke.</p>
+<p>From action planning to deployment scheduling, teams keep availability, performance and costs in view. Checklists, offline capability and escalation paths ensure deadlines are met. (No MET/CAL or MET/TEAM integration required — focused on project &amp; maintenance control.)</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Project &amp; action management incl. deployment planning</li>
+<li>Planned/unplanned maintenance with checklists &amp; offline mode</li>
+<li>Dashboards for availability, performance &amp; cost/benefit</li>
+</ul>
+</div>
+<div class="usecase-highlight">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+<h4 class="uk-heading-bullet">Key facts</h4>
+<ul class="uk-list uk-list-divider">
+<li>City-wide renewable energy systems at a glance</li>
+<li>Planned &amp; unplanned maintenance from one system</li>
+<li>Dashboards for availability &amp; performance</li>
+</ul>
+<a class="uk-button uk-button-text uk-margin-top" href="#">
+<span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>Highlights as PDF
+                  </a>
+</div>
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+<div class="usecase-visual">
+<img alt="Screenshot of the calServer maintenance and project planning for Berlin Stadtwerke" class="uk-border-rounded usecase-visual__image" decoding="async" height="540" loading="lazy" src="{{ basePath }}/uploads/calserver-usecase-berlin-wartung.webp" width="960"/>
+</div>
+</div>
+</div>
+</div>
+</li>
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-flex-top" data-uk-grid="">
+<div class="usecase-story uk-first-column uk-scrollspy-inview">
+<span class="pill pill--badge uk-margin-small-bottom">Quality management</span>
+<h3 class="uk-h2">VDE – agile order management &amp; intranet</h3>
+<p class="uk-text-lead">calServer bundles agile order control and document flows for testing and certification programmes.</p>
+<p>Teams plan, prioritise and document processes on a customisable board; series are versioned, traceable and audit-proof. Roles and templates are distributed in a targeted manner. Bidirectional sync with Fluke MET/TEAM and MET/CAL keeps measurement and order data consistent.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Agile order board with SLAs, escalations and templates</li>
+<li>Audit-proof DMS repository including approval workflow</li>
+<li>Bidirectional MET/TEAM &amp; MET/CAL synchronisation</li>
+</ul>
+</div>
+<div class="usecase-highlight">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card">
+<h4 class="uk-heading-bullet">Key facts</h4>
+<ul class="uk-list uk-list-divider">
+<li>Agile order board (SLAs, escalation logic)</li>
+<li>Audit trails &amp; versioned approvals</li>
+<li>Bidirectional sync with Fluke MET/TEAM &amp; MET/CAL</li>
+</ul>
+<a class="uk-button uk-button-text uk-margin-top" href="#">
+<span class="uk-margin-small-right" data-uk-icon="icon: file-pdf"></span>Highlights as PDF
+                  </a>
+</div>
+<div class="uk-card uk-card-default uk-card-body uk-card-hover usecase-card usecase-card--visual uk-margin-top">
+<div class="usecase-visual">
+<img alt="Screenshot of the calServer mandate boards with DMS integration in the VDE-UNE-CASE" class="uk-border-rounded usecase-visual__image" decoding="async" height="540" loading="lazy" src="{{ basePath }}/uploads/calserver-usecase-vde-auftragsboard.webp" width="960"/>
+</div>
+</div>
+</div>
+</div>
+</li>
+</ul>
+</div>
+</section>
+<section class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow" id="modes">
+<div class="uk-container">
+<h2 class="uk-heading-line uk-light"><span>Operating modes that suit you</span></h2>
+<ul class="uk-subnav uk-subnav-pill uk-margin" data-uk-switcher="">
+<li><a href="#">Cloud</a></li>
+<li><a href="#">On-premise</a></li>
+</ul>
+<ul class="uk-switcher uk-margin" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid="">
+<div class="anim">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+<h3 class="uk-card-title">Immediately ready to go</h3>
+<ul class="uk-list uk-list-bullet muted">
+<li>Provision in a few days</li>
+<li>Automated updates &amp; monitoring</li>
+<li>Backup strategy included</li>
+</ul>
+</div>
+</div>
+<div class="anim">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+<h3 class="uk-card-title">Secure &amp; scalable</h3>
+<ul class="uk-list uk-list-bullet muted">
+<li>Data center in Germany</li>
+<li>ISO 27001 certified infrastructure</li>
+<li>Flexible number of users</li>
+</ul>
+</div>
+</div>
+</div>
+</li>
+<li>
+<div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid="">
+<div class="anim">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+<h3 class="uk-card-title">Full control</h3>
+<ul class="uk-list uk-list-bullet muted">
+<li>Operation in your own network</li>
+<li>Support with installation &amp; updates</li>
+<li>Integration into existing systems</li>
+</ul>
+</div>
+</div>
+<div class="anim">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+<h3 class="uk-card-title">Individual security</h3>
+<ul class="uk-list uk-list-bullet muted">
+<li>Connection to your identity management</li>
+<li>Flexible backup and maintenance windows</li>
+<li>Support via SLA packages</li>
+</ul>
+</div>
+</div>
+</div>
+</li>
+</ul>
+</div>
+</section>
+<section class="uk-section uk-section-default" id="pricing">
+<div class="uk-container">
+<div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
+<h2 class="uk-heading-line"><span>Prices that create clarity</span></h2>
+<span class="muted">Honest, transparent and without hidden costs.</span>
+</div>
+<div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-large uk-grid-match" data-uk-grid="" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+<div class="anim">
+<div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
+<h3>Standard</h3>
+<p class="muted">The solid basis for small teams.</p>
+<p class="uk-text-large uk-text-bold">from 250 €/month</p>
+<ul class="uk-list uk-list-bullet uk-text-left muted">
+<li>Up to 2 clients</li>
+<li>All core modules included</li>
+<li>Email support within 24 hours</li>
+</ul>
+<a class="uk-button uk-button-default" href="#offer">Request a non-binding offer</a>
+</div>
+</div>
+<div class="anim">
+<div class="uk-card uk-card-primary uk-card-primary--highlight uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative">
+<span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Recommended</span>
+<h3>Performance</h3>
+<p>For larger teams that need more speed.</p>
+<p class="uk-text-large uk-text-bold">on request</p>
+<ul class="uk-list uk-list-bullet uk-text-left">
+<li>Unlimited users</li>
+<li>Extended automation</li>
+<li>Prioritised support &amp; SLA</li>
+</ul>
+<a class="uk-button uk-button-default" href="#offer">Request advice</a>
+</div>
+</div>
+<div class="anim">
+<div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
+<h3>Enterprise</h3>
+<p class="muted">Individually tailored to your processes.</p>
+<p class="uk-text-large uk-text-bold">custom quote</p>
+<ul class="uk-list uk-list-bullet uk-text-left muted">
+<li>Own client structures</li>
+<li>On-premise or hybrid</li>
+<li>Integration &amp; project support</li>
+</ul>
+<a class="uk-button uk-button-default" href="#offer">Request offer</a>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section class="uk-section uk-section-muted" id="faq">
+<div class="uk-container">
+<h2 class="uk-heading-line"><span>Frequently asked questions</span></h2>
+<ul data-uk-accordion="">
+<li>
+<a class="uk-accordion-title" href="#">How quickly can we get started with the cloud version?</a>
+<div class="uk-accordion-content">
+<p>Typically within a few days — we personally guide the kick-off.</p>
+</div>
+</li>
+<li>
+<a class="uk-accordion-title" href="#">Can I switch between the cloud and on-premise?</a>
+<div class="uk-accordion-content">
+<p>Yes, a change is possible at any time. We support with migration and data transfer.</p>
+</div>
+</li>
+<li>
+<a class="uk-accordion-title" href="#">Which data imports are possible?</a>
+<div class="uk-accordion-content">
+<p>Excel/CSV imports, API interfaces and individual integrations.</p>
+</div>
+</li>
+<li>
+<a class="uk-accordion-title" href="#">How does support work?</a>
+<div class="uk-accordion-content">
+<p>Support via email, phone or ticket system — depending on the plan, even with an SLA.</p>
+</div>
+</li>
+<li>
+<a class="uk-accordion-title" href="#">What happens to my data after the test?</a>
+<div class="uk-accordion-content">
+<p>After testing you decide: continue using, export or delete — full transparency.</p>
+</div>
+</li>
+</ul>
+<div class="uk-margin-top">
+<span class="muted">Still haven't found what you need?</span>
+<a class="uk-margin-small-left" href="#contact-form">More questions → Contact</a>
+</div>
+</div>
+</section>
+<section class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow" id="demo">
+<div class="uk-container">
+<div class="calserver-highlight__intro uk-text-center">
+<h2 class="uk-heading-small uk-margin-remove-bottom">Ready to experience calServer live?</h2>
+<p class="uk-text-lead uk-margin-small-top">Try it now or book a demo — we'll show how your processes run in calServer.</p>
+</div>
+<div class="uk-grid-large uk-child-width-1-1 uk-child-width-1-2@m uk-grid-match" data-uk-grid="" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
+<div class="anim">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+<div>
+<h3 class="uk-card-title">Book live demo</h3>
+<p class="muted">We guide you through calServer, answer questions and highlight suitable workflows.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Individual presentation with industry focus</li>
+<li>Direct exchange with our experts</li>
+<li>Concrete recommendations for your deployment</li>
+</ul>
+</div>
+<div class="calserver-highlight-card__actions">
+<a class="uk-button uk-button-primary" href="https://calendly.com/calhelp/calserver-vorstellung" rel="noopener" target="_blank">Book demo</a>
+<span class="muted">Approx. 45-minute individual session</span>
+</div>
+</div>
+</div>
+<div class="anim">
+<div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
+<div>
+<h3 class="uk-card-title">Secure test access</h3>
+<p class="muted">Start in your own environment and explore calServer with your processes.</p>
+<ul class="uk-list uk-list-bullet muted">
+<li>Setup after a brief alignment</li>
+<li>Best practices for a quick start</li>
+<li>Support team by your side</li>
+</ul>
+</div>
+<div class="calserver-highlight-card__actions">
+<a class="uk-button uk-button-default" href="#offer" id="trial">Test now</a>
+<span class="muted">Access &amp; demo environment included</span>
+</div>
+</div>
+</div>
+</div>
+<p class="muted uk-text-small uk-text-center uk-margin-medium-top">* Demo access and test environment after a short alignment.</p>
+</div>
+</section>
+<section class="uk-section" id="contact-us">
+<div class="uk-container">
+<h2 class="uk-heading-medium uk-text-center" data-uk-scrollspy="cls: uk-animation-slide-top-small">Still have questions? We are here for you.</h2>
+<p class="uk-text-lead uk-text-center" data-uk-scrollspy="cls: uk-animation-fade; delay: 150">Whether you need trial access, an offer or tailored advice — we guarantee a personal follow-up.</p>
+<div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" data-uk-grid="" data-uk-scrollspy="target: &gt; div; cls: uk-animation-slide-right-small; delay: 150">
+<div>
+<form class="uk-form-stacked uk-width-large uk-margin-auto" data-contact-endpoint="{{ basePath }}/calserver/contact" id="contact-form">
+<div class="uk-margin">
+<label class="uk-form-label" for="form-name">Your name</label>
+<input class="uk-input" id="form-name" name="name" required="" type="text"/>
+</div>
+<div class="uk-margin">
+<label class="uk-form-label" for="form-email">Email</label>
+<input class="uk-input" id="form-email" name="email" required="" type="email"/>
+</div>
+<div class="uk-margin">
+<label class="uk-form-label" for="form-msg">Message</label>
+<textarea class="uk-textarea" id="form-msg" name="message" required="" rows="5"></textarea>
+</div>
+<div class="uk-margin turnstile-field" data-turnstile-container="">
+<div class="turnstile-widget">{{ turnstile_widget }}</div>
+<p class="uk-text-small turnstile-hint" data-turnstile-hint="" hidden="">Please confirm that you are not a robot.</p>
+</div>
+<div class="uk-margin">
+<label><input class="uk-checkbox" name="privacy" required="" type="checkbox"/> I agree that my data may be stored for processing purposes.</label>
+</div>
+<input aria-hidden="true" autocomplete="off" class="uk-hidden" name="company" tabindex="-1" type="text"/>
+<input name="csrf_token" type="hidden" value="{{ csrf_token }}"/>
+<button class="btn btn-black uk-button uk-button-secondary uk-button-large uk-width-1-1" type="submit">Send</button>
+</form>
+</div>
+<div>
+<div class="uk-grid uk-child-width-1-1 uk-grid-small">
+<div><div aria-hidden="true" class="uk-form-label"> </div></div>
+<div>
+<div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
+<p class="uk-margin-small-bottom uk-text-large">Email</p>
+<a class="uk-text-lead uk-link-reset js-email-link" data-domain="calhelp.de" data-user="office" href="#">office [at] calhelp.de</a>
+</div>
+</div>
+<div>
+<div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
+<p class="uk-margin-small-bottom uk-text-large">Phone</p>
+<a class="uk-text-lead uk-link-reset" href="tel:+4933203609080">+49 33203 609080</a>
+</div>
+</div>
+<div>
+<div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
+<p class="uk-margin-small-bottom uk-text-large">Customer reviews</p>
+<div
+  class="calserver-proseal"
+  data-calserver-proseal
+  data-widget-id="1503aa9a-ae86-41d0-8ce9-05ed6f0a4856"
+  data-widget-language="de-DE">
+  <div class="calserver-proseal__placeholder" data-calserver-proseal-placeholder>
+    <p class="uk-text-small uk-margin-small-bottom">Reviews load once you allow marketing cookies.</p>
+    <button class="uk-button uk-button-primary uk-button-small" type="button" data-calserver-proseal-consent>Show reviews</button>
+    <p class="uk-text-meta uk-margin-small-top">You can change this anytime in the cookie settings.</p>
+    <p class="uk-text-meta uk-margin-small-top calserver-proseal__error" data-calserver-proseal-error hidden>Reviews could not be loaded. Please try again later.</p>
+  </div>
+  <div class="calserver-proseal__embed" id="proSealWidget" data-proseal-target hidden></div>
+  <noscript>
+    <p class="uk-text-small uk-margin-small-top">
+      <a class="uk-link-muted" href="https://www.provenexpert.com/calhelp/?utm_source=seals&amp;utm_campaign=embedded-proseal&amp;utm_medium=profile&amp;utm_content=1503aa9a-ae86-41d0-8ce9-05ed6f0a4856" rel="noopener" target="_blank">View customer reviews on ProvenExpert</a>
+    </p>
+  </noscript>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<div data-uk-modal="" id="contact-modal">
+<div class="uk-modal-dialog uk-modal-body">
+<p aria-live="polite" id="contact-modal-message"></p>
+<button class="uk-button uk-button-primary uk-modal-close" type="button">OK</button>
+</div>
+</div>
+
+$$
+)
+ON CONFLICT (slug) DO UPDATE
+SET title = EXCLUDED.title,
+    content = EXCLUDED.content;

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -712,6 +712,47 @@ body.qr-landing:not([data-theme="dark"]) .contact-card span{
   color:#000;
 }
 
+.calserver-proseal{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.calserver-proseal__placeholder{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.calserver-proseal__placeholder p{
+  margin:0;
+}
+
+.calserver-proseal__embed{
+  min-height:120px;
+}
+
+.calserver-proseal__embed[hidden]{
+  display:none !important;
+}
+
+.calserver-proseal[data-state="loading"] .calserver-proseal__placeholder,
+.calserver-proseal[data-state="loaded"] .calserver-proseal__placeholder{
+  display:none;
+}
+
+.calserver-proseal__error[hidden]{
+  display:none !important;
+}
+
+.calserver-proseal[data-state="error"] .calserver-proseal__error{
+  color:var(--qr-muted);
+}
+
+body.qr-landing:not([data-theme="dark"]) .calserver-proseal[data-state="error"] .calserver-proseal__error{
+  color:#333;
+}
+
 /* Form & A11y */
 .qr-landing #contact-form .uk-input,
 .qr-landing #contact-form .uk-textarea{

--- a/public/js/calserver.js
+++ b/public/js/calserver.js
@@ -2,6 +2,11 @@
   const EVENT_NAME = 'calserver:cookie-preference-changed';
   const ALLOW_ATTR = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
   const STORAGE_KEY = (globalThis.STORAGE_KEYS && globalThis.STORAGE_KEYS.CALSERVER_COOKIE_CHOICES) || 'calserverCookieChoices';
+  const PROSEAL_SCRIPT_SRC = 'https://s.provenexpert.net/seals/proseal-v2.js';
+  const PROSEAL_SELECTOR = '[data-calserver-proseal]';
+  let proSealScriptLoading = false;
+  let proSealScriptLoaded = false;
+  const proSealQueue = [];
 
   function readPreferences() {
     if (globalThis.calserverCookie && typeof globalThis.calserverCookie.getPreferences === 'function') {
@@ -134,6 +139,175 @@
     container.classList.add('is-loaded');
   }
 
+  function ensureProSealScript(callback) {
+    if (proSealScriptLoaded) {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return;
+    }
+
+    if (typeof callback === 'function') {
+      proSealQueue.push(callback);
+    }
+
+    if (proSealScriptLoading) {
+      return;
+    }
+
+    proSealScriptLoading = true;
+    const script = document.createElement('script');
+    script.src = PROSEAL_SCRIPT_SRC;
+    script.async = true;
+    script.onload = function () {
+      proSealScriptLoaded = true;
+      proSealScriptLoading = false;
+      const queued = proSealQueue.splice(0, proSealQueue.length);
+      queued.forEach(function (fn) {
+        if (typeof fn === 'function') {
+          try {
+            fn();
+          } catch (error) {
+            /* empty */
+          }
+        }
+      });
+    };
+    script.onerror = function () {
+      proSealScriptLoading = false;
+      proSealQueue.splice(0, proSealQueue.length);
+    };
+
+    document.head.appendChild(script);
+  }
+
+  function setupProSealContainer(container) {
+    if (!container) {
+      return;
+    }
+
+    const target = container.querySelector('[data-proseal-target]');
+    if (!target) {
+      return;
+    }
+
+    if (!target.id) {
+      target.id = 'proSealWidget-' + Math.random().toString(36).slice(2, 10);
+    }
+
+    const placeholder = container.querySelector('[data-calserver-proseal-placeholder]');
+    const consentButton = container.querySelector('[data-calserver-proseal-consent]');
+    const errorMessage = container.querySelector('[data-calserver-proseal-error]');
+    const widgetId = container.getAttribute('data-widget-id');
+    const widgetLanguage = container.getAttribute('data-widget-language') || 'de-DE';
+    let loading = false;
+    let initialized = false;
+
+    const setState = function (state) {
+      container.dataset.state = state;
+      if (errorMessage) {
+        if (state === 'error') {
+          errorMessage.removeAttribute('hidden');
+        } else {
+          errorMessage.setAttribute('hidden', '');
+        }
+      }
+    };
+
+    if (!widgetId) {
+      setState('error');
+      return;
+    }
+
+    const loadWidget = function () {
+      if (initialized || loading) {
+        return;
+      }
+
+      loading = true;
+      setState('loading');
+
+      ensureProSealScript(function () {
+        loading = false;
+
+        if (!container.isConnected) {
+          setState('idle');
+          return;
+        }
+
+        const provenExpert = globalThis.provenExpert;
+        if (!provenExpert || typeof provenExpert.proSeal !== 'function') {
+          setState('error');
+          return;
+        }
+
+        try {
+          provenExpert.proSeal({
+            widgetId: widgetId,
+            language: widgetLanguage,
+            usePageLanguage: false,
+            bannerColor: '#097E92',
+            textColor: '#FFFFFF',
+            showBackPage: true,
+            showReviews: true,
+            hideDate: true,
+            hideName: false,
+            googleStars: true,
+            displayReviewerLastName: false,
+            embeddedSelector: '#' + target.id
+          });
+          target.removeAttribute('hidden');
+          initialized = true;
+          setState('loaded');
+          document.removeEventListener(EVENT_NAME, handlePreference);
+        } catch (error) {
+          setState('error');
+        }
+      });
+    };
+
+    const handlePreference = function (event) {
+      if (event && event.detail && event.detail.marketing) {
+        loadWidget();
+      }
+    };
+
+    document.addEventListener(EVENT_NAME, handlePreference);
+
+    if (consentButton) {
+      consentButton.addEventListener('click', function () {
+        if (initialized) {
+          return;
+        }
+
+        ensureMarketingConsent();
+        loadWidget();
+      });
+    }
+
+    if (marketingAllowed()) {
+      loadWidget();
+    } else {
+      setState('idle');
+      if (placeholder) {
+        placeholder.removeAttribute('hidden');
+      }
+    }
+  }
+
+  function initProSealWidgets() {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const containers = document.querySelectorAll(PROSEAL_SELECTOR);
+    if (!containers.length) {
+      return;
+    }
+
+    containers.forEach(setupProSealContainer);
+  }
+
   document.addEventListener('DOMContentLoaded', function () {
     const containers = document.querySelectorAll('[data-calserver-video]');
     if (!containers.length) {
@@ -173,4 +347,6 @@
       });
     });
   });
+
+  document.addEventListener('DOMContentLoaded', initProSealWidgets);
 })();


### PR DESCRIPTION
## Summary
- add the ProvenExpert ProSeal trust widget next to the calServer contact cards in German and English content, including consent placeholder and noscript fallback
- load and style the trust widget via calserver.js and landing.css only after marketing consent is granted

## Testing
- php -S 0.0.0.0:8080 -t public public/router.php

------
https://chatgpt.com/codex/tasks/task_e_68daa003581c832bbd0509b13b6099cf