### PR TITLE
Localize calServer footer tagline

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -334,6 +334,7 @@ return [
     'calserver_nav_faq' => 'FAQ',
     'calserver_nav_demo' => 'Demo buchen',
     'calserver_nav_trial' => 'Jetzt testen',
+    'calserver_footer_tagline' => 'Kalibrier- und Inventarverwaltung aus Deutschland – mit klaren Workflows und sicheren Prozessen.',
     'text_no_catalogs' => 'Keine Kataloge',
     'text_no_marketing_pages' => 'Keine Marketing-Seiten gefunden.',
     'text_no_data' => 'Keine Daten',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -336,6 +336,7 @@ return [
     'calserver_nav_faq' => 'FAQ',
     'calserver_nav_demo' => 'Book demo',
     'calserver_nav_trial' => 'Start trial',
+    'calserver_footer_tagline' => 'Calibration and inventory management from Germany – with clear workflows and secure processes.',
     'text_no_catalogs' => 'No catalogs',
     'text_no_marketing_pages' => 'No marketing pages found.',
     'text_no_data' => 'No data',

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -369,7 +369,7 @@
   <div class="footer-columns">
     <div class="footer-section footer-about">
       <strong>calServer</strong>
-      <p>Kalibrier- und Inventarverwaltung aus Deutschland – mit klaren Workflows und sicheren Prozessen.</p>
+      <p>{{ t('calserver_footer_tagline') }}</p>
     </div>
     <div class="footer-section footer-contact">
       <strong>Kontakt</strong>


### PR DESCRIPTION
## Summary
- add a translation key for the calServer footer tagline in both German and English
- use the translation helper in the footer to render the localized tagline text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab0744ca4832ba35c4658c44b01f1