### PR TITLE
Ensure German language toggle keeps lang parameter

### DIFF
--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -223,10 +223,10 @@ document.addEventListener('DOMContentLoaded', () => {
   langButtons.forEach(btn => btn.addEventListener('click', () => {
     const lang = btn.dataset.lang;
     const url = new URL(window.location.href);
-    if (lang === 'de') {
-      url.searchParams.delete('lang');
-    } else {
+    if (lang) {
       url.searchParams.set('lang', lang);
+    } else {
+      url.searchParams.delete('lang');
     }
     window.location.href = url.toString();
   }));


### PR DESCRIPTION
## Summary
- set the landing language switch to always persist the selected locale in the URL
- confirmed that marketing pages respond to the explicit `lang=de` parameter after toggling back from English

## Testing
- python - <<'PY' ...


------
https://chatgpt.com/codex/tasks/task_e_68da9d65f108832bb25f86baaf2f2e7c