### PR TITLE
Add ProvenExpert rating widget to marketing pages

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -806,3 +806,15 @@ body.qr-landing:not(.high-contrast) #contact-form .uk-checkbox:focus-visible{
 /* Proof badges */
 .qr-landing .qr-proof { display:flex; align-items:center; gap:16px; }
 .qr-landing .qr-proof img { height:28px; }
+
+.provenexpert-rating {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.provenexpert-rating iframe,
+.provenexpert-rating > * {
+  max-width: 100%;
+}

--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -7,6 +7,7 @@ namespace App\Controller\Marketing;
 use App\Application\Seo\PageSeoConfigService;
 use App\Service\MailService;
 use App\Service\PageService;
+use App\Service\ProvenExpertRatingService;
 use App\Service\TurnstileConfig;
 use App\Support\BasePathHelper;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -22,18 +23,21 @@ class MarketingPageController
     private PageSeoConfigService $seo;
     private ?string $slug;
     private TurnstileConfig $turnstileConfig;
+    private ProvenExpertRatingService $provenExpert;
 
     public function __construct(
         ?string $slug = null,
         ?PageService $pages = null,
         ?PageSeoConfigService $seo = null,
-        ?TurnstileConfig $turnstileConfig = null
+        ?TurnstileConfig $turnstileConfig = null,
+        ?ProvenExpertRatingService $provenExpert = null
     )
     {
         $this->slug = $slug;
         $this->pages = $pages ?? new PageService();
         $this->seo = $seo ?? new PageSeoConfigService();
         $this->turnstileConfig = $turnstileConfig ?? TurnstileConfig::fromEnv();
+        $this->provenExpert = $provenExpert ?? new ProvenExpertRatingService();
     }
 
     public function __invoke(Request $request, Response $response, array $args = []): Response
@@ -108,6 +112,10 @@ class MarketingPageController
             'turnstileSiteKey' => $this->turnstileConfig->isEnabled() ? $this->turnstileConfig->getSiteKey() : null,
             'turnstileEnabled' => $this->turnstileConfig->isEnabled(),
         ];
+
+        if (in_array($templateSlug, ['calserver', 'landing'], true)) {
+            $data['provenExpertRating'] = $this->provenExpert->getAggregateRatingMarkup();
+        }
 
         if ($canonicalUrl !== null) {
             $data['hreflangLinks'] = $this->buildHreflangLinks($config?->getHreflang(), $canonicalUrl);

--- a/src/Service/ProvenExpertRatingService.php
+++ b/src/Service/ProvenExpertRatingService.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use function chmod;
+use function curl_close;
+use function curl_error;
+use function curl_exec;
+use function curl_init;
+use function curl_setopt;
+use function curl_version;
+use function defined;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function filemtime;
+use function is_array;
+use function is_dir;
+use function is_writable;
+use function json_decode;
+use function json_encode;
+use function mkdir;
+use function sprintf;
+use function sys_get_temp_dir;
+use function touch;
+use function dirname;
+use const CURL_IPRESOLVE_V4;
+use const CURLOPT_CONNECTTIMEOUT;
+use const CURLOPT_IPRESOLVE;
+use const CURLOPT_RETURNTRANSFER;
+use const CURLOPT_SSL_VERIFYPEER;
+use const CURLOPT_TIMEOUT;
+use const CURLOPT_URL;
+use const CURLOPT_USERPWD;
+
+class ProvenExpertRatingService
+{
+    private const API_URL = 'https://www.provenexpert.com/api_rating_v2.json';
+    private const SCRIPT_VERSION = '1.8';
+    private const CACHE_FILENAME = 'provenexpert_92e095e9afee5f761169703fff4730ee.json';
+    private const ERROR_FILENAME = 'provenexpert_error.txt';
+    private const CACHE_LIFETIME = 3600;
+
+    private string $apiId;
+    private string $apiKey;
+    private string $cacheFile;
+    private string $errorFile;
+
+    public function __construct(?string $apiId = null, ?string $apiKey = null, ?string $cacheDirectory = null)
+    {
+        $this->apiId = $apiId ?? getenv('PROVENEXPERT_API_ID') ?: '1tmo5LmpmpQpmqGB1xGAiAmZ38zZmV3o';
+        $this->apiKey = $apiKey ?? getenv('PROVENEXPERT_API_KEY') ?: 'AGyuLJEzAmx4BJV5LJDjLwEvMQMyLmxjBGuwAmRjBGp';
+
+        $directory = $cacheDirectory ?? sys_get_temp_dir();
+        if (!is_dir($directory)) {
+            @mkdir($directory, 0777, true);
+        }
+
+        $this->cacheFile = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . self::CACHE_FILENAME;
+        $this->errorFile = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . self::ERROR_FILENAME;
+
+        if (!file_exists($this->cacheFile)) {
+            @touch($this->cacheFile);
+            @chmod($this->cacheFile, 0666);
+        }
+    }
+
+    public function getAggregateRatingMarkup(): string
+    {
+        $data = $this->loadData();
+        if ($data === null) {
+            return '';
+        }
+
+        if (($data['status'] ?? null) === 'success' && isset($data['aggregateRating'])) {
+            $markup = (string) $data['aggregateRating'];
+            if ($markup !== '') {
+                return $markup;
+            }
+        }
+
+        return '<!-- provenexpert response error [v' . self::SCRIPT_VERSION . '] -->';
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function loadData(): ?array
+    {
+        $cached = $this->readCache();
+        $cacheFresh = $this->isCacheFresh();
+
+        if ($cacheFresh && $cached !== null) {
+            return $cached;
+        }
+
+        $fetched = $this->fetch();
+        if ($fetched !== null) {
+            if (($fetched['status'] ?? null) === 'success') {
+                $this->writeCache($fetched);
+                return $fetched;
+            }
+
+            if ($cached !== null) {
+                $this->touchCache();
+                return $cached;
+            }
+
+            return $fetched;
+        }
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $fallback = ['status' => 'error'];
+        $this->writeCache($fallback);
+
+        return $fallback;
+    }
+
+    private function fetch(): ?array
+    {
+        if (!function_exists('curl_init')) {
+            $this->logError('no curl package installed');
+            return null;
+        }
+
+        $handler = curl_init();
+        if ($handler === false) {
+            $this->logError('curl init failed');
+            return null;
+        }
+
+        $query = sprintf('?v=%s', self::SCRIPT_VERSION);
+        curl_setopt($handler, CURLOPT_TIMEOUT, 2);
+        curl_setopt($handler, CURLOPT_CONNECTTIMEOUT, 2);
+        curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handler, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($handler, CURLOPT_URL, self::API_URL . $query);
+        curl_setopt($handler, CURLOPT_USERPWD, $this->apiId . ':' . $this->apiKey);
+        if (defined('CURLOPT_IPRESOLVE') && defined('CURL_IPRESOLVE_V4')) {
+            curl_setopt($handler, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+        }
+
+        $json = curl_exec($handler);
+        if ($json === false) {
+            $this->logCurlError($handler);
+            curl_close($handler);
+            return null;
+        }
+        curl_close($handler);
+
+        $data = json_decode((string) $json, true);
+        if (!is_array($data)) {
+            $this->logError('json error' . PHP_EOL . PHP_EOL . (string) $json);
+            return null;
+        }
+
+        return $data;
+    }
+
+    private function readCache(): ?array
+    {
+        if (!file_exists($this->cacheFile)) {
+            return null;
+        }
+
+        $contents = @file_get_contents($this->cacheFile);
+        if ($contents === false || $contents === '') {
+            return null;
+        }
+
+        $decoded = json_decode($contents, true);
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function writeCache(array $data): void
+    {
+        if (!is_writable($this->cacheFile) && !is_writable(dirname($this->cacheFile))) {
+            return;
+        }
+
+        $encoded = json_encode($data);
+        if ($encoded === false) {
+            return;
+        }
+
+        @file_put_contents($this->cacheFile, $encoded);
+    }
+
+    private function touchCache(): void
+    {
+        @touch($this->cacheFile, time() - (int) (self::CACHE_LIFETIME / 10));
+    }
+
+    private function isCacheFresh(): bool
+    {
+        if (!file_exists($this->cacheFile)) {
+            return false;
+        }
+
+        $mtime = filemtime($this->cacheFile);
+        if ($mtime === false) {
+            return false;
+        }
+
+        return (time() - $mtime) <= self::CACHE_LIFETIME;
+    }
+
+    private function logError(string $message): void
+    {
+        $log = sprintf('%s [v%s]', $message, self::SCRIPT_VERSION);
+        @file_put_contents($this->errorFile, $log);
+    }
+
+    /**
+     * @param resource $handler
+     */
+    private function logCurlError($handler): void
+    {
+        $errorMessage = 'curl error';
+        $error = curl_error($handler);
+        if ($error !== '') {
+            $errorMessage .= PHP_EOL . PHP_EOL . $error;
+        }
+
+        $version = curl_version();
+        if (is_array($version)) {
+            $errorMessage .= PHP_EOL . PHP_EOL . json_encode($version);
+        }
+
+        $this->logError($errorMessage);
+    }
+}

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -256,6 +256,11 @@
             <div class="qr-proof uk-margin-top">
               <span>{{ hero.proof }}</span>
             </div>
+            {% if provenExpertRating is defined and provenExpertRating %}
+              <div class="provenexpert-rating uk-margin-top" aria-label="Bewertungen">
+                {{ provenExpertRating|raw }}
+              </div>
+            {% endif %}
           </div>
           <div class="calserver-hero-grid__media" data-uk-scrollspy="cls: uk-animation-slide-right-small; repeat: true">
             <div class="calserver-hero-video">

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -153,6 +153,11 @@
             <div class="qr-proof uk-margin-top">
               <span>Bereits bei Firmen-Events &amp; Stadtfesten erprobt</span>
             </div>
+            {% if provenExpertRating is defined and provenExpertRating %}
+              <div class="provenexpert-rating uk-margin-top" aria-label="Bewertungen">
+                {{ provenExpertRating|raw }}
+              </div>
+            {% endif %}
           </div>
           <div>
             <div class="qr-mockup uk-card qr-card">


### PR DESCRIPTION
## Summary
- add a ProvenExpert rating service that fetches and caches the aggregated review markup
- expose the rating markup to the calServer and landing marketing templates and display it in the hero sections
- style the embedded rating widget so it aligns with existing proof elements

## Testing
- ./vendor/bin/phpunit --filter CalserverControllerTest
- ./vendor/bin/phpunit --filter PageControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68daa1236790832bbf0df553bd4938b3