### PR TITLE
Ensure import groups are separated by blank lines

### DIFF
--- a/src/Application/RateLimiting/ApcuRateLimitStore.php
+++ b/src/Application/RateLimiting/ApcuRateLimitStore.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Application\RateLimiting;
 
 use APCUIterator;
+
 use function apcu_delete;
 use function apcu_enabled;
 use function apcu_fetch;

--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Routing\RouteContext;
 use Slim\Views\Twig;
 use Twig\Error\LoaderError;
+
 use function htmlspecialchars;
 
 class MarketingPageController

--- a/src/Service/MediaLibraryService.php
+++ b/src/Service/MediaLibraryService.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;
+
 use function str_starts_with;
 
 /**

--- a/src/Service/ProvenExpertRatingService.php
+++ b/src/Service/ProvenExpertRatingService.php
@@ -26,6 +26,7 @@ use function sprintf;
 use function sys_get_temp_dir;
 use function touch;
 use function dirname;
+
 use const CURL_IPRESOLVE_V4;
 use const CURLOPT_CONNECTTIMEOUT;
 use const CURLOPT_IPRESOLVE;


### PR DESCRIPTION
## Summary
- insert blank lines between class imports and function imports in the Apcu rate limit store
- separate import groups in the marketing page controller and media library service
- add spacing between function and constant import groups in the ProvenExpert rating service

## Testing
- `vendor/bin/phpcs` *(fails due to existing coding standard issues outside the modified files)*

------
https://chatgpt.com/codex/tasks/task_e_68dab554f9b4832b8755f6d81a63fcfb