### PR TITLE
Update calserver pricing cards for new subscription model

### DIFF
--- a/migrations/20250926_update_calserver_page.sql
+++ b/migrations/20250926_update_calserver_page.sql
@@ -1008,54 +1008,55 @@ VALUES (
 
     <section id="pricing" class="uk-section uk-section-default">
       <div class="uk-container">
-        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
-          <h2 class="uk-heading-line"><span>Preise, die Klarheit schaffen</span></h2>
-          <span class="muted">Ehrlich, transparent, ohne versteckte Kosten.</span>
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap calserver-pricing__header">
+          <h2 class="uk-heading-line"><span>Abomodelle für Ihren Betrieb</span></h2>
+          <span class="muted">Alle Pakete inkl. persönlichem Kick-off und 7 Tagen Testphase.</span>
         </div>
         <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-large uk-grid-match"
              data-uk-grid
              data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
           <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
-              <h3>Standard</h3>
-              <p class="muted">Die solide Basis für kleine Teams.</p>
-              <p class="uk-text-large uk-text-bold">ab 250 €/Monat</p>
+            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft calserver-pricing-card">
+              <h3>Cloud Team</h3>
+              <p class="muted">Managed SaaS für kleinere Qualitäts-Teams.</p>
+              <p class="uk-text-large uk-text-bold">ab 390&nbsp;€/Monat</p>
               <ul class="uk-list uk-list-bullet uk-text-left muted">
-                <li>Bis 2 Mandanten</li>
-                <li>Alle Kernmodule inklusive</li>
-                <li>E-Mail-Support innerhalb von 24 h</li>
+                <li>Bis 3 Mandanten &amp; 1.000 Geräte</li>
+                <li>Alle Kernmodule, Erinnerungen &amp; Workflows</li>
+                <li>Support per E-Mail innerhalb eines Werktags</li>
               </ul>
-              <a class="uk-button uk-button-default" href="#offer">Unverbindliches Angebot</a>
+              <a class="uk-button uk-button-default" href="#offer">Paket anfragen</a>
             </div>
           </div>
           <div class="anim">
-            <div class="uk-card uk-card-primary uk-card-primary--highlight uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative">
-              <span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Empfohlen</span>
-              <h3>Performance</h3>
-              <p>Für größere Teams mit mehr Tempo.</p>
-              <p class="uk-text-large uk-text-bold">auf Anfrage</p>
+            <div class="uk-card uk-card-primary uk-card-primary--highlight uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative calserver-pricing-card">
+              <span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Beliebtestes Paket</span>
+              <h3>Cloud Scale</h3>
+              <p>Für wachsende Organisationen mit mehreren Standorten.</p>
+              <p class="uk-text-large uk-text-bold">ab 690&nbsp;€/Monat</p>
               <ul class="uk-list uk-list-bullet uk-text-left">
-                <li>Unbegrenzte Nutzer:innen</li>
-                <li>Erweiterte Automatisierungen</li>
-                <li>Priorisierter Support &amp; SLA</li>
+                <li>Unbegrenzte Nutzer:innen &amp; Mandanten</li>
+                <li>Automatisierungen, API &amp; Ticket-Workflows</li>
+                <li>Priorisierter Support mit festen Reaktionszeiten</li>
               </ul>
-              <a class="uk-button uk-button-default" href="#offer">Beratung anfragen</a>
+              <a class="uk-button uk-button-default" href="#offer">Beratung vereinbaren</a>
             </div>
           </div>
           <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
+            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft calserver-pricing-card">
               <h3>Enterprise</h3>
-              <p class="muted">Individuell zugeschnitten auf Ihre Prozesse.</p>
-              <p class="uk-text-large uk-text-bold">individuell</p>
+              <p class="muted">Individuelle Projekte für On-Premise &amp; Hybrid.</p>
+              <p class="uk-text-large uk-text-bold">Projektangebot</p>
               <ul class="uk-list uk-list-bullet uk-text-left muted">
-                <li>Eigene Mandanten-Strukturen</li>
-                <li>On-Premise oder Hybrid</li>
-                <li>Integrationen &amp; Projektbegleitung</li>
+                <li>Dedizierte Umgebungen &amp; Sicherheitskonzepte</li>
+                <li>Integration in ERP, MES &amp; Identitätsmanagement</li>
+                <li>Begleitung durch Customer-Success &amp; SLA</li>
               </ul>
-              <a class="uk-button uk-button-default" href="#offer">Angebot anfordern</a>
+              <a class="uk-button uk-button-default" href="#offer">Individuelles Angebot</a>
             </div>
           </div>
         </div>
+        <p class="muted uk-text-small uk-margin-top">Optional buchbar: Validierte Prozesse, Schulungen vor Ort sowie dedizierte Hotline. Wir erstellen Ihr Angebot im persönlichen Gespräch.</p>
       </div>
     </section>
 

--- a/migrations/20250928_add_calserver_en_page.sql
+++ b/migrations/20250928_add_calserver_en_page.sql
@@ -888,52 +888,53 @@ VALUES (
 </section>
 <section class="uk-section uk-section-default" id="pricing">
 <div class="uk-container">
-<div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
-<h2 class="uk-heading-line"><span>Prices that create clarity</span></h2>
-<span class="muted">Honest, transparent and without hidden costs.</span>
+<div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap calserver-pricing__header">
+<h2 class="uk-heading-line"><span>Subscriptions built for your operations</span></h2>
+<span class="muted">Every plan includes a personal kick-off and a 7-day trial.</span>
 </div>
 <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-large uk-grid-match" data-uk-grid="" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
 <div class="anim">
-<div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
-<h3>Standard</h3>
-<p class="muted">The solid basis for small teams.</p>
-<p class="uk-text-large uk-text-bold">from 250 €/month</p>
+<div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft calserver-pricing-card">
+<h3>Cloud Team</h3>
+<p class="muted">Managed SaaS for dedicated quality teams.</p>
+<p class="uk-text-large uk-text-bold">from €390/month</p>
 <ul class="uk-list uk-list-bullet uk-text-left muted">
-<li>Up to 2 clients</li>
-<li>All core modules included</li>
-<li>Email support within 24 hours</li>
+<li>Up to 3 tenants &amp; 1,000 instruments</li>
+<li>Core modules, reminders &amp; workflow automation</li>
+<li>Email support with next-business-day response</li>
 </ul>
-<a class="uk-button uk-button-default" href="#offer">Request a non-binding offer</a>
+<a class="uk-button uk-button-default" href="#offer">Request package</a>
 </div>
 </div>
 <div class="anim">
-<div class="uk-card uk-card-primary uk-card-primary--highlight uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative">
-<span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Recommended</span>
-<h3>Performance</h3>
-<p>For larger teams that need more speed.</p>
-<p class="uk-text-large uk-text-bold">on request</p>
+<div class="uk-card uk-card-primary uk-card-primary--highlight uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative calserver-pricing-card">
+<span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Most popular</span>
+<h3>Cloud Scale</h3>
+<p>For growing organisations operating across multiple sites.</p>
+<p class="uk-text-large uk-text-bold">from €690/month</p>
 <ul class="uk-list uk-list-bullet uk-text-left">
-<li>Unlimited users</li>
-<li>Extended automation</li>
-<li>Prioritised support &amp; SLA</li>
+<li>Unlimited users and tenants</li>
+<li>Advanced automation, API &amp; ticket workflows</li>
+<li>Priority support with committed response times</li>
 </ul>
-<a class="uk-button uk-button-default" href="#offer">Request advice</a>
+<a class="uk-button uk-button-default" href="#offer">Schedule consultation</a>
 </div>
 </div>
 <div class="anim">
-<div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
+<div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft calserver-pricing-card">
 <h3>Enterprise</h3>
-<p class="muted">Individually tailored to your processes.</p>
-<p class="uk-text-large uk-text-bold">custom quote</p>
+<p class="muted">Tailored projects for on-premise &amp; hybrid setups.</p>
+<p class="uk-text-large uk-text-bold">Project-based quote</p>
 <ul class="uk-list uk-list-bullet uk-text-left muted">
-<li>Own client structures</li>
-<li>On-premise or hybrid</li>
-<li>Integration &amp; project support</li>
+<li>Dedicated environments &amp; security concepts</li>
+<li>Integration with ERP, MES &amp; identity platforms</li>
+<li>Customer success guidance and SLA coverage</li>
 </ul>
-<a class="uk-button uk-button-default" href="#offer">Request offer</a>
+<a class="uk-button uk-button-default" href="#offer">Request custom quote</a>
 </div>
 </div>
 </div>
+<p class="muted uk-text-small uk-margin-top">Optional add-ons: validated processes, on-site training and a dedicated hotline — we scope your package together.</p>
 </div>
 </section>
 <section class="uk-section uk-section-muted" id="faq">

--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1047,6 +1047,31 @@ body.qr-landing.calserver-theme .calserver-logo-marquee__item img {
     filter: drop-shadow(0 4px 10px rgba(15, 23, 42, 0.25));
 }
 
+body.qr-landing.calserver-theme .calserver-pricing__header {
+    gap: 12px;
+}
+
+body.qr-landing.calserver-theme .calserver-pricing-card {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    height: 100%;
+}
+
+body.qr-landing.calserver-theme .calserver-pricing-card .uk-list {
+    margin-top: 4px;
+    flex-grow: 1;
+}
+
+body.qr-landing.calserver-theme .calserver-pricing-card .uk-button {
+    margin-top: auto;
+    align-self: center;
+}
+
+body.qr-landing.calserver-theme .calserver-pricing-card .uk-text-bold {
+    font-size: clamp(1.4rem, 1.1vw + 1.1rem, 2rem);
+}
+
 @keyframes calserver-marquee {
     0% {
         transform: translateX(0);

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -1381,54 +1381,55 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
 
     <section id="pricing" class="uk-section uk-section-default">
       <div class="uk-container">
-        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap">
-          <h2 class="uk-heading-line"><span>Preise, die Klarheit schaffen</span></h2>
-          <span class="muted">Ehrlich, transparent, ohne versteckte Kosten.</span>
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-wrap calserver-pricing__header">
+          <h2 class="uk-heading-line"><span>Abomodelle für Ihren Betrieb</span></h2>
+          <span class="muted">Alle Pakete inkl. persönlichem Kick-off und 7 Tagen Testphase.</span>
         </div>
         <div class="uk-child-width-1-1 uk-child-width-1-3@m uk-grid-large uk-grid-match"
              data-uk-grid
              data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
           <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
-              <h3>Standard</h3>
-              <p class="muted">Die solide Basis für kleine Teams.</p>
-              <p class="uk-text-large uk-text-bold">ab 250 €/Monat</p>
+            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft calserver-pricing-card">
+              <h3>Cloud Team</h3>
+              <p class="muted">Managed SaaS für kleinere Qualitäts-Teams.</p>
+              <p class="uk-text-large uk-text-bold">ab 390&nbsp;€/Monat</p>
               <ul class="uk-list uk-list-bullet uk-text-left muted">
-                <li>Bis 2 Mandanten</li>
-                <li>Alle Kernmodule inklusive</li>
-                <li>E-Mail-Support innerhalb von 24 h</li>
+                <li>Bis 3 Mandanten &amp; 1.000 Geräte</li>
+                <li>Alle Kernmodule, Erinnerungen &amp; Workflows</li>
+                <li>Support per E-Mail innerhalb eines Werktags</li>
               </ul>
-              <a class="uk-button uk-button-default" href="#offer">Unverbindliches Angebot</a>
+              <a class="uk-button uk-button-default" href="#offer">Paket anfragen</a>
             </div>
           </div>
           <div class="anim">
-            <div class="uk-card uk-card-primary uk-card-primary--highlight uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative">
-              <span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Empfohlen</span>
-              <h3>Performance</h3>
-              <p>Für größere Teams mit mehr Tempo.</p>
-              <p class="uk-text-large uk-text-bold">auf Anfrage</p>
+            <div class="uk-card uk-card-primary uk-card-primary--highlight uk-card-body uk-text-center uk-card-hover shadow-soft uk-position-relative calserver-pricing-card">
+              <span class="pill pill--badge uk-position-absolute uk-position-top-right uk-margin-small">Beliebtestes Paket</span>
+              <h3>Cloud Scale</h3>
+              <p>Für wachsende Organisationen mit mehreren Standorten.</p>
+              <p class="uk-text-large uk-text-bold">ab 690&nbsp;€/Monat</p>
               <ul class="uk-list uk-list-bullet uk-text-left">
-                <li>Unbegrenzte Nutzer:innen</li>
-                <li>Erweiterte Automatisierungen</li>
-                <li>Priorisierter Support &amp; SLA</li>
+                <li>Unbegrenzte Nutzer:innen &amp; Mandanten</li>
+                <li>Automatisierungen, API &amp; Ticket-Workflows</li>
+                <li>Priorisierter Support mit festen Reaktionszeiten</li>
               </ul>
-              <a class="uk-button uk-button-default" href="#offer">Beratung anfragen</a>
+              <a class="uk-button uk-button-default" href="#offer">Beratung vereinbaren</a>
             </div>
           </div>
           <div class="anim">
-            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft">
+            <div class="uk-card uk-card-default uk-card-body uk-text-center uk-card-hover shadow-soft calserver-pricing-card">
               <h3>Enterprise</h3>
-              <p class="muted">Individuell zugeschnitten auf Ihre Prozesse.</p>
-              <p class="uk-text-large uk-text-bold">individuell</p>
+              <p class="muted">Individuelle Projekte für On-Premise &amp; Hybrid.</p>
+              <p class="uk-text-large uk-text-bold">Projektangebot</p>
               <ul class="uk-list uk-list-bullet uk-text-left muted">
-                <li>Eigene Mandanten-Strukturen</li>
-                <li>On-Premise oder Hybrid</li>
-                <li>Integrationen &amp; Projektbegleitung</li>
+                <li>Dedizierte Umgebungen &amp; Sicherheitskonzepte</li>
+                <li>Integration in ERP, MES &amp; Identitätsmanagement</li>
+                <li>Begleitung durch Customer-Success &amp; SLA</li>
               </ul>
-              <a class="uk-button uk-button-default" href="#offer">Angebot anfordern</a>
+              <a class="uk-button uk-button-default" href="#offer">Individuelles Angebot</a>
             </div>
           </div>
         </div>
+        <p class="muted uk-text-small uk-margin-top">Optional buchbar: Validierte Prozesse, Schulungen vor Ort sowie dedizierte Hotline. Wir erstellen Ihr Angebot im persönlichen Gespräch.</p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- refresh the German calServer pricing section with the Cloud Team/Scale/Enterprise plans and optional services note
- mirror the new plan structure on the English marketing page migration
- add dedicated pricing card helpers to the calServer stylesheet for consistent spacing

## Testing
- not run (marketing copy change)


------
https://chatgpt.com/codex/tasks/task_e_68dab12beec8832bb8788108d802046e