### PR TITLE
Add intro copy to calServer operating modes section

### DIFF
--- a/migrations/20250926_update_calserver_page.sql
+++ b/migrations/20250926_update_calserver_page.sql
@@ -948,6 +948,7 @@ VALUES (
     <section id="modes" class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow">
       <div class="uk-container">
         <h2 class="uk-heading-line uk-light"><span>Betriebsarten, die zu Ihnen passen</span></h2>
+        <p class="muted uk-margin-small-top">Wählen Sie, wie calServer betrieben wird: als sichere Cloud-Lösung oder in Ihrer eigenen Umgebung.</p>
         <ul class="uk-subnav uk-subnav-pill uk-margin" data-uk-switcher>
           <li><a href="#">Cloud</a></li>
           <li><a href="#">On-Premise</a></li>

--- a/migrations/20250927_update_calserver_visual_assets.sql
+++ b/migrations/20250927_update_calserver_visual_assets.sql
@@ -972,6 +972,7 @@ VALUES (
     <section id="modes" class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow">
       <div class="uk-container">
         <h2 class="uk-heading-line uk-light"><span>Betriebsarten, die zu Ihnen passen</span></h2>
+        <p class="muted uk-margin-small-top">Wählen Sie, wie calServer betrieben wird: als sichere Cloud-Lösung oder in Ihrer eigenen Umgebung.</p>
         <ul class="uk-subnav uk-subnav-pill uk-margin" data-uk-switcher>
           <li><a href="#">Cloud</a></li>
           <li><a href="#">On-Premise</a></li>

--- a/migrations/20250928_add_calserver_en_page.sql
+++ b/migrations/20250928_add_calserver_en_page.sql
@@ -830,6 +830,7 @@ VALUES (
 <section class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow" id="modes">
 <div class="uk-container">
 <h2 class="uk-heading-line uk-light"><span>Operating modes that suit you</span></h2>
+<p class="muted uk-margin-small-top">Choose how calServer runs: as a secure cloud service or within your own infrastructure.</p>
 <ul class="uk-subnav uk-subnav-pill uk-margin" data-uk-switcher="">
 <li><a href="#">Cloud</a></li>
 <li><a href="#">On-premise</a></li>

--- a/migrations/20250930_add_calserver_proseal_widget.sql
+++ b/migrations/20250930_add_calserver_proseal_widget.sql
@@ -972,6 +972,7 @@ VALUES (
     <section id="modes" class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow">
       <div class="uk-container">
         <h2 class="uk-heading-line uk-light"><span>Betriebsarten, die zu Ihnen passen</span></h2>
+        <p class="muted uk-margin-small-top">Wählen Sie, wie calServer betrieben wird: als sichere Cloud-Lösung oder in Ihrer eigenen Umgebung.</p>
         <ul class="uk-subnav uk-subnav-pill uk-margin" data-uk-switcher>
           <li><a href="#">Cloud</a></li>
           <li><a href="#">On-Premise</a></li>
@@ -2103,6 +2104,7 @@ VALUES (
 <section class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow" id="modes">
 <div class="uk-container">
 <h2 class="uk-heading-line uk-light"><span>Operating modes that suit you</span></h2>
+<p class="muted uk-margin-small-top">Choose how calServer runs: as a secure cloud service or within your own infrastructure.</p>
 <ul class="uk-subnav uk-subnav-pill uk-margin" data-uk-switcher="">
 <li><a href="#">Cloud</a></li>
 <li><a href="#">On-premise</a></li>

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -1321,6 +1321,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
     <section id="modes" class="uk-section uk-section-primary uk-light calserver-highlight calserver-section-glow">
       <div class="uk-container">
         <h2 class="uk-heading-line uk-light"><span>Betriebsarten, die zu Ihnen passen</span></h2>
+        <p class="muted uk-margin-small-top">Wählen Sie, wie calServer betrieben wird: als sichere Cloud-Lösung oder in Ihrer eigenen Umgebung.</p>
         <ul class="uk-subnav uk-subnav-pill uk-margin" data-uk-switcher>
           <li><a href="#">Cloud</a></li>
           <li><a href="#">On-Premise</a></li>


### PR DESCRIPTION
## Summary
- add a short explanatory paragraph to the calServer operating modes section in the German marketing page migrations and sqlite schema
- add matching English copy to the calServer operating modes section migrations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daafa85100832b8c86c62a88fd95d1