### PR TITLE
Adopt inline braces for function declarations

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,10 @@
     <arg name="extensions" value="php"/>
 
     <!-- inherit rules from: -->
-    <rule ref="PSR12"/>
+    <rule ref="PSR12">
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
+        <exclude name="Squiz.Functions.FunctionDeclaration.BraceOnSameLine"/>
+    </rule>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.Files.LineLength">
         <properties>

--- a/src/Application/Actions/Action.php
+++ b/src/Application/Actions/Action.php
@@ -22,8 +22,7 @@ abstract class Action
 
     protected array $args;
 
-    public function __construct(LoggerInterface $logger)
-    {
+    public function __construct(LoggerInterface $logger) {
         $this->logger = $logger;
     }
 
@@ -31,8 +30,7 @@ abstract class Action
      * @throws HttpNotFoundException
      * @throws HttpBadRequestException
      */
-    public function __invoke(Request $request, Response $response, array $args): Response
-    {
+    public function __invoke(Request $request, Response $response, array $args): Response {
         $this->request = $request;
         $this->response = $response;
         $this->args = $args;
@@ -53,8 +51,7 @@ abstract class Action
     /**
      * @return array|object
      */
-    protected function getFormData()
-    {
+    protected function getFormData() {
         return $this->request->getParsedBody();
     }
 
@@ -62,8 +59,7 @@ abstract class Action
      * @return mixed
      * @throws HttpBadRequestException
      */
-    protected function resolveArg(string $name)
-    {
+    protected function resolveArg(string $name) {
         if (!isset($this->args[$name])) {
             throw new HttpBadRequestException($this->request, "Could not resolve argument `{$name}`.");
         }
@@ -74,15 +70,13 @@ abstract class Action
     /**
      * @param array|object|null $data
      */
-    protected function respondWithData($data = null, int $statusCode = 200): Response
-    {
+    protected function respondWithData($data = null, int $statusCode = 200): Response {
         $payload = new ActionPayload($statusCode, $data);
 
         return $this->respond($payload);
     }
 
-    protected function respond(ActionPayload $payload): Response
-    {
+    protected function respond(ActionPayload $payload): Response {
         try {
             $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
             $this->response->getBody()->write($json);

--- a/src/Application/Actions/ActionError.php
+++ b/src/Application/Actions/ActionError.php
@@ -22,37 +22,31 @@ class ActionError implements JsonSerializable
 
     private ?string $description;
 
-    public function __construct(string $type, ?string $description = null)
-    {
+    public function __construct(string $type, ?string $description = null) {
         $this->type = $type;
         $this->description = $description;
     }
 
-    public function getType(): string
-    {
+    public function getType(): string {
         return $this->type;
     }
 
-    public function setType(string $type): self
-    {
+    public function setType(string $type): self {
         $this->type = $type;
         return $this;
     }
 
-    public function getDescription(): ?string
-    {
+    public function getDescription(): ?string {
         return $this->description;
     }
 
-    public function setDescription(?string $description = null): self
-    {
+    public function setDescription(?string $description = null): self {
         $this->description = $description;
         return $this;
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize(): array
-    {
+    public function jsonSerialize(): array {
         return [
             'type' => $this->type,
             'description' => $this->description,

--- a/src/Application/Actions/ActionPayload.php
+++ b/src/Application/Actions/ActionPayload.php
@@ -27,27 +27,23 @@ class ActionPayload implements JsonSerializable
         $this->error = $error;
     }
 
-    public function getStatusCode(): int
-    {
+    public function getStatusCode(): int {
         return $this->statusCode;
     }
 
     /**
      * @return array|null|object
      */
-    public function getData()
-    {
+    public function getData() {
         return $this->data;
     }
 
-    public function getError(): ?ActionError
-    {
+    public function getError(): ?ActionError {
         return $this->error;
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize(): array
-    {
+    public function jsonSerialize(): array {
         $payload = [
             'statusCode' => $this->statusCode,
         ];

--- a/src/Application/Actions/User/ListUsersAction.php
+++ b/src/Application/Actions/User/ListUsersAction.php
@@ -11,8 +11,7 @@ class ListUsersAction extends UserAction
     /**
      * {@inheritdoc}
      */
-    protected function action(): Response
-    {
+    protected function action(): Response {
         $users = $this->userRepository->findAll();
 
         $this->logger->info("Users list was viewed.");

--- a/src/Application/Actions/User/UserAction.php
+++ b/src/Application/Actions/User/UserAction.php
@@ -12,8 +12,7 @@ abstract class UserAction extends Action
 {
     protected UserRepository $userRepository;
 
-    public function __construct(LoggerInterface $logger, UserRepository $userRepository)
-    {
+    public function __construct(LoggerInterface $logger, UserRepository $userRepository) {
         parent::__construct($logger);
         $this->userRepository = $userRepository;
     }

--- a/src/Application/Actions/User/ViewUserAction.php
+++ b/src/Application/Actions/User/ViewUserAction.php
@@ -11,8 +11,7 @@ class ViewUserAction extends UserAction
     /**
      * {@inheritdoc}
      */
-    protected function action(): Response
-    {
+    protected function action(): Response {
         $userId = (int) $this->resolveArg('id');
         $user = $this->userRepository->findUserOfId($userId);
 

--- a/src/Application/EventListener/SeoConfigListener.php
+++ b/src/Application/EventListener/SeoConfigListener.php
@@ -16,26 +16,22 @@ class SeoConfigListener
 {
     private PageSeoCache $cache;
 
-    public function __construct(PageSeoCache $cache)
-    {
+    public function __construct(PageSeoCache $cache) {
         $this->cache = $cache;
     }
 
-    public static function register(EventDispatcher $dispatcher, PageSeoCache $cache): void
-    {
+    public static function register(EventDispatcher $dispatcher, PageSeoCache $cache): void {
         $listener = new self($cache);
         $dispatcher->addListener(SeoConfigSaved::class, [$listener, 'onSaved']);
         $dispatcher->addListener(SeoConfigUpdated::class, [$listener, 'onUpdated']);
     }
 
-    public function onSaved(SeoConfigSaved $event): void
-    {
+    public function onSaved(SeoConfigSaved $event): void {
         // Invalidate cache and trigger any additional hooks such as search-console pings.
         $this->cache->invalidate($event->getConfig()->getPageId());
     }
 
-    public function onUpdated(SeoConfigUpdated $event): void
-    {
+    public function onUpdated(SeoConfigUpdated $event): void {
         // Invalidate cache and trigger any additional hooks such as search-console pings.
         $this->cache->invalidate($event->getConfig()->getPageId());
     }

--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -25,8 +25,7 @@ class HttpErrorHandler extends SlimErrorHandler
     /**
      * @inheritdoc
      */
-    protected function respond(): Response
-    {
+    protected function respond(): Response {
         $exception = $this->exception;
         $statusCode = 500;
         $error = new ActionError(

--- a/src/Application/Handlers/ShutdownHandler.php
+++ b/src/Application/Handlers/ShutdownHandler.php
@@ -37,8 +37,7 @@ class ShutdownHandler
     /**
      * Invoke the shutdown handler.
      */
-    public function __invoke()
-    {
+    public function __invoke() {
         $error = error_get_last();
         if ($error) {
             $errorFile = $error['file'];

--- a/src/Application/Middleware/AdminAuthMiddleware.php
+++ b/src/Application/Middleware/AdminAuthMiddleware.php
@@ -19,8 +19,7 @@ class AdminAuthMiddleware implements MiddlewareInterface
     /**
      * {@inheritdoc}
      */
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
             $accept = $request->getHeaderLine('Accept');

--- a/src/Application/Middleware/CsrfMiddleware.php
+++ b/src/Application/Middleware/CsrfMiddleware.php
@@ -18,8 +18,7 @@ class CsrfMiddleware implements MiddlewareInterface
     /**
      * {@inheritDoc}
      */
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         $token = $_SESSION['csrf_token'] ?? null;
 
         if ($request->getMethod() === 'POST') {

--- a/src/Application/Middleware/DomainMiddleware.php
+++ b/src/Application/Middleware/DomainMiddleware.php
@@ -21,8 +21,7 @@ class DomainMiddleware implements MiddlewareInterface
     /**
      * {@inheritDoc}
      */
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         $originalHost = strtolower($request->getUri()->getHost());
         $host = $this->normalizeHost($originalHost);
         $marketingHost = $this->normalizeHost($originalHost, stripAdmin: false);
@@ -111,8 +110,7 @@ class DomainMiddleware implements MiddlewareInterface
     /**
      * @return list<string>
      */
-    private function getMarketingDomains(): array
-    {
+    private function getMarketingDomains(): array {
         $env = (string) getenv('MARKETING_DOMAINS');
         if ($env === '') {
             return [];
@@ -136,8 +134,7 @@ class DomainMiddleware implements MiddlewareInterface
         return array_values(array_unique($normalized));
     }
 
-    private function normalizeHost(string $host, bool $stripAdmin = true): string
-    {
+    private function normalizeHost(string $host, bool $stripAdmin = true): string {
         $host = strtolower($host);
 
         $pattern = $stripAdmin ? '/^(www|admin)\./' : '/^www\./';

--- a/src/Application/Middleware/LanguageMiddleware.php
+++ b/src/Application/Middleware/LanguageMiddleware.php
@@ -16,14 +16,12 @@ class LanguageMiddleware implements MiddlewareInterface
     private TranslationService $translator;
     private string $defaultLocale;
 
-    public function __construct(TranslationService $translator, string $defaultLocale = 'de')
-    {
+    public function __construct(TranslationService $translator, string $defaultLocale = 'de') {
         $this->translator = $translator;
         $this->defaultLocale = $defaultLocale;
     }
 
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         $first = empty($_SESSION['lang']);
         $params = $request->getQueryParams();
         $locale = (string)($params['lang'] ?? ($_SESSION['lang'] ?? $this->defaultLocale));

--- a/src/Application/Middleware/ProxyMiddleware.php
+++ b/src/Application/Middleware/ProxyMiddleware.php
@@ -14,8 +14,7 @@ use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
  */
 class ProxyMiddleware implements MiddlewareInterface
 {
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         $uri = $request->getUri();
 
         $proto = $request->getHeaderLine('X-Forwarded-Proto');

--- a/src/Application/Middleware/RateLimitMiddleware.php
+++ b/src/Application/Middleware/RateLimitMiddleware.php
@@ -20,15 +20,13 @@ class RateLimitMiddleware implements MiddlewareInterface
 
     private static ?RateLimitStore $defaultStore = null;
 
-    public function __construct(int $maxRequests = 5, int $windowSeconds = 60, ?RateLimitStore $store = null)
-    {
+    public function __construct(int $maxRequests = 5, int $windowSeconds = 60, ?RateLimitStore $store = null) {
         $this->maxRequests = $maxRequests;
         $this->windowSeconds = $windowSeconds;
         $this->store = $store ?? self::getPersistentStore();
     }
 
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         if (!isset($_SESSION) || !is_array($_SESSION)) {
             $_SESSION = [];
         }
@@ -55,18 +53,15 @@ class RateLimitMiddleware implements MiddlewareInterface
         return $handler->handle($request);
     }
 
-    public static function setPersistentStore(RateLimitStore $store): void
-    {
+    public static function setPersistentStore(RateLimitStore $store): void {
         self::$defaultStore = $store;
     }
 
-    public static function resetPersistentStorage(): void
-    {
+    public static function resetPersistentStorage(): void {
         self::getPersistentStore()->reset();
     }
 
-    private static function getPersistentStore(): RateLimitStore
-    {
+    private static function getPersistentStore(): RateLimitStore {
         if (self::$defaultStore === null) {
             self::$defaultStore = RateLimitStoreFactory::createDefault();
         }
@@ -74,22 +69,19 @@ class RateLimitMiddleware implements MiddlewareInterface
         return self::$defaultStore;
     }
 
-    private function tooManyRequestsResponse(): Response
-    {
+    private function tooManyRequestsResponse(): Response {
         $response = new SlimResponse(429);
 
         return $response->withHeader('Retry-After', (string) $this->windowSeconds);
     }
 
-    private function incrementPersistentCounter(Request $request): int
-    {
+    private function incrementPersistentCounter(Request $request): int {
         $hash = $this->fingerprintRequest($request);
 
         return $this->store->increment($hash, $this->windowSeconds);
     }
 
-    private function fingerprintRequest(Request $request): string
-    {
+    private function fingerprintRequest(Request $request): string {
         $serverParams = $request->getServerParams();
         $ip = (string) ($serverParams['REMOTE_ADDR'] ?? 'unknown');
         $ua = $request->getHeaderLine('User-Agent');

--- a/src/Application/Middleware/RoleAuthMiddleware.php
+++ b/src/Application/Middleware/RoleAuthMiddleware.php
@@ -21,13 +21,11 @@ class RoleAuthMiddleware implements MiddlewareInterface
      */
     private array $roles;
 
-    public function __construct(string ...$roles)
-    {
+    public function __construct(string ...$roles) {
         $this->roles = $roles;
     }
 
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         if ($this->roles === []) {
             return $handler->handle($request);
         }

--- a/src/Application/Middleware/SessionMiddleware.php
+++ b/src/Application/Middleware/SessionMiddleware.php
@@ -17,8 +17,7 @@ class SessionMiddleware implements Middleware
     /**
      * {@inheritdoc}
      */
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         $cookies = $request->getCookieParams();
         $hasSessionCookie = isset($cookies[session_name()]);
 
@@ -85,8 +84,7 @@ class SessionMiddleware implements Middleware
         return $response;
     }
 
-    private function hostMatchesDomain(string $host, string $domain): bool
-    {
+    private function hostMatchesDomain(string $host, string $domain): bool {
         $domain = ltrim($domain, '.');
 
         return strcasecmp($host, $domain) === 0

--- a/src/Application/Middleware/UrlMiddleware.php
+++ b/src/Application/Middleware/UrlMiddleware.php
@@ -17,13 +17,11 @@ class UrlMiddleware implements MiddlewareInterface
 {
     private Twig $twig;
 
-    public function __construct(Twig $twig)
-    {
+    public function __construct(Twig $twig) {
         $this->twig = $twig;
     }
 
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         $uri = $request->getUri();
         $scheme = $uri->getScheme() !== '' ? $uri->getScheme() : 'http';
         $host = $uri->getHost() !== '' ? $uri->getHost() : 'localhost';

--- a/src/Application/RateLimiting/ApcuRateLimitStore.php
+++ b/src/Application/RateLimiting/ApcuRateLimitStore.php
@@ -19,16 +19,14 @@ class ApcuRateLimitStore implements RateLimitStore
     /** @var array<string, true> */
     private array $keys = [];
 
-    public static function isSupported(): bool
-    {
+    public static function isSupported(): bool {
         return function_exists('apcu_fetch')
             && function_exists('apcu_store')
             && function_exists('apcu_delete')
             && (!function_exists('apcu_enabled') || apcu_enabled());
     }
 
-    public function increment(string $key, int $windowSeconds): int
-    {
+    public function increment(string $key, int $windowSeconds): int {
         $namespacedKey = self::PREFIX . $key;
         $now = time();
 
@@ -46,8 +44,7 @@ class ApcuRateLimitStore implements RateLimitStore
         return $count;
     }
 
-    public function reset(): void
-    {
+    public function reset(): void {
         if (!self::isSupported()) {
             return;
         }
@@ -70,8 +67,7 @@ class ApcuRateLimitStore implements RateLimitStore
     /**
      * @param array<string, int> $entry
      */
-    private function isExpired(array $entry, int $now, int $windowSeconds): bool
-    {
+    private function isExpired(array $entry, int $now, int $windowSeconds): bool {
         $start = (int) ($entry['start'] ?? 0);
 
         return $start === 0 || ($now - $start) > $windowSeconds;

--- a/src/Application/RateLimiting/FilesystemRateLimitStore.php
+++ b/src/Application/RateLimiting/FilesystemRateLimitStore.php
@@ -8,14 +8,12 @@ class FilesystemRateLimitStore implements RateLimitStore
 {
     private string $directory;
 
-    public function __construct(?string $directory = null)
-    {
+    public function __construct(?string $directory = null) {
         $directory = $directory ?? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rate_limit';
         $this->directory = rtrim($directory, DIRECTORY_SEPARATOR);
     }
 
-    public function increment(string $key, int $windowSeconds): int
-    {
+    public function increment(string $key, int $windowSeconds): int {
         $path = $this->pathFor($key);
         $now = time();
         $entry = $this->read($path, $now, $windowSeconds);
@@ -28,8 +26,7 @@ class FilesystemRateLimitStore implements RateLimitStore
         return $count;
     }
 
-    public function reset(): void
-    {
+    public function reset(): void {
         if (!is_dir($this->directory)) {
             return;
         }
@@ -46,8 +43,7 @@ class FilesystemRateLimitStore implements RateLimitStore
     /**
      * @return array{count:int,start:int}
      */
-    private function read(string $path, int $now, int $windowSeconds): array
-    {
+    private function read(string $path, int $now, int $windowSeconds): array {
         if (is_file($path)) {
             $contents = file_get_contents($path);
             if ($contents !== false) {
@@ -70,8 +66,7 @@ class FilesystemRateLimitStore implements RateLimitStore
     /**
      * @param array{count:int,start:int} $data
      */
-    private function write(string $path, array $data): void
-    {
+    private function write(string $path, array $data): void {
         $dir = dirname($path);
         if (!is_dir($dir)) {
             @mkdir($dir, 0777, true);
@@ -80,8 +75,7 @@ class FilesystemRateLimitStore implements RateLimitStore
         file_put_contents($path, json_encode($data), LOCK_EX);
     }
 
-    private function pathFor(string $key): string
-    {
+    private function pathFor(string $key): string {
         return $this->directory . DIRECTORY_SEPARATOR . 'rlm_' . $key . '.json';
     }
 }

--- a/src/Application/RateLimiting/RateLimitStoreFactory.php
+++ b/src/Application/RateLimiting/RateLimitStoreFactory.php
@@ -6,8 +6,7 @@ namespace App\Application\RateLimiting;
 
 final class RateLimitStoreFactory
 {
-    public static function createDefault(?string $directory = null): RateLimitStore
-    {
+    public static function createDefault(?string $directory = null): RateLimitStore {
         if (ApcuRateLimitStore::isSupported()) {
             return new ApcuRateLimitStore();
         }

--- a/src/Application/ResponseEmitter/ResponseEmitter.php
+++ b/src/Application/ResponseEmitter/ResponseEmitter.php
@@ -15,8 +15,7 @@ class ResponseEmitter extends SlimResponseEmitter
     /**
      * {@inheritdoc}
      */
-    public function emit(ResponseInterface $response): void
-    {
+    public function emit(ResponseInterface $response): void {
         // Allowed origin for cross-site requests. Adjust as needed for deployment.
         $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
 

--- a/src/Application/Routing/RedirectManager.php
+++ b/src/Application/Routing/RedirectManager.php
@@ -14,16 +14,14 @@ class RedirectManager
 {
     private PDO $pdo;
 
-    public function __construct(?PDO $pdo = null)
-    {
+    public function __construct(?PDO $pdo = null) {
         $this->pdo = $pdo ?? Database::connectFromEnv();
     }
 
     /**
      * Register a redirect from one path or URL to another.
      */
-    public function register(string $from, string $to, int $status = 301): void
-    {
+    public function register(string $from, string $to, int $status = 301): void {
         $stmt = $this->pdo->prepare('INSERT INTO redirects(source, target, status) VALUES(?,?,?)');
         $stmt->execute([$from, $to, $status]);
     }

--- a/src/Application/Security/AuthorizationMiddleware.php
+++ b/src/Application/Security/AuthorizationMiddleware.php
@@ -18,13 +18,11 @@ class AuthorizationMiddleware implements MiddlewareInterface
 {
     private string $requiredRole;
 
-    public function __construct(string $requiredRole)
-    {
+    public function __construct(string $requiredRole) {
         $this->requiredRole = $requiredRole;
     }
 
-    public function process(Request $request, RequestHandler $handler): Response
-    {
+    public function process(Request $request, RequestHandler $handler): Response {
         if ($this->requiredRole === '') {
             return $handler->handle($request);
         }

--- a/src/Application/Seo/PageSeoConfigService.php
+++ b/src/Application/Seo/PageSeoConfigService.php
@@ -40,8 +40,7 @@ class PageSeoConfigService
         SeoConfigListener::register($this->dispatcher, $this->cache);
     }
 
-    public function load(int $pageId): ?PageSeoConfig
-    {
+    public function load(int $pageId): ?PageSeoConfig {
         $cached = $this->cache->get($pageId);
         if ($cached !== null) {
             return $cached;
@@ -77,8 +76,7 @@ class PageSeoConfigService
         return null;
     }
 
-    public function save(PageSeoConfig $config): void
-    {
+    public function save(PageSeoConfig $config): void {
         $stmt = $this->pdo->prepare('SELECT slug, canonical_url, domain FROM page_seo_config WHERE page_id = ?');
         $stmt->execute([$config->getPageId()]);
         $existing = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
@@ -148,8 +146,7 @@ class PageSeoConfigService
      *
      * @return array<string,mixed>
      */
-    public function defaultConfig(int $pageId): array
-    {
+    public function defaultConfig(int $pageId): array {
         return [
             'pageId' => $pageId,
             'slug' => '',
@@ -167,8 +164,7 @@ class PageSeoConfigService
         ];
     }
 
-    private function normalizeSchemaJson(?string $json): ?string
-    {
+    private function normalizeSchemaJson(?string $json): ?string {
         if ($json === null) {
             return null;
         }
@@ -189,8 +185,7 @@ class PageSeoConfigService
      * @param array<string,mixed> $data
      * @return array<string,string>
      */
-    public function validate(array $data): array
-    {
+    public function validate(array $data): array {
         $data['domain'] = $this->normalizeDomain(isset($data['domain']) ? (string) $data['domain'] : null);
 
         $rawFavicon = isset($data['faviconPath']) ? (string) $data['faviconPath'] : '';
@@ -223,8 +218,7 @@ class PageSeoConfigService
         return $errors;
     }
 
-    private function normalizeDomain(?string $domain): ?string
-    {
+    private function normalizeDomain(?string $domain): ?string {
         if ($domain === null) {
             return null;
         }
@@ -239,8 +233,7 @@ class PageSeoConfigService
         return $normalized === '' ? null : $normalized;
     }
 
-    public function normalizeFaviconPath(?string $path): ?string
-    {
+    public function normalizeFaviconPath(?string $path): ?string {
         if ($path === null) {
             return null;
         }

--- a/src/Application/Seo/SeoValidator.php
+++ b/src/Application/Seo/SeoValidator.php
@@ -18,8 +18,7 @@ class SeoValidator
      * @param array<string,mixed> $data
      * @return array<string,string>
      */
-    public function validate(array $data): array
-    {
+    public function validate(array $data): array {
         $errors = [];
 
         $slug = (string)($data['slug'] ?? '');

--- a/src/Application/Settings/Settings.php
+++ b/src/Application/Settings/Settings.php
@@ -8,16 +8,14 @@ class Settings implements SettingsInterface
 {
     private array $settings;
 
-    public function __construct(array $settings)
-    {
+    public function __construct(array $settings) {
         $this->settings = $settings;
     }
 
     /**
      * @return mixed
      */
-    public function get(string $key = '')
-    {
+    public function get(string $key = '') {
         return (empty($key)) ? $this->settings : $this->settings[$key];
     }
 }

--- a/src/Controller/Admin/DomainContactTemplateController.php
+++ b/src/Controller/Admin/DomainContactTemplateController.php
@@ -19,14 +19,12 @@ class DomainContactTemplateController
     private DomainContactTemplateService $templates;
     private DomainStartPageService $domains;
 
-    public function __construct(DomainContactTemplateService $templates, DomainStartPageService $domains)
-    {
+    public function __construct(DomainContactTemplateService $templates, DomainStartPageService $domains) {
         $this->templates = $templates;
         $this->domains = $domains;
     }
 
-    public function show(Request $request, Response $response, array $args): Response
-    {
+    public function show(Request $request, Response $response, array $args): Response {
         $domain = isset($args['domain']) ? (string) $args['domain'] : '';
         $normalized = $this->domains->normalizeDomain($domain);
         if ($normalized === '' || !$this->isAllowedDomain($normalized)) {
@@ -56,8 +54,7 @@ class DomainContactTemplateController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
-    public function save(Request $request, Response $response): Response
-    {
+    public function save(Request $request, Response $response): Response {
         $translator = $request->getAttribute('translator');
         $translationService = $translator instanceof TranslationService ? $translator : null;
 
@@ -118,8 +115,7 @@ class DomainContactTemplateController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
-    private function isAllowedDomain(string $normalized): bool
-    {
+    private function isAllowedDomain(string $normalized): bool {
         $mainDomain = getenv('MAIN_DOMAIN') ?: '';
         $marketing = getenv('MARKETING_DOMAINS') ?: '';
         $known = $this->domains->determineDomains($mainDomain, (string) $marketing);

--- a/src/Controller/Admin/DomainStartPageController.php
+++ b/src/Controller/Admin/DomainStartPageController.php
@@ -32,8 +32,7 @@ class DomainStartPageController
         $this->pageService = $pageService;
     }
 
-    public function index(Request $request, Response $response): Response
-    {
+    public function index(Request $request, Response $response): Response {
         $translator = $request->getAttribute('translator');
         $translationService = $translator instanceof TranslationService ? $translator : null;
 
@@ -144,8 +143,7 @@ class DomainStartPageController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
-    public function save(Request $request, Response $response): Response
-    {
+    public function save(Request $request, Response $response): Response {
         $translator = $request->getAttribute('translator');
         $translationService = $translator instanceof TranslationService ? $translator : null;
 
@@ -247,8 +245,7 @@ class DomainStartPageController
     /**
      * @return array<string,string>
      */
-    private function buildOptionLabels(?TranslationService $translationService): array
-    {
+    private function buildOptionLabels(?TranslationService $translationService): array {
         $options = $this->domainService->getStartPageOptions($this->pageService);
 
         if ($translationService !== null) {

--- a/src/Controller/Admin/LandingpageController.php
+++ b/src/Controller/Admin/LandingpageController.php
@@ -31,8 +31,7 @@ class LandingpageController
         ?PageSeoConfigService $seoService = null,
         ?PageService $pageService = null,
         ?DomainStartPageService $domainService = null
-    )
-    {
+    ) {
         $this->seoService = $seoService ?? new PageSeoConfigService();
         $this->pageService = $pageService ?? new PageService();
         $this->domainService = $domainService ?? new DomainStartPageService(Database::connectFromEnv());
@@ -41,8 +40,7 @@ class LandingpageController
     /**
      * Display the SEO edit form.
      */
-    public function page(Request $request, Response $response): Response
-    {
+    public function page(Request $request, Response $response): Response {
         $view = Twig::fromRequest($request);
         $pages = $this->getMarketingPages();
         if ($pages === []) {
@@ -70,8 +68,7 @@ class LandingpageController
     /**
      * Persist SEO settings submitted via POST.
      */
-    public function save(Request $request, Response $response): Response
-    {
+    public function save(Request $request, Response $response): Response {
         $data = $request->getParsedBody();
         if (!is_array($data)) {
             return $response->withStatus(400);
@@ -153,8 +150,7 @@ class LandingpageController
     /**
      * @return Page[]
      */
-    private function getMarketingPages(): array
-    {
+    private function getMarketingPages(): array {
         $pages = $this->pageService->getAll();
 
         return array_values(array_filter(
@@ -166,8 +162,7 @@ class LandingpageController
     /**
      * @param Page[] $pages
      */
-    private function determineSelectedPage(array $pages, string $slug): Page
-    {
+    private function determineSelectedPage(array $pages, string $slug): Page {
         foreach ($pages as $page) {
             if ($slug !== '' && $page->getSlug() === $slug) {
                 return $page;
@@ -181,8 +176,7 @@ class LandingpageController
      * @param Page[] $pages
      * @return array<int,array{id:int,slug:string,title:string,config:array<string,mixed>}> keyed by page id
      */
-    private function buildSeoPageList(array $pages, Page $selected, string $host): array
-    {
+    private function buildSeoPageList(array $pages, Page $selected, string $host): array {
         $mappings = $this->domainService->getAllMappings();
         $domainsBySlug = [];
         foreach ($mappings as $domain => $config) {

--- a/src/Controller/Admin/PageController.php
+++ b/src/Controller/Admin/PageController.php
@@ -19,16 +19,14 @@ class PageController
     /** @var string[]|null */
     private ?array $editableSlugs = null;
 
-    public function __construct(?PageService $pageService = null)
-    {
+    public function __construct(?PageService $pageService = null) {
         $this->pageService = $pageService ?? new PageService();
     }
 
     /**
      * Display the edit form for a static page.
      */
-    public function edit(Request $request, Response $response, array $args): Response
-    {
+    public function edit(Request $request, Response $response, array $args): Response {
         $slug = $args['slug'] ?? '';
         if (!in_array($slug, $this->getEditableSlugs(), true)) {
             return $response->withStatus(404);
@@ -49,8 +47,7 @@ class PageController
     /**
      * Persist new HTML for a static page.
      */
-    public function update(Request $request, Response $response, array $args): Response
-    {
+    public function update(Request $request, Response $response, array $args): Response {
         $slug = $args['slug'] ?? '';
         if (!in_array($slug, $this->getEditableSlugs(), true)) {
             return $response->withStatus(404);
@@ -67,8 +64,7 @@ class PageController
         return $response->withStatus(204);
     }
 
-    public function delete(Request $request, Response $response, array $args): Response
-    {
+    public function delete(Request $request, Response $response, array $args): Response {
         $slug = $args['slug'] ?? '';
         if (!in_array($slug, $this->getEditableSlugs(), true)) {
             return $response->withStatus(404);
@@ -84,8 +80,7 @@ class PageController
         return $response->withStatus(204);
     }
 
-    public function create(Request $request, Response $response): Response
-    {
+    public function create(Request $request, Response $response): Response {
         $data = $request->getParsedBody();
         $contentType = strtolower($request->getHeaderLine('Content-Type'));
         if (str_contains($contentType, 'application/json')) {
@@ -140,8 +135,7 @@ class PageController
      *
      * @return string[]
      */
-    private function getEditableSlugs(): array
-    {
+    private function getEditableSlugs(): array {
         if ($this->editableSlugs !== null) {
             return $this->editableSlugs;
         }

--- a/src/Controller/Admin/ProfileController.php
+++ b/src/Controller/Admin/ProfileController.php
@@ -12,8 +12,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class ProfileController
 {
-    public function update(Request $request, Response $response): Response
-    {
+    public function update(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data)) {
             return $response->withStatus(400);

--- a/src/Controller/AdminCatalogController.php
+++ b/src/Controller/AdminCatalogController.php
@@ -18,16 +18,14 @@ class AdminCatalogController
     /**
      * Inject dependencies.
      */
-    public function __construct(CatalogService $service)
-    {
+    public function __construct(CatalogService $service) {
         $this->service = $service;
     }
 
     /**
      * Provide paginated catalog data as JSON.
      */
-    public function catalogs(Request $request, Response $response): Response
-    {
+    public function catalogs(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $page = max(1, (int) ($params['page'] ?? 1));
         $perPage = max(1, (int) ($params['perPage'] ?? 50));
@@ -50,8 +48,7 @@ class AdminCatalogController
     /**
      * Return the first catalog (name and description only).
      */
-    public function sample(Request $request, Response $response): Response
-    {
+    public function sample(Request $request, Response $response): Response {
         $items = $this->service->fetchPagedCatalogs(0, 1, 'asc');
         $first = $items[0] ?? null;
         $payload = $first === null

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -39,8 +39,7 @@ class AdminController
     /**
      * Render the admin dashboard page.
      */
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $view = Twig::fromRequest($request);
         $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
         $_SESSION['csrf_token'] = $csrf;
@@ -282,8 +281,7 @@ class AdminController
      * @param Page[] $pages
      * @return Page[]
      */
-    private function filterMarketingPages(array $pages): array
-    {
+    private function filterMarketingPages(array $pages): array {
         return array_values(array_filter(
             $pages,
             static fn (Page $page): bool => !in_array($page->getSlug(), LandingpageSeoController::EXCLUDED_SLUGS, true)
@@ -293,8 +291,7 @@ class AdminController
     /**
      * @param Page[] $pages
      */
-    private function selectSeoPage(array $pages, string $slug): ?Page
-    {
+    private function selectSeoPage(array $pages, string $slug): ?Page {
         if ($pages === []) {
             return null;
         }
@@ -317,8 +314,7 @@ class AdminController
         array $pages,
         DomainStartPageService $domainService,
         string $host
-    ): array
-    {
+    ): array {
         $mappings = $domainService->getAllMappings();
         $domainsBySlug = [];
         foreach ($mappings as $domain => $config) {

--- a/src/Controller/AdminLogsController.php
+++ b/src/Controller/AdminLogsController.php
@@ -14,8 +14,7 @@ class AdminLogsController
     /**
      * Display recent application logs.
      */
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $appLog = LogService::tail('app');
         $stripeLog = LogService::tail('stripe');
         $slimLog = LogService::tailDocker('slim-1');

--- a/src/Controller/AdminMediaController.php
+++ b/src/Controller/AdminMediaController.php
@@ -27,8 +27,7 @@ class AdminMediaController
         MediaLibraryService $media,
         ConfigService $config,
         LandingMediaReferenceService $landing
-    )
-    {
+    ) {
         $this->media = $media;
         $this->config = $config;
         $this->landing = $landing;
@@ -37,8 +36,7 @@ class AdminMediaController
     /**
      * Render the media library page.
      */
-    public function index(Request $request, Response $response): Response
-    {
+    public function index(Request $request, Response $response): Response {
         $view = Twig::fromRequest($request);
         $csrf = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(16));
         $_SESSION['csrf_token'] = $csrf;
@@ -64,8 +62,7 @@ class AdminMediaController
     /**
      * Return a paginated list of files as JSON.
      */
-    public function list(Request $request, Response $response): Response
-    {
+    public function list(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $scope = (string) ($params['scope'] ?? MediaLibraryService::SCOPE_GLOBAL);
         $page = max(1, (int) ($params['page'] ?? 1));
@@ -134,30 +131,35 @@ class AdminMediaController
         $availableFolders = $this->collectFolders($files);
 
         if ($search !== '') {
-            $files = array_values(array_filter(
-                $files,
-                static fn(array $file): bool => stripos((string) $file['name'], $search) !== false
-            ));
+            $files = array_values(
+                array_filter(
+                    $files,
+                    static fn(array $file): bool => stripos((string) $file['name'], $search) !== false
+                )
+            );
         }
 
         $rawTagFilters = $this->normalizeTags($params['tags'] ?? []);
         $activeTagFilters = array_map(static fn(string $tag): string => mb_strtolower($tag), $rawTagFilters);
         if ($activeTagFilters !== []) {
-            $files = array_values(array_filter(
-                $files,
-                static function (array $file) use ($activeTagFilters): bool {
-                    $fileTags = array_map(static fn(string $tag): string => mb_strtolower($tag),
-                        array_map('strval', $file['tags'] ?? [])
-                    );
-                    foreach ($activeTagFilters as $tag) {
-                        if (!in_array($tag, $fileTags, true)) {
-                            return false;
+            $files = array_values(
+                array_filter(
+                    $files,
+                    static function (array $file) use ($activeTagFilters): bool {
+                        $fileTags = array_map(
+                            static fn(string $tag): string => mb_strtolower($tag),
+                            array_map('strval', $file['tags'] ?? [])
+                        );
+                        foreach ($activeTagFilters as $tag) {
+                            if (!in_array($tag, $fileTags, true)) {
+                                return false;
+                            }
                         }
-                    }
 
-                    return true;
-                }
-            ));
+                        return true;
+                    }
+                )
+            );
         }
 
         $folderParam = $params['folder'] ?? null;
@@ -165,24 +167,28 @@ class AdminMediaController
             && mb_strtolower(trim($folderParam)) === self::FOLDER_NONE;
         $rawFolderFilter = $withoutFolder ? null : $this->normalizeFolder($folderParam);
         if ($withoutFolder) {
-            $files = array_values(array_filter(
-                $files,
-                static function (array $file): bool {
-                    $folder = $file['folder'] ?? null;
-                    return !is_string($folder) || $folder === '';
-                }
-            ));
-        } elseif ($rawFolderFilter !== null) {
-            $files = array_values(array_filter(
-                $files,
-                static function (array $file) use ($rawFolderFilter): bool {
-                    $folder = $file['folder'] ?? null;
-                    if (!is_string($folder) || $folder === '') {
-                        return false;
+            $files = array_values(
+                array_filter(
+                    $files,
+                    static function (array $file): bool {
+                        $folder = $file['folder'] ?? null;
+                        return !is_string($folder) || $folder === '';
                     }
-                    return mb_strtolower($folder) === $rawFolderFilter;
-                }
-            ));
+                )
+            );
+        } elseif ($rawFolderFilter !== null) {
+            $files = array_values(
+                array_filter(
+                    $files,
+                    static function (array $file) use ($rawFolderFilter): bool {
+                        $folder = $file['folder'] ?? null;
+                        if (!is_string($folder) || $folder === '') {
+                            return false;
+                        }
+                        return mb_strtolower($folder) === $rawFolderFilter;
+                    }
+                )
+            );
         }
 
         $total = count($files);
@@ -218,8 +224,7 @@ class AdminMediaController
     /**
      * Handle file uploads.
      */
-    public function upload(Request $request, Response $response): Response
-    {
+    public function upload(Request $request, Response $response): Response {
         $body = $request->getParsedBody();
         if (!is_array($body)) {
             $body = [];
@@ -268,8 +273,7 @@ class AdminMediaController
     /**
      * Replace an existing file with a new upload.
      */
-    public function replace(Request $request, Response $response): Response
-    {
+    public function replace(Request $request, Response $response): Response {
         $body = $request->getParsedBody();
         if (!is_array($body)) {
             $body = [];
@@ -309,8 +313,7 @@ class AdminMediaController
     /**
      * Convert an existing image to WebP.
      */
-    public function convert(Request $request, Response $response): Response
-    {
+    public function convert(Request $request, Response $response): Response {
         $data = $this->parseBody($request);
         $scope = (string) ($data['scope'] ?? MediaLibraryService::SCOPE_GLOBAL);
         $name = (string) ($data['name'] ?? '');
@@ -339,8 +342,7 @@ class AdminMediaController
     /**
      * Rename a file.
      */
-    public function rename(Request $request, Response $response): Response
-    {
+    public function rename(Request $request, Response $response): Response {
         $data = $this->parseBody($request);
         $scope = (string) ($data['scope'] ?? MediaLibraryService::SCOPE_GLOBAL);
         $old = (string) ($data['oldName'] ?? '');
@@ -385,8 +387,7 @@ class AdminMediaController
     /**
      * Delete a file from the library.
      */
-    public function delete(Request $request, Response $response): Response
-    {
+    public function delete(Request $request, Response $response): Response {
         $data = $this->parseBody($request);
         $scope = (string) ($data['scope'] ?? MediaLibraryService::SCOPE_GLOBAL);
         $name = (string) ($data['name'] ?? '');
@@ -415,8 +416,7 @@ class AdminMediaController
      * @param list<array<string,mixed>> $files
      * @return list<string>
      */
-    private function collectTags(array $files): array
-    {
+    private function collectTags(array $files): array {
         $tags = [];
         foreach ($files as $file) {
             $entries = $file['tags'] ?? [];
@@ -448,8 +448,7 @@ class AdminMediaController
      * @param list<array<string,mixed>> $files
      * @return list<string>
      */
-    private function collectFolders(array $files): array
-    {
+    private function collectFolders(array $files): array {
         $folders = [];
         foreach ($files as $file) {
             $folder = $file['folder'] ?? null;
@@ -472,8 +471,7 @@ class AdminMediaController
      * @param mixed $value
      * @return list<string>
      */
-    private function normalizeTags($value): array
-    {
+    private function normalizeTags($value): array {
         if (is_string($value)) {
             try {
                 $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
@@ -517,8 +515,7 @@ class AdminMediaController
     /**
      * @param mixed $value
      */
-    private function normalizeFolder($value): ?string
-    {
+    private function normalizeFolder($value): ?string {
         if (is_array($value)) {
             $value = reset($value);
         }
@@ -554,8 +551,7 @@ class AdminMediaController
      * @param array<string,mixed> $input
      * @return array{tagsProvided:bool,tags:list<string>,folderProvided:bool,folder:?string}
      */
-    private function extractMetadata(array $input): array
-    {
+    private function extractMetadata(array $input): array {
         $result = [
             'tagsProvided' => false,
             'tags' => [],
@@ -579,8 +575,7 @@ class AdminMediaController
     /**
      * @param array<string,mixed> $payload
      */
-    private function json(Response $response, array $payload, int $status = 200): Response
-    {
+    private function json(Response $response, array $payload, int $status = 200): Response {
         try {
             $response->getBody()->write(json_encode($payload, JSON_THROW_ON_ERROR));
         } catch (JsonException $e) {
@@ -593,8 +588,7 @@ class AdminMediaController
             ->withStatus($status);
     }
 
-    private function jsonError(Response $response, string $message, int $status): Response
-    {
+    private function jsonError(Response $response, string $message, int $status): Response {
         $payload = [
             'error' => $message,
             'limits' => $this->media->getLimits(),
@@ -611,8 +605,7 @@ class AdminMediaController
     /**
      * @return array<string,mixed>
      */
-    private function parseBody(Request $request): array
-    {
+    private function parseBody(Request $request): array {
         if ($request->getHeaderLine('Content-Type') === 'application/json') {
             $raw = (string) $request->getBody();
             $data = json_decode($raw, true);
@@ -626,4 +619,3 @@ class AdminMediaController
         return is_array($data) ? $data : [];
     }
 }
-

--- a/src/Controller/AdminSubscriptionCheckoutController.php
+++ b/src/Controller/AdminSubscriptionCheckoutController.php
@@ -17,8 +17,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
  */
 class AdminSubscriptionCheckoutController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $logger = LogService::create('stripe');
         try {
             $sessionToken = $_SESSION['csrf_token'] ?? '';
@@ -151,8 +150,7 @@ class AdminSubscriptionCheckoutController
         }
     }
 
-    private function jsonError(Response $response, int $status, string $message): Response
-    {
+    private function jsonError(Response $response, int $status, string $message): Response {
         $payload = ['error' => $message];
         $log = LogService::tail('stripe');
         if ($log !== '') {

--- a/src/Controller/BackupController.php
+++ b/src/Controller/BackupController.php
@@ -20,8 +20,7 @@ class BackupController
     /**
      * Configure backup directory and optional import controller.
      */
-    public function __construct(string $dir, ?ImportController $importController = null)
-    {
+    public function __construct(string $dir, ?ImportController $importController = null) {
         $this->dir = rtrim($dir, '/');
         $this->importController = $importController;
     }
@@ -29,8 +28,7 @@ class BackupController
     /**
      * Render the backup table rows server-side.
      */
-    public function index(Request $request, Response $response): Response
-    {
+    public function index(Request $request, Response $response): Response {
         if (!is_dir($this->dir)) {
             $response->getBody()->write(json_encode([
                 'error' => 'Backup directory not found',
@@ -64,8 +62,7 @@ class BackupController
     /**
      * Restore a backup by delegating to the ImportController.
      */
-    public function restore(Request $request, Response $response, array $args): Response
-    {
+    public function restore(Request $request, Response $response, array $args): Response {
         if ($this->importController === null) {
             return $response->withStatus(500);
         }
@@ -75,8 +72,7 @@ class BackupController
     /**
      * Create a ZIP archive of the requested backup and return it for download.
      */
-    public function download(Request $request, Response $response, array $args): Response
-    {
+    public function download(Request $request, Response $response, array $args): Response {
         $name = basename((string)($args['name'] ?? ''));
         $path = $this->dir . '/' . $name;
         if (!is_dir($path)) {
@@ -119,8 +115,7 @@ class BackupController
     /**
      * Delete the specified backup directory.
      */
-    public function delete(Request $request, Response $response, array $args): Response
-    {
+    public function delete(Request $request, Response $response, array $args): Response {
         $name = basename((string)($args['name'] ?? ''));
         if (!preg_match('/^[A-Za-z0-9._-]+$/', $name) || $name === '.' || $name === '..') {
             return $response->withStatus(400);
@@ -164,8 +159,7 @@ class BackupController
         return $response->withStatus(204);
     }
 
-    private function deleteError(Response $response, string $path, bool $isDir): Response
-    {
+    private function deleteError(Response $response, string $path, bool $isDir): Response {
         $response->getBody()->write(json_encode([
             'error' => 'Failed to delete ' . ($isDir ? 'directory' : 'file'),
             'path' => $path,

--- a/src/Controller/CatalogController.php
+++ b/src/Controller/CatalogController.php
@@ -19,16 +19,14 @@ class CatalogController
     /**
      * Inject catalog service dependency.
      */
-    public function __construct(CatalogService $service)
-    {
+    public function __construct(CatalogService $service) {
         $this->service = $service;
     }
 
     /**
      * Check if the current session has one of the given roles.
      */
-    private function hasRole(string ...$roles): bool
-    {
+    private function hasRole(string ...$roles): bool {
         $role = $_SESSION['user']['role'] ?? null;
         return $role !== null && in_array($role, $roles, true);
     }
@@ -36,8 +34,7 @@ class CatalogController
     /**
      * Retrieve a catalog JSON file or redirect to its public view.
      */
-    public function get(Request $request, Response $response, array $args): Response
-    {
+    public function get(Request $request, Response $response, array $args): Response {
         $file = basename($args['file']);
         $accept = strtolower($request->getHeaderLine('Accept'));
         $params = $request->getQueryParams();
@@ -67,8 +64,7 @@ class CatalogController
     /**
      * Retrieve catalog questions after validating session token and access.
      */
-    public function getQuestions(Request $request, Response $response, array $args): Response
-    {
+    public function getQuestions(Request $request, Response $response, array $args): Response {
         $headerToken = $request->getHeaderLine('X-CSRF-Token');
         $sessionToken = (string) ($_SESSION['csrf_token'] ?? '');
         if ($sessionToken === '' || $headerToken === '' || !hash_equals($sessionToken, $headerToken)) {
@@ -93,8 +89,7 @@ class CatalogController
     /**
      * Update the specified catalog file with the provided data.
      */
-    public function post(Request $request, Response $response, array $args): Response
-    {
+    public function post(Request $request, Response $response, array $args): Response {
         if (!$this->hasRole(Roles::ADMIN, Roles::CATALOG_EDITOR)) {
             return $response->withStatus(403);
         }
@@ -121,8 +116,7 @@ class CatalogController
     /**
      * Create a new catalog or overwrite the existing one.
      */
-    public function create(Request $request, Response $response, array $args): Response
-    {
+    public function create(Request $request, Response $response, array $args): Response {
         if (!$this->hasRole(Roles::ADMIN, Roles::CATALOG_EDITOR)) {
             return $response->withStatus(403);
         }
@@ -140,8 +134,7 @@ class CatalogController
     /**
      * Delete a catalog file and all its questions.
      */
-    public function delete(Request $request, Response $response, array $args): Response
-    {
+    public function delete(Request $request, Response $response, array $args): Response {
         if (!$this->hasRole(Roles::ADMIN, Roles::CATALOG_EDITOR)) {
             return $response->withStatus(403);
         }
@@ -154,8 +147,7 @@ class CatalogController
     /**
      * Remove a question from the specified catalog.
      */
-    public function deleteQuestion(Request $request, Response $response, array $args): Response
-    {
+    public function deleteQuestion(Request $request, Response $response, array $args): Response {
         if (!$this->hasRole(Roles::ADMIN, Roles::CATALOG_EDITOR)) {
             return $response->withStatus(403);
         }

--- a/src/Controller/CatalogDesignController.php
+++ b/src/Controller/CatalogDesignController.php
@@ -15,13 +15,11 @@ class CatalogDesignController
 {
     private CatalogService $catalogs;
 
-    public function __construct(CatalogService $catalogs)
-    {
+    public function __construct(CatalogService $catalogs) {
         $this->catalogs = $catalogs;
     }
 
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $slug = (string)$request->getAttribute('slug');
         $path = $this->catalogs->getDesignPath($slug);
         if ($path === null || $path === '') {
@@ -35,8 +33,7 @@ class CatalogDesignController
         return $response->withHeader('Content-Type', 'application/pdf');
     }
 
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $slug = (string)$request->getAttribute('slug');
         $files = $request->getUploadedFiles();
         if (!isset($files['file'])) {

--- a/src/Controller/CatalogSessionController.php
+++ b/src/Controller/CatalogSessionController.php
@@ -15,8 +15,7 @@ class CatalogSessionController
     /**
      * Handle the incoming request.
      */
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         $slug = is_array($data) ? ($data['slug'] ?? '') : '';
         $remember = is_array($data) ? (bool)($data['remember'] ?? false) : false;

--- a/src/Controller/CatalogStickerController.php
+++ b/src/Controller/CatalogStickerController.php
@@ -118,8 +118,7 @@ class CatalogStickerController
         $this->images = $images ?? new ImageUploadService(sys_get_temp_dir());
     }
 
-    private function pct(float|string|null $v): float
-    {
+    private function pct(float|string|null $v): float {
         $f = (float) $v;
         if (!is_finite($f)) {
             $f = 0.0;
@@ -127,8 +126,7 @@ class CatalogStickerController
         return max(0.0, min(100.0, $f));
     }
 
-    public function getSettings(Request $request, Response $response): Response
-    {
+    public function getSettings(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $uid = (string) ($params['event_uid'] ?? '');
         if ($uid === '') {
@@ -195,8 +193,7 @@ class CatalogStickerController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
-    public function saveSettings(Request $request, Response $response): Response
-    {
+    public function saveSettings(Request $request, Response $response): Response {
         $data = $request->getParsedBody();
         if ($request->getHeaderLine('Content-Type') === 'application/json') {
             $data = json_decode((string) $request->getBody(), true);
@@ -249,8 +246,7 @@ class CatalogStickerController
         return $response->withStatus(204);
     }
 
-    public function pdf(Request $request, Response $response): Response
-    {
+    public function pdf(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $uid = (string)($params['event_uid'] ?? ($params['event'] ?? ''));
         if ($uid === '') {
@@ -497,8 +493,7 @@ class CatalogStickerController
             ->withHeader('Content-Disposition', 'inline; filename="catalog-stickers.pdf"');
     }
 
-    public function uploadBackground(Request $request, Response $response): Response
-    {
+    public function uploadBackground(Request $request, Response $response): Response {
         $files = $request->getUploadedFiles();
         if (!isset($files['file'])) {
             $response->getBody()->write('missing file');
@@ -549,8 +544,7 @@ class CatalogStickerController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
-    private function sanitizePdfText(string $text): string
-    {
+    private function sanitizePdfText(string $text): string {
         $converted = @iconv('UTF-8', 'CP1252//TRANSLIT', $text);
         if ($converted === false) {
             return preg_replace('/[^\x00-\x7F]/', '?', $text);
@@ -558,8 +552,7 @@ class CatalogStickerController
         return $converted;
     }
 
-    private function wrapText(FPDF $pdf, string $text, float $maxWidth): array
-    {
+    private function wrapText(FPDF $pdf, string $text, float $maxWidth): array {
         $words = preg_split('/\s+/', $text) ?: [];
         $lines = [];
         $line = '';

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -23,8 +23,7 @@ class ConfigController
     /**
      * Inject configuration service dependency.
      */
-    public function __construct(ConfigService $service, ConfigValidator $validator, EventService $events)
-    {
+    public function __construct(ConfigService $service, ConfigValidator $validator, EventService $events) {
         $this->service   = $service;
         $this->validator = $validator;
         $this->events    = $events;
@@ -33,8 +32,7 @@ class ConfigController
     /**
      * Return the current configuration as JSON.
      */
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $cfg = $this->service->getConfig();
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== 'admin') {
@@ -52,8 +50,7 @@ class ConfigController
     /**
      * Return configuration for the specified event UID.
      */
-    public function getByEvent(Request $request, Response $response, array $args): Response
-    {
+    public function getByEvent(Request $request, Response $response, array $args): Response {
         $uid = (string) ($args['uid'] ?? '');
         $cfg = $this->service->getConfigForEvent($uid);
         $role = $_SESSION['user']['role'] ?? null;
@@ -72,8 +69,7 @@ class ConfigController
     /**
      * Persist a new configuration payload.
      */
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== Roles::ADMIN && $role !== Roles::EVENT_MANAGER) {
             return $response->withStatus(403);

--- a/src/Controller/DatenschutzController.php
+++ b/src/Controller/DatenschutzController.php
@@ -17,8 +17,7 @@ use Slim\Views\Twig;
  */
 class DatenschutzController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $service = new PageService();
         $html = $service->get('datenschutz');
         if ($html === null) {

--- a/src/Controller/EventConfigController.php
+++ b/src/Controller/EventConfigController.php
@@ -20,8 +20,7 @@ class EventConfigController
     private ConfigService $config;
     private ImageUploadService $images;
 
-    public function __construct(EventService $events, ConfigService $config, ImageUploadService $images)
-    {
+    public function __construct(EventService $events, ConfigService $config, ImageUploadService $images) {
         $this->events = $events;
         $this->config = $config;
         $this->images = $images;
@@ -30,8 +29,7 @@ class EventConfigController
     /**
      * Return configuration details for the given event UID.
      */
-    public function show(Request $request, Response $response, array $args): Response
-    {
+    public function show(Request $request, Response $response, array $args): Response {
         $uid = (string) ($args['id'] ?? '');
         $event = $this->events->getByUid($uid);
         if ($event === null) {
@@ -47,8 +45,7 @@ class EventConfigController
     /**
      * Update configuration for the specified event UID.
      */
-    public function update(Request $request, Response $response, array $args): Response
-    {
+    public function update(Request $request, Response $response, array $args): Response {
         $uid = (string) ($args['id'] ?? '');
         $event = $this->events->getByUid($uid);
         if ($event === null) {

--- a/src/Controller/EventController.php
+++ b/src/Controller/EventController.php
@@ -15,20 +15,17 @@ class EventController
 {
     private EventService $service;
 
-    public function __construct(EventService $service)
-    {
+    public function __construct(EventService $service) {
         $this->service = $service;
     }
 
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $data = $this->service->getAll();
         $response->getBody()->write(json_encode($data));
         return $response->withHeader('Content-Type', 'application/json');
     }
 
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $data = json_decode((string)$request->getBody(), true);
         if (!is_array($data)) {
             return $response->withStatus(400);

--- a/src/Controller/EventImageController.php
+++ b/src/Controller/EventImageController.php
@@ -15,16 +15,14 @@ class EventImageController
 {
     private ConfigService $config;
 
-    public function __construct(ConfigService $config)
-    {
+    public function __construct(ConfigService $config) {
         $this->config = $config;
     }
 
     /**
      * Return an image from the event's image directory.
      */
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $uid = (string) $request->getAttribute('uid');
         $file = (string) $request->getAttribute('file');
         $uid = preg_replace('~[^a-z0-9\-]~i', '', $uid);

--- a/src/Controller/EventListController.php
+++ b/src/Controller/EventListController.php
@@ -17,8 +17,7 @@ use PDO;
  */
 class EventListController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $view = Twig::fromRequest($request);
         $pdo = $request->getAttribute('pdo');
         if (!$pdo instanceof PDO) {

--- a/src/Controller/EvidenceController.php
+++ b/src/Controller/EvidenceController.php
@@ -47,8 +47,7 @@ class EvidenceController
     /**
      * Store an uploaded photo and link it to a result entry.
      */
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $files = $request->getUploadedFiles();
         if (!isset($files['photo'])) {
             $response->getBody()->write('missing file');
@@ -125,8 +124,7 @@ class EvidenceController
     /**
      * Serve a stored evidence photo.
      */
-    public function get(Request $request, Response $response, array $args = []): Response
-    {
+    public function get(Request $request, Response $response, array $args = []): Response {
         $team = isset($args['team']) ? preg_replace('/[^A-Za-z0-9_-]/', '_', (string)$args['team']) : '';
         $file = basename((string)($args['file'] ?? ''));
         $base = $this->config->getEventImagesDir() . '/photos';
@@ -148,8 +146,7 @@ class EvidenceController
     /**
      * Rotate an existing photo clockwise by 90 degrees.
      */
-    public function rotate(Request $request, Response $response): Response
-    {
+    public function rotate(Request $request, Response $response): Response {
         $data = $request->getParsedBody() ?? [];
         $ct = $request->getHeaderLine('Content-Type');
         if (str_starts_with($ct, 'application/json')) {

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -59,8 +59,7 @@ class ExportController
     /**
      * Export current data and create a timestamped backup directory.
      */
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         if (!is_dir($this->backupDir)) {
             if (!mkdir($this->backupDir, 0777, true)) {
                 $response->getBody()->write(json_encode([
@@ -91,8 +90,7 @@ class ExportController
     /**
      * Export current data to the default demo data directory.
      */
-    public function exportDefaults(Request $request, Response $response): Response
-    {
+    public function exportDefaults(Request $request, Response $response): Response {
         $this->exportToDir($this->defaultDir);
         return $response->withStatus(204);
     }
@@ -100,8 +98,7 @@ class ExportController
     /**
      * Write configuration, results, teams and catalogs to the given directory.
      */
-    private function exportToDir(string $dir): void
-    {
+    private function exportToDir(string $dir): void {
         if (!is_dir($dir)) {
             mkdir($dir . '/kataloge', 0777, true);
         } elseif (!is_dir($dir . '/kataloge')) {

--- a/src/Controller/FaqController.php
+++ b/src/Controller/FaqController.php
@@ -19,8 +19,7 @@ class FaqController
     /**
      * Render the FAQ page.
      */
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $service = new PageService();
         $html = $service->get('faq');
         if ($html === null) {

--- a/src/Controller/GlobalMediaController.php
+++ b/src/Controller/GlobalMediaController.php
@@ -10,12 +10,10 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class GlobalMediaController
 {
-    public function __construct(private ConfigService $config)
-    {
+    public function __construct(private ConfigService $config) {
     }
 
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $file = (string) $request->getAttribute('file');
         $file = basename($file);
         if ($file === '') {

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -20,8 +20,7 @@ class HelpController
     /**
      * Render the help view.
      */
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $view = Twig::fromRequest($request);
         $pdo = $request->getAttribute('pdo');
         if (!$pdo instanceof PDO) {

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -23,8 +23,7 @@ class HomeController
     /**
      * Display the start page with catalog selection.
      */
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $view = Twig::fromRequest($request);
         $pdo = $request->getAttribute('pdo');
         if (!$pdo instanceof PDO) {

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -60,16 +60,14 @@ class ImportController
     /**
      * Import data from the default data directory.
      */
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         return $this->importFromDir($this->dataDir, $response);
     }
 
     /**
      * Import demo data from the default directory used on first installation.
      */
-    public function restoreDefaults(Request $request, Response $response): Response
-    {
+    public function restoreDefaults(Request $request, Response $response): Response {
         $data = $this->decodeJson((string) $request->getBody(), $response);
         if ($data instanceof Response) {
             return $data;
@@ -100,8 +98,7 @@ class ImportController
     /**
      * Import data from a specified backup folder.
      */
-    public function import(Request $request, Response $response, array $args): Response
-    {
+    public function import(Request $request, Response $response, array $args): Response {
         $dir = (string)($args['name'] ?? '');
         if (
             $dir === ''
@@ -120,8 +117,7 @@ class ImportController
      *
      * @return mixed|Response
      */
-    private function decodeJson(string $json, Response $response): mixed
-    {
+    private function decodeJson(string $json, Response $response): mixed {
         $data = json_decode($json, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
             $response->getBody()->write(
@@ -138,8 +134,7 @@ class ImportController
     /**
      * Helper to import configuration, catalogs, results and more from a directory.
      */
-    private function importFromDir(string $dir, Response $response): Response
-    {
+    private function importFromDir(string $dir, Response $response): Response {
         $catalogDir = $dir . '/kataloge';
         $catalogsFile = $catalogDir . '/catalogs.json';
         if (!is_readable($catalogsFile)) {

--- a/src/Controller/ImpressumController.php
+++ b/src/Controller/ImpressumController.php
@@ -17,8 +17,7 @@ use Slim\Views\Twig;
  */
 class ImpressumController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $service = new PageService();
         $html = $service->get('impressum');
         if ($html === null) {

--- a/src/Controller/InvitationController.php
+++ b/src/Controller/InvitationController.php
@@ -17,8 +17,7 @@ class InvitationController
     private InvitationService $service;
     private MailService $mailer;
 
-    public function __construct(InvitationService $service, MailService $mailer)
-    {
+    public function __construct(InvitationService $service, MailService $mailer) {
         $this->service = $service;
         $this->mailer = $mailer;
     }
@@ -26,8 +25,7 @@ class InvitationController
     /**
      * Accept email and name, send invitation link.
      */
-    public function send(Request $request, Response $response): Response
-    {
+    public function send(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data)) {
             return $response->withStatus(400);

--- a/src/Controller/LizenzController.php
+++ b/src/Controller/LizenzController.php
@@ -16,8 +16,7 @@ use Slim\Views\Twig;
  */
 class LizenzController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $service = new PageService();
         $html = $service->get('lizenz');
         if ($html === null) {

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -24,8 +24,7 @@ class LoginController
     /**
      * Display the login form.
      */
-    public function show(Request $request, Response $response): Response
-    {
+    public function show(Request $request, Response $response): Response {
         $pdo = $request->getAttribute('pdo');
         if (!$pdo instanceof PDO) {
             $pdo = Database::connectFromEnv();
@@ -53,8 +52,7 @@ class LoginController
     /**
      * Verify credentials and start an admin session on success.
      */
-    public function login(Request $request, Response $response): Response
-    {
+    public function login(Request $request, Response $response): Response {
         $data = $request->getParsedBody();
         if (str_starts_with($request->getHeaderLine('Content-Type'), 'application/json')) {
             $data = json_decode((string) $request->getBody(), true);

--- a/src/Controller/LogoController.php
+++ b/src/Controller/LogoController.php
@@ -20,8 +20,7 @@ class LogoController
     /**
      * Inject services.
      */
-    public function __construct(ConfigService $config, ?ImageUploadService $images = null)
-    {
+    public function __construct(ConfigService $config, ?ImageUploadService $images = null) {
         $this->config = $config;
         $this->images = $images ?? new ImageUploadService(sys_get_temp_dir());
     }
@@ -29,8 +28,7 @@ class LogoController
     /**
      * Return the stored logo image in the requested format.
      */
-    public function get(Request $request, Response $response, array $args = []): Response
-    {
+    public function get(Request $request, Response $response, array $args = []): Response {
         $file = (string)($request->getAttribute('file') ?? '');
         $ext = strtolower((string)($request->getAttribute('ext') ?? 'png'));
         $uid = '';
@@ -65,8 +63,7 @@ class LogoController
     /**
      * Upload and store a new logo image.
      */
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $files = $request->getUploadedFiles();
         if (!isset($files['file'])) {
             $response->getBody()->write('missing file');

--- a/src/Controller/LogoutController.php
+++ b/src/Controller/LogoutController.php
@@ -17,8 +17,7 @@ class LogoutController
     /**
      * Destroy the admin session and redirect to login.
      */
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $_SESSION = [];
         session_destroy();
 

--- a/src/Controller/Marketing/CalserverController.php
+++ b/src/Controller/Marketing/CalserverController.php
@@ -9,8 +9,7 @@ use App\Service\PageService;
 
 class CalserverController extends MarketingPageController
 {
-    public function __construct(?PageService $pages = null, ?PageSeoConfigService $seo = null)
-    {
+    public function __construct(?PageService $pages = null, ?PageSeoConfigService $seo = null) {
         parent::__construct('calserver', $pages, $seo);
     }
 }

--- a/src/Controller/Marketing/ContactController.php
+++ b/src/Controller/Marketing/ContactController.php
@@ -21,8 +21,7 @@ use RuntimeException;
  */
 class ContactController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $data = $request->getParsedBody();
         if (!is_array($data)) {
             $body = $request->getBody();

--- a/src/Controller/Marketing/LandingController.php
+++ b/src/Controller/Marketing/LandingController.php
@@ -9,8 +9,7 @@ use App\Service\PageService;
 
 class LandingController extends MarketingPageController
 {
-    public function __construct(?PageService $pages = null, ?PageSeoConfigService $seo = null)
-    {
+    public function __construct(?PageService $pages = null, ?PageSeoConfigService $seo = null) {
         parent::__construct('landing', $pages, $seo);
     }
 }

--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -32,8 +32,7 @@ class MarketingPageController
         ?PageSeoConfigService $seo = null,
         ?TurnstileConfig $turnstileConfig = null,
         ?ProvenExpertRatingService $provenExpert = null
-    )
-    {
+    ) {
         $this->slug = $slug;
         $this->pages = $pages ?? new PageService();
         $this->seo = $seo ?? new PageSeoConfigService();
@@ -41,8 +40,7 @@ class MarketingPageController
         $this->provenExpert = $provenExpert ?? new ProvenExpertRatingService();
     }
 
-    public function __invoke(Request $request, Response $response, array $args = []): Response
-    {
+    public function __invoke(Request $request, Response $response, array $args = []): Response {
         $templateSlug = $this->slug ?? (string) ($args['slug'] ?? '');
         if ($templateSlug === '' || !preg_match('/^[a-z0-9-]+$/', $templateSlug)) {
             return $response->withStatus(404);
@@ -134,8 +132,7 @@ class MarketingPageController
      *
      * @return array<int,array{href:string,hreflang:string}>
      */
-    private function buildHreflangLinks(?string $hreflang, string $canonicalUrl): array
-    {
+    private function buildHreflangLinks(?string $hreflang, string $canonicalUrl): array {
         if ($hreflang === null) {
             return [];
         }
@@ -192,8 +189,7 @@ class MarketingPageController
         return $links;
     }
 
-    private function resolveLocalizedSlug(string $baseSlug, string $locale): string
-    {
+    private function resolveLocalizedSlug(string $baseSlug, string $locale): string {
         $locale = strtolower(trim($locale));
         if ($locale === '' || $locale === 'de') {
             return $baseSlug;

--- a/src/Controller/OnboardingController.php
+++ b/src/Controller/OnboardingController.php
@@ -17,8 +17,7 @@ use PDO;
  */
 class OnboardingController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $view = Twig::fromRequest($request);
         $mainDomain = getenv('MAIN_DOMAIN')
             ?: getenv('DOMAIN')

--- a/src/Controller/OnboardingEmailController.php
+++ b/src/Controller/OnboardingEmailController.php
@@ -18,16 +18,14 @@ class OnboardingEmailController
 {
     private EmailConfirmationService $service;
 
-    public function __construct(EmailConfirmationService $service)
-    {
+    public function __construct(EmailConfirmationService $service) {
         $this->service = $service;
     }
 
     /**
      * Accept email and send confirmation link.
      */
-    public function request(Request $request, Response $response): Response
-    {
+    public function request(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data)) {
             return $response->withStatus(400);
@@ -61,8 +59,7 @@ class OnboardingEmailController
     /**
      * Confirm email via token and redirect back to onboarding.
      */
-    public function confirm(Request $request, Response $response): Response
-    {
+    public function confirm(Request $request, Response $response): Response {
         $token = (string) ($request->getQueryParams()['token'] ?? '');
         if ($token === '') {
             return $response->withStatus(400);
@@ -91,8 +88,7 @@ class OnboardingEmailController
     /**
      * Return 204 if email is confirmed, 404 otherwise.
      */
-    public function status(Request $request, Response $response): Response
-    {
+    public function status(Request $request, Response $response): Response {
         $email = (string) ($request->getQueryParams()['email'] ?? '');
         if ($email === '') {
             return $response->withStatus(400);

--- a/src/Controller/OnboardingSessionController.php
+++ b/src/Controller/OnboardingSessionController.php
@@ -15,8 +15,7 @@ class OnboardingSessionController
     /**
      * Return current onboarding data as JSON.
      */
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $data = $_SESSION['onboarding'] ?? [];
         $payload = json_encode($data, JSON_THROW_ON_ERROR);
         $response->getBody()->write($payload);
@@ -26,8 +25,7 @@ class OnboardingSessionController
     /**
      * Merge provided data into the onboarding session.
      */
-    public function store(Request $request, Response $response): Response
-    {
+    public function store(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data)) {
             return $response->withStatus(400);
@@ -40,8 +38,7 @@ class OnboardingSessionController
     /**
      * Clear onboarding data from the session.
      */
-    public function clear(Request $request, Response $response): Response
-    {
+    public function clear(Request $request, Response $response): Response {
         unset($_SESSION['onboarding']);
         return $response->withStatus(204);
     }

--- a/src/Controller/PasswordController.php
+++ b/src/Controller/PasswordController.php
@@ -39,8 +39,7 @@ class PasswordController
     /**
      * Update the current user's password using the provided request body.
      */
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $data = $request->getParsedBody();
         if ($request->getHeaderLine('Content-Type') === 'application/json') {
             $data = json_decode((string) $request->getBody(), true);

--- a/src/Controller/PasswordResetController.php
+++ b/src/Controller/PasswordResetController.php
@@ -39,8 +39,7 @@ class PasswordResetController
     /**
      * Accept username or email, generate token and send reset link.
      */
-    public function request(Request $request, Response $response): Response
-    {
+    public function request(Request $request, Response $response): Response {
         $isJson = $request->getHeaderLine('Content-Type') === 'application/json';
         $data = $request->getParsedBody();
         if ($isJson) {
@@ -105,8 +104,7 @@ class PasswordResetController
     /**
      * Verify token and set new password.
      */
-    public function confirm(Request $request, Response $response): Response
-    {
+    public function confirm(Request $request, Response $response): Response {
         $data = $request->getParsedBody();
         if ($request->getHeaderLine('Content-Type') === 'application/json') {
             $data = json_decode((string) $request->getBody(), true);

--- a/src/Controller/PlayerSessionController.php
+++ b/src/Controller/PlayerSessionController.php
@@ -15,8 +15,7 @@ class PlayerSessionController
     /**
      * Handle the incoming request.
      */
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         $name = is_array($data) ? ($data['name'] ?? '') : '';
         if (!is_string($name) || trim($name) === '') {

--- a/src/Controller/QrController.php
+++ b/src/Controller/QrController.php
@@ -58,8 +58,7 @@ class QrController
     /**
      * Generate a catalog QR code with default styling.
      */
-    public function catalog(Request $request, Response $response): Response
-    {
+    public function catalog(Request $request, Response $response): Response {
         $cfg = $this->config->getConfig();
         try {
             $out = $this->qrService->generateCatalog($request->getQueryParams(), $cfg);
@@ -77,8 +76,7 @@ class QrController
     /**
      * Generate a team QR code with default styling using QrCodeService defaults.
      */
-    public function team(Request $request, Response $response): Response
-    {
+    public function team(Request $request, Response $response): Response {
         $cfg = $this->config->getConfig();
         try {
             $out = $this->qrService->generateTeam($request->getQueryParams(), $cfg);
@@ -96,8 +94,7 @@ class QrController
     /**
      * Generate an event QR code with default styling.
      */
-    public function event(Request $request, Response $response): Response
-    {
+    public function event(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $event = (string)($params['event'] ?? '');
         if ($event === '') {
@@ -124,8 +121,7 @@ class QrController
     /**
      * Render a QR code image based on query parameters.
      */
-    public function image(Request $request, Response $response): Response
-    {
+    public function image(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $text = (string)($params['t'] ?? '?');
         if ($text === '') {
@@ -161,8 +157,7 @@ class QrController
     /**
      * Render a PDF containing the QR code.
      */
-    public function pdf(Request $request, Response $response): Response
-    {
+    public function pdf(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $team   = (string)($params['t'] ?? '');
         if ($team === '') {
@@ -261,8 +256,7 @@ class QrController
     /**
      * Render a PDF with invitations for all teams.
      */
-    public function pdfAll(Request $request, Response $response): Response
-    {
+    public function pdfAll(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $teams = $this->teams->getAll();
         if ($teams === []) {
@@ -366,8 +360,7 @@ class QrController
             ->withHeader('Content-Disposition', 'inline; filename="invites.pdf"');
     }
 
-    private function errorResponse(Response $response): Response
-    {
+    private function errorResponse(Response $response): Response {
         $response->getBody()->write('Failed to generate QR code');
         return $response->withHeader('Content-Type', 'text/plain')->withStatus(500);
     }
@@ -376,8 +369,7 @@ class QrController
      * Convert a UTF-8 string to the Windows-1252 encoding used by FPDF.
      * Unsupported characters are approximated or omitted.
      */
-    private function sanitizePdfText(string $text): string
-    {
+    private function sanitizePdfText(string $text): string {
         $converted = @iconv('UTF-8', 'CP1252//TRANSLIT', $text);
         if ($converted === false) {
             // Fallback: replace any byte outside the ASCII range
@@ -406,8 +398,7 @@ class QrController
         $this->renderHtmlNode($pdf, $doc->documentElement);
     }
 
-    private function renderHtmlNode(FPDF $pdf, \DOMNode $node): void
-    {
+    private function renderHtmlNode(FPDF $pdf, \DOMNode $node): void {
         foreach ($node->childNodes as $child) {
             if ($child instanceof \DOMText) {
                 $text = $this->sanitizePdfText($child->nodeValue);

--- a/src/Controller/QrLogoController.php
+++ b/src/Controller/QrLogoController.php
@@ -17,14 +17,12 @@ class QrLogoController
     private ConfigService $config;
     private ImageUploadService $images;
 
-    public function __construct(ConfigService $config, ?ImageUploadService $images = null)
-    {
+    public function __construct(ConfigService $config, ?ImageUploadService $images = null) {
         $this->config = $config;
         $this->images = $images ?? new ImageUploadService(sys_get_temp_dir());
     }
 
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $file = (string)($request->getAttribute('file') ?? '');
         $ext = strtolower((string)($request->getAttribute('ext') ?? 'png'));
         $uid = '';
@@ -72,8 +70,7 @@ class QrLogoController
         return $response->withHeader('Content-Type', $contentType);
     }
 
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $files = $request->getUploadedFiles();
         if (!isset($files['file'])) {
             $response->getBody()->write('missing file');

--- a/src/Controller/RegisterController.php
+++ b/src/Controller/RegisterController.php
@@ -21,8 +21,7 @@ class RegisterController
     /**
      * Display the registration form.
      */
-    public function show(Request $request, Response $response): Response
-    {
+    public function show(Request $request, Response $response): Response {
         $pdo = $request->getAttribute('pdo');
         if (!$pdo instanceof PDO) {
             $pdo = Database::connectFromEnv();
@@ -36,8 +35,7 @@ class RegisterController
     /**
      * Handle registration form submission.
      */
-    public function register(Request $request, Response $response): Response
-    {
+    public function register(Request $request, Response $response): Response {
         $pdo = $request->getAttribute('pdo');
         if (!$pdo instanceof PDO) {
             $pdo = Database::connectFromEnv();

--- a/src/Controller/ResultController.php
+++ b/src/Controller/ResultController.php
@@ -53,8 +53,7 @@ class ResultController
     /**
      * Return all stored results as JSON.
      */
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $eventUid = (string)($params['event_uid'] ?? '');
         $content = json_encode($this->service->getAll($eventUid), JSON_PRETTY_PRINT);
@@ -65,8 +64,7 @@ class ResultController
     /**
      * Return per-question results as JSON.
      */
-    public function getQuestions(Request $request, Response $response): Response
-    {
+    public function getQuestions(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $eventUid = (string)($params['event_uid'] ?? '');
         $content = json_encode($this->service->getQuestionResults($eventUid), JSON_PRETTY_PRINT);
@@ -77,8 +75,7 @@ class ResultController
     /**
      * Download all results as a CSV file.
      */
-    public function download(Request $request, Response $response): Response
-    {
+    public function download(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $eventUid = (string)($params['event_uid'] ?? '');
         $data = $this->service->getAll($eventUid);
@@ -99,8 +96,7 @@ class ResultController
     /**
      * Store a new result or mark a puzzle as solved.
      */
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $eventUid = (string)($params['event_uid'] ?? '');
         $data = json_decode((string) $request->getBody(), true);
@@ -153,8 +149,7 @@ class ResultController
     /**
      * Render the HTML results page.
      */
-    public function page(Request $request, Response $response): Response
-    {
+    public function page(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $eventUid = (string)($params['event_uid'] ?? '');
         $view = Twig::fromRequest($request);
@@ -197,8 +192,7 @@ class ResultController
     /**
      * Clear all results and associated photos.
      */
-    public function delete(Request $request, Response $response): Response
-    {
+    public function delete(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $eventUid = (string)($params['event_uid'] ?? '');
         $this->service->clear($eventUid);
@@ -221,8 +215,7 @@ class ResultController
     /**
      * Render a PDF summary for all teams.
      */
-    public function pdf(Request $request, Response $response): Response
-    {
+    public function pdf(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $eventUid = (string)($params['event_uid'] ?? '');
         $results = $this->service->getAll($eventUid);
@@ -449,8 +442,7 @@ class ResultController
      * @param array<string,mixed> $r
      * @return list<string|int>
      */
-    private function mapResultRow(array $r): array
-    {
+    private function mapResultRow(array $r): array {
         return [
             (string)($r['name'] ?? ''),
             (int)($r['attempt'] ?? 0),
@@ -471,8 +463,7 @@ class ResultController
      *
      * @param list<array<string|int>> $rows
      */
-    private function buildCsv(array $rows): string
-    {
+    private function buildCsv(array $rows): string {
         $lines = [];
         foreach ($rows as $row) {
             $cells = array_map(static function ($v) {
@@ -483,8 +474,7 @@ class ResultController
         return implode("\n", $lines) . "\n";
     }
 
-    private function sanitizePdfText(string $text): string
-    {
+    private function sanitizePdfText(string $text): string {
         $converted = @iconv('UTF-8', 'CP1252//TRANSLIT', $text);
         if ($converted === false) {
             return preg_replace('/[^\x00-\x7F]/', '?', $text);

--- a/src/Controller/SettingsController.php
+++ b/src/Controller/SettingsController.php
@@ -16,20 +16,17 @@ class SettingsController
 {
     private SettingsService $service;
 
-    public function __construct(SettingsService $service)
-    {
+    public function __construct(SettingsService $service) {
         $this->service = $service;
     }
 
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $settings = $this->service->getAll();
         $response->getBody()->write(json_encode($settings, JSON_PRETTY_PRINT));
         return $response->withHeader('Content-Type', 'application/json');
     }
 
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $role = $_SESSION['user']['role'] ?? null;
         if ($role !== Roles::ADMIN) {
             return $response->withStatus(403);

--- a/src/Controller/StripeCheckoutController.php
+++ b/src/Controller/StripeCheckoutController.php
@@ -15,8 +15,7 @@ use Throwable;
  */
 class StripeCheckoutController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data)) {
             return $response->withStatus(400);
@@ -85,15 +84,13 @@ class StripeCheckoutController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
-    private function jsonError(Response $response, int $status, string $message): Response
-    {
+    private function jsonError(Response $response, int $status, string $message): Response {
         $payload = json_encode(['error' => $message]);
         $response->getBody()->write($payload !== false ? $payload : '{}');
         return $response->withStatus($status)->withHeader('Content-Type', 'application/json');
     }
 
-    private function reportError(Throwable $e): void
-    {
+    private function reportError(Throwable $e): void {
         error_log($e->getMessage());
         error_log($e->getTraceAsString());
 

--- a/src/Controller/StripeSessionController.php
+++ b/src/Controller/StripeSessionController.php
@@ -15,8 +15,7 @@ use App\Infrastructure\Database;
  */
 class StripeSessionController
 {
-    public function __invoke(Request $request, Response $response, array $args): Response
-    {
+    public function __invoke(Request $request, Response $response, array $args): Response {
         $sessionId = (string) ($args['id'] ?? '');
         $service = $request->getAttribute('stripeService');
         if (!$service instanceof StripeService) {

--- a/src/Controller/StripeWebhookController.php
+++ b/src/Controller/StripeWebhookController.php
@@ -16,8 +16,7 @@ use Stripe\Webhook;
  */
 class StripeWebhookController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $payload = (string) $request->getBody();
         $sigHeader = $request->getHeaderLine('Stripe-Signature');
         $webhookSecret = getenv('STRIPE_WEBHOOK_SECRET') ?: '';
@@ -149,8 +148,7 @@ class StripeWebhookController
         return $response->withStatus(200);
     }
 
-    private function mapPriceToPlan(string $priceId): ?string
-    {
+    private function mapPriceToPlan(string $priceId): ?string {
         $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
         $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';
         $map = [

--- a/src/Controller/SubscriptionController.php
+++ b/src/Controller/SubscriptionController.php
@@ -16,8 +16,7 @@ use Stripe\StripeClient;
  */
 class SubscriptionController
 {
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $host = $request->getUri()->getHost();
         $parts = explode('.', $host);
         $mainDomain = getenv('MAIN_DOMAIN') ?: $host;

--- a/src/Controller/SummaryController.php
+++ b/src/Controller/SummaryController.php
@@ -21,8 +21,7 @@ class SummaryController
     /**
      * Inject configuration service dependency.
      */
-    public function __construct(ConfigService $config, EventService $events)
-    {
+    public function __construct(ConfigService $config, EventService $events) {
         $this->config = $config;
         $this->events = $events;
     }
@@ -30,8 +29,7 @@ class SummaryController
     /**
      * Render the summary page.
      */
-    public function __invoke(Request $request, Response $response): Response
-    {
+    public function __invoke(Request $request, Response $response): Response {
         $view = Twig::fromRequest($request);
         $params = $request->getQueryParams();
         $uid = (string)($params['event'] ?? '');

--- a/src/Controller/TeamController.php
+++ b/src/Controller/TeamController.php
@@ -20,14 +20,12 @@ class TeamController
     /**
      * Inject team service dependency.
      */
-    public function __construct(TeamService $service, ConfigService $config)
-    {
+    public function __construct(TeamService $service, ConfigService $config) {
         $this->service = $service;
         $this->config = $config;
     }
 
-    private function setEventFromRequest(Request $request): void
-    {
+    private function setEventFromRequest(Request $request): void {
         $params = $request->getQueryParams();
         if (isset($params['event_uid'])) {
             $this->config->setActiveEventUid((string) $params['event_uid']);
@@ -37,8 +35,7 @@ class TeamController
     /**
      * Return the list of teams as JSON.
      */
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $this->setEventFromRequest($request);
         $data = $this->service->getAll();
         $response->getBody()->write(json_encode($data));
@@ -48,8 +45,7 @@ class TeamController
     /**
      * Replace the entire list of teams with the provided data.
      */
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $this->setEventFromRequest($request);
         $body = (string) $request->getBody();
         $data = json_decode($body, true);

--- a/src/Controller/TenantController.php
+++ b/src/Controller/TenantController.php
@@ -18,14 +18,12 @@ class TenantController
     private TenantService $service;
     private bool $displayErrors;
 
-    public function __construct(TenantService $service, bool $displayErrors = false)
-    {
+    public function __construct(TenantService $service, bool $displayErrors = false) {
         $this->service = $service;
         $this->displayErrors = $displayErrors;
     }
 
-    public function create(Request $request, Response $response): Response
-    {
+    public function create(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data) || !isset($data['uid'], $data['schema'])) {
             return $response->withStatus(400);
@@ -87,8 +85,7 @@ class TenantController
         return $response->withStatus(201);
     }
 
-    public function delete(Request $request, Response $response): Response
-    {
+    public function delete(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data) || !isset($data['uid'])) {
             return $response->withStatus(400);
@@ -100,8 +97,7 @@ class TenantController
     /**
      * Check if a tenant with the given subdomain already exists.
      */
-    public function exists(Request $request, Response $response, array $args): Response
-    {
+    public function exists(Request $request, Response $response, array $args): Response {
         $sub = (string) ($args['subdomain'] ?? '');
         return $this->service->exists($sub)
             ? $response->withStatus(200)
@@ -111,8 +107,7 @@ class TenantController
     /**
      * Import missing tenants by scanning available schemas.
      */
-    public function sync(Request $request, Response $response): Response
-    {
+    public function sync(Request $request, Response $response): Response {
         try {
             $count = $this->service->importMissing();
             $response->getBody()->write(json_encode(['imported' => $count]));
@@ -130,8 +125,7 @@ class TenantController
     /**
      * Export tenant list as CSV file.
      */
-    public function export(Request $request, Response $response): Response
-    {
+    public function export(Request $request, Response $response): Response {
         $tenants = $this->service->getAll();
         $handle = fopen('php://temp', 'r+');
         fputcsv($handle, ['subdomain', 'plan', 'billing', 'email', 'created_at']);
@@ -156,8 +150,7 @@ class TenantController
     /**
      * List all tenants as JSON.
      */
-    public function list(Request $request, Response $response): Response
-    {
+    public function list(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $query = isset($params['query']) ? (string) $params['query'] : '';
         $list = $this->service->getAll($query);
@@ -168,8 +161,7 @@ class TenantController
     /**
      * Render tenant list as HTML.
      */
-    public function listHtml(Request $request, Response $response): Response
-    {
+    public function listHtml(Request $request, Response $response): Response {
         $params = $request->getQueryParams();
         $status = isset($params['status']) ? (string) $params['status'] : '';
         $query = isset($params['query']) ? (string) $params['query'] : '';
@@ -200,8 +192,7 @@ class TenantController
     /**
      * Provide a simple tenant report as CSV with plan counts.
      */
-    public function report(Request $request, Response $response): Response
-    {
+    public function report(Request $request, Response $response): Response {
         $tenants = $this->service->getAll();
         $stats = [];
         foreach ($tenants as $row) {

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -16,16 +16,14 @@ class UserController
 {
     private UserService $service;
 
-    public function __construct(UserService $service)
-    {
+    public function __construct(UserService $service) {
         $this->service = $service;
     }
 
     /**
      * Return all users as JSON.
      */
-    public function get(Request $request, Response $response): Response
-    {
+    public function get(Request $request, Response $response): Response {
         $list = $this->service->getAll();
         $response->getBody()->write(json_encode($list));
         return $response->withHeader('Content-Type', 'application/json');
@@ -34,8 +32,7 @@ class UserController
     /**
      * Replace the user list with the provided data.
      */
-    public function post(Request $request, Response $response): Response
-    {
+    public function post(Request $request, Response $response): Response {
         $data = json_decode((string) $request->getBody(), true);
         if (!is_array($data)) {
             return $response->withStatus(400);

--- a/src/Domain/Event/SeoConfigSaved.php
+++ b/src/Domain/Event/SeoConfigSaved.php
@@ -13,13 +13,11 @@ class SeoConfigSaved
 {
     private PageSeoConfig $config;
 
-    public function __construct(PageSeoConfig $config)
-    {
+    public function __construct(PageSeoConfig $config) {
         $this->config = $config;
     }
 
-    public function getConfig(): PageSeoConfig
-    {
+    public function getConfig(): PageSeoConfig {
         return $this->config;
     }
 }

--- a/src/Domain/Event/SeoConfigUpdated.php
+++ b/src/Domain/Event/SeoConfigUpdated.php
@@ -13,13 +13,11 @@ class SeoConfigUpdated
 {
     private PageSeoConfig $config;
 
-    public function __construct(PageSeoConfig $config)
-    {
+    public function __construct(PageSeoConfig $config) {
         $this->config = $config;
     }
 
-    public function getConfig(): PageSeoConfig
-    {
+    public function getConfig(): PageSeoConfig {
         return $this->config;
     }
 }

--- a/src/Domain/Page.php
+++ b/src/Domain/Page.php
@@ -19,37 +19,31 @@ class Page implements JsonSerializable
 
     private string $content;
 
-    public function __construct(int $id, string $slug, string $title, string $content)
-    {
+    public function __construct(int $id, string $slug, string $title, string $content) {
         $this->id = $id;
         $this->slug = $slug;
         $this->title = $title;
         $this->content = $content;
     }
 
-    public function getId(): int
-    {
+    public function getId(): int {
         return $this->id;
     }
 
-    public function getSlug(): string
-    {
+    public function getSlug(): string {
         return $this->slug;
     }
 
-    public function getTitle(): string
-    {
+    public function getTitle(): string {
         return $this->title;
     }
 
-    public function getContent(): string
-    {
+    public function getContent(): string {
         return $this->content;
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize(): array
-    {
+    public function jsonSerialize(): array {
         return [
             'id' => $this->id,
             'slug' => $this->slug,

--- a/src/Domain/PageSeoConfig.php
+++ b/src/Domain/PageSeoConfig.php
@@ -70,90 +70,74 @@ class PageSeoConfig implements JsonSerializable
         $this->faviconPath = $faviconPath;
     }
 
-    public function getPageId(): int
-    {
+    public function getPageId(): int {
         return $this->pageId;
     }
 
-    public function getMetaTitle(): ?string
-    {
+    public function getMetaTitle(): ?string {
         return $this->metaTitle;
     }
 
-    public function getMetaDescription(): ?string
-    {
+    public function getMetaDescription(): ?string {
         return $this->metaDescription;
     }
 
-    public function getSlug(): string
-    {
+    public function getSlug(): string {
         return $this->slug;
     }
 
-    public function getCanonicalUrl(): ?string
-    {
+    public function getCanonicalUrl(): ?string {
         return $this->canonicalUrl;
     }
 
-    public function getDomain(): ?string
-    {
+    public function getDomain(): ?string {
         return $this->domain;
     }
 
-    public function getRobotsMeta(): ?string
-    {
+    public function getRobotsMeta(): ?string {
         return $this->robotsMeta;
     }
 
-    public function getOgTitle(): ?string
-    {
+    public function getOgTitle(): ?string {
         return $this->ogTitle;
     }
 
-    public function getOgDescription(): ?string
-    {
+    public function getOgDescription(): ?string {
         return $this->ogDescription;
     }
 
-    public function getOgImage(): ?string
-    {
+    public function getOgImage(): ?string {
         return $this->ogImage;
     }
 
-    public function getSchemaJson(): ?string
-    {
+    public function getSchemaJson(): ?string {
         return $this->schemaJson;
     }
 
-    public function getHreflang(): ?string
-    {
+    public function getHreflang(): ?string {
         return $this->hreflang;
     }
 
-    public function getFaviconPath(): ?string
-    {
+    public function getFaviconPath(): ?string {
         return $this->faviconPath;
     }
 
     /**
      * @return Page|null
      */
-    public function getPage()
-    {
+    public function getPage() {
         return $this->page;
     }
 
     /**
      * @param Page $page
      */
-    public function setPage($page): void
-    {
+    public function setPage($page): void {
         $this->page = $page;
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize(): array
-    {
+    public function jsonSerialize(): array {
         return [
             'pageId' => $this->pageId,
             'metaTitle' => $this->metaTitle,

--- a/src/Domain/Plan.php
+++ b/src/Domain/Plan.php
@@ -13,8 +13,7 @@ enum Plan: string
     /**
      * @return array<string,int|null>
      */
-    public function limits(): array
-    {
+    public function limits(): array {
         return match ($this) {
             self::STARTER => [
                 'maxEvents' => 1,

--- a/src/Domain/User/User.php
+++ b/src/Domain/User/User.php
@@ -16,37 +16,31 @@ class User implements JsonSerializable
 
     private string $lastName;
 
-    public function __construct(?int $id, string $username, string $firstName, string $lastName)
-    {
+    public function __construct(?int $id, string $username, string $firstName, string $lastName) {
         $this->id = $id;
         $this->username = strtolower($username);
         $this->firstName = ucfirst($firstName);
         $this->lastName = ucfirst($lastName);
     }
 
-    public function getId(): ?int
-    {
+    public function getId(): ?int {
         return $this->id;
     }
 
-    public function getUsername(): string
-    {
+    public function getUsername(): string {
         return $this->username;
     }
 
-    public function getFirstName(): string
-    {
+    public function getFirstName(): string {
         return $this->firstName;
     }
 
-    public function getLastName(): string
-    {
+    public function getLastName(): string {
         return $this->lastName;
     }
 
     #[\ReturnTypeWillChange]
-    public function jsonSerialize(): array
-    {
+    public function jsonSerialize(): array {
         return [
             'id' => $this->id,
             'username' => $this->username,

--- a/src/Infrastructure/Cache/PageSeoCache.php
+++ b/src/Infrastructure/Cache/PageSeoCache.php
@@ -14,18 +14,15 @@ class PageSeoCache
     /** @var array<int, PageSeoConfig> */
     private array $cache = [];
 
-    public function get(int $pageId): ?PageSeoConfig
-    {
+    public function get(int $pageId): ?PageSeoConfig {
         return $this->cache[$pageId] ?? null;
     }
 
-    public function set(PageSeoConfig $config): void
-    {
+    public function set(PageSeoConfig $config): void {
         $this->cache[$config->getPageId()] = $config;
     }
 
-    public function invalidate(int $pageId): void
-    {
+    public function invalidate(int $pageId): void {
         unset($this->cache[$pageId]);
     }
 }

--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -20,8 +20,7 @@ class Database
      * `POSTGRES_CONNECT_RETRY_DELAY` environment variables. The delay doubles
      * after each failed attempt to give the database more time to recover.
      */
-    public static function connectFromEnv(int $retries = 5, int $delay = 1): PDO
-    {
+    public static function connectFromEnv(int $retries = 5, int $delay = 1): PDO {
         $envRetries = getenv('POSTGRES_CONNECT_RETRIES');
         if ($envRetries !== false) {
             $retries = (int) $envRetries;
@@ -57,8 +56,7 @@ class Database
      * This method is intended for PostgreSQL databases and will always
      * execute a `SET search_path` statement to select the provided schema.
      */
-    public static function connectWithSchema(string $schema): PDO
-    {
+    public static function connectWithSchema(string $schema): PDO {
         $pdo = self::connectFromEnv();
         if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
             $pdo->exec('SET search_path TO ' . $pdo->quote($schema));

--- a/src/Infrastructure/Event/EventDispatcher.php
+++ b/src/Infrastructure/Event/EventDispatcher.php
@@ -12,13 +12,11 @@ class EventDispatcher
     /** @var array<string, callable[]> */
     private array $listeners = [];
 
-    public function addListener(string $eventClass, callable $listener): void
-    {
+    public function addListener(string $eventClass, callable $listener): void {
         $this->listeners[$eventClass][] = $listener;
     }
 
-    public function dispatch(object $event): void
-    {
+    public function dispatch(object $event): void {
         $class = $event::class;
         foreach ($this->listeners[$class] ?? [] as $listener) {
             $listener($event);

--- a/src/Infrastructure/Migrations/Migrator.php
+++ b/src/Infrastructure/Migrations/Migrator.php
@@ -8,8 +8,7 @@ use PDO;
 
 class Migrator
 {
-    public static function migrate(PDO $pdo, string $dir): void
-    {
+    public static function migrate(PDO $pdo, string $dir): void {
         $pdo->exec('CREATE TABLE IF NOT EXISTS migrations (version TEXT PRIMARY KEY)');
         $stmt = $pdo->query('SELECT version FROM migrations');
         $applied = $stmt->fetchAll(PDO::FETCH_COLUMN) ?: [];

--- a/src/Infrastructure/Persistence/User/InMemoryUserRepository.php
+++ b/src/Infrastructure/Persistence/User/InMemoryUserRepository.php
@@ -18,8 +18,7 @@ class InMemoryUserRepository implements UserRepository
     /**
      * @param User[]|null $users
      */
-    public function __construct(?array $users = null)
-    {
+    public function __construct(?array $users = null) {
         $this->users = $users ?? [
             1 => new User(1, 'bill.gates', 'Bill', 'Gates'),
             2 => new User(2, 'steve.jobs', 'Steve', 'Jobs'),
@@ -32,16 +31,14 @@ class InMemoryUserRepository implements UserRepository
     /**
      * {@inheritdoc}
      */
-    public function findAll(): array
-    {
+    public function findAll(): array {
         return array_values($this->users);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function findUserOfId(int $id): User
-    {
+    public function findUserOfId(int $id): User {
         if (!isset($this->users[$id])) {
             throw new UserNotFoundException();
         }

--- a/src/Service/AuditLogger.php
+++ b/src/Service/AuditLogger.php
@@ -13,8 +13,7 @@ class AuditLogger
 {
     private PDO $pdo;
 
-    public function __construct(PDO $pdo)
-    {
+    public function __construct(PDO $pdo) {
         $this->pdo = $pdo;
     }
 
@@ -24,8 +23,7 @@ class AuditLogger
      * @param string               $action  Name of the action.
      * @param array<string,mixed>  $context Additional context information.
      */
-    public function log(string $action, array $context = []): void
-    {
+    public function log(string $action, array $context = []): void {
         $json = json_encode($context);
         $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
         $sql = $driver === 'pgsql'

--- a/src/Service/AwardService.php
+++ b/src/Service/AwardService.php
@@ -20,8 +20,7 @@ class AwardService
      *     points:list<array{team:string,place:int}>
      * }
      */
-    public function computeRankings(array $results, ?int $catalogCount = null): array
-    {
+    public function computeRankings(array $results, ?int $catalogCount = null): array {
         $catalogs = [];
         $puzzleTimes = [];
         $catalogTimes = [];
@@ -104,8 +103,7 @@ class AwardService
      * } $rankings
      * @param array<string,array{title:string,desc:string}>|null $info
      */
-    public function buildText(string $team, array $rankings, ?array $info = null): ?string
-    {
+    public function buildText(string $team, array $rankings, ?array $info = null): ?string {
         $defaults = [
             'catalog' => [
                 'title' => 'Katalogmeister',
@@ -153,8 +151,7 @@ class AwardService
      * @param array<string,array{title:string,desc:string}>|null $info
      * @return list<array{place:int,title:string,desc:string}>
      */
-    public function getAwards(string $team, array $rankings, ?array $info = null): array
-    {
+    public function getAwards(string $team, array $rankings, ?array $info = null): array {
         $defaults = [
             'catalog' => [
                 'title' => 'Katalogmeister',
@@ -189,8 +186,7 @@ class AwardService
         return $list;
     }
 
-    private function placeDescription(string $key, int $place, string $default): string
-    {
+    private function placeDescription(string $key, int $place, string $default): string {
         return match ($place) {
             2 => match ($key) {
                 'puzzle' => 'zweit schnellstes Lösen des Rätselworts',
@@ -211,8 +207,7 @@ class AwardService
      *
      * @param list<string> $items
      */
-    private function join(array $items): string
-    {
+    private function join(array $items): string {
         if (count($items) === 0) {
             return '';
         }

--- a/src/Service/CatalogService.php
+++ b/src/Service/CatalogService.php
@@ -24,8 +24,7 @@ class CatalogService
     /** @var bool|null detected presence of the design_path column */
     private ?bool $hasDesign = null;
 
-    private function event(): string
-    {
+    private function event(): string {
         return $this->eventUid !== '' ? $this->eventUid : $this->config->getActiveEventUid();
     }
 
@@ -50,8 +49,7 @@ class CatalogService
     /**
      * Ensure the optional comment column exists and remember the result.
      */
-    private function hasCommentColumn(): bool
-    {
+    private function hasCommentColumn(): bool {
         if ($this->hasComment !== null) {
             return $this->hasComment;
         }
@@ -72,8 +70,7 @@ class CatalogService
     /**
      * Ensure the optional design_path column exists and remember the result.
      */
-    private function hasDesignColumn(): bool
-    {
+    private function hasDesignColumn(): bool {
         if ($this->hasDesign !== null) {
             return $this->hasDesign;
         }
@@ -94,8 +91,7 @@ class CatalogService
     /**
      * Fetch catalogs with pagination.
      */
-    public function fetchPagedCatalogs(int $offset, int $limit, string $order): array
-    {
+    public function fetchPagedCatalogs(int $offset, int $limit, string $order): array {
         $fields = 'uid,sort_order,slug,file,name,description,raetsel_buchstabe';
         if ($this->hasCommentColumn()) {
             $fields .= ',comment';
@@ -142,8 +138,7 @@ class CatalogService
     /**
      * Count catalogs for the active event.
      */
-    public function countCatalogs(): int
-    {
+    public function countCatalogs(): int {
         $uid = $this->event();
         $sql = 'SELECT COUNT(*) FROM catalogs';
         $params = [];
@@ -165,8 +160,7 @@ class CatalogService
     /**
      * Return the catalog slug for the given file name.
      */
-    public function slugByFile(string $file): ?string
-    {
+    public function slugByFile(string $file): ?string {
         $uid = $this->event();
         $sql = 'SELECT slug FROM catalogs WHERE file=?';
         $params = [basename($file)];
@@ -188,8 +182,7 @@ class CatalogService
     /**
      * Find the catalog UID by its slug.
      */
-    public function uidBySlug(string $slug): ?string
-    {
+    public function uidBySlug(string $slug): ?string {
         $event = $this->event();
         $sql = 'SELECT uid FROM catalogs WHERE slug=?';
         $params = [$slug];
@@ -211,8 +204,7 @@ class CatalogService
     /**
      * Create a catalog entry if it does not already exist.
      */
-    public function createCatalog(string $file): void
-    {
+    public function createCatalog(string $file): void {
         $slug = pathinfo($file, PATHINFO_FILENAME);
         $event = $this->event();
 
@@ -275,8 +267,7 @@ class CatalogService
     /**
      * Read a catalog or the catalog index and return it as JSON.
      */
-    public function read(string $file): ?string
-    {
+    public function read(string $file): ?string {
         if ($file === 'catalogs.json') {
             $fields = 'uid,sort_order,slug,file,name,description,raetsel_buchstabe';
             if ($this->hasCommentColumn()) {
@@ -382,8 +373,7 @@ class CatalogService
      *
      * @param array|string $data
      */
-    public function write(string $file, $data): void
-    {
+    public function write(string $file, $data): void {
         if ($file === 'catalogs.json') {
             if (!is_array($data)) {
                 $data = json_decode((string)$data, true) ?? [];
@@ -647,8 +637,7 @@ class CatalogService
     /**
      * Delete a catalog and all associated questions.
      */
-    public function delete(string $file): void
-    {
+    public function delete(string $file): void {
         if ($file === 'catalogs.json') {
             $uid = $this->event();
             if ($uid !== '') {
@@ -684,8 +673,7 @@ class CatalogService
     /**
      * Remove a question at a specific index from a catalog file.
      */
-    public function deleteQuestion(string $file, int $index): void
-    {
+    public function deleteQuestion(string $file, int $index): void {
         $slug = pathinfo($file, PATHINFO_FILENAME);
         $uid = $this->event();
         $sql = 'SELECT uid FROM catalogs WHERE slug=?';
@@ -713,8 +701,7 @@ class CatalogService
     /**
      * Return the design path for the given catalog slug.
      */
-    public function getDesignPath(string $slug): ?string
-    {
+    public function getDesignPath(string $slug): ?string {
         if (!$this->hasDesignColumn()) {
             return null;
         }
@@ -741,8 +728,7 @@ class CatalogService
     /**
      * Update the design path for the given catalog slug.
      */
-    public function setDesignPath(string $slug, ?string $path): void
-    {
+    public function setDesignPath(string $slug, ?string $path): void {
         if (!$this->hasDesignColumn()) {
             return;
         }

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -47,8 +47,7 @@ class ConfigService
     /**
      * Inject PDO instance used for database operations.
      */
-    public function __construct(PDO $pdo)
-    {
+    public function __construct(PDO $pdo) {
         $this->pdo = $pdo;
         $this->pdo->exec(
             'CREATE TABLE IF NOT EXISTS active_event(' .
@@ -60,8 +59,7 @@ class ConfigService
     /**
      * Retrieve configuration as pretty printed JSON.
      */
-    public function getJson(): ?string
-    {
+    public function getJson(): ?string {
         $uid = $this->getActiveEventUid();
         $row = null;
         if ($uid !== '') {
@@ -87,8 +85,7 @@ class ConfigService
     /**
      * Retrieve configuration JSON for a specific event UID.
      */
-    public function getJsonForEvent(string $uid): ?string
-    {
+    public function getJsonForEvent(string $uid): ?string {
         $stmt = $this->pdo->prepare('SELECT * FROM config WHERE event_uid = ? LIMIT 1');
         $stmt->execute([$uid]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
@@ -106,8 +103,7 @@ class ConfigService
     /**
      * Return configuration values as an associative array.
      */
-    public function getConfig(): array
-    {
+    public function getConfig(): array {
         $uid = $this->getActiveEventUid();
         if ($uid === '') {
             return [];
@@ -125,8 +121,7 @@ class ConfigService
     /**
      * Return configuration for the given event UID or an empty array if none exists.
      */
-    public function getConfigForEvent(string $uid): array
-    {
+    public function getConfigForEvent(string $uid): array {
         $stmt = $this->pdo->prepare('SELECT * FROM config WHERE event_uid = ? LIMIT 1');
         $stmt->execute([$uid]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
@@ -142,8 +137,7 @@ class ConfigService
      * @param array<string,mixed> $cfg
      * @return array<string,mixed>
      */
-    public static function removePuzzleInfo(array $cfg): array
-    {
+    public static function removePuzzleInfo(array $cfg): array {
         unset($cfg['puzzleWord'], $cfg['puzzleFeedback']);
         return $cfg;
     }
@@ -156,8 +150,7 @@ class ConfigService
     /**
      * Remove unwanted HTML tags from user provided text.
      */
-    public static function sanitizeHtml(string $html): string
-    {
+    public static function sanitizeHtml(string $html): string {
         return strip_tags($html, self::ALLOWED_HTML_TAGS);
     }
 
@@ -166,8 +159,7 @@ class ConfigService
      *
      * @return list<string>
      */
-    private function getConfigColumns(): array
-    {
+    private function getConfigColumns(): array {
         $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
         if ($driver === 'sqlite') {
             $stmt = $this->pdo->query('PRAGMA table_info(config)');
@@ -185,8 +177,7 @@ class ConfigService
     /**
      * Replace stored configuration with new values.
      */
-    public function saveConfig(array $data): void
-    {
+    public function saveConfig(array $data): void {
         if (isset($data['pageTitle']) && !isset($data['title'])) {
             $data['title'] = $data['pageTitle'];
         }
@@ -314,8 +305,7 @@ class ConfigService
     /**
      * Update the UID of the currently active event.
      */
-    public function setActiveEventUid(string $uid): void
-    {
+    public function setActiveEventUid(string $uid): void {
         if ($uid !== '') {
             try {
                 $check = $this->pdo->prepare('SELECT 1 FROM events WHERE uid = ? LIMIT 1');
@@ -349,8 +339,7 @@ class ConfigService
     /**
      * Ensure a configuration row exists for the given event UID.
      */
-    public function ensureConfigForEvent(string $uid): void
-    {
+    public function ensureConfigForEvent(string $uid): void {
         if ($uid === '') {
             return;
         }
@@ -365,8 +354,7 @@ class ConfigService
     /**
      * Return the UID of the currently active event or an empty string.
      */
-    public function getActiveEventUid(): string
-    {
+    public function getActiveEventUid(): string {
         if ($this->activeEvent !== null) {
             return $this->activeEvent;
         }
@@ -384,8 +372,7 @@ class ConfigService
     /**
      * Return the relative path to the image directory of an event.
      */
-    public function getEventImagesPath(?string $uid = null): string
-    {
+    public function getEventImagesPath(?string $uid = null): string {
         $uid = $uid ?? $this->getActiveEventUid();
         return '/events/' . $uid . '/images';
     }
@@ -393,16 +380,14 @@ class ConfigService
     /**
      * Return the relative path to the shared uploads directory.
      */
-    public function getGlobalUploadsPath(): string
-    {
+    public function getGlobalUploadsPath(): string {
         return '/uploads';
     }
 
     /**
      * Return the absolute path to the image directory of an event and ensure it exists.
      */
-    public function getEventImagesDir(?string $uid = null): string
-    {
+    public function getEventImagesDir(?string $uid = null): string {
         $uid = $uid ?? $this->getActiveEventUid();
         $dir = dirname(__DIR__, 2) . '/data' . $this->getEventImagesPath($uid);
         if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
@@ -414,8 +399,7 @@ class ConfigService
     /**
      * Return the absolute path to the shared uploads directory and ensure it exists.
      */
-    public function getGlobalUploadsDir(): string
-    {
+    public function getGlobalUploadsDir(): string {
         $dir = dirname(__DIR__, 2) . '/data' . $this->getGlobalUploadsPath();
         if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
             throw new RuntimeException('unable to create uploads directory');
@@ -426,8 +410,7 @@ class ConfigService
     /**
      * Move legacy image files into the new event image directory structure.
      */
-    public function migrateEventImages(?string $uid = null): void
-    {
+    public function migrateEventImages(?string $uid = null): void {
         $uid = $uid ?? $this->getActiveEventUid();
         if ($uid === '') {
             return;
@@ -483,8 +466,7 @@ class ConfigService
      * @param array<string,mixed> $row
      * @return array<string,mixed>
      */
-    private function normalizeKeys(array $row): array
-    {
+    private function normalizeKeys(array $row): array {
         $keys = [
             'displayErrorDetails',
             'QRUser',

--- a/src/Service/ConfigValidator.php
+++ b/src/Service/ConfigValidator.php
@@ -42,8 +42,7 @@ class ConfigValidator
      *
      * @return array{config: array<string,mixed>, errors: array<string,string>}
      */
-    public function validate(array $data, ?string $eventName = null): array
-    {
+    public function validate(array $data, ?string $eventName = null): array {
         $config = [];
         $errors = [];
 
@@ -99,8 +98,7 @@ class ConfigValidator
         return ['config' => $config, 'errors' => $errors];
     }
 
-    private function isValidColor(string $color): bool
-    {
+    private function isValidColor(string $color): bool {
         return (bool)preg_match('/^#([0-9a-fA-F]{3}){1,2}$/', $color);
     }
 }

--- a/src/Service/DomainContactTemplateService.php
+++ b/src/Service/DomainContactTemplateService.php
@@ -15,8 +15,7 @@ class DomainContactTemplateService
     private PDO $pdo;
     private DomainStartPageService $domainService;
 
-    public function __construct(PDO $pdo, ?DomainStartPageService $domainService = null)
-    {
+    public function __construct(PDO $pdo, ?DomainStartPageService $domainService = null) {
         $this->pdo = $pdo;
         $this->domainService = $domainService ?? new DomainStartPageService($pdo);
     }
@@ -26,8 +25,7 @@ class DomainContactTemplateService
      *
      * @return array{domain:string,sender_name:?string,recipient_html:?string,recipient_text:?string,sender_html:?string,sender_text:?string}|null
      */
-    public function get(string $domain): ?array
-    {
+    public function get(string $domain): ?array {
         $normalized = $this->normalizeDomain($domain);
         if ($normalized === '') {
             return null;
@@ -68,8 +66,7 @@ class DomainContactTemplateService
      *
      * @return array{domain:string,sender_name:?string,recipient_html:?string,recipient_text:?string,sender_html:?string,sender_text:?string}|null
      */
-    public function getForHost(string $host): ?array
-    {
+    public function getForHost(string $host): ?array {
         return $this->get($host);
     }
 
@@ -78,8 +75,7 @@ class DomainContactTemplateService
      *
      * @param array{sender_name:?string,recipient_html:?string,recipient_text:?string,sender_html:?string,sender_text:?string} $data
      */
-    public function save(string $domain, array $data): void
-    {
+    public function save(string $domain, array $data): void {
         $normalized = $this->normalizeDomain($domain);
         if ($normalized === '') {
             throw new PDOException('Invalid domain supplied');
@@ -108,13 +104,11 @@ class DomainContactTemplateService
         $stmt->execute($payload);
     }
 
-    private function normalizeDomain(string $domain): string
-    {
+    private function normalizeDomain(string $domain): string {
         return $this->domainService->normalizeDomain($domain);
     }
 
-    private function normalizeNullable(?string $value, bool $trimWhitespace = true): ?string
-    {
+    private function normalizeNullable(?string $value, bool $trimWhitespace = true): ?string {
         if ($value === null) {
             return null;
         }

--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -21,8 +21,7 @@ class DomainStartPageService
 
     private PDO $pdo;
 
-    public function __construct(PDO $pdo)
-    {
+    public function __construct(PDO $pdo) {
         $this->pdo = $pdo;
     }
 
@@ -31,8 +30,7 @@ class DomainStartPageService
      *
      * @return array<string,string> Map of slug => label
      */
-    public function getStartPageOptions(PageService $pageService): array
-    {
+    public function getStartPageOptions(PageService $pageService): array {
         $options = [];
 
         foreach (self::CORE_START_PAGES as $slug) {
@@ -52,8 +50,7 @@ class DomainStartPageService
         return $options;
     }
 
-    private function buildLabelFromSlug(string $slug): string
-    {
+    private function buildLabelFromSlug(string $slug): string {
         $parts = array_filter(explode('-', $slug), static fn ($part): bool => $part !== '');
         if ($parts === []) {
             return ucfirst($slug);
@@ -70,8 +67,7 @@ class DomainStartPageService
     /**
      * Determine the configured start page for the given host.
      */
-    public function getStartPage(string $host): ?string
-    {
+    public function getStartPage(string $host): ?string {
         $config = $this->getConfigForHost($host);
 
         if ($config === null) {
@@ -88,8 +84,7 @@ class DomainStartPageService
      *
      * @return array{domain:string,start_page:string,email:?string}|null
      */
-    public function getConfigForHost(string $host, bool $includeSensitive = false): ?array
-    {
+    public function getConfigForHost(string $host, bool $includeSensitive = false): ?array {
         $host = strtolower(trim($host));
         if ($host === '') {
             return null;
@@ -119,8 +114,7 @@ class DomainStartPageService
     /**
      * Persist or update the start page for a given domain.
      */
-    public function saveStartPage(string $domain, string $startPage): void
-    {
+    public function saveStartPage(string $domain, string $startPage): void {
         $this->saveDomainConfig($domain, $startPage, null);
     }
 
@@ -132,8 +126,7 @@ class DomainStartPageService
         string $startPage,
         ?string $email = null,
         array $smtpConfig = []
-    ): void
-    {
+    ): void {
         $normalized = $this->normalizeDomain($domain);
         if ($normalized === '') {
             throw new PDOException('Invalid domain supplied');
@@ -181,8 +174,7 @@ class DomainStartPageService
      *
      * @return array<string,array{start_page:string,email:?string,smtp_host:?string,smtp_user:?string,smtp_port:?int,smtp_encryption:?string,smtp_dsn:?string,has_smtp_pass:bool}> Associative array of domain => config
      */
-    public function getAllMappings(): array
-    {
+    public function getAllMappings(): array {
         $stmt = $this->pdo->query(
             "SELECT domain, start_page, email, smtp_host, smtp_user, smtp_port, smtp_encryption, smtp_dsn,
                 CASE WHEN smtp_pass IS NOT NULL AND smtp_pass <> '' THEN 1 ELSE 0 END AS has_smtp_pass
@@ -228,8 +220,7 @@ class DomainStartPageService
      *
      * @return array{domain:string,start_page:string,email:?string,smtp_host:?string,smtp_user:?string,smtp_port:?int,smtp_encryption:?string,smtp_dsn:?string,has_smtp_pass:bool,smtp_pass:?string}|null
      */
-    public function getDomainConfig(string $domain, bool $includeSensitive = false): ?array
-    {
+    public function getDomainConfig(string $domain, bool $includeSensitive = false): ?array {
         $normalized = $this->normalizeDomain($domain);
         if ($normalized === '') {
             return null;
@@ -292,8 +283,7 @@ class DomainStartPageService
      *
      * @return array<int,array{domain:string,normalized:string,type:string}>
      */
-    public function determineDomains(?string $mainDomain, string $marketingConfig, string $currentHost = ''): array
-    {
+    public function determineDomains(?string $mainDomain, string $marketingConfig, string $currentHost = ''): array {
         $domains = [];
 
         $normalizedMain = $this->normalizeDomain((string) $mainDomain);
@@ -346,8 +336,7 @@ class DomainStartPageService
     /**
      * Normalize a hostname by trimming and removing known prefixes.
      */
-    public function normalizeDomain(string $domain, bool $stripAdmin = true): string
-    {
+    public function normalizeDomain(string $domain, bool $stripAdmin = true): string {
         $domain = strtolower(trim($domain));
         if ($domain === '') {
             return '';
@@ -359,8 +348,7 @@ class DomainStartPageService
         return $normalized;
     }
 
-    private function normalizeEmail(?string $email): ?string
-    {
+    private function normalizeEmail(?string $email): ?string {
         if ($email === null) {
             return null;
         }
@@ -376,8 +364,7 @@ class DomainStartPageService
      *
      * @return array{smtp_host:?string,smtp_user:?string,smtp_pass:?string,smtp_port:?int,smtp_encryption:?string,smtp_dsn:?string,update_pass:bool}
      */
-    private function normalizeSmtpConfig(array $smtpConfig, ?array $existing): array
-    {
+    private function normalizeSmtpConfig(array $smtpConfig, ?array $existing): array {
         $host = isset($existing['smtp_host']) && $existing['smtp_host'] !== null ? (string) $existing['smtp_host'] : null;
         $user = isset($existing['smtp_user']) && $existing['smtp_user'] !== null ? (string) $existing['smtp_user'] : null;
         $port = isset($existing['smtp_port']) && $existing['smtp_port'] !== null ? (int) $existing['smtp_port'] : null;

--- a/src/Service/EmailConfirmationService.php
+++ b/src/Service/EmailConfirmationService.php
@@ -18,8 +18,7 @@ class EmailConfirmationService
     private int $ttl;
     private LoggerInterface $logger;
 
-    public function __construct(PDO $pdo, int $ttlSeconds = 86400, ?LoggerInterface $logger = null)
-    {
+    public function __construct(PDO $pdo, int $ttlSeconds = 86400, ?LoggerInterface $logger = null) {
         $this->pdo = $pdo;
         $this->ttl = $ttlSeconds;
         $this->logger = $logger ?? new NullLogger();
@@ -28,8 +27,7 @@ class EmailConfirmationService
     /**
      * Generate token for email and store it.
      */
-    public function createToken(string $email): string
-    {
+    public function createToken(string $email): string {
         $this->cleanupExpired();
 
         $token = bin2hex(random_bytes(16));
@@ -53,8 +51,7 @@ class EmailConfirmationService
     /**
      * Verify token and mark email as confirmed.
      */
-    public function confirmToken(string $token): ?string
-    {
+    public function confirmToken(string $token): ?string {
         $this->cleanupExpired();
 
         $stmt = $this->pdo->prepare('SELECT email, expires_at FROM email_confirmations WHERE token = ?');
@@ -87,8 +84,7 @@ class EmailConfirmationService
     /**
      * Check whether given email is confirmed.
      */
-    public function isConfirmed(string $email): bool
-    {
+    public function isConfirmed(string $email): bool {
         $this->cleanupExpired();
 
         $stmt = $this->pdo->prepare('SELECT confirmed FROM email_confirmations WHERE email = ?');
@@ -97,8 +93,7 @@ class EmailConfirmationService
         return $row !== false && (int) $row['confirmed'] === 1;
     }
 
-    private function deleteToken(string $email): void
-    {
+    private function deleteToken(string $email): void {
         $stmt = $this->pdo->prepare('DELETE FROM email_confirmations WHERE email = ?');
         $stmt->execute([$email]);
     }
@@ -106,8 +101,7 @@ class EmailConfirmationService
     /**
      * Remove expired tokens.
      */
-    public function cleanupExpired(): void
-    {
+    public function cleanupExpired(): void {
         $stmt = $this->pdo->prepare('DELETE FROM email_confirmations WHERE expires_at <= ?');
         $stmt->execute([(new DateTimeImmutable())->format('Y-m-d H:i:s')]);
     }

--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -35,8 +35,7 @@ class EventService
      *
      * @return list<array{uid:string,name:string,start_date:?string,end_date:?string,description:?string,published:bool}>
      */
-    public function getAll(): array
-    {
+    public function getAll(): array {
         $sql = 'SELECT uid,name,start_date,end_date,description,published,sort_order FROM events ORDER BY sort_order';
         $stmt = $this->pdo->query($sql);
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -77,8 +76,7 @@ class EventService
      *     draft?:bool
      * }> $events
      */
-    public function saveAll(array $events): void
-    {
+    public function saveAll(array $events): void {
         $existingStmt = $this->pdo->query('SELECT uid FROM events');
         $existing = $existingStmt->fetchAll(PDO::FETCH_COLUMN);
 
@@ -158,8 +156,7 @@ class EventService
      *
      * @return array{uid:string,name:string,start_date:?string,end_date:?string,description:?string}|null
      */
-    public function getFirst(): ?array
-    {
+    public function getFirst(): ?array {
         $stmt = $this->pdo->query('SELECT uid,name,start_date,end_date,description FROM events ORDER BY name LIMIT 1');
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($row === false) {
@@ -175,8 +172,7 @@ class EventService
      *
      * @return array{uid:string,slug:string,name:string,start_date:?string,end_date:?string,description:?string}|null
      */
-    public function getByUid(string $uid): ?array
-    {
+    public function getByUid(string $uid): ?array {
         $stmt = $this->pdo->prepare('SELECT uid,slug,name,start_date,end_date,description FROM events WHERE uid = ?');
         $stmt->execute([$uid]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -213,8 +209,7 @@ class EventService
      *
      * @return array{uid:string,slug:string,name:string,start_date:?string,end_date:?string,description:?string}|null
      */
-    public function getBySlug(string $slug): ?array
-    {
+    public function getBySlug(string $slug): ?array {
         $stmt = $this->pdo->prepare('SELECT uid,slug,name,start_date,end_date,description FROM events WHERE slug = ?');
         $stmt->execute([$slug]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -229,16 +224,14 @@ class EventService
     /**
      * Find the UID for the given event slug.
      */
-    public function uidBySlug(string $slug): ?string
-    {
+    public function uidBySlug(string $slug): ?string {
         $stmt = $this->pdo->prepare('SELECT uid FROM events WHERE slug = ?');
         $stmt->execute([$slug]);
         $uid = $stmt->fetchColumn();
         return $uid === false ? null : (string) $uid;
     }
 
-    private function formatDate(?string $value): ?string
-    {
+    private function formatDate(?string $value): ?string {
         if ($value === null || $value === '') {
             return $value;
         }

--- a/src/Service/ImageUploadService.php
+++ b/src/Service/ImageUploadService.php
@@ -18,14 +18,12 @@ class ImageUploadService
     private string $dataDir;
     private ImageManager $manager;
 
-    public function __construct(?string $dataDir = null)
-    {
+    public function __construct(?string $dataDir = null) {
         $this->dataDir = $dataDir ?? dirname(__DIR__, 2) . '/data';
         $this->manager = extension_loaded('imagick') ? ImageManager::imagick() : ImageManager::gd();
     }
 
-    public function getDataDir(): string
-    {
+    public function getDataDir(): string {
         return $this->dataDir;
     }
 
@@ -52,16 +50,14 @@ class ImageUploadService
         }
     }
 
-    public function readImage(UploadedFileInterface $file, bool $autoOrient = false): ImageInterface
-    {
+    public function readImage(UploadedFileInterface $file, bool $autoOrient = false): ImageInterface {
         $stream = $file->getStream();
         $image = $this->manager->read($stream->detach());
 
         return $this->prepareImage($image, $autoOrient);
     }
 
-    public function readExistingImage(string $path, bool $autoOrient = false): ImageInterface
-    {
+    public function readExistingImage(string $path, bool $autoOrient = false): ImageInterface {
         if (!is_file($path)) {
             throw new \RuntimeException('file not found');
         }
@@ -71,8 +67,7 @@ class ImageUploadService
         return $this->prepareImage($image, $autoOrient);
     }
 
-    private function prepareImage(ImageInterface $image, bool $autoOrient): ImageInterface
-    {
+    private function prepareImage(ImageInterface $image, bool $autoOrient): ImageInterface {
         $width = $image->width();
         $height = $image->height();
         $pixelCount = $width * $height;

--- a/src/Service/InvitationService.php
+++ b/src/Service/InvitationService.php
@@ -18,8 +18,7 @@ class InvitationService
     private int $ttl;
     private LoggerInterface $logger;
 
-    public function __construct(PDO $pdo, int $ttlSeconds = 86400, ?LoggerInterface $logger = null)
-    {
+    public function __construct(PDO $pdo, int $ttlSeconds = 86400, ?LoggerInterface $logger = null) {
         $this->pdo = $pdo;
         $this->ttl = $ttlSeconds;
         $this->logger = $logger ?? new NullLogger();
@@ -28,8 +27,7 @@ class InvitationService
     /**
      * Generate and store a token for the given email.
      */
-    public function createToken(string $email): string
-    {
+    public function createToken(string $email): string {
         $this->cleanupExpired();
 
         $token = bin2hex(random_bytes(16));
@@ -48,8 +46,7 @@ class InvitationService
     /**
      * Verify token and return associated email. Token is removed.
      */
-    public function consumeToken(string $token): ?string
-    {
+    public function consumeToken(string $token): ?string {
         $this->cleanupExpired();
 
         $stmt = $this->pdo->prepare('SELECT email, expires_at FROM invitations WHERE token = ?');
@@ -76,8 +73,7 @@ class InvitationService
         return $email;
     }
 
-    private function deleteToken(string $email): void
-    {
+    private function deleteToken(string $email): void {
         $stmt = $this->pdo->prepare('DELETE FROM invitations WHERE email = ?');
         $stmt->execute([$email]);
     }
@@ -85,8 +81,7 @@ class InvitationService
     /**
      * Remove expired tokens.
      */
-    public function cleanupExpired(): void
-    {
+    public function cleanupExpired(): void {
         $stmt = $this->pdo->prepare('DELETE FROM invitations WHERE expires_at <= ?');
         $stmt->execute([(new DateTimeImmutable())->format('Y-m-d H:i:s')]);
     }

--- a/src/Service/LandingMediaReferenceService.php
+++ b/src/Service/LandingMediaReferenceService.php
@@ -25,8 +25,7 @@ class LandingMediaReferenceService
     private const TYPE_MARKUP = 'markup';
     private const TYPE_SEO = 'seo';
 
-    public function __construct(PageService $pages, PageSeoConfigService $seo, ConfigService $config)
-    {
+    public function __construct(PageService $pages, PageSeoConfigService $seo, ConfigService $config) {
         $this->pages = $pages;
         $this->seo = $seo;
         $this->config = $config;
@@ -37,8 +36,7 @@ class LandingMediaReferenceService
      *
      * @return list<array{slug:string,title:string}>
      */
-    public function getLandingSlugs(): array
-    {
+    public function getLandingSlugs(): array {
         $slugs = [];
         foreach ($this->getLandingPages() as $page) {
             $slugs[] = [
@@ -59,8 +57,7 @@ class LandingMediaReferenceService
      *     missing:list<array<string,mixed>>
      * }
      */
-    public function collect(): array
-    {
+    public function collect(): array {
         $landingPages = $this->getLandingPages();
         $slugs = [];
         $files = [];
@@ -113,8 +110,7 @@ class LandingMediaReferenceService
     /**
      * Normalize a public upload URL or path to the canonical internal representation.
      */
-    public function normalizeFilePath(?string $path): ?string
-    {
+    public function normalizeFilePath(?string $path): ?string {
         if ($path === null) {
             return null;
         }
@@ -126,8 +122,7 @@ class LandingMediaReferenceService
     /**
      * @return Page[]
      */
-    private function getLandingPages(): array
-    {
+    private function getLandingPages(): array {
         $pages = $this->pages->getAll();
 
         return array_values(array_filter(
@@ -145,8 +140,7 @@ class LandingMediaReferenceService
     /**
      * @return list<array<string,mixed>>
      */
-    private function collectFromMarkup(Page $page): array
-    {
+    private function collectFromMarkup(Page $page): array {
         $content = $page->getContent();
         if ($content === '') {
             return [];
@@ -186,8 +180,7 @@ class LandingMediaReferenceService
     /**
      * @return list<array<string,mixed>>
      */
-    private function collectFromSeo(Page $page, PageSeoConfig $config): array
-    {
+    private function collectFromSeo(Page $page, PageSeoConfig $config): array {
         $references = [];
         $fields = [
             'ogImage' => $config->getOgImage(),
@@ -218,8 +211,7 @@ class LandingMediaReferenceService
      * @param list<array<string,mixed>> $references
      * @return list<array<string,mixed>>
      */
-    private function deduplicateReferences(array $references): array
-    {
+    private function deduplicateReferences(array $references): array {
         $unique = [];
         $seen = [];
 
@@ -244,8 +236,7 @@ class LandingMediaReferenceService
      * @param list<array<string,mixed>> $existing
      * @param array<string,mixed> $candidate
      */
-    private function referenceExists(array $existing, array $candidate): bool
-    {
+    private function referenceExists(array $existing, array $candidate): bool {
         foreach ($existing as $reference) {
             if (
                 ($reference['slug'] ?? null) === ($candidate['slug'] ?? null)
@@ -259,8 +250,7 @@ class LandingMediaReferenceService
         return false;
     }
 
-    private function resolveAbsolutePath(string $normalized): string
-    {
+    private function resolveAbsolutePath(string $normalized): string {
         if (!str_starts_with($normalized, 'uploads/')) {
             throw new RuntimeException('invalid upload path: ' . $normalized);
         }
@@ -276,8 +266,7 @@ class LandingMediaReferenceService
      * @param array<string,mixed> $reference
      * @return array<string,mixed>
      */
-    private function buildMissingEntry(array $reference, string $path): array
-    {
+    private function buildMissingEntry(array $reference, string $path): array {
         $folder = $this->extractFolder($path);
         $name = pathinfo($path, PATHINFO_FILENAME);
         $extension = pathinfo($path, PATHINFO_EXTENSION);
@@ -296,8 +285,7 @@ class LandingMediaReferenceService
      *
      * @return array<string,string>
      */
-    private function collectImageAltMap(string $content): array
-    {
+    private function collectImageAltMap(string $content): array {
         if ($content === '') {
             return [];
         }
@@ -328,8 +316,7 @@ class LandingMediaReferenceService
         return $map;
     }
 
-    private function extractFolder(string $path): ?string
-    {
+    private function extractFolder(string $path): ?string {
         $segments = explode('/', trim($path, '/'));
         if (count($segments) <= 2) {
             return null;
@@ -342,8 +329,7 @@ class LandingMediaReferenceService
         return implode('/', $segments);
     }
 
-    private function sanitizeUploadPath(string $value): string
-    {
+    private function sanitizeUploadPath(string $value): string {
         $trimmed = trim($value);
         if ($trimmed === '') {
             return '';

--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -19,8 +19,7 @@ class LogService
     /**
      * Create a logger instance for the given channel.
      */
-    public static function create(string $channel = 'app'): LoggerInterface
-    {
+    public static function create(string $channel = 'app'): LoggerInterface {
         $root = dirname(__DIR__, 2);
         $logDir = $root . '/logs';
         if (!is_dir($logDir) && !mkdir($logDir, 0777, true) && !is_dir($logDir)) {
@@ -37,8 +36,7 @@ class LogService
     /**
      * Fetch the most recent log lines for the given channel.
      */
-    public static function tail(string $channel, int $lines = 20): string
-    {
+    public static function tail(string $channel, int $lines = 20): string {
         $root = dirname(__DIR__, 2);
         $file = $root . '/logs/' . $channel . '.log';
         if (!is_file($file)) {
@@ -54,8 +52,7 @@ class LogService
     /**
      * Fetch the most recent Docker log lines for the given container.
      */
-    public static function tailDocker(string $container, int $lines = 20): string
-    {
+    public static function tailDocker(string $container, int $lines = 20): string {
         $result = runSyncProcess('docker', ['logs', '--tail', (string) $lines, $container]);
         if ($result['stdout'] !== '') {
             return $result['stdout'];

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -27,8 +27,7 @@ class MailService
     private ?AuditLogger $audit;
     private string $baseUrl;
 
-    private static function loadEnvConfig(): array
-    {
+    private static function loadEnvConfig(): array {
         $root = dirname(__DIR__, 2);
         $envFile = $root . '/.env';
         $env = [];
@@ -49,8 +48,7 @@ class MailService
         ];
     }
 
-    public static function isConfigured(): bool
-    {
+    public static function isConfigured(): bool {
         $config = self::loadEnvConfig();
 
         if ($config['mailer_dsn'] !== '') {
@@ -60,8 +58,7 @@ class MailService
         return $config['host'] !== '' && $config['user'] !== '' && $config['pass'] !== '';
     }
 
-    public function __construct(Environment $twig, ?AuditLogger $audit = null)
-    {
+    public function __construct(Environment $twig, ?AuditLogger $audit = null) {
         $config = self::loadEnvConfig();
 
         $mailerDsn  = $config['mailer_dsn'];
@@ -121,15 +118,13 @@ class MailService
         $this->baseUrl = $mainDomain !== '' ? 'https://' . $mainDomain : '';
     }
 
-    protected function createTransport(string $dsn): MailerInterface
-    {
+    protected function createTransport(string $dsn): MailerInterface {
         $transport = Transport::fromDsn($dsn);
 
         return new Mailer($transport);
     }
 
-    private function baseUrlFromLink(string $link): string
-    {
+    private function baseUrlFromLink(string $link): string {
         $parts = parse_url($link);
         if (isset($parts['scheme'], $parts['host'])) {
             $url = $parts['scheme'] . '://' . $parts['host'];
@@ -145,8 +140,7 @@ class MailService
     /**
      * Send password reset mail with link.
      */
-    public function sendPasswordReset(string $to, string $link): void
-    {
+    public function sendPasswordReset(string $to, string $link): void {
         $html = $this->twig->render('emails/password_reset.twig', [
             'link'     => $link,
             'base_url' => $this->baseUrlFromLink($link),
@@ -166,8 +160,7 @@ class MailService
     /**
      * Send double opt-in email with confirmation link.
      */
-    public function sendDoubleOptIn(string $to, string $link): void
-    {
+    public function sendDoubleOptIn(string $to, string $link): void {
         $html = $this->twig->render('emails/double_optin.twig', [
             'link'     => $link,
             'base_url' => $this->baseUrlFromLink($link),
@@ -185,8 +178,7 @@ class MailService
     /**
      * Send invitation email with registration link.
      */
-    public function sendInvitation(string $to, string $name, string $link): void
-    {
+    public function sendInvitation(string $to, string $name, string $link): void {
         $html = $this->twig->render('emails/invitation.twig', [
             'name'     => $name,
             'link'     => $link,
@@ -209,8 +201,7 @@ class MailService
      *
      * @return string Rendered HTML content of the email
      */
-    public function sendWelcome(string $to, string $domain, string $link): string
-    {
+    public function sendWelcome(string $to, string $domain, string $link): string {
         $adminLink = sprintf('https://%s/admin', $domain);
 
         $baseUrl = 'https://' . $domain;
@@ -245,8 +236,7 @@ class MailService
         ?array $templateData = null,
         ?string $fromEmail = null,
         ?array $smtpOverride = null
-    ): void
-    {
+    ): void {
         $activeMailer = $this->mailer;
         if (is_array($smtpOverride)) {
             $overrideMailer = $this->buildOverrideMailer($smtpOverride);
@@ -312,8 +302,7 @@ class MailService
         $this->audit?->log('contact_mail', ['from' => $replyTo]);
     }
 
-    private function buildContactContext(string $name, string $replyTo, string $message): array
-    {
+    private function buildContactContext(string $name, string $replyTo, string $message): array {
         $safeMessage = nl2br(htmlspecialchars($message, ENT_QUOTES, 'UTF-8'));
 
         return [
@@ -326,8 +315,7 @@ class MailService
         ];
     }
 
-    private function renderTemplateString(?string $template, array $context): ?string
-    {
+    private function renderTemplateString(?string $template, array $context): ?string {
         if ($template === null) {
             return null;
         }
@@ -346,8 +334,7 @@ class MailService
         return null;
     }
 
-    private function determineContactFromAddress(?string $fromEmail, ?string $senderName): string
-    {
+    private function determineContactFromAddress(?string $fromEmail, ?string $senderName): string {
         $email = $fromEmail !== null ? trim($fromEmail) : '';
         if ($email === '') {
             return $this->from;
@@ -361,21 +348,18 @@ class MailService
         return sprintf('%s <%s>', $name, $email);
     }
 
-    private function buildDefaultRecipientText(string $name, string $replyTo, string $message): string
-    {
+    private function buildDefaultRecipientText(string $name, string $replyTo, string $message): string {
         return sprintf("Kontaktanfrage von %s (%s)\n\n%s", $name, $replyTo, $message);
     }
 
-    private function buildDefaultSenderText(string $name, string $message): string
-    {
+    private function buildDefaultSenderText(string $name, string $message): string {
         return sprintf("Hallo %s,\n\n%s\n\n%s", $name, 'vielen Dank für Ihre Nachricht. Hier ist eine Kopie Ihrer Anfrage:', $message);
     }
 
     /**
      * @param array<string,mixed> $config
      */
-    private function buildOverrideMailer(array $config): ?MailerInterface
-    {
+    private function buildOverrideMailer(array $config): ?MailerInterface {
         $dsnValue = isset($config['smtp_dsn']) ? trim((string) $config['smtp_dsn']) : '';
         if ($dsnValue !== '') {
             try {

--- a/src/Service/MediaLibraryService.php
+++ b/src/Service/MediaLibraryService.php
@@ -36,8 +36,7 @@ class MediaLibraryService
     private ConfigService $config;
     private ImageUploadService $images;
 
-    public function __construct(ConfigService $config, ImageUploadService $images)
-    {
+    public function __construct(ConfigService $config, ImageUploadService $images) {
         $this->config = $config;
         $this->images = $images;
     }
@@ -47,8 +46,7 @@ class MediaLibraryService
      *
      * @return list<array<string, mixed>>
      */
-    public function listFiles(string $scope, ?string $eventUid = null): array
-    {
+    public function listFiles(string $scope, ?string $eventUid = null): array {
         [$dir, , $publicPath, $resolvedUid] = $this->resolveScope($scope, $eventUid);
         $metadata = $this->readMetadata($dir);
 
@@ -230,8 +228,7 @@ class MediaLibraryService
     /**
      * Convert an existing raster image to WebP and store it alongside the original file.
      */
-    public function convertFileToWebp(string $scope, string $name, ?string $eventUid = null): array
-    {
+    public function convertFileToWebp(string $scope, string $name, ?string $eventUid = null): array {
         $name = $this->sanitizeExistingName($name);
 
         [$dir, $relative, $publicPath, $resolvedUid] = $this->resolveScope($scope, $eventUid);
@@ -378,8 +375,7 @@ class MediaLibraryService
     /**
      * Delete a file within the given scope.
      */
-    public function deleteFile(string $scope, string $name, ?string $eventUid = null): void
-    {
+    public function deleteFile(string $scope, string $name, ?string $eventUid = null): void {
         $name = $this->sanitizeExistingName($name);
         [$dir] = $this->resolveScope($scope, $eventUid);
         $path = $dir . DIRECTORY_SEPARATOR . $name;
@@ -401,8 +397,7 @@ class MediaLibraryService
      *
      * @return array{maxSize:int, allowedExtensions:list<string>, allowedMimeTypes:list<string>}
      */
-    public function getLimits(): array
-    {
+    public function getLimits(): array {
         return [
             'maxSize' => self::MAX_UPLOAD_SIZE,
             'allowedExtensions' => self::ALLOWED_EXTENSIONS,
@@ -413,8 +408,7 @@ class MediaLibraryService
     /**
      * @return array{0:string,1:string,2:string,3:?string}
      */
-    private function resolveScope(string $scope, ?string $eventUid): array
-    {
+    private function resolveScope(string $scope, ?string $eventUid): array {
         if ($scope === self::SCOPE_EVENT) {
             $uid = $eventUid ?? $this->config->getActiveEventUid();
             if ($uid === '') {
@@ -437,8 +431,7 @@ class MediaLibraryService
         return [$dir, $relative, $public, null];
     }
 
-    private function sanitizeExistingName(string $name): string
-    {
+    private function sanitizeExistingName(string $name): string {
         $name = trim($name);
         if ($name === '' || str_contains($name, '/') || str_contains($name, '\\')) {
             throw new RuntimeException('invalid filename');
@@ -449,16 +442,14 @@ class MediaLibraryService
         return $name;
     }
 
-    private function sanitizeBaseName(string $base): string
-    {
+    private function sanitizeBaseName(string $base): string {
         $base = strtolower(trim($base));
         $base = preg_replace('/[^a-z0-9_-]+/i', '-', $base) ?? '';
         $base = trim($base, '-_');
         return $base;
     }
 
-    private function uniqueBaseName(string $dir, string $base, string $extension): string
-    {
+    private function uniqueBaseName(string $dir, string $base, string $extension): string {
         $candidate = $base;
         $suffix = 1;
         while (is_file($dir . DIRECTORY_SEPARATOR . $candidate . '.' . $extension)) {
@@ -529,8 +520,7 @@ class MediaLibraryService
     /**
      * @return array<string, array{tags:list<string>,folder:?string}>
      */
-    private function readMetadata(string $dir): array
-    {
+    private function readMetadata(string $dir): array {
         $path = $dir . DIRECTORY_SEPARATOR . self::METADATA_FILE;
         if (!is_file($path)) {
             return [];
@@ -560,8 +550,7 @@ class MediaLibraryService
     /**
      * @param array<string, array{tags:list<string>,folder:?string}> $metadata
      */
-    private function persistMetadata(string $dir, array $metadata): void
-    {
+    private function persistMetadata(string $dir, array $metadata): void {
         $path = $dir . DIRECTORY_SEPARATOR . self::METADATA_FILE;
         if ($metadata === []) {
             if (is_file($path)) {
@@ -629,8 +618,7 @@ class MediaLibraryService
      * @param array<string,mixed>|null $meta
      * @return array{tags:list<string>,folder:?string}
      */
-    private function normalizeMetadataEntry(?array $meta): array
-    {
+    private function normalizeMetadataEntry(?array $meta): array {
         $meta = $meta ?? [];
         $tags = $this->normalizeTags($meta['tags'] ?? []);
         $folder = $this->normalizeFolder($meta['folder'] ?? null);
@@ -645,8 +633,7 @@ class MediaLibraryService
      * @param mixed $value
      * @return list<string>
      */
-    private function normalizeTags($value): array
-    {
+    private function normalizeTags($value): array {
         $items = [];
         if (is_string($value)) {
             $items = preg_split('/[,;]/', $value) ?: [];
@@ -682,8 +669,7 @@ class MediaLibraryService
     /**
      * @param mixed $value
      */
-    private function normalizeFolder($value): ?string
-    {
+    private function normalizeFolder($value): ?string {
         if (!is_string($value)) {
             return null;
         }
@@ -711,4 +697,3 @@ class MediaLibraryService
         return implode('/', $clean);
     }
 }
-

--- a/src/Service/NginxService.php
+++ b/src/Service/NginxService.php
@@ -35,8 +35,7 @@ class NginxService
         $this->httpClient = $httpClient ?? new \GuzzleHttp\Client();
     }
 
-    public function createVhost(string $sub): void
-    {
+    public function createVhost(string $sub): void {
         if ($this->domain === '') {
             throw new \RuntimeException('DOMAIN not configured');
         }
@@ -61,8 +60,7 @@ class NginxService
     /**
      * Trigger nginx reload via the reloader service.
      */
-    public function reload(): void
-    {
+    public function reload(): void {
         try {
             $res = $this->httpClient->request(
                 'POST',

--- a/src/Service/PageService.php
+++ b/src/Service/PageService.php
@@ -19,25 +19,21 @@ class PageService
 {
     private PDO $pdo;
 
-    public function __construct(?PDO $pdo = null)
-    {
+    public function __construct(?PDO $pdo = null) {
         $this->pdo = $pdo ?? Database::connectFromEnv();
     }
 
-    public function get(string $slug): ?string
-    {
+    public function get(string $slug): ?string {
         $page = $this->findBySlug($slug);
         return $page?->getContent();
     }
 
-    public function save(string $slug, string $content): void
-    {
+    public function save(string $slug, string $content): void {
         $stmt = $this->pdo->prepare('UPDATE pages SET content = ?, updated_at = CURRENT_TIMESTAMP WHERE slug = ?');
         $stmt->execute([$content, $slug]);
     }
 
-    public function delete(string $slug): void
-    {
+    public function delete(string $slug): void {
         $normalized = trim($slug);
         if ($normalized === '') {
             return;
@@ -47,8 +43,7 @@ class PageService
         $stmt->execute([$normalized]);
     }
 
-    public function create(string $slug, string $title, string $content): Page
-    {
+    public function create(string $slug, string $title, string $content): Page {
         $normalizedSlug = strtolower(trim($slug));
         if ($normalizedSlug === '') {
             throw new InvalidArgumentException('Bitte gib einen Slug an.');
@@ -85,8 +80,7 @@ class PageService
      *
      * @return Page[]
      */
-    public function getAll(): array
-    {
+    public function getAll(): array {
         $stmt = $this->pdo->query('SELECT id, slug, title, content FROM pages ORDER BY title');
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
 
@@ -107,8 +101,7 @@ class PageService
         return $pages;
     }
 
-    public function findById(int $id): ?Page
-    {
+    public function findById(int $id): ?Page {
         if ($id <= 0) {
             return null;
         }
@@ -129,8 +122,7 @@ class PageService
         return new Page((int) $row['id'], $slug, $title, (string) ($row['content'] ?? ''));
     }
 
-    public function findBySlug(string $slug): ?Page
-    {
+    public function findBySlug(string $slug): ?Page {
         $normalized = trim($slug);
         if ($normalized === '') {
             return null;
@@ -152,8 +144,7 @@ class PageService
         return new Page((int) $row['id'], $pageSlug, $title, (string) ($row['content'] ?? ''));
     }
 
-    private function loadCreatedPage(string $slug): Page
-    {
+    private function loadCreatedPage(string $slug): Page {
         $page = $this->findBySlug($slug);
         if ($page === null) {
             throw new RuntimeException('Die neu angelegte Seite konnte nicht geladen werden.');

--- a/src/Service/PageVariableService.php
+++ b/src/Service/PageVariableService.php
@@ -15,8 +15,7 @@ class PageVariableService
     /**
      * Apply profile-based replacements on the given HTML.
      */
-    public static function apply(string $html): string
-    {
+    public static function apply(string $html): string {
         try {
             $pdo = Database::connectFromEnv();
             $profile = (new TenantService($pdo))->getMainTenant();

--- a/src/Service/PasswordPolicy.php
+++ b/src/Service/PasswordPolicy.php
@@ -9,8 +9,7 @@ class PasswordPolicy
     /**
      * Validate the given password against security requirements.
      */
-    public function validate(string $pass): bool
-    {
+    public function validate(string $pass): bool {
         if (strlen($pass) < 8) {
             return false;
         }

--- a/src/Service/PasswordResetService.php
+++ b/src/Service/PasswordResetService.php
@@ -41,8 +41,7 @@ class PasswordResetService
     /**
      * Generate and store a new token for the given user id.
      */
-    public function createToken(int $userId): string
-    {
+    public function createToken(int $userId): string {
         $this->cleanupExpired();
 
         $stmt = $this->pdo->prepare('DELETE FROM password_resets WHERE user_id=?');
@@ -69,8 +68,7 @@ class PasswordResetService
      *
      * The token is removed regardless of validity.
      */
-    public function consumeToken(string $token): ?int
-    {
+    public function consumeToken(string $token): ?int {
         $this->cleanupExpired();
 
         $hash = hash_hmac('sha256', $token, $this->secret);
@@ -101,8 +99,7 @@ class PasswordResetService
     /**
      * Remove a single token.
      */
-    public function deleteToken(int $userId, string $token): void
-    {
+    public function deleteToken(int $userId, string $token): void {
         $hash = hash_hmac('sha256', $token, $this->secret);
         $stmt = $this->pdo->prepare('DELETE FROM password_resets WHERE user_id=? AND token_hash=?');
         $stmt->execute([$userId, $hash]);
@@ -111,8 +108,7 @@ class PasswordResetService
     /**
      * Remove expired tokens.
      */
-    public function cleanupExpired(): void
-    {
+    public function cleanupExpired(): void {
         $stmt = $this->pdo->prepare('DELETE FROM password_resets WHERE expires_at <= ?');
         $stmt->execute([
             (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Y-m-d H:i:sP')

--- a/src/Service/Pdf.php
+++ b/src/Service/Pdf.php
@@ -17,8 +17,7 @@ class Pdf extends Fpdi
     private string $logoPath;
     private float $bodyStartY = 10.0;
 
-    public function __construct(string $title, string $subtitle, string $logoPath = '')
-    {
+    public function __construct(string $title, string $subtitle, string $logoPath = '') {
         parent::__construct();
         $this->SetCompression(false);
         $this->title = $title;
@@ -30,8 +29,7 @@ class Pdf extends Fpdi
      * Render logo, title and subtitle at the top of each page.
      */
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function Header(): void
-    {
+    public function Header(): void {
         $logoFile = $this->logoPath;
         $logoTemp = null;
         $qrSize = 20.0; // keep same dimensions as original header code
@@ -66,8 +64,7 @@ class Pdf extends Fpdi
         }
     }
 
-    public function getBodyStartY(): float
-    {
+    public function getBodyStartY(): float {
         return $this->bodyStartY;
     }
 }

--- a/src/Service/PhotoConsentService.php
+++ b/src/Service/PhotoConsentService.php
@@ -18,8 +18,7 @@ class PhotoConsentService
     /**
      * Inject database connection.
      */
-    public function __construct(PDO $pdo, ConfigService $config)
-    {
+    public function __construct(PDO $pdo, ConfigService $config) {
         $this->pdo = $pdo;
         $this->config = $config;
     }
@@ -27,8 +26,7 @@ class PhotoConsentService
     /**
      * Add a new photo consent entry.
      */
-    public function add(string $team, int $time): void
-    {
+    public function add(string $team, int $time): void {
         $uid = $this->config->getActiveEventUid();
         $stmt = $this->pdo->prepare('INSERT INTO photo_consents(team,time,event_uid) VALUES(?,?,?)');
         $stmt->execute([$team, $time, $uid]);
@@ -39,8 +37,7 @@ class PhotoConsentService
      *
      * @return array<int, array{team:string,time:int}>
      */
-    public function getAll(): array
-    {
+    public function getAll(): array {
         $uid = $this->config->getActiveEventUid();
         $sql = 'SELECT team,time FROM photo_consents';
         $params = [];
@@ -59,8 +56,7 @@ class PhotoConsentService
      *
      * @param list<array<string, mixed>> $consents
      */
-    public function saveAll(array $consents): void
-    {
+    public function saveAll(array $consents): void {
         $uid = $this->config->getActiveEventUid();
         $this->pdo->beginTransaction();
         if ($uid !== '') {

--- a/src/Service/PlayerService.php
+++ b/src/Service/PlayerService.php
@@ -13,16 +13,14 @@ class PlayerService
 {
     private PDO $pdo;
 
-    public function __construct(PDO $pdo)
-    {
+    public function __construct(PDO $pdo) {
         $this->pdo = $pdo;
     }
 
     /**
      * Store a player's data in the database.
      */
-    public function save(string $eventUid, string $playerName, string $playerUid): void
-    {
+    public function save(string $eventUid, string $playerName, string $playerUid): void {
         if ($eventUid === '' || $playerName === '' || $playerUid === '') {
             return;
         }
@@ -35,8 +33,7 @@ class PlayerService
     /**
      * Retrieve a player's name by event and UID.
      */
-    public function findName(string $eventUid, string $playerUid): ?string
-    {
+    public function findName(string $eventUid, string $playerUid): ?string {
         if ($eventUid === '' || $playerUid === '') {
             return null;
         }

--- a/src/Service/ProvenExpertRatingService.php
+++ b/src/Service/ProvenExpertRatingService.php
@@ -49,8 +49,7 @@ class ProvenExpertRatingService
     private string $cacheFile;
     private string $errorFile;
 
-    public function __construct(?string $apiId = null, ?string $apiKey = null, ?string $cacheDirectory = null)
-    {
+    public function __construct(?string $apiId = null, ?string $apiKey = null, ?string $cacheDirectory = null) {
         $this->apiId = $apiId ?? getenv('PROVENEXPERT_API_ID') ?: '1tmo5LmpmpQpmqGB1xGAiAmZ38zZmV3o';
         $this->apiKey = $apiKey ?? getenv('PROVENEXPERT_API_KEY') ?: 'AGyuLJEzAmx4BJV5LJDjLwEvMQMyLmxjBGuwAmRjBGp';
 
@@ -68,8 +67,7 @@ class ProvenExpertRatingService
         }
     }
 
-    public function getAggregateRatingMarkup(): string
-    {
+    public function getAggregateRatingMarkup(): string {
         $data = $this->loadData();
         if ($data === null) {
             return '';
@@ -88,8 +86,7 @@ class ProvenExpertRatingService
     /**
      * @return array<string,mixed>|null
      */
-    private function loadData(): ?array
-    {
+    private function loadData(): ?array {
         $cached = $this->readCache();
         $cacheFresh = $this->isCacheFresh();
 
@@ -122,8 +119,7 @@ class ProvenExpertRatingService
         return $fallback;
     }
 
-    private function fetch(): ?array
-    {
+    private function fetch(): ?array {
         if (!function_exists('curl_init')) {
             $this->logError('no curl package installed');
             return null;
@@ -163,8 +159,7 @@ class ProvenExpertRatingService
         return $data;
     }
 
-    private function readCache(): ?array
-    {
+    private function readCache(): ?array {
         if (!file_exists($this->cacheFile)) {
             return null;
         }
@@ -178,8 +173,7 @@ class ProvenExpertRatingService
         return is_array($decoded) ? $decoded : null;
     }
 
-    private function writeCache(array $data): void
-    {
+    private function writeCache(array $data): void {
         if (!is_writable($this->cacheFile) && !is_writable(dirname($this->cacheFile))) {
             return;
         }
@@ -192,13 +186,11 @@ class ProvenExpertRatingService
         @file_put_contents($this->cacheFile, $encoded);
     }
 
-    private function touchCache(): void
-    {
+    private function touchCache(): void {
         @touch($this->cacheFile, time() - (int) (self::CACHE_LIFETIME / 10));
     }
 
-    private function isCacheFresh(): bool
-    {
+    private function isCacheFresh(): bool {
         if (!file_exists($this->cacheFile)) {
             return false;
         }
@@ -211,8 +203,7 @@ class ProvenExpertRatingService
         return (time() - $mtime) <= self::CACHE_LIFETIME;
     }
 
-    private function logError(string $message): void
-    {
+    private function logError(string $message): void {
         $log = sprintf('%s [v%s]', $message, self::SCRIPT_VERSION);
         @file_put_contents($this->errorFile, $log);
     }
@@ -220,8 +211,7 @@ class ProvenExpertRatingService
     /**
      * @param resource $handler
      */
-    private function logCurlError($handler): void
-    {
+    private function logCurlError($handler): void {
         $errorMessage = 'curl error';
         $error = curl_error($handler);
         if ($error !== '') {

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -44,8 +44,7 @@ class QrCodeService
      * @param array{fg?:string,bg?:string} $options
      * @return array{mime:string,body:string}
      */
-    public function generateQrCode(string $data, string $format = 'svg', array $options = []): array
-    {
+    public function generateQrCode(string $data, string $format = 'svg', array $options = []): array {
         $fg = $this->parseHex($options['fg'] ?? '2E2E2E', '2E2E2E');
         $bg = $this->parseHex($options['bg'] ?? 'F9F9F9', 'F9F9F9');
 
@@ -67,8 +66,7 @@ class QrCodeService
     /**
      * @return array{mime:string,body:string}
      */
-    public function generateCatalog(array $q, array $cfg = []): array
-    {
+    public function generateCatalog(array $q, array $cfg = []): array {
         $defaults = [
             't' => 'https://quizrace.app/?katalog=station',
             'fg' => ltrim((string)($cfg['qrColorCatalog'] ?? 'dc0000'), '#'),
@@ -80,8 +78,7 @@ class QrCodeService
     /**
      * @return array{mime:string,body:string}
      */
-    public function generateTeam(array $q, array $cfg = []): array
-    {
+    public function generateTeam(array $q, array $cfg = []): array {
         $defaults = [
             't' => 'Team 1',
             'fg' => ltrim((string)($cfg['qrColorTeam'] ?? '004bc8'), '#'),
@@ -93,8 +90,7 @@ class QrCodeService
     /**
      * @return array{mime:string,body:string}
      */
-    public function generateEvent(array $q, array $cfg = []): array
-    {
+    public function generateEvent(array $q, array $cfg = []): array {
         $defaults = [
             't' => 'https://quizrace.app/?event=station',
             'fg' => ltrim((string)($cfg['qrColorEvent'] ?? '00a65a'), '#'),
@@ -114,8 +110,7 @@ class QrCodeService
      * } $defaults
      * @return array{mime:string,body:string}
      */
-    private function buildQrWithCenterLogoParam(array $q, array $defaults): array
-    {
+    private function buildQrWithCenterLogoParam(array $q, array $defaults): array {
         $data = (string)($q['t'] ?? $defaults['t']);
         $format = strtolower((string)($q['format'] ?? 'png'));
         if (!in_array($format, ['png', 'svg'], true)) {
@@ -185,8 +180,7 @@ class QrCodeService
      * } $p
      * @return array{mime:string,body:string}
      */
-    private function renderQr(string $data, array $p): array
-    {
+    private function renderQr(string $data, array $p): array {
         $scale = max(1, (int)round($p['size'] / 41));
         $marginModules = max(0, (int)round($p['margin'] / $scale));
 
@@ -330,8 +324,7 @@ class QrCodeService
      * @param array<string,mixed> $cfg
      * @return array<string,mixed>
      */
-    private function mergeDesignDefaults(array $defaults, array $cfg): array
-    {
+    private function mergeDesignDefaults(array $defaults, array $cfg): array {
         if (($cfg['qrLabelLine1'] ?? '') !== '') {
             $defaults['text1'] = (string)$cfg['qrLabelLine1'];
         }
@@ -353,8 +346,7 @@ class QrCodeService
     /**
      * @return array{0:int,1:int,2:int}
      */
-    private function parseHex(string $hex, string $fallback = '000000'): array
-    {
+    private function parseHex(string $hex, string $fallback = '000000'): array {
         $h = preg_replace('/[^0-9a-f]/i', '', $hex);
         if ($h === '') {
             $h = $fallback;
@@ -370,8 +362,7 @@ class QrCodeService
         ];
     }
 
-    private function clampInt(mixed $v, int $min, int $max, int $def): int
-    {
+    private function clampInt(mixed $v, int $min, int $max, int $def): int {
         $i = filter_var($v, FILTER_VALIDATE_INT);
         if ($i === false) {
             $i = $def;

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -17,8 +17,7 @@ class ResultService
     /**
      * Inject database connection.
      */
-    public function __construct(PDO $pdo)
-    {
+    public function __construct(PDO $pdo) {
         $this->pdo = $pdo;
     }
 
@@ -26,8 +25,7 @@ class ResultService
     /**
      * Fetch all stored results along with catalog names.
      */
-    public function getAll(string $eventUid = ''): array
-    {
+    public function getAll(string $eventUid = ''): array {
         $sql = <<<'SQL'
             SELECT r.name, r.catalog, r.attempt, r.correct, r.total, r.time,
                 r.puzzleTime AS "puzzleTime", r.photo,
@@ -63,8 +61,7 @@ class ResultService
     /**
      * Retrieve per-question results including prompts.
      */
-    public function getQuestionResults(string $eventUid = ''): array
-    {
+    public function getQuestionResults(string $eventUid = ''): array {
         $sql = <<<'SQL'
             SELECT qr.name, qr.catalog, qr.question_id, qr.attempt, qr.correct,
                 qr.answer_text, qr.photo, qr.consent,
@@ -104,8 +101,7 @@ class ResultService
      *
      * @return array<int, array<string, mixed>>
      */
-    public function getQuestionRows(string $eventUid = ''): array
-    {
+    public function getQuestionRows(string $eventUid = ''): array {
         $sql = 'SELECT name,catalog,question_id,attempt,correct,answer_text,photo,consent,event_uid '
             . 'FROM question_results';
         $params = [];
@@ -122,8 +118,7 @@ class ResultService
     /**
      * Check whether a result exists for the given player and catalog.
      */
-    public function exists(string $name, string $catalog, string $eventUid = ''): bool
-    {
+    public function exists(string $name, string $catalog, string $eventUid = ''): bool {
         $sql = 'SELECT 1 FROM results WHERE name=? AND catalog=?';
         $params = [$name, $catalog];
         if ($eventUid !== '') {
@@ -139,8 +134,7 @@ class ResultService
     /**
      * @param array<string, mixed> $data
      */
-    public function add(array $data, string $eventUid = ''): array
-    {
+    public function add(array $data, string $eventUid = ''): array {
         $name = (string)($data['name'] ?? '');
         $catalog = (string)($data['catalog'] ?? '');
         $wrong = array_map('intval', $data['wrong'] ?? []);
@@ -228,8 +222,7 @@ class ResultService
     /**
      * Remove all result entries including per-question logs.
      */
-    public function clear(string $eventUid = ''): void
-    {
+    public function clear(string $eventUid = ''): void {
         if ($eventUid !== '') {
             $del = $this->pdo->prepare('DELETE FROM results WHERE event_uid=?');
             $del->execute([$eventUid]);
@@ -244,8 +237,7 @@ class ResultService
     /**
      * Mark the puzzle word as solved for the latest entry of the given user.
      */
-    public function markPuzzle(string $name, string $catalog, int $time, string $eventUid = ''): bool
-    {
+    public function markPuzzle(string $name, string $catalog, int $time, string $eventUid = ''): bool {
         $sql = 'SELECT id, puzzleTime AS "puzzleTime" FROM results WHERE name=? AND catalog=?';
         $params = [$name, $catalog];
         if ($eventUid !== '') {
@@ -269,8 +261,7 @@ class ResultService
     /**
      * Associate a photo path with the latest result entry for the user.
      */
-    public function setPhoto(string $name, string $catalog, string $path, string $eventUid = ''): void
-    {
+    public function setPhoto(string $name, string $catalog, string $path, string $eventUid = ''): void {
         $baseSql = 'SELECT id FROM results WHERE name=? AND catalog=?';
         $params = [$name, $catalog];
         $id = false;
@@ -300,8 +291,7 @@ class ResultService
      *
      * @param list<array<string, mixed>> $results
      */
-    public function saveAll(array $results, string $eventUid = ''): void
-    {
+    public function saveAll(array $results, string $eventUid = ''): void {
         $this->pdo->beginTransaction();
         if ($eventUid !== '') {
             $del = $this->pdo->prepare('DELETE FROM results WHERE event_uid=?');
@@ -339,8 +329,7 @@ class ResultService
      *
      * @param list<array<string, mixed>> $rows
      */
-    public function saveQuestionRows(array $rows, string $eventUid = ''): void
-    {
+    public function saveQuestionRows(array $rows, string $eventUid = ''): void {
         $this->pdo->beginTransaction();
         if ($eventUid !== '') {
             $del = $this->pdo->prepare('DELETE FROM question_results WHERE event_uid=?');

--- a/src/Service/SessionService.php
+++ b/src/Service/SessionService.php
@@ -13,16 +13,14 @@ class SessionService
 {
     private PDO $pdo;
 
-    public function __construct(PDO $pdo)
-    {
+    public function __construct(PDO $pdo) {
         $this->pdo = $pdo;
     }
 
     /**
      * Store the current session id for the given user.
      */
-    public function persistSession(int $userId, string $sessionId): void
-    {
+    public function persistSession(int $userId, string $sessionId): void {
         $stmt = $this->pdo->prepare(
             'INSERT INTO user_sessions(user_id, session_id) VALUES(?, ?) ON CONFLICT DO NOTHING'
         );
@@ -32,8 +30,7 @@ class SessionService
     /**
      * Invalidate all sessions associated with the given user id.
      */
-    public function invalidateUserSessions(int $userId): void
-    {
+    public function invalidateUserSessions(int $userId): void {
         $stmt = $this->pdo->prepare('SELECT session_id FROM user_sessions WHERE user_id=?');
         $stmt->execute([$userId]);
         $ids = $stmt->fetchAll(PDO::FETCH_COLUMN);

--- a/src/Service/SettingsService.php
+++ b/src/Service/SettingsService.php
@@ -13,8 +13,7 @@ class SettingsService
 {
     private PDO $pdo;
 
-    public function __construct(PDO $pdo)
-    {
+    public function __construct(PDO $pdo) {
         $this->pdo = $pdo;
     }
 
@@ -23,8 +22,7 @@ class SettingsService
      *
      * @return array<string,string>
      */
-    public function getAll(): array
-    {
+    public function getAll(): array {
         $stmt = $this->pdo->query('SELECT key, value FROM settings');
         return $stmt->fetchAll(PDO::FETCH_KEY_PAIR) ?: [];
     }
@@ -32,8 +30,7 @@ class SettingsService
     /**
      * Get a single setting value or default if none exists.
      */
-    public function get(string $key, ?string $default = null): ?string
-    {
+    public function get(string $key, ?string $default = null): ?string {
         $stmt = $this->pdo->prepare('SELECT value FROM settings WHERE key=?');
         $stmt->execute([$key]);
         $val = $stmt->fetchColumn();
@@ -48,8 +45,7 @@ class SettingsService
      *
      * @param array<string,string> $data
      */
-    public function save(array $data): void
-    {
+    public function save(array $data): void {
         $this->pdo->beginTransaction();
         $stmt = $this->pdo->prepare(
             'INSERT INTO settings(key,value) VALUES(?,?) '

--- a/src/Service/StripeService.php
+++ b/src/Service/StripeService.php
@@ -13,8 +13,7 @@ class StripeService
 {
     private StripeClient $client;
 
-    public function __construct(?string $apiKey = null, ?StripeClient $client = null)
-    {
+    public function __construct(?string $apiKey = null, ?StripeClient $client = null) {
         if ($client !== null) {
             $this->client = $client;
             return;
@@ -85,8 +84,7 @@ class StripeService
     /**
      * Get the publishable key for the current environment.
      */
-    public function getPublishableKey(): string
-    {
+    public function getPublishableKey(): string {
         $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
         $envKey = $useSandbox ? 'STRIPE_SANDBOX_PUBLISHABLE_KEY' : 'STRIPE_PUBLISHABLE_KEY';
         $altKey = $useSandbox ? 'STRIPE_SANDBOX_PUBLISHABLE' : 'STRIPE_PUBLISHABLE';
@@ -96,8 +94,7 @@ class StripeService
     /**
      * Look up a Stripe customer id by email address.
      */
-    public function findCustomerIdByEmail(string $email): ?string
-    {
+    public function findCustomerIdByEmail(string $email): ?string {
         $customers = $this->client->customers->all([
             'email' => $email,
             'limit' => 1,
@@ -109,8 +106,7 @@ class StripeService
     /**
      * Create a new customer and return its id.
      */
-    public function createCustomer(string $email, ?string $name = null): string
-    {
+    public function createCustomer(string $email, ?string $name = null): string {
         $params = ['email' => $email];
         if ($name !== null) {
             $params['name'] = $name;
@@ -122,8 +118,7 @@ class StripeService
     /**
      * Create a billing portal session and return its URL.
      */
-    public function createBillingPortal(string $customerId, string $returnUrl): string
-    {
+    public function createBillingPortal(string $customerId, string $returnUrl): string {
         $session = $this->client->billingPortal->sessions->create([
             'customer' => $customerId,
             'return_url' => $returnUrl,
@@ -134,8 +129,7 @@ class StripeService
     /**
      * Check whether a checkout session has been paid.
      */
-    public function isCheckoutSessionPaid(string $sessionId): bool
-    {
+    public function isCheckoutSessionPaid(string $sessionId): bool {
         return $this->getCheckoutSessionInfo($sessionId)['paid'];
     }
 
@@ -144,8 +138,7 @@ class StripeService
      *
      * @return array{paid:bool, customer_id:?string, client_reference_id:?string, plan:?string}
      */
-    public function getCheckoutSessionInfo(string $sessionId): array
-    {
+    public function getCheckoutSessionInfo(string $sessionId): array {
         try {
             $session = $this->client->checkout->sessions->retrieve(
                 $sessionId,
@@ -196,8 +189,7 @@ class StripeService
      *
      * @return array{plan:?string, amount:int, currency:string, status:string, next_payment:?string}|null
      */
-    public function getActiveSubscription(string $customerId): ?array
-    {
+    public function getActiveSubscription(string $customerId): ?array {
         $subs = $this->client->subscriptions->all([
             'customer' => $customerId,
             'status' => 'active',
@@ -243,8 +235,7 @@ class StripeService
     /**
      * Update the price of the first subscription for the given customer.
      */
-    public function updateSubscriptionForCustomer(string $customerId, string $priceId): void
-    {
+    public function updateSubscriptionForCustomer(string $customerId, string $priceId): void {
         $subs = $this->client->subscriptions->all([
             'customer' => $customerId,
             'limit' => 1,
@@ -268,8 +259,7 @@ class StripeService
     /**
      * Cancel the first subscription for the given customer.
      */
-    public function cancelSubscriptionForCustomer(string $customerId): void
-    {
+    public function cancelSubscriptionForCustomer(string $customerId): void {
         $subs = $this->client->subscriptions->all([
             'customer' => $customerId,
             'limit' => 1,
@@ -294,8 +284,7 @@ class StripeService
      *     invoice_pdf: ?string
      * }>
      */
-    public function listInvoices(string $customerId): array
-    {
+    public function listInvoices(string $customerId): array {
         $invoices = $this->client->invoices->all([
             'customer' => $customerId,
             'limit' => 24,
@@ -322,8 +311,7 @@ class StripeService
      *
      * @return array{ok:bool, missing:string[], warnings:string[]}
      */
-    public static function isConfigured(): array
-    {
+    public static function isConfigured(): array {
         $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
         $prefix = $useSandbox ? 'STRIPE_SANDBOX_' : 'STRIPE_';
 
@@ -384,8 +372,7 @@ class StripeService
      *
      * @return array{ok:bool, issues:string[]}
      */
-    public static function preflight(): array
-    {
+    public static function preflight(): array {
         $issues = [];
         $useSandbox = filter_var(getenv('STRIPE_SANDBOX'), FILTER_VALIDATE_BOOLEAN);
         $sk = $useSandbox

--- a/src/Service/SummaryPhotoService.php
+++ b/src/Service/SummaryPhotoService.php
@@ -15,8 +15,7 @@ class SummaryPhotoService
     private PDO $pdo;
     private ConfigService $config;
 
-    public function __construct(PDO $pdo, ConfigService $config)
-    {
+    public function __construct(PDO $pdo, ConfigService $config) {
         $this->pdo = $pdo;
         $this->config = $config;
     }
@@ -24,8 +23,7 @@ class SummaryPhotoService
     /**
      * Store a new summary photo path.
      */
-    public function add(string $name, string $path, int $time): void
-    {
+    public function add(string $name, string $path, int $time): void {
         $uid = $this->config->getActiveEventUid();
         $stmt = $this->pdo->prepare(
             'INSERT INTO summary_photos(name,path,time,event_uid) VALUES(?,?,?,?)'
@@ -38,8 +36,7 @@ class SummaryPhotoService
      *
      * @return list<array{name:string,path:string,time:int}>
      */
-    public function getAll(): array
-    {
+    public function getAll(): array {
         $uid = $this->config->getActiveEventUid();
         $sql = 'SELECT name,path,time FROM summary_photos';
         $params = [];
@@ -58,8 +55,7 @@ class SummaryPhotoService
      *
      * @param list<array<string, mixed>> $photos
      */
-    public function saveAll(array $photos): void
-    {
+    public function saveAll(array $photos): void {
         $uid = $this->config->getActiveEventUid();
         $this->pdo->beginTransaction();
         if ($uid !== '') {

--- a/src/Service/TeamService.php
+++ b/src/Service/TeamService.php
@@ -38,8 +38,7 @@ class TeamService
     /**
      * Retrieve the ordered list of teams.
      */
-    public function getAll(): array
-    {
+    public function getAll(): array {
         $uid = $this->config->getActiveEventUid();
         if ($uid === '') {
             return [];
@@ -53,8 +52,7 @@ class TeamService
     /**
      * Create a team with the given name if it does not exist yet.
      */
-    public function addIfMissing(string $name): void
-    {
+    public function addIfMissing(string $name): void {
         $uid = $this->config->getActiveEventUid();
         $sql = 'SELECT uid FROM teams WHERE name=?';
         $params = [$name];
@@ -89,8 +87,7 @@ class TeamService
     /**
      * @param array<int, string> $teams
      */
-    public function saveAll(array $teams): void
-    {
+    public function saveAll(array $teams): void {
         $uid = $this->config->getActiveEventUid();
 
         $teamCount = count($teams);

--- a/src/Service/TenantService.php
+++ b/src/Service/TenantService.php
@@ -130,8 +130,7 @@ class TenantService
     /**
      * Drop the tenant schema and remove its record.
      */
-    public function deleteTenant(string $uid): void
-    {
+    public function deleteTenant(string $uid): void {
         $stmt = $this->pdo->prepare('SELECT subdomain FROM tenants WHERE uid = ?');
         $stmt->execute([$uid]);
         $schema = $stmt->fetchColumn();
@@ -146,8 +145,7 @@ class TenantService
     /**
      * Check whether a tenant with the given subdomain exists.
      */
-    public function exists(string $subdomain): bool
-    {
+    public function exists(string $subdomain): bool {
         if ($this->isReserved($subdomain)) {
             return true;
         }
@@ -173,13 +171,11 @@ class TenantService
         return false;
     }
 
-    private function isReserved(string $subdomain): bool
-    {
+    private function isReserved(string $subdomain): bool {
         return in_array(strtolower($subdomain), self::RESERVED_SUBDOMAINS, true);
     }
 
-    private function hasTable(string $name): bool
-    {
+    private function hasTable(string $name): bool {
         $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
         if ($driver === 'sqlite') {
             $stmt = $this->pdo->prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?");
@@ -191,8 +187,7 @@ class TenantService
         return $stmt->fetchColumn() !== null;
     }
 
-    private function hasColumn(string $table, string $column): bool
-    {
+    private function hasColumn(string $table, string $column): bool {
         $driver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
         if ($driver === 'sqlite') {
             $stmt = $this->pdo->query('PRAGMA table_info(' . $this->pdo->quote($table) . ')');
@@ -212,8 +207,7 @@ class TenantService
     /**
      * Seed demo data from the bundled data directory into the current schema.
      */
-    private function seedDemoData(): void
-    {
+    private function seedDemoData(): void {
         $base = dirname(__DIR__, 2);
         $dataDir = $base . '/data';
         if (!is_dir($dataDir)) {
@@ -354,8 +348,7 @@ class TenantService
     /**
      * Retrieve the plan for a tenant identified by subdomain.
      */
-    public function getPlanBySubdomain(string $subdomain): ?string
-    {
+    public function getPlanBySubdomain(string $subdomain): ?string {
         $stmt = $this->pdo->prepare('SELECT plan FROM tenants WHERE subdomain = ?');
         $stmt->execute([$subdomain]);
         $plan = $stmt->fetchColumn();
@@ -367,8 +360,7 @@ class TenantService
      *
      * @return array<string,int|null>|null
      */
-    public function getCustomLimitsBySubdomain(string $subdomain): ?array
-    {
+    public function getCustomLimitsBySubdomain(string $subdomain): ?array {
         $stmt = $this->pdo->prepare('SELECT custom_limits FROM tenants WHERE subdomain = ?');
         $stmt->execute([$subdomain]);
         $json = $stmt->fetchColumn();
@@ -384,8 +376,7 @@ class TenantService
      *
      * @param array<string,int|null>|null $limits
      */
-    public function setCustomLimits(string $subdomain, ?array $limits): void
-    {
+    public function setCustomLimits(string $subdomain, ?array $limits): void {
         $stmt = $this->pdo->prepare('UPDATE tenants SET custom_limits = ? WHERE subdomain = ?');
         $stmt->execute([$limits !== null ? json_encode($limits) : null, $subdomain]);
     }
@@ -395,8 +386,7 @@ class TenantService
      *
      * @return array<string,int|null>
      */
-    public function getLimitsBySubdomain(string $subdomain): array
-    {
+    public function getLimitsBySubdomain(string $subdomain): array {
         $custom = $this->getCustomLimitsBySubdomain($subdomain);
         if ($custom !== null) {
             return $custom;
@@ -424,8 +414,7 @@ class TenantService
      *   created_at:string
      * }|null
      */
-    public function getBySubdomain(string $subdomain): ?array
-    {
+    public function getBySubdomain(string $subdomain): ?array {
         $stmt = $this->pdo->prepare(
             'SELECT uid, subdomain, plan, billing_info, stripe_customer_id, imprint_name, '
             . 'imprint_street, imprint_zip, imprint_city, imprint_email, custom_limits, '
@@ -448,8 +437,7 @@ class TenantService
      *
      * @return array<string,mixed>
      */
-    public function getMainTenant(): array
-    {
+    public function getMainTenant(): array {
         $tenant = $this->getBySubdomain('main');
         if ($tenant !== null) {
             return $tenant;
@@ -492,8 +480,7 @@ class TenantService
      *
      * @param array<string,mixed> $data
      */
-    public function updateProfile(string $subdomain, array $data): void
-    {
+    public function updateProfile(string $subdomain, array $data): void {
         foreach ($data as &$value) {
             if ($value === '') {
                 $value = null;
@@ -592,8 +579,7 @@ class TenantService
      *
      * @param array<string,mixed> $data
      */
-    public function updateByStripeCustomerId(string $customerId, array $data): void
-    {
+    public function updateByStripeCustomerId(string $customerId, array $data): void {
         $stmt = $this->pdo->prepare('SELECT subdomain FROM tenants WHERE stripe_customer_id = ?');
         $stmt->execute([$customerId]);
         $sub = $stmt->fetchColumn();
@@ -606,8 +592,7 @@ class TenantService
     /**
      * Remove Stripe association and plan for a given customer.
      */
-    public function removeStripeCustomer(string $customerId): void
-    {
+    public function removeStripeCustomer(string $customerId): void {
         $stmt = $this->pdo->prepare(
             'UPDATE tenants SET stripe_customer_id = NULL, plan = NULL WHERE stripe_customer_id = ?'
         );
@@ -617,8 +602,7 @@ class TenantService
     /**
      * Cancel the plan for a given customer.
      */
-    public function cancelPlanForCustomer(string $customerId): void
-    {
+    public function cancelPlanForCustomer(string $customerId): void {
         $stmt = $this->pdo->prepare(
             'UPDATE tenants SET plan = NULL WHERE stripe_customer_id = ?'
         );
@@ -628,8 +612,7 @@ class TenantService
     /**
      * Import tenant records for schemas that are missing in the tenants table.
      */
-    public function importMissing(): int
-    {
+    public function importMissing(): int {
         $existing = $this->pdo
             ->query('SELECT subdomain FROM tenants')
             ->fetchAll(PDO::FETCH_COLUMN);
@@ -700,8 +683,7 @@ class TenantService
      *   created_at:string
      * }>
      */
-    public function getAll(string $query = ''): array
-    {
+    public function getAll(string $query = ''): array {
         $sql = 'SELECT uid, subdomain, plan, billing_info, stripe_customer_id, '
             . 'stripe_subscription_id, stripe_status, imprint_name, imprint_street, imprint_zip, '
             . 'imprint_city, imprint_email, custom_limits, plan_started_at, '

--- a/src/Service/TranslationService.php
+++ b/src/Service/TranslationService.php
@@ -9,13 +9,11 @@ class TranslationService
     private array $translations = [];
     private string $locale;
 
-    public function __construct(string $locale = 'de')
-    {
+    public function __construct(string $locale = 'de') {
         $this->loadLocale($locale);
     }
 
-    public function loadLocale(string $locale): void
-    {
+    public function loadLocale(string $locale): void {
         $file = __DIR__ . '/../../resources/lang/' . $locale . '.php';
         if (!is_readable($file)) {
             $locale = 'de';
@@ -25,13 +23,11 @@ class TranslationService
         $this->translations = is_readable($file) ? require $file : [];
     }
 
-    public function translate(string $key): string
-    {
+    public function translate(string $key): string {
         return $this->translations[$key] ?? $key;
     }
 
-    public function getLocale(): string
-    {
+    public function getLocale(): string {
         return $this->locale;
     }
 }

--- a/src/Service/TurnstileConfig.php
+++ b/src/Service/TurnstileConfig.php
@@ -10,8 +10,7 @@ class TurnstileConfig
     private ?string $secretKey;
     private bool $enabled;
 
-    public function __construct(?string $siteKey, ?string $secretKey, bool $enabled = true)
-    {
+    public function __construct(?string $siteKey, ?string $secretKey, bool $enabled = true) {
         $siteKey = $this->normalize($siteKey);
         $secretKey = $this->normalize($secretKey);
         $this->enabled = $enabled;
@@ -19,31 +18,26 @@ class TurnstileConfig
         $this->secretKey = $secretKey;
     }
 
-    public static function fromEnv(): self
-    {
+    public static function fromEnv(): self {
         $siteKey = getenv('TURNSTILE_SITE_KEY') ?: null;
         $secretKey = getenv('TURNSTILE_SECRET_KEY') ?: null;
 
         return new self($siteKey, $secretKey);
     }
 
-    public function isEnabled(): bool
-    {
+    public function isEnabled(): bool {
         return $this->enabled && $this->siteKey !== null && $this->secretKey !== null;
     }
 
-    public function getSiteKey(): ?string
-    {
+    public function getSiteKey(): ?string {
         return $this->siteKey;
     }
 
-    public function getSecretKey(): ?string
-    {
+    public function getSecretKey(): ?string {
         return $this->secretKey;
     }
 
-    private function normalize(?string $value): ?string
-    {
+    private function normalize(?string $value): ?string {
         if ($value === null) {
             return null;
         }

--- a/src/Service/TurnstileVerificationService.php
+++ b/src/Service/TurnstileVerificationService.php
@@ -28,8 +28,7 @@ class TurnstileVerificationService
         $this->logger = $logger ?? new NullLogger();
     }
 
-    public function verify(?string $token, ?string $ip = null): bool
-    {
+    public function verify(?string $token, ?string $ip = null): bool {
         if (!$this->config->isEnabled()) {
             return true;
         }

--- a/src/Service/UrlService.php
+++ b/src/Service/UrlService.php
@@ -8,8 +8,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class UrlService
 {
-    public static function determineBaseUrl(Request $req): string
-    {
+    public static function determineBaseUrl(Request $req): string {
         $uri = $req->getUri();
         $baseUrl = $uri->getScheme() . '://' . $uri->getHost();
         $port = $uri->getPort();

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -14,8 +14,7 @@ class UserService
 {
     private PDO $pdo;
 
-    public function __construct(PDO $pdo)
-    {
+    public function __construct(PDO $pdo) {
         $this->pdo = $pdo;
     }
 
@@ -24,8 +23,7 @@ class UserService
      *
      * @return array{id:int,username:string,password:string,email:?string,role:string,active:bool}|null
      */
-    public function getByUsername(string $username): ?array
-    {
+    public function getByUsername(string $username): ?array {
         $stmt = $this->pdo->prepare(
             'SELECT id,username,password,email,role,active FROM users WHERE LOWER(username) = LOWER(?)'
         );
@@ -39,8 +37,7 @@ class UserService
      *
      * @return array{id:int,username:string,password:string,email:?string,role:string,active:bool}|null
      */
-    public function getByEmail(string $email): ?array
-    {
+    public function getByEmail(string $email): ?array {
         $stmt = $this->pdo->prepare(
             'SELECT id,username,password,email,role,active FROM users WHERE LOWER(email) = LOWER(?)'
         );
@@ -54,8 +51,7 @@ class UserService
      *
      * @return array{id:int,username:string,password:string,email:?string,role:string,active:bool}|null
      */
-    public function getById(int $id): ?array
-    {
+    public function getById(int $id): ?array {
         $stmt = $this->pdo->prepare('SELECT id,username,password,email,role,active FROM users WHERE id=?');
         $stmt->execute([$id]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -88,8 +84,7 @@ class UserService
     /**
      * Update the password for a user identified by id.
      */
-    public function updatePassword(int $id, string $password): void
-    {
+    public function updatePassword(int $id, string $password): void {
         $stmt = $this->pdo->prepare('UPDATE users SET password=? WHERE id=?');
         $stmt->execute([
             password_hash($password, PASSWORD_DEFAULT),
@@ -100,8 +95,7 @@ class UserService
     /**
      * Retrieve the email for the given user id.
      */
-    public function getEmail(int $id): ?string
-    {
+    public function getEmail(int $id): ?string {
         $stmt = $this->pdo->prepare('SELECT email FROM users WHERE id=?');
         $stmt->execute([$id]);
         $value = $stmt->fetchColumn();
@@ -111,8 +105,7 @@ class UserService
     /**
      * Update the email for the given user id.
      */
-    public function setEmail(int $id, ?string $email): void
-    {
+    public function setEmail(int $id, ?string $email): void {
         $stmt = $this->pdo->prepare('UPDATE users SET email=? WHERE id=?');
         $stmt->execute([$email, $id]);
     }
@@ -122,8 +115,7 @@ class UserService
      *
      * @return list<array{id:int,username:string,email:?string,role:string,active:bool,position:int}>
      */
-    public function getAll(): array
-    {
+    public function getAll(): array {
         $stmt = $this->pdo->query('SELECT id,username,email,role,active,position FROM users ORDER BY position');
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -133,8 +125,7 @@ class UserService
      *
      * @param list<array{id?:int,username:string,email?:?string,role:string,password?:string,active?:bool,position?:int}> $users
      */
-    public function saveAll(array $users): void
-    {
+    public function saveAll(array $users): void {
         $this->pdo->beginTransaction();
         $existing = [];
         foreach ($this->pdo->query('SELECT id FROM users') as $row) {

--- a/src/Service/VersionService.php
+++ b/src/Service/VersionService.php
@@ -12,8 +12,7 @@ class VersionService
     /**
      * Return the current application version.
      */
-    public function getCurrentVersion(): string
-    {
+    public function getCurrentVersion(): string {
         $root = dirname(__DIR__, 2);
 
         $versionFile = $root . '/VERSION';

--- a/src/Support/BasePathHelper.php
+++ b/src/Support/BasePathHelper.php
@@ -6,12 +6,10 @@ namespace App\Support;
 
 final class BasePathHelper
 {
-    private function __construct()
-    {
+    private function __construct() {
     }
 
-    public static function normalize(?string $basePath): string
-    {
+    public static function normalize(?string $basePath): string {
         if ($basePath === null) {
             return '';
         }

--- a/src/Twig/TranslationExtension.php
+++ b/src/Twig/TranslationExtension.php
@@ -10,13 +10,11 @@ class TranslationExtension extends AbstractExtension
 {
     private TranslationService $translator;
 
-    public function __construct(TranslationService $translator)
-    {
+    public function __construct(TranslationService $translator) {
         $this->translator = $translator;
     }
 
-    public function getFunctions(): array
-    {
+    public function getFunctions(): array {
         return [
             new TwigFunction('t', [$this->translator, 'translate']),
             new TwigFunction('locale', [$this->translator, 'getLocale']),

--- a/src/Twig/UikitExtension.php
+++ b/src/Twig/UikitExtension.php
@@ -7,15 +7,13 @@ use Twig\TwigFilter;
 
 class UikitExtension extends AbstractExtension
 {
-    public function getFilters(): array
-    {
+    public function getFilters(): array {
         return [
             new TwigFilter('uikitify', [$this, 'uikitify'], ['is_safe' => ['html']]),
         ];
     }
 
-    public function uikitify(string $html): string
-    {
+    public function uikitify(string $html): string {
         $patterns = [
             '/<h([1-6])([^>]*)>/i',
             '/<\/h([1-6])>/i',

--- a/src/process_helpers.php
+++ b/src/process_helpers.php
@@ -10,8 +10,7 @@ use Symfony\Component\Process\Process;
  * Run a shell script in the background.
  * Falls back to exec if the Symfony Process component is unavailable.
  */
-function runBackgroundProcess(string $script, array $args = []): void
-{
+function runBackgroundProcess(string $script, array $args = []): void {
     $cmd = array_merge([$script], $args);
 
     $logDir = dirname(__DIR__) . '/logs';
@@ -52,8 +51,7 @@ function runBackgroundProcess(string $script, array $args = []): void
  *
  * @return array{success: bool, stdout: string, stderr: string}
  */
-function runSyncProcess(string $script, array $args = [], bool $throwOnError = false): array
-{
+function runSyncProcess(string $script, array $args = [], bool $throwOnError = false): array {
     $cmd = array_merge([$script], $args);
 
     try {

--- a/tests/Application/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/Application/Middleware/RateLimitMiddlewareTest.php
@@ -15,22 +15,19 @@ use Slim\Psr7\Factory\ServerRequestFactory;
 
 class RateLimitMiddlewareTest extends TestCase
 {
-    protected function setUp(): void
-    {
+    protected function setUp(): void {
         parent::setUp();
         RateLimitMiddleware::resetPersistentStorage();
         $_SESSION = [];
     }
 
-    protected function tearDown(): void
-    {
+    protected function tearDown(): void {
         RateLimitMiddleware::resetPersistentStorage();
         $_SESSION = [];
         parent::tearDown();
     }
 
-    public function testPersistentLimitBlocksAcrossSessions(): void
-    {
+    public function testPersistentLimitBlocksAcrossSessions(): void {
         $middleware = new RateLimitMiddleware(2, 3600);
         $factory = new ServerRequestFactory();
         $request = $factory->createServerRequest(
@@ -43,8 +40,7 @@ class RateLimitMiddlewareTest extends TestCase
         );
 
         $handler = new class implements RequestHandlerInterface {
-            public function handle(ServerRequestInterface $request): ResponseInterface
-            {
+            public function handle(ServerRequestInterface $request): ResponseInterface {
                 $factory = new ResponseFactory();
 
                 return $factory->createResponse(204);
@@ -63,8 +59,7 @@ class RateLimitMiddlewareTest extends TestCase
         $this->assertSame('3600', $response->getHeaderLine('Retry-After'));
     }
 
-    public function testInjectedPersistentStoreIsHonored(): void
-    {
+    public function testInjectedPersistentStoreIsHonored(): void {
         $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'rate_limit_injected_' . uniqid('', true);
         $store = new FilesystemRateLimitStore($dir);
         $store->reset();
@@ -74,8 +69,7 @@ class RateLimitMiddlewareTest extends TestCase
         $request = $factory->createServerRequest('POST', 'https://example.com/landing/contact');
 
         $handler = new class implements RequestHandlerInterface {
-            public function handle(ServerRequestInterface $request): ResponseInterface
-            {
+            public function handle(ServerRequestInterface $request): ResponseInterface {
                 $factory = new ResponseFactory();
 
                 return $factory->createResponse(204);

--- a/tests/Controller/AdminCatalogControllerTest.php
+++ b/tests/Controller/AdminCatalogControllerTest.php
@@ -14,8 +14,7 @@ use Tests\TestCase;
 
 class AdminCatalogControllerTest extends TestCase
 {
-    public function testCatalogsEndpointReturnsPagedJson(): void
-    {
+    public function testCatalogsEndpointReturnsPagedJson(): void {
         $db = tempnam(sys_get_temp_dir(), 'db');
         putenv('POSTGRES_DSN=sqlite:' . $db);
         putenv('POSTGRES_USER=');

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -14,8 +14,7 @@ use Tests\TestCase;
 
 class AdminControllerTest extends TestCase
 {
-    private function setupDb(): string
-    {
+    private function setupDb(): string {
         $db = tempnam(sys_get_temp_dir(), 'db');
         putenv('POSTGRES_DSN=sqlite:' . $db);
         putenv('POSTGRES_USER=');
@@ -25,8 +24,7 @@ class AdminControllerTest extends TestCase
         $_ENV['POSTGRES_PASSWORD'] = '';
         return $db;
     }
-    public function testRedirectWhenNotLoggedIn(): void
-    {
+    public function testRedirectWhenNotLoggedIn(): void {
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_unset();
             session_destroy();
@@ -45,8 +43,7 @@ class AdminControllerTest extends TestCase
         unlink($db);
     }
 
-    public function testAdminPageAfterLogin(): void
-    {
+    public function testAdminPageAfterLogin(): void {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
@@ -60,8 +57,7 @@ class AdminControllerTest extends TestCase
         unlink($db);
     }
 
-    public function testDashboardShowsGreeting(): void
-    {
+    public function testDashboardShowsGreeting(): void {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
@@ -74,8 +70,7 @@ class AdminControllerTest extends TestCase
         unlink($db);
     }
 
-    public function testRedirectForWrongRole(): void
-    {
+    public function testRedirectForWrongRole(): void {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
@@ -88,8 +83,7 @@ class AdminControllerTest extends TestCase
         unlink($db);
     }
 
-    public function testProfileShowsMainDomainData(): void
-    {
+    public function testProfileShowsMainDomainData(): void {
         $db = $this->setupDb();
         putenv('MAIN_DOMAIN=example.com');
         $_ENV['MAIN_DOMAIN'] = 'example.com';
@@ -109,8 +103,7 @@ class AdminControllerTest extends TestCase
         unset($_ENV['MAIN_DOMAIN']);
     }
 
-    public function testPagesAndProfileDataLoadedOnEvents(): void
-    {
+    public function testPagesAndProfileDataLoadedOnEvents(): void {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
@@ -125,8 +118,7 @@ class AdminControllerTest extends TestCase
         unlink($db);
     }
 
-    public function testEventsEmbeddedOnPage(): void
-    {
+    public function testEventsEmbeddedOnPage(): void {
         $db = $this->setupDb();
         $pdo = new PDO('sqlite:' . $db);
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
@@ -146,8 +138,7 @@ class AdminControllerTest extends TestCase
         unlink($db);
     }
 
-    public function testInvalidEventQueryReturns404(): void
-    {
+    public function testInvalidEventQueryReturns404(): void {
         $db = $this->setupDb();
         $pdo = new PDO('sqlite:' . $db);
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
@@ -169,8 +160,7 @@ class AdminControllerTest extends TestCase
      *
      * @runInSeparateProcess
      */
-    public function testStripeCustomerIdStoredOnMainDomain(): void
-    {
+    public function testStripeCustomerIdStoredOnMainDomain(): void {
         require_once __DIR__ . '/../Service/StripeServiceStub.php';
         $db = $this->setupDb();
         putenv('MAIN_DOMAIN=example.com');
@@ -197,8 +187,7 @@ class AdminControllerTest extends TestCase
      *
      * @runInSeparateProcess
      */
-    public function testSubscriptionPageShowsEmailInputWhenTenantMissing(): void
-    {
+    public function testSubscriptionPageShowsEmailInputWhenTenantMissing(): void {
         require_once __DIR__ . '/../Service/StripeServiceStub.php';
         $db = $this->setupDb();
         putenv('MAIN_DOMAIN=example.com');
@@ -218,8 +207,7 @@ class AdminControllerTest extends TestCase
         unset($_ENV['MAIN_DOMAIN']);
     }
 
-    public function testSetSubscriptionPlanAllowsDowngrade(): void
-    {
+    public function testSetSubscriptionPlanAllowsDowngrade(): void {
         $db = $this->setupDb();
         putenv('MAIN_DOMAIN=example.com');
         $_ENV['MAIN_DOMAIN'] = 'example.com';
@@ -259,8 +247,7 @@ class AdminControllerTest extends TestCase
         unset($_ENV['MAIN_DOMAIN']);
     }
 
-    public function testSubscriptionToggleAllowedForDemo(): void
-    {
+    public function testSubscriptionToggleAllowedForDemo(): void {
         $db = $this->setupDb();
         $pdo = new PDO('sqlite:' . $db);
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
@@ -297,8 +284,7 @@ class AdminControllerTest extends TestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function testStripeApiCalledOnPlanChange(): void
-    {
+    public function testStripeApiCalledOnPlanChange(): void {
         require_once __DIR__ . '/../Service/StripeServiceStub.php';
         \App\Service\StripeService::$calls = [];
 

--- a/tests/Controller/AdminRedirectTest.php
+++ b/tests/Controller/AdminRedirectTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class AdminRedirectTest extends TestCase
 {
-    public function testUnknownAdminPathRedirectsToAdmin(): void
-    {
+    public function testUnknownAdminPathRedirectsToAdmin(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];

--- a/tests/Controller/AdminSubscriptionCheckoutControllerTest.php
+++ b/tests/Controller/AdminSubscriptionCheckoutControllerTest.php
@@ -9,8 +9,7 @@ use Tests\TestCase;
 
 final class AdminSubscriptionCheckoutControllerTest extends TestCase
 {
-    public function testCheckoutUsesProfileOnMainDomain(): void
-    {
+    public function testCheckoutUsesProfileOnMainDomain(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];

--- a/tests/Controller/BackupControllerTest.php
+++ b/tests/Controller/BackupControllerTest.php
@@ -3,13 +3,11 @@
 declare(strict_types=1);
 
 namespace App\Controller {
-    function rmdir(string $dir): bool
-    {
+    function rmdir(string $dir): bool {
         return \Tests\Controller\BackupControllerTest::callRmdir($dir);
     }
 
-    function unlink(string $filename): bool
-    {
+    function unlink(string $filename): bool {
         return \Tests\Controller\BackupControllerTest::callUnlink($filename);
     }
 }
@@ -28,31 +26,27 @@ namespace Tests\Controller {
         /** @var callable|null */
         public static $unlinkCallback = null;
 
-        public static function callRmdir(string $dir): bool
-        {
+        public static function callRmdir(string $dir): bool {
             if (self::$rmdirCallback !== null) {
                 return (self::$rmdirCallback)($dir);
             }
             return \rmdir($dir);
         }
 
-        public static function callUnlink(string $file): bool
-        {
+        public static function callUnlink(string $file): bool {
             if (self::$unlinkCallback !== null) {
                 return (self::$unlinkCallback)($file);
             }
             return \unlink($file);
         }
 
-        protected function tearDown(): void
-        {
+        protected function tearDown(): void {
             self::$rmdirCallback = null;
             self::$unlinkCallback = null;
             parent::tearDown();
         }
 
-        public function testDeleteSuccess(): void
-        {
+        public function testDeleteSuccess(): void {
             $base = sys_get_temp_dir() . '/bct_' . uniqid();
             mkdir($base . '/ok', 0777, true);
             file_put_contents($base . '/ok/test.txt', 'a');
@@ -69,8 +63,7 @@ namespace Tests\Controller {
             \rmdir($base);
         }
 
-        public function testDeleteFailure(): void
-        {
+        public function testDeleteFailure(): void {
             $base = sys_get_temp_dir() . '/bct_' . uniqid();
             mkdir($base . '/fail', 0777, true);
             file_put_contents($base . '/fail/test.txt', 'a');
@@ -96,8 +89,7 @@ namespace Tests\Controller {
             \rmdir($base);
         }
 
-        public function testDeleteFileFailure(): void
-        {
+        public function testDeleteFileFailure(): void {
             $base = sys_get_temp_dir() . '/bct_' . uniqid();
             mkdir($base . '/fail', 0777, true);
             file_put_contents($base . '/fail/test.txt', 'a');
@@ -123,8 +115,7 @@ namespace Tests\Controller {
             \rmdir($base);
         }
 
-        public function testDeleteInvalidName(): void
-        {
+        public function testDeleteInvalidName(): void {
             $base = sys_get_temp_dir() . '/bct_' . uniqid();
             mkdir($base, 0777, true);
 

--- a/tests/Controller/CalserverControllerTest.php
+++ b/tests/Controller/CalserverControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class CalserverControllerTest extends TestCase
 {
-    protected function setUp(): void
-    {
+    protected function setUp(): void {
         parent::setUp();
         $pdo = $this->getDatabase();
         try {
@@ -19,8 +18,7 @@ class CalserverControllerTest extends TestCase
         }
     }
 
-    public function testCalserverPage(): void
-    {
+    public function testCalserverPage(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
@@ -38,8 +36,7 @@ class CalserverControllerTest extends TestCase
         }
     }
 
-    public function testCalserverPageTenant(): void
-    {
+    public function testCalserverPageTenant(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();

--- a/tests/Controller/CatalogControllerLimitTest.php
+++ b/tests/Controller/CatalogControllerLimitTest.php
@@ -14,8 +14,7 @@ use Tests\TestCase;
 
 class CatalogControllerLimitTest extends TestCase
 {
-    public function testPostCatalogsLimitExceededReturns402(): void
-    {
+    public function testPostCatalogsLimitExceededReturns402(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('e1')");
@@ -60,8 +59,7 @@ class CatalogControllerLimitTest extends TestCase
         session_destroy();
     }
 
-    public function testPostQuestionsLimitExceededReturns402(): void
-    {
+    public function testPostQuestionsLimitExceededReturns402(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('e1')");

--- a/tests/Controller/CatalogControllerTest.php
+++ b/tests/Controller/CatalogControllerTest.php
@@ -12,8 +12,7 @@ use Slim\Psr7\Response;
 
 class CatalogControllerTest extends TestCase
 {
-    public function testGetNotFound(): void
-    {
+    public function testGetNotFound(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
@@ -62,8 +61,7 @@ class CatalogControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testRedirectIncludesEvent(): void
-    {
+    public function testRedirectIncludesEvent(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
@@ -116,8 +114,7 @@ class CatalogControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostAndGet(): void
-    {
+    public function testPostAndGet(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
@@ -190,8 +187,7 @@ class CatalogControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testCreateAndDelete(): void
-    {
+    public function testCreateAndDelete(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
@@ -269,8 +265,7 @@ class CatalogControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testDeleteQuestion(): void
-    {
+    public function testDeleteQuestion(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
@@ -330,8 +325,7 @@ class CatalogControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostInvalidJson(): void
-    {
+    public function testPostInvalidJson(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');

--- a/tests/Controller/CatalogQuestionsControllerTest.php
+++ b/tests/Controller/CatalogQuestionsControllerTest.php
@@ -12,8 +12,7 @@ use Slim\Psr7\Response;
 
 class CatalogQuestionsControllerTest extends TestCase
 {
-    public function testGetQuestionsRequiresValidTokenAndWhitelist(): void
-    {
+    public function testGetQuestionsRequiresValidTokenAndWhitelist(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');

--- a/tests/Controller/CatalogStickerControllerTest.php
+++ b/tests/Controller/CatalogStickerControllerTest.php
@@ -17,8 +17,7 @@ use Tests\TestCase;
 
 class CatalogStickerControllerTest extends TestCase
 {
-    public function testPdfWithEmptyParameters(): void
-    {
+    public function testPdfWithEmptyParameters(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
         $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')");
@@ -26,8 +25,7 @@ class CatalogStickerControllerTest extends TestCase
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
-            public function generateCatalog(array $q, array $cfg = []): array
-            {
+            public function generateCatalog(array $q, array $cfg = []): array {
                 $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
                 return ['mime' => 'image/png', 'body' => $img];
             }
@@ -51,8 +49,7 @@ class CatalogStickerControllerTest extends TestCase
         $this->assertGreaterThan(0, strlen($body));
     }
 
-    public function testPdfWithValidParameters(): void
-    {
+    public function testPdfWithValidParameters(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
         $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')");
@@ -60,8 +57,7 @@ class CatalogStickerControllerTest extends TestCase
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
-            public function generateCatalog(array $q, array $cfg = []): array
-            {
+            public function generateCatalog(array $q, array $cfg = []): array {
                 $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
                 return ['mime' => 'image/png', 'body' => $img];
             }
@@ -85,8 +81,7 @@ class CatalogStickerControllerTest extends TestCase
         $this->assertGreaterThan(0, strlen($body));
     }
 
-    public function testPdfWithAdditionalTemplate(): void
-    {
+    public function testPdfWithAdditionalTemplate(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
         $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')");
@@ -94,8 +89,7 @@ class CatalogStickerControllerTest extends TestCase
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
-            public function generateCatalog(array $q, array $cfg = []): array
-            {
+            public function generateCatalog(array $q, array $cfg = []): array {
                 $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
                 return ['mime' => 'image/png', 'body' => $img];
             }
@@ -113,8 +107,7 @@ class CatalogStickerControllerTest extends TestCase
         $this->assertGreaterThan(0, strlen($body));
     }
 
-    public function testPdfUsesDefaultTemplateL7163(): void
-    {
+    public function testPdfUsesDefaultTemplateL7163(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
         for ($i = 0; $i < 14; $i++) {
@@ -128,8 +121,7 @@ class CatalogStickerControllerTest extends TestCase
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
-            public function generateCatalog(array $q, array $cfg = []): array
-            {
+            public function generateCatalog(array $q, array $cfg = []): array {
                 $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
                 return ['mime' => 'image/png', 'body' => $img];
             }
@@ -142,8 +134,7 @@ class CatalogStickerControllerTest extends TestCase
         $this->assertSame(1, preg_match_all('/\/Type \/Page\b/', $body));
     }
 
-    public function testPdfEmbedsBackgroundImage(): void
-    {
+    public function testPdfEmbedsBackgroundImage(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
         $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')");
@@ -151,8 +142,7 @@ class CatalogStickerControllerTest extends TestCase
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
-            public function generateCatalog(array $q, array $cfg = []): array
-            {
+            public function generateCatalog(array $q, array $cfg = []): array {
                 $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
                 return ['mime' => 'image/png', 'body' => $img];
             }
@@ -182,8 +172,7 @@ class CatalogStickerControllerTest extends TestCase
         $this->assertSame(1, preg_match_all('/\/Subtype\s*\/Image\b/', $withBg));
     }
 
-    public function testGetSettingsProvidesPreviewFields(): void
-    {
+    public function testGetSettingsProvidesPreviewFields(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, description, published, sort_order) VALUES('ev1','ev1','EventTitle','EventDesc',1,0)");
         $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','CatName','CatDesc','A','ev1')");
@@ -214,8 +203,7 @@ class CatalogStickerControllerTest extends TestCase
         $this->assertFalse($data['stickerPrintCatalog']);
     }
 
-    public function testUploadBackgroundStoresImageAndConfig(): void
-    {
+    public function testUploadBackgroundStoresImageAndConfig(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
         $config = new ConfigService($pdo);
@@ -248,8 +236,7 @@ class CatalogStickerControllerTest extends TestCase
         unlink($filePath);
     }
 
-    public function testGetSettingsClearsMissingBackground(): void
-    {
+    public function testGetSettingsClearsMissingBackground(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
         $config = new ConfigService($pdo);
@@ -273,8 +260,7 @@ class CatalogStickerControllerTest extends TestCase
         $this->assertNull($cfg['stickerBgPath']);
     }
 
-    public function testGetSettingsFixesOutdatedBackgroundPath(): void
-    {
+    public function testGetSettingsFixesOutdatedBackgroundPath(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
         $config = new ConfigService($pdo);

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -13,8 +13,7 @@ use Slim\Psr7\Response;
 
 class ConfigControllerTest extends TestCase
 {
-    public function testGetNotFound(): void
-    {
+    public function testGetNotFound(): void {
         $pdo = $this->createDatabase();
         $controller = new ConfigController(new ConfigService($pdo), new ConfigValidator(), new EventService($pdo));
         $request = $this->createRequest('GET', '/config.json');
@@ -23,8 +22,7 @@ class ConfigControllerTest extends TestCase
         $this->assertEquals(404, $response->getStatusCode());
     }
 
-    public function testPostAndGet(): void
-    {
+    public function testPostAndGet(): void {
         $pdo = $this->createDatabase();
         $service = new ConfigService($pdo);
         $eventService = new EventService($pdo);
@@ -45,8 +43,7 @@ class ConfigControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostInvalidJson(): void
-    {
+    public function testPostInvalidJson(): void {
         $pdo = $this->createDatabase();
         $service = new ConfigService($pdo);
         $controller = new ConfigController($service, new ConfigValidator(), new EventService($pdo));
@@ -66,8 +63,7 @@ class ConfigControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostInvalidColor(): void
-    {
+    public function testPostInvalidColor(): void {
         $pdo = $this->createDatabase();
         $service = new ConfigService($pdo);
         $eventService = new EventService($pdo);
@@ -88,8 +84,7 @@ class ConfigControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostEventUidOnly(): void
-    {
+    public function testPostEventUidOnly(): void {
         $pdo = $this->createDatabase();
         $service = new ConfigService($pdo);
         $eventService = new EventService($pdo);
@@ -108,8 +103,7 @@ class ConfigControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostInvalidEventUid(): void
-    {
+    public function testPostInvalidEventUid(): void {
         $pdo = $this->createDatabase();
         $service = new ConfigService($pdo);
         $controller = new ConfigController($service, new ConfigValidator(), new EventService($pdo));
@@ -125,8 +119,7 @@ class ConfigControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testGetByEvent(): void
-    {
+    public function testGetByEvent(): void {
         $pdo = $this->createDatabase();
         $service = new ConfigService($pdo);
         $eventService = new EventService($pdo);
@@ -143,8 +136,7 @@ class ConfigControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostDeniedForNonAdmin(): void
-    {
+    public function testPostDeniedForNonAdmin(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 2, 'role' => 'user'];

--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -16,8 +16,7 @@ class ContactControllerTest extends TestCase
     /**
      * @dataProvider contactRoutesProvider
      */
-    public function testContactFormSendsMail(string $route): void
-    {
+    public function testContactFormSendsMail(string $route): void {
         RateLimitMiddleware::resetPersistentStorage();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
@@ -38,8 +37,7 @@ class ContactControllerTest extends TestCase
         try {
             $mailer = new class extends MailService {
                 public array $args = [];
-                public function __construct()
-                {
+                public function __construct() {
                 }
                 public function sendContact(
                     string $to,
@@ -137,16 +135,14 @@ class ContactControllerTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function contactRoutesProvider(): array
-    {
+    public function contactRoutesProvider(): array {
         return [
             ['/landing/contact'],
             ['/calserver/contact'],
         ];
     }
 
-    public function testContactFormRequiresCaptchaWhenConfigured(): void
-    {
+    public function testContactFormRequiresCaptchaWhenConfigured(): void {
         RateLimitMiddleware::resetPersistentStorage();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
@@ -186,8 +182,7 @@ class ContactControllerTest extends TestCase
         $this->assertSame(422, $response->getStatusCode());
     }
 
-    public function testContactFormRejectsWhenCaptchaFails(): void
-    {
+    public function testContactFormRejectsWhenCaptchaFails(): void {
         RateLimitMiddleware::resetPersistentStorage();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
@@ -198,14 +193,12 @@ class ContactControllerTest extends TestCase
         $_COOKIE[session_name()] = session_id();
 
         $config = new TurnstileConfig('site', 'secret');
-        $verifier = new class($config) extends TurnstileVerificationService {
-            public function __construct(TurnstileConfig $config)
-            {
+        $verifier = new class ($config) extends TurnstileVerificationService {
+            public function __construct(TurnstileConfig $config) {
                 parent::__construct($config);
             }
 
-            public function verify(?string $token, ?string $ip = null): bool
-            {
+            public function verify(?string $token, ?string $ip = null): bool {
                 return false;
             }
         };
@@ -239,8 +232,7 @@ class ContactControllerTest extends TestCase
         $this->assertSame(422, $response->getStatusCode());
     }
 
-    public function testContactFormAcceptsWithValidCaptcha(): void
-    {
+    public function testContactFormAcceptsWithValidCaptcha(): void {
         RateLimitMiddleware::resetPersistentStorage();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
@@ -251,16 +243,14 @@ class ContactControllerTest extends TestCase
         $_COOKIE[session_name()] = session_id();
 
         $config = new TurnstileConfig('site', 'secret');
-        $verifier = new class($config) extends TurnstileVerificationService {
+        $verifier = new class ($config) extends TurnstileVerificationService {
             public array $calls = [];
 
-            public function __construct(TurnstileConfig $config)
-            {
+            public function __construct(TurnstileConfig $config) {
                 parent::__construct($config);
             }
 
-            public function verify(?string $token, ?string $ip = null): bool
-            {
+            public function verify(?string $token, ?string $ip = null): bool {
                 $this->calls[] = [$token, $ip];
 
                 return true;
@@ -269,8 +259,7 @@ class ContactControllerTest extends TestCase
 
         $mailer = new class extends MailService {
             public array $sent = [];
-            public function __construct()
-            {
+            public function __construct() {
             }
             public function sendContact(
                 string $to,
@@ -318,8 +307,7 @@ class ContactControllerTest extends TestCase
         $this->assertNotEmpty($mailer->sent);
     }
 
-    public function testContactFormUsesDomainSpecificEmail(): void
-    {
+    public function testContactFormUsesDomainSpecificEmail(): void {
         RateLimitMiddleware::resetPersistentStorage();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
@@ -344,8 +332,7 @@ class ContactControllerTest extends TestCase
 
             $mailer = new class extends MailService {
                 public array $args = [];
-                public function __construct()
-                {
+                public function __construct() {
                 }
                 public function sendContact(
                     string $to,
@@ -409,8 +396,7 @@ class ContactControllerTest extends TestCase
         }
     }
 
-    public function testContactFormUsesDomainSpecificSmtpOverride(): void
-    {
+    public function testContactFormUsesDomainSpecificSmtpOverride(): void {
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
         }
@@ -437,8 +423,7 @@ class ContactControllerTest extends TestCase
 
             $mailer = new class extends MailService {
                 public array $args = [];
-                public function __construct()
-                {
+                public function __construct() {
                 }
                 public function sendContact(
                     string $to,
@@ -503,8 +488,7 @@ class ContactControllerTest extends TestCase
         }
     }
 
-    public function testContactFormHoneypotBlocksMail(): void
-    {
+    public function testContactFormHoneypotBlocksMail(): void {
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
         }
@@ -521,8 +505,7 @@ class ContactControllerTest extends TestCase
         try {
             $mailer = new class extends MailService {
                 public bool $called = false;
-                public function __construct()
-                {
+                public function __construct() {
                 }
                 public function sendContact(
                     string $to,
@@ -578,8 +561,7 @@ class ContactControllerTest extends TestCase
         }
     }
 
-    public function testContactFormIgnoresInvalidDomainEmail(): void
-    {
+    public function testContactFormIgnoresInvalidDomainEmail(): void {
         RateLimitMiddleware::resetPersistentStorage();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
@@ -604,8 +586,7 @@ class ContactControllerTest extends TestCase
 
             $mailer = new class extends MailService {
                 public array $args = [];
-                public function __construct()
-                {
+                public function __construct() {
                 }
                 public function sendContact(
                     string $to,

--- a/tests/Controller/DatenschutzControllerTest.php
+++ b/tests/Controller/DatenschutzControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class DatenschutzControllerTest extends TestCase
 {
-    public function testDatenschutzPage(): void
-    {
+    public function testDatenschutzPage(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/datenschutz');
         $response = $app->handle($request);

--- a/tests/Controller/DomainAccessTest.php
+++ b/tests/Controller/DomainAccessTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class DomainAccessTest extends TestCase
 {
-    public function testMarketingRoutesOnMainDomain(): void
-    {
+    public function testMarketingRoutesOnMainDomain(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $pdo = $this->getDatabase();
@@ -30,8 +29,7 @@ class DomainAccessTest extends TestCase
         }
     }
 
-    public function testCalserverRouteOnMainDomain(): void
-    {
+    public function testCalserverRouteOnMainDomain(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
@@ -46,8 +44,7 @@ class DomainAccessTest extends TestCase
         }
     }
 
-    public function testTenantApiRejectedOnSubdomain(): void
-    {
+    public function testTenantApiRejectedOnSubdomain(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
@@ -69,8 +66,7 @@ class DomainAccessTest extends TestCase
         }
     }
 
-    public function testTenantCheckRejectedOnSubdomain(): void
-    {
+    public function testTenantCheckRejectedOnSubdomain(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
@@ -92,8 +88,7 @@ class DomainAccessTest extends TestCase
         }
     }
 
-    public function testMarketingSlugOnMarketingDomain(): void
-    {
+    public function testMarketingSlugOnMarketingDomain(): void {
         $oldMain = getenv('MAIN_DOMAIN');
         $oldMarketing = getenv('MARKETING_DOMAINS');
         putenv('MAIN_DOMAIN=main.test');
@@ -126,8 +121,7 @@ class DomainAccessTest extends TestCase
         }
     }
 
-    public function testUnknownSlugOnMarketingDomainReturns404(): void
-    {
+    public function testUnknownSlugOnMarketingDomainReturns404(): void {
         $oldMain = getenv('MAIN_DOMAIN');
         $oldMarketing = getenv('MARKETING_DOMAINS');
         putenv('MAIN_DOMAIN=main.test');

--- a/tests/Controller/DomainStartPageControllerTest.php
+++ b/tests/Controller/DomainStartPageControllerTest.php
@@ -10,8 +10,7 @@ use Tests\TestCase;
 
 class DomainStartPageControllerTest extends TestCase
 {
-    public function testCanSaveNewMarketingPageAsStartPage(): void
-    {
+    public function testCanSaveNewMarketingPageAsStartPage(): void {
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
         }

--- a/tests/Controller/EventConfigControllerTest.php
+++ b/tests/Controller/EventConfigControllerTest.php
@@ -12,8 +12,7 @@ use Tests\TestCase;
 
 class EventConfigControllerTest extends TestCase
 {
-    public function testUpdateInvalidData(): void
-    {
+    public function testUpdateInvalidData(): void {
         $pdo = $this->createDatabase();
         $eventService = new EventService($pdo);
         $eventService->saveAll([['uid' => 'ev1', 'name' => 'Test']]);
@@ -28,8 +27,7 @@ class EventConfigControllerTest extends TestCase
         $this->assertStringContainsString('errors', (string) $response->getBody());
     }
 
-    public function testUpdateValidData(): void
-    {
+    public function testUpdateValidData(): void {
         $pdo = $this->createDatabase();
         $eventService = new EventService($pdo);
         $eventService->saveAll([['uid' => 'ev1', 'name' => 'Test']]);

--- a/tests/Controller/EventImageControllerTest.php
+++ b/tests/Controller/EventImageControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class EventImageControllerTest extends TestCase
 {
-    public function testServesEventImage(): void
-    {
+    public function testServesEventImage(): void {
         $dir = __DIR__ . '/../../data/events/evimg/images';
         if (!is_dir($dir)) {
             mkdir($dir, 0775, true);

--- a/tests/Controller/EventsRouteTest.php
+++ b/tests/Controller/EventsRouteTest.php
@@ -18,8 +18,7 @@ use Tests\TestCase;
 
 class EventsRouteTest extends TestCase
 {
-    public function testEventsListAccessibleForCatalogEditor(): void
-    {
+    public function testEventsListAccessibleForCatalogEditor(): void {
         $app = $this->getAppInstance();
         if (session_status() !== PHP_SESSION_ACTIVE) {
             session_start();
@@ -33,8 +32,7 @@ class EventsRouteTest extends TestCase
         @session_destroy();
     }
 
-    public function testStarterPlanLimitExceeded(): void
-    {
+    public function testStarterPlanLimitExceeded(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO tenants(uid, subdomain, plan) VALUES('t1','foo','starter')");
 
@@ -77,8 +75,7 @@ class EventsRouteTest extends TestCase
         @session_destroy();
     }
 
-    public function testStarterPlanLimitExceededOnMainDomain(): void
-    {
+    public function testStarterPlanLimitExceededOnMainDomain(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO tenants(uid, subdomain, plan) VALUES('t1','main','starter')");
         putenv('MAIN_DOMAIN=example.com');

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -18,8 +18,7 @@ use Slim\Psr7\Response;
 
 class ExportControllerTest extends TestCase
 {
-    private function createServices(): array
-    {
+    private function createServices(): array {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('ev1','ev1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");
@@ -37,8 +36,7 @@ class ExportControllerTest extends TestCase
         ];
     }
 
-    public function testExportIncludesEvents(): void
-    {
+    public function testExportIncludesEvents(): void {
         [$catalog, $config, $results, $teams, $consents, $summary, $events] = $this->createServices();
         $tmp = sys_get_temp_dir() . '/export_' . uniqid();
         mkdir($tmp, 0777, true);
@@ -71,8 +69,7 @@ class ExportControllerTest extends TestCase
         rmdir($tmp);
     }
 
-    public function testExportDefaultsCreatesDemoData(): void
-    {
+    public function testExportDefaultsCreatesDemoData(): void {
         [$catalog, $config, $results, $teams, $consents, $summary, $events] = $this->createServices();
         $tmp = sys_get_temp_dir() . '/export_' . uniqid();
         mkdir($tmp, 0777, true);

--- a/tests/Controller/ExportImportControllerTest.php
+++ b/tests/Controller/ExportImportControllerTest.php
@@ -19,8 +19,7 @@ use PDO;
 
 class ExportImportControllerTest extends TestCase
 {
-    private function createServices(): array
-    {
+    private function createServices(): array {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('ev1','ev1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");
@@ -38,8 +37,7 @@ class ExportImportControllerTest extends TestCase
         ];
     }
 
-    public function testQuestionResultsRoundTrip(): void
-    {
+    public function testQuestionResultsRoundTrip(): void {
         [$catalog, $config, $results, $teams, $consents, $summary, $events, $pdo] = $this->createServices();
         // prepare catalog and questions
         $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES('u1',1,'c1','c1.json','Cat')");

--- a/tests/Controller/FaqControllerTest.php
+++ b/tests/Controller/FaqControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class FaqControllerTest extends TestCase
 {
-    public function testFaqPage(): void
-    {
+    public function testFaqPage(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/faq');
         $response = $app->handle($request);

--- a/tests/Controller/GlobalMediaControllerTest.php
+++ b/tests/Controller/GlobalMediaControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class GlobalMediaControllerTest extends TestCase
 {
-    public function testServesGlobalUpload(): void
-    {
+    public function testServesGlobalUpload(): void {
         $dir = __DIR__ . '/../../data/uploads';
         $createdDir = false;
         if (!is_dir($dir)) {

--- a/tests/Controller/HelpControllerTest.php
+++ b/tests/Controller/HelpControllerTest.php
@@ -8,16 +8,14 @@ use Tests\TestCase;
 
 class HelpControllerTest extends TestCase
 {
-    public function testHelpPage(): void
-    {
+    public function testHelpPage(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/help');
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testInvitePlaceholderIsReplaced(): void
-    {
+    public function testInvitePlaceholderIsReplaced(): void {
         $dbFile = tempnam(sys_get_temp_dir(), 'db');
         $pdo = new \PDO('sqlite:' . $dbFile);
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
@@ -81,8 +79,7 @@ class HelpControllerTest extends TestCase
         unlink($dbFile);
     }
 
-    public function testInviteTextIsSanitized(): void
-    {
+    public function testInviteTextIsSanitized(): void {
         $dbFile = tempnam(sys_get_temp_dir(), 'db');
         $pdo = new \PDO('sqlite:' . $dbFile);
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -9,8 +9,7 @@ use Tests\TestCase;
 
 class HomeControllerTest extends TestCase
 {
-    private function setupDb(): string
-    {
+    private function setupDb(): string {
         $db = tempnam(sys_get_temp_dir(), 'db');
         putenv('MAIN_DOMAIN=main.test');
         $_ENV['MAIN_DOMAIN'] = 'main.test';
@@ -34,8 +33,7 @@ class HomeControllerTest extends TestCase
         return $request->withUri($request->getUri()->withHost('main.test'));
     }
 
-    public function testHomePage(): void
-    {
+    public function testHomePage(): void {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/');
@@ -44,8 +42,7 @@ class HomeControllerTest extends TestCase
         unlink($db);
     }
 
-    public function testEventCatalogOverview(): void
-    {
+    public function testEventCatalogOverview(): void {
         $db = $this->setupDb();
         $this->getAppInstance();
         $pdo = \App\Infrastructure\Database::connectFromEnv();
@@ -69,8 +66,7 @@ class HomeControllerTest extends TestCase
         }
     }
 
-    private function withCompetitionMode(callable $fn): void
-    {
+    private function withCompetitionMode(callable $fn): void {
         // Ensure a fresh database and seed a catalog entry for the tests
         $db = $this->setupDb();
         $this->getAppInstance();
@@ -92,8 +88,7 @@ class HomeControllerTest extends TestCase
         }
     }
 
-    public function testCompetitionRedirect(): void
-    {
+    public function testCompetitionRedirect(): void {
         $this->withCompetitionMode(function () {
             $app = $this->getAppInstance();
             $request = $this->createRequest('GET', '/')->withQueryParams(['event' => 'event']);
@@ -103,8 +98,7 @@ class HomeControllerTest extends TestCase
         });
     }
 
-    public function testCompetitionAllowsCatalog(): void
-    {
+    public function testCompetitionAllowsCatalog(): void {
         $this->withCompetitionMode(function () {
             $app = $this->getAppInstance();
             $request = $this->createRequest('GET', '/')->withQueryParams([
@@ -116,8 +110,7 @@ class HomeControllerTest extends TestCase
         });
     }
 
-    public function testCompetitionAllowsCatalogSlugCaseInsensitive(): void
-    {
+    public function testCompetitionAllowsCatalogSlugCaseInsensitive(): void {
         $this->withCompetitionMode(function () {
             $app = $this->getAppInstance();
             $request = $this->createRequest('GET', '/')->withQueryParams([
@@ -129,8 +122,7 @@ class HomeControllerTest extends TestCase
         });
     }
 
-    public function testEventsAsHomePage(): void
-    {
+    public function testEventsAsHomePage(): void {
         $db = $this->setupDb();
         $this->getAppInstance();
         $pdo = \App\Infrastructure\Database::connectFromEnv();
@@ -149,8 +141,7 @@ class HomeControllerTest extends TestCase
         }
     }
 
-    public function testLandingAsHomePage(): void
-    {
+    public function testLandingAsHomePage(): void {
         $db = $this->setupDb();
         $this->getAppInstance();
         $pdo = \App\Infrastructure\Database::connectFromEnv();
@@ -171,8 +162,7 @@ class HomeControllerTest extends TestCase
         }
     }
 
-    public function testLandingSkippedWithCatalogLink(): void
-    {
+    public function testLandingSkippedWithCatalogLink(): void {
         $db = $this->setupDb();
         $this->getAppInstance();
         $pdo = \App\Infrastructure\Database::connectFromEnv();
@@ -197,8 +187,7 @@ class HomeControllerTest extends TestCase
         }
     }
 
-    public function testLandingShownWithoutParamsDespiteSessionCatalog(): void
-    {
+    public function testLandingShownWithoutParamsDespiteSessionCatalog(): void {
         $db = $this->setupDb();
         $this->getAppInstance();
         $pdo = \App\Infrastructure\Database::connectFromEnv();
@@ -228,8 +217,7 @@ class HomeControllerTest extends TestCase
         }
     }
 
-    public function testHomePageWithSlug(): void
-    {
+    public function testHomePageWithSlug(): void {
         $db = $this->setupDb();
         $this->getAppInstance();
         $pdo = \App\Infrastructure\Database::connectFromEnv();

--- a/tests/Controller/ImportControllerTest.php
+++ b/tests/Controller/ImportControllerTest.php
@@ -18,8 +18,7 @@ use PDO;
 
 class ImportControllerTest extends TestCase
 {
-    private function createServices(): array
-    {
+    private function createServices(): array {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('ev1','ev1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");
@@ -37,8 +36,7 @@ class ImportControllerTest extends TestCase
         ];
     }
 
-    public function testImport(): void
-    {
+    public function testImport(): void {
         [$catalog, $config, $results, $teams, $consents, $summary, $events] = $this->createServices();
         $tmp = sys_get_temp_dir() . '/import_' . uniqid();
         mkdir($tmp . '/kataloge', 0777, true);
@@ -87,8 +85,7 @@ class ImportControllerTest extends TestCase
         rmdir($tmp);
     }
 
-    public function testImportTwiceDoesNotDuplicateSummaryPhotos(): void
-    {
+    public function testImportTwiceDoesNotDuplicateSummaryPhotos(): void {
         [
             $catalog,
             $config,
@@ -138,8 +135,7 @@ class ImportControllerTest extends TestCase
         rmdir($tmp);
     }
 
-    public function testImportRejectsInvalidName(): void
-    {
+    public function testImportRejectsInvalidName(): void {
         [$catalog, $config, $results, $teams, $consents, $summary, $events] = $this->createServices();
         $tmp = sys_get_temp_dir() . '/import_' . uniqid();
         mkdir($tmp, 0777, true);
@@ -164,8 +160,7 @@ class ImportControllerTest extends TestCase
         rmdir($tmp);
     }
 
-    public function testImportRejectsInvalidJsonFile(): void
-    {
+    public function testImportRejectsInvalidJsonFile(): void {
         [$catalog, $config, $results, $teams, $consents, $summary, $events] = $this->createServices();
         $tmp = sys_get_temp_dir() . '/import_' . uniqid();
         mkdir($tmp . '/kataloge', 0777, true);
@@ -195,8 +190,7 @@ class ImportControllerTest extends TestCase
         rmdir($tmp);
     }
 
-    public function testRestoreDefaults(): void
-    {
+    public function testRestoreDefaults(): void {
         [$catalog, $config, $results, $teams, $consents, $summary, $events] = $this->createServices();
         $base = sys_get_temp_dir() . '/import_' . uniqid();
         $default = dirname($base) . '/data-default';
@@ -238,8 +232,7 @@ class ImportControllerTest extends TestCase
         rmdir($default);
     }
 
-    public function testRestoreDefaultsRejectsInvalidJson(): void
-    {
+    public function testRestoreDefaultsRejectsInvalidJson(): void {
         [$catalog, $config, $results, $teams, $consents, $summary, $events] = $this->createServices();
         $base = sys_get_temp_dir() . '/import_' . uniqid();
         mkdir($base, 0777, true);

--- a/tests/Controller/ImpressumControllerTest.php
+++ b/tests/Controller/ImpressumControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class ImpressumControllerTest extends TestCase
 {
-    public function testImpressumPage(): void
-    {
+    public function testImpressumPage(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/impressum');
         $response = $app->handle($request);

--- a/tests/Controller/LandingControllerTest.php
+++ b/tests/Controller/LandingControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class LandingControllerTest extends TestCase
 {
-    protected function setUp(): void
-    {
+    protected function setUp(): void {
         parent::setUp();
         $pdo = $this->getDatabase();
         try {
@@ -24,16 +23,14 @@ HTML;
         }
     }
 
-    public function testLandingPage(): void
-    {
+    public function testLandingPage(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/landing');
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testLandingPageTenant(): void
-    {
+    public function testLandingPageTenant(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
@@ -48,8 +45,7 @@ HTML;
         }
     }
 
-    public function testContactFormHiddenWhenMailConfigMissing(): void
-    {
+    public function testContactFormHiddenWhenMailConfigMissing(): void {
         $host = getenv('SMTP_HOST');
         $user = getenv('SMTP_USER');
         $pass = getenv('SMTP_PASS');
@@ -81,8 +77,7 @@ HTML;
         }
     }
 
-    public function testContactFormVisibleWhenMailConfigured(): void
-    {
+    public function testContactFormVisibleWhenMailConfigured(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -105,8 +100,7 @@ HTML;
         unset($_ENV['SMTP_HOST'], $_ENV['SMTP_USER'], $_ENV['SMTP_PASS']);
     }
 
-    public function testLandingPageIncludesTurnstileWidgetWhenConfigured(): void
-    {
+    public function testLandingPageIncludesTurnstileWidgetWhenConfigured(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -137,8 +131,7 @@ HTML;
         unset($_ENV['TURNSTILE_SITE_KEY'], $_ENV['TURNSTILE_SECRET_KEY']);
     }
 
-    public function testLandingPageContainsFaqLink(): void
-    {
+    public function testLandingPageContainsFaqLink(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/landing');
         $response = $app->handle($request);
@@ -146,8 +139,7 @@ HTML;
         $this->assertStringContainsString('href="/faq"', $body);
     }
 
-    public function testMarketingRouteAliasReturnsLandingPage(): void
-    {
+    public function testMarketingRouteAliasReturnsLandingPage(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
@@ -164,8 +156,7 @@ HTML;
         }
     }
 
-    public function testUnknownMarketingSlugReturns404(): void
-    {
+    public function testUnknownMarketingSlugReturns404(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();

--- a/tests/Controller/LizenzControllerTest.php
+++ b/tests/Controller/LizenzControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class LizenzControllerTest extends TestCase
 {
-    public function testLizenzPage(): void
-    {
+    public function testLizenzPage(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/lizenz');
         $response = $app->handle($request);

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -12,16 +12,14 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class LoginControllerTest extends TestCase
 {
-    protected function setUp(): void
-    {
+    protected function setUp(): void {
         parent::setUp();
         putenv('MAIN_DOMAIN=example.com');
         $_ENV['MAIN_DOMAIN'] = 'example.com';
         $_SERVER['HTTP_HOST'] = 'example.com';
     }
 
-    protected function tearDown(): void
-    {
+    protected function tearDown(): void {
         putenv('MAIN_DOMAIN');
         unset($_ENV['MAIN_DOMAIN'], $_SERVER['HTTP_HOST']);
         parent::tearDown();
@@ -38,8 +36,7 @@ class LoginControllerTest extends TestCase
         return $request->withUri($request->getUri()->withHost('example.com'));
     }
 
-    public function testLoginPageShowsVersion(): void
-    {
+    public function testLoginPageShowsVersion(): void {
         putenv('APP_VERSION=1.2.3');
         $_ENV['APP_VERSION'] = '1.2.3';
 
@@ -52,8 +49,7 @@ class LoginControllerTest extends TestCase
         unset($_ENV['APP_VERSION']);
     }
 
-    public function testLoginPageGeneratesCsrfToken(): void
-    {
+    public function testLoginPageGeneratesCsrfToken(): void {
         $app = $this->getAppInstance();
         $response = $app->handle($this->createRequest('GET', '/login'));
         $this->assertSame(200, $response->getStatusCode());
@@ -64,8 +60,7 @@ class LoginControllerTest extends TestCase
         );
     }
 
-    public function testLoginPersistsSession(): void
-    {
+    public function testLoginPersistsSession(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('alice', 'secret', 'alice@example.com', Roles::ADMIN);
@@ -90,8 +85,7 @@ class LoginControllerTest extends TestCase
         $this->assertSame(1, (int) $stmt->fetchColumn());
     }
 
-    public function testLoginPersistsSessionOnLocalhost(): void
-    {
+    public function testLoginPersistsSessionOnLocalhost(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('frank', 'secret', 'frank@example.com', Roles::ADMIN);
@@ -117,8 +111,7 @@ class LoginControllerTest extends TestCase
         $this->assertSame(1, (int) $stmt->fetchColumn());
     }
 
-    public function testLoginByEmail(): void
-    {
+    public function testLoginByEmail(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('bob', 'secret', 'bob@example.com', Roles::ADMIN);
@@ -136,8 +129,7 @@ class LoginControllerTest extends TestCase
         $this->assertSame(302, $response->getStatusCode());
     }
 
-    public function testLoginWithJsonCharset(): void
-    {
+    public function testLoginWithJsonCharset(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('dave', 'secret', 'dave@example.com', Roles::ADMIN);
@@ -156,8 +148,7 @@ class LoginControllerTest extends TestCase
         $this->assertSame(302, $response->getStatusCode());
     }
 
-    public function testEventManagerLoginRedirectsToAdmin(): void
-    {
+    public function testEventManagerLoginRedirectsToAdmin(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('eva', 'secret', 'eva@example.com', Roles::EVENT_MANAGER);
@@ -183,8 +174,7 @@ class LoginControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testTeamManagerLoginRedirectsToAdmin(): void
-    {
+    public function testTeamManagerLoginRedirectsToAdmin(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('trent', 'secret', 'trent@example.com', Roles::TEAM_MANAGER);
@@ -210,8 +200,7 @@ class LoginControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testLoginRedirectRespectsBasePath(): void
-    {
+    public function testLoginRedirectRespectsBasePath(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('erin', 'secret', 'erin@example.com', Roles::ADMIN);
@@ -237,8 +226,7 @@ class LoginControllerTest extends TestCase
         unset($_ENV['BASE_PATH']);
     }
 
-    public function testLoginRedirectsToMainDomainOnWrongHost(): void
-    {
+    public function testLoginRedirectsToMainDomainOnWrongHost(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('grace', 'secret', 'grace@example.com', Roles::ADMIN);
@@ -266,8 +254,7 @@ class LoginControllerTest extends TestCase
         unset($_ENV['MAIN_DOMAIN'], $_SERVER['HTTP_HOST']);
     }
 
-    public function testUnknownUserShowsMessage(): void
-    {
+    public function testUnknownUserShowsMessage(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['csrf_token'] = 'tok';
@@ -282,8 +269,7 @@ class LoginControllerTest extends TestCase
         $this->assertStringContainsString('Benutzer nicht gefunden', (string) $response->getBody());
     }
 
-    public function testWrongPasswordShowsMessage(): void
-    {
+    public function testWrongPasswordShowsMessage(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('carol', 'secret', 'carol@example.com', Roles::ADMIN);

--- a/tests/Controller/LogoControllerTest.php
+++ b/tests/Controller/LogoControllerTest.php
@@ -13,8 +13,7 @@ use Slim\Psr7\Stream;
 
 class LogoControllerTest extends TestCase
 {
-    public function testGetFallbackLogo(): void
-    {
+    public function testGetFallbackLogo(): void {
         $pdo = $this->createDatabase();
         $cfg = new ConfigService($pdo);
         $cfg->saveConfig([]);
@@ -31,8 +30,7 @@ class LogoControllerTest extends TestCase
         @rename(dirname(__DIR__, 2) . '/data/uploads/logo.webp.bak', dirname(__DIR__, 2) . '/data/uploads/logo.webp');
     }
 
-    public function testPostAndGet(): void
-    {
+    public function testPostAndGet(): void {
         $tmpConfig = tempnam(sys_get_temp_dir(), 'cfg');
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
@@ -80,8 +78,7 @@ class LogoControllerTest extends TestCase
         unlink(sys_get_temp_dir() . '/uploads/logo.png');
     }
 
-    public function testPostAndGetWebp(): void
-    {
+    public function testPostAndGetWebp(): void {
         $tmpConfig = tempnam(sys_get_temp_dir(), 'cfg');
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
@@ -135,8 +132,7 @@ class LogoControllerTest extends TestCase
         unlink(sys_get_temp_dir() . '/uploads/logo.webp');
     }
 
-    public function testLogoPerEvent(): void
-    {
+    public function testLogoPerEvent(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -196,8 +192,7 @@ class LogoControllerTest extends TestCase
         unlink(sys_get_temp_dir() . '/events/e1/images/logo.png');
     }
 
-    public function testGetWithDynamicFilename(): void
-    {
+    public function testGetWithDynamicFilename(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE active_event(event_uid TEXT PRIMARY KEY);');
@@ -245,8 +240,7 @@ class LogoControllerTest extends TestCase
         unlink(sys_get_temp_dir() . '/events/dyn/images/logo.png');
     }
 
-    public function testGetLogoForSpecificEventWhileAnotherActive(): void
-    {
+    public function testGetLogoForSpecificEventWhileAnotherActive(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, sort_order INTEGER DEFAULT 0);');

--- a/tests/Controller/LogoutControllerTest.php
+++ b/tests/Controller/LogoutControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class LogoutControllerTest extends TestCase
 {
-    public function testLogoutRedirectsToLogin(): void
-    {
+    public function testLogoutRedirectsToLogin(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
@@ -20,8 +19,7 @@ class LogoutControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testLogoutRedirectRespectsBasePath(): void
-    {
+    public function testLogoutRedirectRespectsBasePath(): void {
         putenv('BASE_PATH=/base');
         $_ENV['BASE_PATH'] = '/base';
 

--- a/tests/Controller/NginxReloadRouteTest.php
+++ b/tests/Controller/NginxReloadRouteTest.php
@@ -13,8 +13,7 @@ use Tests\TestCase;
 
 class NginxReloadRouteTest extends TestCase
 {
-    public function testRequestSentWhenUrlConfigured(): void
-    {
+    public function testRequestSentWhenUrlConfigured(): void {
         $old = getenv('NGINX_RELOADER_URL');
         putenv('NGINX_RELOAD_TOKEN=changeme');
         putenv('NGINX_RELOADER_URL=http://localhost/reload');

--- a/tests/Controller/OnboardingEmailControllerTest.php
+++ b/tests/Controller/OnboardingEmailControllerTest.php
@@ -10,8 +10,7 @@ use Tests\TestCase;
 
 class OnboardingEmailControllerTest extends TestCase
 {
-    public function testPostRequiresCsrfToken(): void
-    {
+    public function testPostRequiresCsrfToken(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['csrf_token'] = 'tok';
@@ -25,12 +24,10 @@ class OnboardingEmailControllerTest extends TestCase
         $request = $request->withAttribute(
             'mailService',
             new class extends MailService {
-                public function __construct()
-                {
+                public function __construct() {
                 }
 
-                public function sendDoubleOptIn(string $to, string $link): void
-                {
+                public function sendDoubleOptIn(string $to, string $link): void {
                 }
             }
         );
@@ -40,8 +37,7 @@ class OnboardingEmailControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostRespectsRateLimitAndCsrf(): void
-    {
+    public function testPostRespectsRateLimitAndCsrf(): void {
         $app = $this->getAppInstance();
         $pdo = Database::connectFromEnv();
         $pdo->exec(
@@ -66,11 +62,9 @@ class OnboardingEmailControllerTest extends TestCase
 
         $mailer = new class extends MailService {
             public array $sent = [];
-            public function __construct()
-            {
+            public function __construct() {
             }
-            public function sendDoubleOptIn(string $to, string $link): void
-            {
+            public function sendDoubleOptIn(string $to, string $link): void {
                 $this->sent[] = [$to, $link];
             }
         };
@@ -97,8 +91,7 @@ class OnboardingEmailControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostRejectsInvalidEmailAddress(): void
-    {
+    public function testPostRejectsInvalidEmailAddress(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['csrf_token'] = 'tok';
@@ -118,8 +111,7 @@ class OnboardingEmailControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testPostAcceptsTrimmedValidEmail(): void
-    {
+    public function testPostAcceptsTrimmedValidEmail(): void {
         $app = $this->getAppInstance();
         $this->setupEmailConfirmations();
         session_start();
@@ -128,11 +120,9 @@ class OnboardingEmailControllerTest extends TestCase
 
         $mailer = new class extends MailService {
             public array $sent = [];
-            public function __construct()
-            {
+            public function __construct() {
             }
-            public function sendDoubleOptIn(string $to, string $link): void
-            {
+            public function sendDoubleOptIn(string $to, string $link): void {
                 $this->sent[] = [$to, $link];
             }
         };
@@ -154,8 +144,7 @@ class OnboardingEmailControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testTokenCreationStoresTokenAndSendsMail(): void
-    {
+    public function testTokenCreationStoresTokenAndSendsMail(): void {
         $app = $this->getAppInstance();
         $pdo = $this->setupEmailConfirmations();
         session_start();
@@ -164,11 +153,9 @@ class OnboardingEmailControllerTest extends TestCase
 
         $mailer = new class extends MailService {
             public array $sent = [];
-            public function __construct()
-            {
+            public function __construct() {
             }
-            public function sendDoubleOptIn(string $to, string $link): void
-            {
+            public function sendDoubleOptIn(string $to, string $link): void {
                 $this->sent[] = [$to, $link];
             }
         };
@@ -197,8 +184,7 @@ class OnboardingEmailControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testLinkUsesForwardedHeaders(): void
-    {
+    public function testLinkUsesForwardedHeaders(): void {
         $app = $this->getAppInstance();
         $pdo = $this->setupEmailConfirmations();
         session_start();
@@ -207,11 +193,9 @@ class OnboardingEmailControllerTest extends TestCase
 
         $mailer = new class extends MailService {
             public array $sent = [];
-            public function __construct()
-            {
+            public function __construct() {
             }
-            public function sendDoubleOptIn(string $to, string $link): void
-            {
+            public function sendDoubleOptIn(string $to, string $link): void {
                 $this->sent[] = [$to, $link];
             }
         };
@@ -238,8 +222,7 @@ class OnboardingEmailControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testLinkAndRedirectRespectBasePath(): void
-    {
+    public function testLinkAndRedirectRespectBasePath(): void {
         $oldBase = getenv('BASE_PATH');
         putenv('BASE_PATH=/base');
         $_ENV['BASE_PATH'] = '/base';
@@ -252,11 +235,9 @@ class OnboardingEmailControllerTest extends TestCase
 
         $mailer = new class extends MailService {
             public array $sent = [];
-            public function __construct()
-            {
+            public function __construct() {
             }
-            public function sendDoubleOptIn(string $to, string $link): void
-            {
+            public function sendDoubleOptIn(string $to, string $link): void {
                 $this->sent[] = [$to, $link];
             }
         };
@@ -297,8 +278,7 @@ class OnboardingEmailControllerTest extends TestCase
         }
     }
 
-    public function testConfirmValidAndInvalidTokens(): void
-    {
+    public function testConfirmValidAndInvalidTokens(): void {
         $app = $this->getAppInstance();
         $pdo = $this->setupEmailConfirmations();
         session_start();
@@ -306,11 +286,9 @@ class OnboardingEmailControllerTest extends TestCase
         unset($_SESSION['rate:/onboarding/email']);
 
         $mailer = new class extends MailService {
-            public function __construct()
-            {
+            public function __construct() {
             }
-            public function sendDoubleOptIn(string $to, string $link): void
-            {
+            public function sendDoubleOptIn(string $to, string $link): void {
             }
         };
         $request = $this->createRequest('POST', '/onboarding/email', [
@@ -343,19 +321,16 @@ class OnboardingEmailControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testStatusEndpointReturns404AfterTokenRemoval(): void
-    {
+    public function testStatusEndpointReturns404AfterTokenRemoval(): void {
         $app = $this->getAppInstance();
         $pdo = $this->setupEmailConfirmations();
         session_start();
         $_SESSION['csrf_token'] = 'tok';
 
         $mailer = new class extends MailService {
-            public function __construct()
-            {
+            public function __construct() {
             }
-            public function sendDoubleOptIn(string $to, string $link): void
-            {
+            public function sendDoubleOptIn(string $to, string $link): void {
             }
         };
         $request = $this->createRequest('POST', '/onboarding/email', [
@@ -383,8 +358,7 @@ class OnboardingEmailControllerTest extends TestCase
         session_destroy();
     }
 
-    private function setupEmailConfirmations(): \PDO
-    {
+    private function setupEmailConfirmations(): \PDO {
         $pdo = Database::connectFromEnv();
         $pdo->exec('DROP TABLE IF EXISTS email_confirmations');
         $pdo->exec(

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -13,8 +13,7 @@ class PageControllerTest extends TestCase
     /**
      * @dataProvider editableSlugProvider
      */
-    public function testEditPageIsAccessible(string $slug, string $title): void
-    {
+    public function testEditPageIsAccessible(string $slug, string $title): void {
         $pdo = $this->getDatabase();
         $this->seedPage($pdo, $slug, $title, '<p>content</p>');
 
@@ -28,8 +27,7 @@ class PageControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testUpdatePersistsContent(): void
-    {
+    public function testUpdatePersistsContent(): void {
         $pdo = $this->getDatabase();
         $this->seedPage($pdo, 'landing', 'Landing', '<p>old</p>');
 
@@ -53,8 +51,7 @@ class PageControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testDeleteRemovesPage(): void
-    {
+    public function testDeleteRemovesPage(): void {
         $pdo = $this->getDatabase();
         $this->seedPage($pdo, 'landing', 'Landing', '<p>content</p>');
 
@@ -77,8 +74,7 @@ class PageControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testInvalidSlug(): void
-    {
+    public function testInvalidSlug(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
@@ -89,8 +85,7 @@ class PageControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testCreatePageSuccess(): void
-    {
+    public function testCreatePageSuccess(): void {
         $pdo = $this->getDatabase();
         $pdo->exec("DELETE FROM pages WHERE slug = 'neue-seite'");
 
@@ -128,8 +123,7 @@ class PageControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testCreatePageValidationError(): void
-    {
+    public function testCreatePageValidationError(): void {
         $pdo = $this->getDatabase();
         $pdo->exec("DELETE FROM pages WHERE slug = 'invalid'");
 
@@ -162,8 +156,7 @@ class PageControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testCreatePageConflict(): void
-    {
+    public function testCreatePageConflict(): void {
         $pdo = $this->getDatabase();
         $this->seedPage($pdo, 'konflikt', 'Konflikt', '<p>Alt</p>');
 
@@ -200,8 +193,7 @@ class PageControllerTest extends TestCase
     /**
      * @return array<int, array{0:string,1:string}>
      */
-    public function editableSlugProvider(): array
-    {
+    public function editableSlugProvider(): array {
         return [
             ['landing', 'Landing'],
             ['calserver', 'calServer'],
@@ -209,8 +201,7 @@ class PageControllerTest extends TestCase
         ];
     }
 
-    private function seedPage(PDO $pdo, string $slug, string $title, string $content): void
-    {
+    private function seedPage(PDO $pdo, string $slug, string $title, string $content): void {
         $stmt = $pdo->prepare('DELETE FROM pages WHERE slug = ?');
         $stmt->execute([$slug]);
 

--- a/tests/Controller/PasswordControllerTest.php
+++ b/tests/Controller/PasswordControllerTest.php
@@ -12,8 +12,7 @@ use Tests\TestCase;
 
 class PasswordControllerTest extends TestCase
 {
-    private function createUser(): UserService
-    {
+    private function createUser(): UserService {
         $pdo = Database::connectFromEnv();
         Migrator::migrate($pdo, __DIR__ . '/../../migrations');
         $service = new UserService($pdo);
@@ -21,8 +20,7 @@ class PasswordControllerTest extends TestCase
         return $service;
     }
 
-    public function testRejectWeakPassword(): void
-    {
+    public function testRejectWeakPassword(): void {
         putenv('POSTGRES_DSN=');
         putenv('POSTGRES_USER=');
         putenv('POSTGRES_PASSWORD=');
@@ -44,8 +42,7 @@ class PasswordControllerTest extends TestCase
         session_destroy();
     }
 
-    public function testAcceptStrongPassword(): void
-    {
+    public function testAcceptStrongPassword(): void {
         putenv('POSTGRES_DSN=');
         putenv('POSTGRES_USER=');
         putenv('POSTGRES_PASSWORD=');

--- a/tests/Controller/PasswordResetFlowTest.php
+++ b/tests/Controller/PasswordResetFlowTest.php
@@ -13,8 +13,7 @@ use Tests\TestCase;
 
 class PasswordResetFlowTest extends TestCase
 {
-    public function testFullResetFlow(): void
-    {
+    public function testFullResetFlow(): void {
         putenv('PASSWORD_RESET_SECRET=secret');
         $_ENV['PASSWORD_RESET_SECRET'] = 'secret';
         putenv('POSTGRES_DSN=');
@@ -45,12 +44,10 @@ class PasswordResetFlowTest extends TestCase
         {
             public array $sent = [];
 
-            public function __construct()
-            {
+            public function __construct() {
             }
 
-            public function sendPasswordReset(string $to, string $link): void
-            {
+            public function sendPasswordReset(string $to, string $link): void {
                 $this->sent[] = ['to' => $to, 'link' => $link];
             }
         };
@@ -98,8 +95,7 @@ class PasswordResetFlowTest extends TestCase
         $this->assertTrue(password_verify('Str0ngPass1', (string)$updated['password']));
     }
 
-    public function testRejectWeakPassword(): void
-    {
+    public function testRejectWeakPassword(): void {
         putenv('PASSWORD_RESET_SECRET=secret');
         $_ENV['PASSWORD_RESET_SECRET'] = 'secret';
         putenv('POSTGRES_DSN=');
@@ -123,12 +119,10 @@ class PasswordResetFlowTest extends TestCase
         {
             public array $sent = [];
 
-            public function __construct()
-            {
+            public function __construct() {
             }
 
-            public function sendPasswordReset(string $to, string $link): void
-            {
+            public function sendPasswordReset(string $to, string $link): void {
                 $this->sent[] = ['to' => $to, 'link' => $link];
             }
         };
@@ -166,8 +160,7 @@ class PasswordResetFlowTest extends TestCase
         $this->assertTrue(password_verify('oldpass', (string)$updated['password']));
     }
 
-    public function testRejectMismatchedPasswords(): void
-    {
+    public function testRejectMismatchedPasswords(): void {
         putenv('PASSWORD_RESET_SECRET=secret');
         $_ENV['PASSWORD_RESET_SECRET'] = 'secret';
         putenv('POSTGRES_DSN=');
@@ -191,12 +184,10 @@ class PasswordResetFlowTest extends TestCase
         {
             public array $sent = [];
 
-            public function __construct()
-            {
+            public function __construct() {
             }
 
-            public function sendPasswordReset(string $to, string $link): void
-            {
+            public function sendPasswordReset(string $to, string $link): void {
                 $this->sent[] = ['to' => $to, 'link' => $link];
             }
         };
@@ -234,8 +225,7 @@ class PasswordResetFlowTest extends TestCase
         $this->assertTrue(password_verify('oldpass', (string)$updated['password']));
     }
 
-    public function testRejectMissingPasswordRepeat(): void
-    {
+    public function testRejectMissingPasswordRepeat(): void {
         putenv('PASSWORD_RESET_SECRET=secret');
         $_ENV['PASSWORD_RESET_SECRET'] = 'secret';
         putenv('POSTGRES_DSN=');
@@ -259,12 +249,10 @@ class PasswordResetFlowTest extends TestCase
         {
             public array $sent = [];
 
-            public function __construct()
-            {
+            public function __construct() {
             }
 
-            public function sendPasswordReset(string $to, string $link): void
-            {
+            public function sendPasswordReset(string $to, string $link): void {
                 $this->sent[] = ['to' => $to, 'link' => $link];
             }
         };

--- a/tests/Controller/PasswordResetRequestTest.php
+++ b/tests/Controller/PasswordResetRequestTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class PasswordResetRequestTest extends TestCase
 {
-    public function testRenderResetRequestForm(): void
-    {
+    public function testRenderResetRequestForm(): void {
         $app = $this->getAppInstance();
         session_start();
         $response = $app->handle($this->createRequest('GET', '/password/reset/request'));

--- a/tests/Controller/PlayerProfileTest.php
+++ b/tests/Controller/PlayerProfileTest.php
@@ -9,8 +9,7 @@ use Slim\Psr7\Factory\StreamFactory;
 
 class PlayerProfileTest extends TestCase
 {
-    public function testProfilePageAndApiPlayers(): void
-    {
+    public function testProfilePageAndApiPlayers(): void {
         $pdo = $this->getDatabase();
         $pdo->exec("INSERT INTO events(uid, slug, name) VALUES('ev1','ev1','Test')");
 

--- a/tests/Controller/ProfileAccessTest.php
+++ b/tests/Controller/ProfileAccessTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class ProfileAccessTest extends TestCase
 {
-    private function setupDb(): string
-    {
+    private function setupDb(): string {
         $db = tempnam(sys_get_temp_dir(), 'db');
         putenv('POSTGRES_DSN=sqlite:' . $db);
         putenv('POSTGRES_USER=');
@@ -20,8 +19,7 @@ class ProfileAccessTest extends TestCase
         return $db;
     }
 
-    public function testNonAdminCanAccessProfileAndSubscription(): void
-    {
+    public function testNonAdminCanAccessProfileAndSubscription(): void {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -11,8 +11,7 @@ use PDO;
 
 class ProfileControllerTest extends TestCase
 {
-    private function setupDb(): string
-    {
+    private function setupDb(): string {
         $db = tempnam(sys_get_temp_dir(), 'db');
         putenv('POSTGRES_DSN=sqlite:' . $db);
         putenv('POSTGRES_USER=');
@@ -23,8 +22,7 @@ class ProfileControllerTest extends TestCase
         return $db;
     }
 
-    public function testUpdateProfileMainDomain(): void
-    {
+    public function testUpdateProfileMainDomain(): void {
         $db = $this->setupDb();
         putenv('MAIN_DOMAIN=example.com');
         $_ENV['MAIN_DOMAIN'] = 'example.com';

--- a/tests/Controller/ProfileWelcomeControllerTest.php
+++ b/tests/Controller/ProfileWelcomeControllerTest.php
@@ -13,8 +13,7 @@ use PDO;
 
 class ProfileWelcomeControllerTest extends TestCase
 {
-    public function testResendWelcomeMail(): void
-    {
+    public function testResendWelcomeMail(): void {
         putenv('MAIN_DOMAIN=example.com');
         $_ENV['MAIN_DOMAIN'] = 'example.com';
         putenv('SMTP_HOST=localhost');
@@ -34,13 +33,11 @@ class ProfileWelcomeControllerTest extends TestCase
         $mailer = new class ($twig) extends MailService {
             public array $messages = [];
 
-            protected function createTransport(string $dsn): \Symfony\Component\Mailer\MailerInterface
-            {
+            protected function createTransport(string $dsn): \Symfony\Component\Mailer\MailerInterface {
                 return new class ($this) implements \Symfony\Component\Mailer\MailerInterface {
                     private $outer;
 
-                    public function __construct($outer)
-                    {
+                    public function __construct($outer) {
                         $this->outer = $outer;
                     }
 

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -12,15 +12,13 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class QrControllerTest extends TestCase
 {
-    protected function setUp(): void
-    {
+    protected function setUp(): void {
         parent::setUp();
         putenv('MAIN_DOMAIN=example.com');
         $_ENV['MAIN_DOMAIN'] = 'example.com';
     }
 
-    protected function tearDown(): void
-    {
+    protected function tearDown(): void {
         putenv('MAIN_DOMAIN');
         unset($_ENV['MAIN_DOMAIN']);
         parent::tearDown();
@@ -38,8 +36,7 @@ class QrControllerTest extends TestCase
         return $request->withHeader('Host', 'example.com')->withUri($uri);
     }
 
-    public function testQrImageIsGenerated(): void
-    {
+    public function testQrImageIsGenerated(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/qr.png')->withQueryParams(['t' => 'Test']);
         $response = $app->handle($request);
@@ -49,8 +46,7 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
-    public function testQrImageFallbackWhenTextMissing(): void
-    {
+    public function testQrImageFallbackWhenTextMissing(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/qr.png');
         $response = $app->handle($request);
@@ -60,8 +56,7 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
-    public function testQrImageSvgFormat(): void
-    {
+    public function testQrImageSvgFormat(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/qr.png')
             ->withQueryParams(['t' => 'Demo', 'format' => 'svg']);
@@ -72,8 +67,7 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
-    public function testQrImageAllowsCustomColors(): void
-    {
+    public function testQrImageAllowsCustomColors(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/qr.png')
             ->withQueryParams([
@@ -88,8 +82,7 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
-    public function testCatalogQrDefaults(): void
-    {
+    public function testCatalogQrDefaults(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/qr/catalog');
         $response = $app->handle($request);
@@ -99,8 +92,7 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
-    public function testEventQrDefaults(): void
-    {
+    public function testEventQrDefaults(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/qr/event')->withQueryParams(['event' => '1']);
         $response = $app->handle($request);
@@ -110,8 +102,7 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
-    public function testTeamQrDefaults(): void
-    {
+    public function testTeamQrDefaults(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/qr/team');
         $response = $app->handle($request);
@@ -121,8 +112,7 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
-    public function testTeamQrSvgFormat(): void
-    {
+    public function testTeamQrSvgFormat(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/qr/team')
             ->withQueryParams(['format' => 'svg']);
@@ -133,8 +123,7 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty((string) $response->getBody());
     }
 
-    public function testTeamQrWebpLogo(): void
-    {
+    public function testTeamQrWebpLogo(): void {
         $logoFile = dirname(__DIR__, 2) . '/data/test-logo.webp';
         imagewebp(imagecreatetruecolor(10, 10), $logoFile);
 
@@ -152,8 +141,7 @@ class QrControllerTest extends TestCase
         @unlink($logoFile);
     }
 
-    public function testQrPdfIsGenerated(): void
-    {
+    public function testQrPdfIsGenerated(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/qr.pdf')->withQueryParams(['t' => 'Test', 'event' => '1']);
         $response = $app->handle($request);
@@ -164,8 +152,7 @@ class QrControllerTest extends TestCase
         $this->assertNotEmpty($pdf);
     }
 
-    public function testPdfUsesUploadedLogo(): void
-    {
+    public function testPdfUsesUploadedLogo(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -242,8 +229,7 @@ class QrControllerTest extends TestCase
         unlink(sys_get_temp_dir() . '/uploads/logo.png');
     }
 
-    public function testInvitePlaceholderIsReplaced(): void
-    {
+    public function testInvitePlaceholderIsReplaced(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -309,8 +295,7 @@ class QrControllerTest extends TestCase
         $this->assertStringContainsString('Event', $pdf);
     }
 
-    public function testInviteTextIsSanitizedInPdf(): void
-    {
+    public function testInviteTextIsSanitizedInPdf(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -353,8 +338,7 @@ class QrControllerTest extends TestCase
         $this->assertStringNotContainsString('<script', $pdf);
     }
 
-    public function testAllInvitationsPdfIsGenerated(): void
-    {
+    public function testAllInvitationsPdfIsGenerated(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -421,8 +405,7 @@ class QrControllerTest extends TestCase
         $this->assertEquals(2, substr_count($pdf, 'Event'));
     }
 
-    public function testInvitesPdfUsesResultsWhenTeamsMissing(): void
-    {
+    public function testInvitesPdfUsesResultsWhenTeamsMissing(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -509,8 +492,7 @@ class QrControllerTest extends TestCase
         $this->assertEquals(2, substr_count($pdf, 'Event'));
     }
 
-    public function testInvitesPdfReturnsErrorWhenNoTeams(): void
-    {
+    public function testInvitesPdfReturnsErrorWhenNoTeams(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -540,8 +522,7 @@ class QrControllerTest extends TestCase
         $this->assertSame(404, $response->getStatusCode());
     }
 
-    public function testActiveEventSwitchUpdatesPdf(): void
-    {
+    public function testActiveEventSwitchUpdatesPdf(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -8,16 +8,14 @@ use Tests\TestCase;
 
 class ResultControllerTest extends TestCase
 {
-    public function testQuestionResultsEndpoint(): void
-    {
+    public function testQuestionResultsEndpoint(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/question-results.json');
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testResultsPdfIsGenerated(): void
-    {
+    public function testResultsPdfIsGenerated(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -138,8 +136,7 @@ class ResultControllerTest extends TestCase
         $this->assertStringContainsString('Punkte: 0 von 0', $pdf);
     }
 
-    public function testPdfReflectsActiveEvent(): void
-    {
+    public function testPdfReflectsActiveEvent(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(

--- a/tests/Controller/StripeCheckoutControllerTest.php
+++ b/tests/Controller/StripeCheckoutControllerTest.php
@@ -9,8 +9,7 @@ use Tests\TestCase;
 
 class StripeCheckoutControllerTest extends TestCase
 {
-    public function testPostRequiresSubdomain(): void
-    {
+    public function testPostRequiresSubdomain(): void {
         putenv('STRIPE_SECRET_KEY=key');
         putenv('STRIPE_PUBLISHABLE_KEY=pub');
         putenv('STRIPE_WEBHOOK_SECRET=wh');
@@ -33,8 +32,7 @@ class StripeCheckoutControllerTest extends TestCase
         $this->assertSame(422, $response->getStatusCode());
     }
 
-    public function testPostStartsCheckoutWithReference(): void
-    {
+    public function testPostStartsCheckoutWithReference(): void {
         putenv('STRIPE_SECRET_KEY=key');
         putenv('STRIPE_PUBLISHABLE_KEY=pub');
         putenv('STRIPE_WEBHOOK_SECRET=wh');
@@ -48,8 +46,7 @@ class StripeCheckoutControllerTest extends TestCase
         $service = new class extends StripeService {
             public array $args = [];
 
-            public function __construct()
-            {
+            public function __construct() {
             }
             public function createCheckoutSession(
                 string $priceId,
@@ -89,8 +86,7 @@ class StripeCheckoutControllerTest extends TestCase
         $this->assertStringContainsString('/onboarding/checkout/{CHECKOUT_SESSION_ID}', $service->args['create'][1] ?? '');
     }
 
-    public function testPostReturnsCheckoutUrl(): void
-    {
+    public function testPostReturnsCheckoutUrl(): void {
         putenv('STRIPE_SECRET_KEY=key');
         putenv('STRIPE_PUBLISHABLE_KEY=pub');
         putenv('STRIPE_WEBHOOK_SECRET=wh');
@@ -102,8 +98,7 @@ class StripeCheckoutControllerTest extends TestCase
         session_start();
         $_SESSION['csrf_token'] = 'tok';
         $service = new class extends StripeService {
-            public function __construct()
-            {
+            public function __construct() {
             }
             public function createCheckoutSession(
                 string $priceId,

--- a/tests/Controller/StripeSessionControllerTest.php
+++ b/tests/Controller/StripeSessionControllerTest.php
@@ -9,18 +9,15 @@ use Tests\TestCase;
 
 final class StripeSessionControllerTest extends TestCase
 {
-    public function testUsesSessionIdFromRoute(): void
-    {
+    public function testUsesSessionIdFromRoute(): void {
         $app = $this->getAppInstance();
         $service = new class extends StripeService {
             public array $args = [];
 
-            public function __construct()
-            {
+            public function __construct() {
             }
 
-            public function getCheckoutSessionInfo(string $sessionId): array
-            {
+            public function getCheckoutSessionInfo(string $sessionId): array {
                 $this->args[] = $sessionId;
                 return [
                     'paid' => true,

--- a/tests/Controller/StripeWebhookControllerTest.php
+++ b/tests/Controller/StripeWebhookControllerTest.php
@@ -14,8 +14,7 @@ class StripeWebhookControllerTest extends TestCase
     /**
      * Create a signed Stripe webhook request for the given payload.
      */
-    private function createSignedRequest(string $payload): Request
-    {
+    private function createSignedRequest(string $payload): Request {
         $secret = getenv('STRIPE_WEBHOOK_SECRET') ?: '';
         $timestamp = (string) time();
         $signature = hash_hmac('sha256', $timestamp . '.' . $payload, $secret);
@@ -29,17 +28,14 @@ class StripeWebhookControllerTest extends TestCase
         return $request;
     }
 
-    public function testCheckoutSessionCompletedCreatesTenantFromOnboardingData(): void
-    {
+    public function testCheckoutSessionCompletedCreatesTenantFromOnboardingData(): void {
         putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
         $pdo = new class ('sqlite::memory:') extends \PDO {
-            public function __construct(string $dsn)
-            {
+            public function __construct(string $dsn) {
                 parent::__construct($dsn);
             }
 
-            public function exec($statement): int|false
-            {
+            public function exec($statement): int|false {
                 if (
                     preg_match('/^(CREATE|DROP) SCHEMA/i', $statement)
                     || str_starts_with($statement, 'SET search_path')
@@ -104,8 +100,7 @@ class StripeWebhookControllerTest extends TestCase
         $this->assertSame(1, $count);
     }
 
-    public function testCheckoutSessionCompletedUpdatesCustomerId(): void
-    {
+    public function testCheckoutSessionCompletedUpdatesCustomerId(): void {
         putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
         $app = $this->getAppInstance();
         $pdo = Database::connectFromEnv();
@@ -138,8 +133,7 @@ class StripeWebhookControllerTest extends TestCase
         $this->assertEquals('starter', $row['plan']);
     }
 
-    public function testCustomerSubscriptionUpdatedUpdatesDetails(): void
-    {
+    public function testCustomerSubscriptionUpdatedUpdatesDetails(): void {
         putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
         $app = $this->getAppInstance();
         $pdo = Database::connectFromEnv();
@@ -179,8 +173,7 @@ class StripeWebhookControllerTest extends TestCase
         $this->assertSame('0', (string) $row['stripe_cancel_at_period_end']);
     }
 
-    public function testCustomerSubscriptionDeletedMarksStatusCanceled(): void
-    {
+    public function testCustomerSubscriptionDeletedMarksStatusCanceled(): void {
         putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
         $app = $this->getAppInstance();
         $pdo = Database::connectFromEnv();
@@ -207,8 +200,7 @@ class StripeWebhookControllerTest extends TestCase
         $this->assertEquals('canceled', $row['stripe_status']);
     }
 
-    public function testInvoicePaidUpdatesStripeStatus(): void
-    {
+    public function testInvoicePaidUpdatesStripeStatus(): void {
         putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
         $app = $this->getAppInstance();
         $pdo = Database::connectFromEnv();
@@ -234,8 +226,7 @@ class StripeWebhookControllerTest extends TestCase
         $this->assertEquals('paid', $row['stripe_status']);
     }
 
-    public function testInvoicePaymentFailedSetsStripeStatusPastDue(): void
-    {
+    public function testInvoicePaymentFailedSetsStripeStatusPastDue(): void {
         putenv('STRIPE_WEBHOOK_SECRET=whsec_test');
         $app = $this->getAppInstance();
         $pdo = Database::connectFromEnv();
@@ -261,8 +252,7 @@ class StripeWebhookControllerTest extends TestCase
         $this->assertEquals('past_due', $row['stripe_status']);
     }
 
-    public function testMissingSecretReturns500AndLogs(): void
-    {
+    public function testMissingSecretReturns500AndLogs(): void {
         putenv('STRIPE_WEBHOOK_SECRET=');
         $logFile = __DIR__ . '/../../logs/stripe.log';
         @unlink($logFile);

--- a/tests/Controller/SummaryControllerTest.php
+++ b/tests/Controller/SummaryControllerTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class SummaryControllerTest extends TestCase
 {
-    public function testSummaryPage(): void
-    {
+    public function testSummaryPage(): void {
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/summary');
         $response = $app->handle($request);

--- a/tests/Controller/TeamControllerTest.php
+++ b/tests/Controller/TeamControllerTest.php
@@ -14,8 +14,7 @@ use Tests\TestCase;
 
 class TeamControllerTest extends TestCase
 {
-    public function testPostExceedingTeamLimitReturns402(): void
-    {
+    public function testPostExceedingTeamLimitReturns402(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('e1')");

--- a/tests/Controller/TenantControllerTest.php
+++ b/tests/Controller/TenantControllerTest.php
@@ -13,8 +13,7 @@ use Slim\Psr7\Factory\StreamFactory;
 
 class TenantControllerTest extends TestCase
 {
-    private function setupDb(): string
-    {
+    private function setupDb(): string {
         $db = tempnam(sys_get_temp_dir(), 'db');
         putenv('POSTGRES_DSN=sqlite:' . $db);
         putenv('POSTGRES_USER=');
@@ -25,11 +24,9 @@ class TenantControllerTest extends TestCase
         return $db;
     }
 
-    public function testCreateReturns201(): void
-    {
+    public function testCreateReturns201(): void {
         $service = new class extends TenantService {
-            public function __construct()
-            {
+            public function __construct() {
             }
 
             public function createTenant(
@@ -46,8 +43,7 @@ class TenantControllerTest extends TestCase
             ): void {
             }
 
-            public function deleteTenant(string $uid): void
-            {
+            public function deleteTenant(string $uid): void {
             }
         };
         $controller = new TenantController($service);
@@ -62,14 +58,12 @@ class TenantControllerTest extends TestCase
         $this->assertEquals(201, $response->getStatusCode());
     }
 
-    public function testCreateStoresEmail(): void
-    {
+    public function testCreateStoresEmail(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec('CREATE TABLE tenants(uid TEXT, subdomain TEXT, imprint_email TEXT)');
         $service = new class ($pdo) extends TenantService {
             private PDO $pdo;
-            public function __construct(PDO $pdo)
-            {
+            public function __construct(PDO $pdo) {
                 $this->pdo = $pdo;
             }
 
@@ -89,8 +83,7 @@ class TenantControllerTest extends TestCase
                 $stmt->execute([$uid, $schema, $email]);
             }
 
-            public function deleteTenant(string $uid): void
-            {
+            public function deleteTenant(string $uid): void {
             }
         };
         $controller = new TenantController($service);
@@ -107,11 +100,9 @@ class TenantControllerTest extends TestCase
         $this->assertSame('stored@example.com', $email);
     }
 
-    public function testDeleteReturns204(): void
-    {
+    public function testDeleteReturns204(): void {
         $service = new class extends TenantService {
-            public function __construct()
-            {
+            public function __construct() {
             }
 
             public function createTenant(
@@ -128,8 +119,7 @@ class TenantControllerTest extends TestCase
             ): void {
             }
 
-            public function deleteTenant(string $uid): void
-            {
+            public function deleteTenant(string $uid): void {
             }
         };
         $controller = new TenantController($service);
@@ -140,8 +130,7 @@ class TenantControllerTest extends TestCase
         $this->assertEquals(204, $response->getStatusCode());
     }
 
-    public function testCreateDeniedForNonAdmin(): void
-    {
+    public function testCreateDeniedForNonAdmin(): void {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
@@ -154,8 +143,7 @@ class TenantControllerTest extends TestCase
         unlink($db);
     }
 
-    public function testDeleteDeniedForNonAdmin(): void
-    {
+    public function testDeleteDeniedForNonAdmin(): void {
         $db = $this->setupDb();
         $app = $this->getAppInstance();
         session_start();
@@ -168,8 +156,7 @@ class TenantControllerTest extends TestCase
         unlink($db);
     }
 
-    public function testCreateForbiddenOnTenantDomain(): void
-    {
+    public function testCreateForbiddenOnTenantDomain(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
@@ -187,8 +174,7 @@ class TenantControllerTest extends TestCase
         }
     }
 
-    public function testDeleteForbiddenOnTenantDomain(): void
-    {
+    public function testDeleteForbiddenOnTenantDomain(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main.test');
         $app = $this->getAppInstance();
@@ -206,8 +192,7 @@ class TenantControllerTest extends TestCase
         }
     }
 
-    public function testExistsReturns404ForUnknown(): void
-    {
+    public function testExistsReturns404ForUnknown(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec(
             'CREATE TABLE tenants('
@@ -238,8 +223,7 @@ class TenantControllerTest extends TestCase
         $this->assertEquals(404, $res->getStatusCode());
     }
 
-    public function testExistsReturns200ForExisting(): void
-    {
+    public function testExistsReturns200ForExisting(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec(
             'CREATE TABLE tenants('
@@ -277,8 +261,7 @@ class TenantControllerTest extends TestCase
         $this->assertEquals(200, $res->getStatusCode());
     }
 
-    public function testExistsReturns200ForReserved(): void
-    {
+    public function testExistsReturns200ForReserved(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->exec(
             'CREATE TABLE tenants('
@@ -309,17 +292,14 @@ class TenantControllerTest extends TestCase
         $this->assertEquals(200, $res->getStatusCode());
     }
 
-    public function testExistsReturns200IfTablesExist(): void
-    {
+    public function testExistsReturns200IfTablesExist(): void {
         $pdo = new class ('sqlite::memory:') extends PDO
         {
-            public function __construct($dsn)
-            {
+            public function __construct($dsn) {
                 parent::__construct($dsn);
             }
 
-            public function getAttribute($attr): mixed
-            {
+            public function getAttribute($attr): mixed {
                 if ($attr === PDO::ATTR_DRIVER_NAME) {
                     return 'pgsql';
                 }
@@ -345,11 +325,9 @@ class TenantControllerTest extends TestCase
         $this->assertEquals(200, $res->getStatusCode());
     }
 
-    public function testCreateHandlesPdoException(): void
-    {
+    public function testCreateHandlesPdoException(): void {
         $service = new class extends TenantService {
-            public function __construct()
-            {
+            public function __construct() {
             }
 
             public function createTenant(
@@ -367,8 +345,7 @@ class TenantControllerTest extends TestCase
                 throw new \PDOException('fail');
             }
 
-            public function deleteTenant(string $uid): void
-            {
+            public function deleteTenant(string $uid): void {
             }
         };
         $controller = new TenantController($service);
@@ -381,11 +358,9 @@ class TenantControllerTest extends TestCase
         $this->assertStringContainsString('fail', (string) $res->getBody());
     }
 
-    public function testCreateHandlesThrowable(): void
-    {
+    public function testCreateHandlesThrowable(): void {
         $service = new class extends TenantService {
-            public function __construct()
-            {
+            public function __construct() {
             }
 
             public function createTenant(
@@ -403,8 +378,7 @@ class TenantControllerTest extends TestCase
                 throw new \Exception('boom');
             }
 
-            public function deleteTenant(string $uid): void
-            {
+            public function deleteTenant(string $uid): void {
             }
         };
         $controller = new TenantController($service);
@@ -417,16 +391,13 @@ class TenantControllerTest extends TestCase
         $this->assertStringContainsString('boom', (string) $res->getBody());
     }
 
-    public function testListPassesQueryToService(): void
-    {
+    public function testListPassesQueryToService(): void {
         $service = new class extends TenantService {
             public string $received = '';
-            public function __construct()
-            {
+            public function __construct() {
             }
 
-            public function getAll(string $query = ''): array
-            {
+            public function getAll(string $query = ''): array {
                 $this->received = $query;
                 return [];
             }

--- a/tests/Controller/TenantWelcomeRouteTest.php
+++ b/tests/Controller/TenantWelcomeRouteTest.php
@@ -13,8 +13,7 @@ use PDO;
 
 class TenantWelcomeRouteTest extends TestCase
 {
-    public function testSendWelcomeMail(): void
-    {
+    public function testSendWelcomeMail(): void {
         putenv('MAIN_DOMAIN=example.com');
         $_ENV['MAIN_DOMAIN'] = 'example.com';
         putenv('SMTP_HOST=localhost');
@@ -34,13 +33,11 @@ class TenantWelcomeRouteTest extends TestCase
         $mailer = new class ($twig) extends MailService {
             public array $messages = [];
 
-            protected function createTransport(string $dsn): \Symfony\Component\Mailer\MailerInterface
-            {
+            protected function createTransport(string $dsn): \Symfony\Component\Mailer\MailerInterface {
                 return new class ($this) implements \Symfony\Component\Mailer\MailerInterface {
                     private $outer;
 
-                    public function __construct($outer)
-                    {
+                    public function __construct($outer) {
                         $this->outer = $outer;
                     }
 

--- a/tests/Controller/UpgradeTenantRouteTest.php
+++ b/tests/Controller/UpgradeTenantRouteTest.php
@@ -9,8 +9,7 @@ use Tests\TestCase;
 
 class UpgradeTenantRouteTest extends TestCase
 {
-    public function testUpgradeWorksWithoutTag(): void
-    {
+    public function testUpgradeWorksWithoutTag(): void {
         $script = __DIR__ . '/../../scripts/upgrade_tenant.sh';
         $backup = $script . '.bak';
         rename($script, $backup);

--- a/tests/DeleteTenantScriptTest.php
+++ b/tests/DeleteTenantScriptTest.php
@@ -8,8 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class DeleteTenantScriptTest extends TestCase
 {
-    public function testDeleteTenantRemovesSslArtifacts(): void
-    {
+    public function testDeleteTenantRemovesSslArtifacts(): void {
         $slug = 't' . bin2hex(random_bytes(3));
         $root = dirname(__DIR__);
         $domain = 'example.test';

--- a/tests/DomainMiddlewareTest.php
+++ b/tests/DomainMiddlewareTest.php
@@ -14,8 +14,7 @@ use Slim\Psr7\Response;
 
 class DomainMiddlewareTest extends TestCase
 {
-    public function testWwwHostTreatedAsMain(): void
-    {
+    public function testWwwHostTreatedAsMain(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main-domain.tld');
         $oldMarketing = getenv('MARKETING_DOMAINS');
@@ -28,8 +27,7 @@ class DomainMiddlewareTest extends TestCase
         $handler = new class implements RequestHandlerInterface {
             public ?Request $request = null;
 
-            public function handle(Request $request): ResponseInterface
-            {
+            public function handle(Request $request): ResponseInterface {
                 $this->request = $request;
                 return new Response();
             }
@@ -42,8 +40,7 @@ class DomainMiddlewareTest extends TestCase
         $this->restoreEnv('MARKETING_DOMAINS', $oldMarketing);
     }
 
-    public function testAdminHostTreatedAsMain(): void
-    {
+    public function testAdminHostTreatedAsMain(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main-domain.tld');
         $oldMarketing = getenv('MARKETING_DOMAINS');
@@ -56,8 +53,7 @@ class DomainMiddlewareTest extends TestCase
         $handler = new class implements RequestHandlerInterface {
             public ?Request $request = null;
 
-            public function handle(Request $request): ResponseInterface
-            {
+            public function handle(Request $request): ResponseInterface {
                 $this->request = $request;
                 return new Response();
             }
@@ -70,8 +66,7 @@ class DomainMiddlewareTest extends TestCase
         $this->restoreEnv('MARKETING_DOMAINS', $oldMarketing);
     }
 
-    public function testMissingMainDomainReturnsError(): void
-    {
+    public function testMissingMainDomainReturnsError(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN');
         $oldMarketing = getenv('MARKETING_DOMAINS');
@@ -85,8 +80,7 @@ class DomainMiddlewareTest extends TestCase
         $handler = new class implements RequestHandlerInterface {
             public bool $handled = false;
 
-            public function handle(Request $request): ResponseInterface
-            {
+            public function handle(Request $request): ResponseInterface {
                 $this->handled = true;
                 return new Response();
             }
@@ -106,8 +100,7 @@ class DomainMiddlewareTest extends TestCase
         $this->restoreEnv('MARKETING_DOMAINS', $oldMarketing);
     }
 
-    public function testInvalidMainDomainReturnsError(): void
-    {
+    public function testInvalidMainDomainReturnsError(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main-domain.tld');
         $oldMarketing = getenv('MARKETING_DOMAINS');
@@ -121,8 +114,7 @@ class DomainMiddlewareTest extends TestCase
         $handler = new class implements RequestHandlerInterface {
             public bool $handled = false;
 
-            public function handle(Request $request): ResponseInterface
-            {
+            public function handle(Request $request): ResponseInterface {
                 $this->handled = true;
                 return new Response();
             }
@@ -142,8 +134,7 @@ class DomainMiddlewareTest extends TestCase
         $this->restoreEnv('MARKETING_DOMAINS', $oldMarketing);
     }
 
-    public function testInvalidMainDomainReturnsHtmlError(): void
-    {
+    public function testInvalidMainDomainReturnsHtmlError(): void {
         $old = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main-domain.tld');
         $oldMarketing = getenv('MARKETING_DOMAINS');
@@ -156,8 +147,7 @@ class DomainMiddlewareTest extends TestCase
         $handler = new class implements RequestHandlerInterface {
             public bool $handled = false;
 
-            public function handle(Request $request): ResponseInterface
-            {
+            public function handle(Request $request): ResponseInterface {
                 $this->handled = true;
                 return new Response();
             }
@@ -174,8 +164,7 @@ class DomainMiddlewareTest extends TestCase
         $this->restoreEnv('MARKETING_DOMAINS', $oldMarketing);
     }
 
-    public function testMarketingDomainAllowed(): void
-    {
+    public function testMarketingDomainAllowed(): void {
         $oldMain = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main-domain.tld');
         $oldMarketing = getenv('MARKETING_DOMAINS');
@@ -188,8 +177,7 @@ class DomainMiddlewareTest extends TestCase
         $handler = new class implements RequestHandlerInterface {
             public ?Request $request = null;
 
-            public function handle(Request $request): ResponseInterface
-            {
+            public function handle(Request $request): ResponseInterface {
                 $this->request = $request;
                 return new Response();
             }
@@ -203,8 +191,7 @@ class DomainMiddlewareTest extends TestCase
         $this->restoreEnv('MARKETING_DOMAINS', $oldMarketing);
     }
 
-    public function testMarketingDomainWithWwwAllowed(): void
-    {
+    public function testMarketingDomainWithWwwAllowed(): void {
         $oldMain = getenv('MAIN_DOMAIN');
         putenv('MAIN_DOMAIN=main-domain.tld');
         $oldMarketing = getenv('MARKETING_DOMAINS');
@@ -217,8 +204,7 @@ class DomainMiddlewareTest extends TestCase
         $handler = new class implements RequestHandlerInterface {
             public ?Request $request = null;
 
-            public function handle(Request $request): ResponseInterface
-            {
+            public function handle(Request $request): ResponseInterface {
                 $this->request = $request;
                 return new Response();
             }
@@ -232,8 +218,7 @@ class DomainMiddlewareTest extends TestCase
         $this->restoreEnv('MARKETING_DOMAINS', $oldMarketing);
     }
 
-    private function restoreEnv(string $variable, mixed $value): void
-    {
+    private function restoreEnv(string $variable, mixed $value): void {
         if ($value === false || $value === null) {
             putenv($variable);
             return;

--- a/tests/HealthzEndpointTest.php
+++ b/tests/HealthzEndpointTest.php
@@ -12,8 +12,7 @@ use App\Service\VersionService;
 
 class HealthzEndpointTest extends TestCase
 {
-    protected function getAppInstance(): \Slim\App
-    {
+    protected function getAppInstance(): \Slim\App {
         $app = AppFactory::create();
         $app->get('/healthz', function (Request $request, Response $response) {
             $version = getenv('APP_VERSION');
@@ -34,8 +33,7 @@ class HealthzEndpointTest extends TestCase
         return $app;
     }
 
-    public function testHealthzEndpointReturnsOkJson(): void
-    {
+    public function testHealthzEndpointReturnsOkJson(): void {
         $app = $this->getAppInstance();
         $res = $app->handle($this->createRequest('GET', '/healthz'));
         $this->assertSame(200, $res->getStatusCode());
@@ -49,8 +47,7 @@ class HealthzEndpointTest extends TestCase
         $this->assertSame($time, $dt->format(DATE_ATOM));
     }
 
-    public function testHealthzEndpointUsesAppVersionWhenSet(): void
-    {
+    public function testHealthzEndpointUsesAppVersionWhenSet(): void {
         putenv('APP_VERSION=1.2.3');
         $_ENV['APP_VERSION'] = '1.2.3';
 
@@ -64,8 +61,7 @@ class HealthzEndpointTest extends TestCase
         unset($_ENV['APP_VERSION']);
     }
 
-    public function testHealthzEndpointUsesVersionServiceWhenEnvMissing(): void
-    {
+    public function testHealthzEndpointUsesVersionServiceWhenEnvMissing(): void {
         putenv('APP_VERSION');
         unset($_ENV['APP_VERSION']);
 
@@ -77,8 +73,7 @@ class HealthzEndpointTest extends TestCase
         $this->assertSame($expected, $data['version'] ?? null);
     }
 
-    public function testHealthzEndpointAccessibleForTenantHost(): void
-    {
+    public function testHealthzEndpointAccessibleForTenantHost(): void {
         // Backup current env
         $old = getenv('MAIN_DOMAIN');
         $oldEnv = $_ENV['MAIN_DOMAIN'] ?? null;

--- a/tests/Integration/LoginRedirectMainDomainTest.php
+++ b/tests/Integration/LoginRedirectMainDomainTest.php
@@ -10,8 +10,7 @@ use Tests\TestCase;
 
 final class LoginRedirectMainDomainTest extends TestCase
 {
-    public function testLoginRedirectsToMainDomainOnWrongHost(): void
-    {
+    public function testLoginRedirectsToMainDomainOnWrongHost(): void {
         $pdo = $this->getDatabase();
         $userService = new UserService($pdo);
         $userService->create('heidi', 'secret', 'heidi@example.com', Roles::ADMIN);

--- a/tests/OnboardingScriptTest.php
+++ b/tests/OnboardingScriptTest.php
@@ -8,8 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class OnboardingScriptTest extends TestCase
 {
-    public function testOnboardTenantCreatesComposeFile(): void
-    {
+    public function testOnboardTenantCreatesComposeFile(): void {
         $slug = 't' . bin2hex(random_bytes(3));
         $root = dirname(__DIR__);
         $tenantDir = $root . '/tenants';
@@ -46,8 +45,7 @@ class OnboardingScriptTest extends TestCase
         rmdir(dirname($compose));
     }
 
-    public function testOnboardTenantUsesEnvFile(): void
-    {
+    public function testOnboardTenantUsesEnvFile(): void {
         $slug = 't' . bin2hex(random_bytes(3));
         $root = dirname(__DIR__);
         $tenantDir = $root . '/tenants';

--- a/tests/ProcessHelpersTest.php
+++ b/tests/ProcessHelpersTest.php
@@ -8,8 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class ProcessHelpersTest extends TestCase
 {
-    public function testRunSyncProcessHandlesSpacesInScriptPath(): void
-    {
+    public function testRunSyncProcessHandlesSpacesInScriptPath(): void {
         $dir = sys_get_temp_dir() . '/space dir ' . uniqid();
         mkdir($dir);
         $script = $dir . '/test script.sh';
@@ -23,8 +22,7 @@ class ProcessHelpersTest extends TestCase
         rmdir($dir);
     }
 
-    public function testRunSyncProcessReturnsErrorOutputOnFailure(): void
-    {
+    public function testRunSyncProcessReturnsErrorOutputOnFailure(): void {
         $dir = sys_get_temp_dir() . '/space dir ' . uniqid();
         mkdir($dir);
         $script = $dir . '/test script.sh';

--- a/tests/RobotsTxtTest.php
+++ b/tests/RobotsTxtTest.php
@@ -8,8 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class RobotsTxtTest extends TestCase
 {
-    public function testRouterServesRobotsTxt(): void
-    {
+    public function testRouterServesRobotsTxt(): void {
         $originalBase = getenv('BASE_PATH');
         $originalUri = $_SERVER['REQUEST_URI'] ?? null;
         $originalMethod = $_SERVER['REQUEST_METHOD'] ?? null;

--- a/tests/RoleAccessTest.php
+++ b/tests/RoleAccessTest.php
@@ -8,8 +8,7 @@ use Tests\TestCase;
 
 class RoleAccessTest extends TestCase
 {
-    public function testCatalogEditorCanEditCatalog(): void
-    {
+    public function testCatalogEditorCanEditCatalog(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
@@ -20,8 +19,7 @@ class RoleAccessTest extends TestCase
         session_destroy();
     }
 
-    public function testAnalystCannotEditCatalog(): void
-    {
+    public function testAnalystCannotEditCatalog(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'analyst'];
@@ -33,8 +31,7 @@ class RoleAccessTest extends TestCase
         session_destroy();
     }
 
-    public function testEventManagerCanUpdateConfig(): void
-    {
+    public function testEventManagerCanUpdateConfig(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'event-manager'];
@@ -45,8 +42,7 @@ class RoleAccessTest extends TestCase
         session_destroy();
     }
 
-    public function testTeamManagerCanPostTeams(): void
-    {
+    public function testTeamManagerCanPostTeams(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'team-manager'];
@@ -60,8 +56,7 @@ class RoleAccessTest extends TestCase
         session_destroy();
     }
 
-    public function testAnalystCanAccessResults(): void
-    {
+    public function testAnalystCanAccessResults(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'analyst'];
@@ -71,8 +66,7 @@ class RoleAccessTest extends TestCase
         session_destroy();
     }
 
-    public function testAdminCanAccessSeoForm(): void
-    {
+    public function testAdminCanAccessSeoForm(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
@@ -97,8 +91,7 @@ class RoleAccessTest extends TestCase
         session_destroy();
     }
 
-    public function testCatalogEditorCannotAccessSeoForm(): void
-    {
+    public function testCatalogEditorCannotAccessSeoForm(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];
@@ -113,8 +106,7 @@ class RoleAccessTest extends TestCase
         session_destroy();
     }
 
-    public function testAdminCanViewSeoForm(): void
-    {
+    public function testAdminCanViewSeoForm(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'admin'];
@@ -124,8 +116,7 @@ class RoleAccessTest extends TestCase
         session_destroy();
     }
 
-    public function testCatalogEditorCannotViewSeoForm(): void
-    {
+    public function testCatalogEditorCannotViewSeoForm(): void {
         $app = $this->getAppInstance();
         session_start();
         $_SESSION['user'] = ['id' => 1, 'role' => 'catalog-editor'];

--- a/tests/Service/ArrayLogger.php
+++ b/tests/Service/ArrayLogger.php
@@ -14,13 +14,11 @@ class ArrayLogger extends AbstractLogger
     /** @var list<array{level:string,message:string}> */
     public array $records = [];
 
-    public function log($level, $message, array $context = []): void
-    {
+    public function log($level, $message, array $context = []): void {
         $this->records[] = ['level' => (string) $level, 'message' => (string) $message];
     }
 
-    public function has(string $level, string $fragment): bool
-    {
+    public function has(string $level, string $fragment): bool {
         foreach ($this->records as $r) {
             if ($r['level'] === $level && str_contains($r['message'], $fragment)) {
                 return true;

--- a/tests/Service/AuditLoggerTest.php
+++ b/tests/Service/AuditLoggerTest.php
@@ -10,8 +10,7 @@ use Tests\TestCase;
 
 class AuditLoggerTest extends TestCase
 {
-    public function testLogInsertsRow(): void
-    {
+    public function testLogInsertsRow(): void {
         $pdo = $this->createDatabase();
         $logger = new AuditLogger($pdo);
 

--- a/tests/Service/AwardServiceTest.php
+++ b/tests/Service/AwardServiceTest.php
@@ -9,8 +9,7 @@ use Tests\TestCase;
 
 class AwardServiceTest extends TestCase
 {
-    public function testSecondPlaceStandaloneSingleCategory(): void
-    {
+    public function testSecondPlaceStandaloneSingleCategory(): void {
         $svc = new AwardService();
         $rankings = [
             'puzzle' => [
@@ -27,8 +26,7 @@ class AwardServiceTest extends TestCase
         $this->assertSame($expected, $text);
     }
 
-    public function testSecondPlaceAfterFirstMultipleCategories(): void
-    {
+    public function testSecondPlaceAfterFirstMultipleCategories(): void {
         $svc = new AwardService();
         $rankings = [
             'puzzle' => [
@@ -52,8 +50,7 @@ class AwardServiceTest extends TestCase
         $this->assertSame($expected, $text);
     }
 
-    public function testThirdPlaceOnly(): void
-    {
+    public function testThirdPlaceOnly(): void {
         $svc = new AwardService();
         $rankings = [
             'puzzle' => [
@@ -71,8 +68,7 @@ class AwardServiceTest extends TestCase
         $this->assertSame($expected, $text);
     }
 
-    public function testFullCombination(): void
-    {
+    public function testFullCombination(): void {
         $svc = new AwardService();
         $rankings = [
             'puzzle' => [
@@ -97,8 +93,7 @@ class AwardServiceTest extends TestCase
         $this->assertSame($expected, $text);
     }
 
-    public function testComputeRankingsCalculatesTopTeams(): void
-    {
+    public function testComputeRankingsCalculatesTopTeams(): void {
         $svc = new AwardService();
         $results = [
             ['name' => 'TeamA', 'catalog' => 'cat1', 'time' => 10, 'correct' => 5, 'puzzleTime' => 30],
@@ -139,8 +134,7 @@ class AwardServiceTest extends TestCase
         );
     }
 
-    public function testGetAwardsListsDescriptions(): void
-    {
+    public function testGetAwardsListsDescriptions(): void {
         $svc = new AwardService();
         $rankings = [
             'puzzle' => [

--- a/tests/Service/CatalogServiceTest.php
+++ b/tests/Service/CatalogServiceTest.php
@@ -12,8 +12,7 @@ use Tests\TestCase;
 
 class CatalogServiceTest extends TestCase
 {
-    private function createPdo(): PDO
-    {
+    private function createPdo(): PDO {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
@@ -72,8 +71,7 @@ class CatalogServiceTest extends TestCase
         return $pdo;
     }
 
-    private function createPdoNoComment(): PDO
-    {
+    private function createPdoNoComment(): PDO {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
@@ -131,8 +129,7 @@ class CatalogServiceTest extends TestCase
         return $pdo;
     }
 
-    private function createPdoNoOptionalColumns(): PDO
-    {
+    private function createPdoNoOptionalColumns(): PDO {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
@@ -189,8 +186,7 @@ class CatalogServiceTest extends TestCase
         return $pdo;
     }
 
-    public function testReadWrite(): void
-    {
+    public function testReadWrite(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -219,8 +215,7 @@ class CatalogServiceTest extends TestCase
         );
     }
 
-    public function testWriteWithoutCommentColumn(): void
-    {
+    public function testWriteWithoutCommentColumn(): void {
         $pdo = $this->createPdoNoComment();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -237,8 +232,7 @@ class CatalogServiceTest extends TestCase
         $this->assertSame('ignored', $rows[0]['comment']);
     }
 
-    public function testWriteWithoutOptionalColumns(): void
-    {
+    public function testWriteWithoutOptionalColumns(): void {
         $pdo = $this->createPdoNoOptionalColumns();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -257,8 +251,7 @@ class CatalogServiceTest extends TestCase
         $this->assertSame('d.svg', $rows[0]['design_path']);
     }
 
-    public function testReadReturnsNullIfMissing(): void
-    {
+    public function testReadReturnsNullIfMissing(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -266,8 +259,7 @@ class CatalogServiceTest extends TestCase
         $this->assertNull($service->read('missing.json'));
     }
 
-    public function testDelete(): void
-    {
+    public function testDelete(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -288,8 +280,7 @@ class CatalogServiceTest extends TestCase
         $this->assertSame(0, (int)$stmt->fetchColumn());
     }
 
-    public function testDeleteQuestion(): void
-    {
+    public function testDeleteQuestion(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -313,8 +304,7 @@ class CatalogServiceTest extends TestCase
         $this->assertCount(2, $remaining);
     }
 
-    public function testSlugChangeDoesNotDeleteQuestions(): void
-    {
+    public function testSlugChangeDoesNotDeleteQuestions(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -346,8 +336,7 @@ class CatalogServiceTest extends TestCase
         );
     }
 
-    public function testDuplicateSlugUsesExistingUid(): void
-    {
+    public function testDuplicateSlugUsesExistingUid(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -367,8 +356,7 @@ class CatalogServiceTest extends TestCase
         $this->assertSame('New', $rows[0]['name']);
     }
 
-    public function testReorderCatalogs(): void
-    {
+    public function testReorderCatalogs(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -388,8 +376,7 @@ class CatalogServiceTest extends TestCase
         $this->assertSame('a', $list[1]['slug']);
     }
 
-    public function testNamesRemainAfterReorder(): void
-    {
+    public function testNamesRemainAfterReorder(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -410,8 +397,7 @@ class CatalogServiceTest extends TestCase
         $this->assertSame(['Two', 'One', 'Three'], array_column($rows, 'name'));
     }
 
-    public function testWriteWithoutActiveEventUid(): void
-    {
+    public function testWriteWithoutActiveEventUid(): void {
         $pdo = $this->createPdo();
         $pdo->exec("INSERT INTO config(event_uid) VALUES(NULL)");
         $cfg = new ConfigService($pdo);
@@ -430,8 +416,7 @@ class CatalogServiceTest extends TestCase
         $this->assertSame('ev1', (string)$stmt->fetchColumn());
     }
 
-    public function testWriteAcceptsIdField(): void
-    {
+    public function testWriteAcceptsIdField(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfg);
@@ -448,8 +433,7 @@ class CatalogServiceTest extends TestCase
         $this->assertSame(4, $rows[0]['sort_order']);
     }
 
-    public function testSaveAllRespectsCatalogLimit(): void
-    {
+    public function testSaveAllRespectsCatalogLimit(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('e1');
@@ -475,8 +459,7 @@ class CatalogServiceTest extends TestCase
         $service->write('catalogs.json', $catalogs);
     }
 
-    public function testSaveAllRespectsStandardCatalogLimit(): void
-    {
+    public function testSaveAllRespectsStandardCatalogLimit(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('e1');
@@ -502,8 +485,7 @@ class CatalogServiceTest extends TestCase
         $service->write('catalogs.json', $catalogs);
     }
 
-    public function testWriteRespectsQuestionLimit(): void
-    {
+    public function testWriteRespectsQuestionLimit(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('e1');
@@ -522,8 +504,7 @@ class CatalogServiceTest extends TestCase
         $service->write('c1.json', $questions);
     }
 
-    public function testWriteRespectsStandardQuestionLimit(): void
-    {
+    public function testWriteRespectsStandardQuestionLimit(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('e1');
@@ -542,8 +523,7 @@ class CatalogServiceTest extends TestCase
         $service->write('c1.json', $questions);
     }
 
-    public function testCustomLimitOverridesCatalogLimit(): void
-    {
+    public function testCustomLimitOverridesCatalogLimit(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('e1');
@@ -580,8 +560,7 @@ class CatalogServiceTest extends TestCase
         $service->write('catalogs.json', $catalogs);
     }
 
-    public function testCustomLimitOverridesQuestionLimit(): void
-    {
+    public function testCustomLimitOverridesQuestionLimit(): void {
         $pdo = $this->createPdo();
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('e1');

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -11,8 +11,7 @@ use Throwable;
 
 class ConfigServiceTest extends TestCase
 {
-    public function testReadWriteConfig(): void
-    {
+    public function testReadWriteConfig(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -55,8 +54,7 @@ class ConfigServiceTest extends TestCase
         $this->assertTrue($cfg['QRRemember']);
     }
 
-    public function testGetConfigReturnsEmptyWithoutActiveEvent(): void
-    {
+    public function testGetConfigReturnsEmptyWithoutActiveEvent(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -73,8 +71,7 @@ class ConfigServiceTest extends TestCase
         $this->assertSame([], $service->getConfig());
     }
 
-    public function testGetJsonReturnsNullIfEmpty(): void
-    {
+    public function testGetJsonReturnsNullIfEmpty(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -107,8 +104,7 @@ class ConfigServiceTest extends TestCase
         $this->assertSame([], $service->getConfig());
     }
 
-    public function testSetActiveEventUidRollsBackOnInsertFailure(): void
-    {
+    public function testSetActiveEventUidRollsBackOnInsertFailure(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE config(event_uid TEXT PRIMARY KEY)');
@@ -131,8 +127,7 @@ class ConfigServiceTest extends TestCase
         $this->assertSame('foo', $uid);
     }
 
-    public function testSetActiveEventUidIgnoresUnknownEvent(): void
-    {
+    public function testSetActiveEventUidIgnoresUnknownEvent(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('PRAGMA foreign_keys = ON');
@@ -148,8 +143,7 @@ class ConfigServiceTest extends TestCase
         $this->assertSame('ev1', $uid);
     }
 
-    public function testSetActiveEventUidDoesNotInsertConfigForEmptyEvent(): void
-    {
+    public function testSetActiveEventUidDoesNotInsertConfigForEmptyEvent(): void {
         $pdo = $this->createDatabase();
         $pdo->exec('PRAGMA foreign_keys = ON');
         $service = new ConfigService($pdo);

--- a/tests/Service/DomainContactTemplateServiceTest.php
+++ b/tests/Service/DomainContactTemplateServiceTest.php
@@ -10,8 +10,7 @@ use Tests\TestCase;
 
 class DomainContactTemplateServiceTest extends TestCase
 {
-    public function testSaveAndRetrieveTemplates(): void
-    {
+    public function testSaveAndRetrieveTemplates(): void {
         $pdo = $this->createDatabase();
         $domainService = new DomainStartPageService($pdo);
         $service = new DomainContactTemplateService($pdo, $domainService);

--- a/tests/Service/EventServiceTest.php
+++ b/tests/Service/EventServiceTest.php
@@ -11,8 +11,7 @@ use Tests\TestCase;
 
 class EventServiceTest extends TestCase
 {
-    private function createPdo(): PDO
-    {
+    private function createPdo(): PDO {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -47,8 +46,7 @@ class EventServiceTest extends TestCase
         return $pdo;
     }
 
-    public function testSaveAndGet(): void
-    {
+    public function testSaveAndGet(): void {
         $pdo = $this->createPdo();
         $service = new EventService($pdo);
         $data = [
@@ -71,8 +69,7 @@ class EventServiceTest extends TestCase
         $this->assertTrue($rows[0]['published']);
     }
 
-    public function testGetAllFormatsDates(): void
-    {
+    public function testGetAllFormatsDates(): void {
         $pdo = $this->createPdo();
         $pdo->exec(
             "INSERT INTO events(uid,slug,name,start_date,end_date) " .
@@ -84,8 +81,7 @@ class EventServiceTest extends TestCase
         $this->assertSame('2025-07-04T20:00', $rows[0]['end_date']);
     }
 
-    public function testGetByUid(): void
-    {
+    public function testGetByUid(): void {
         $pdo = $this->createPdo();
         $service = new EventService($pdo);
         $uid = 'uid123';
@@ -95,8 +91,7 @@ class EventServiceTest extends TestCase
         $this->assertSame('Eins', $row['name']);
     }
 
-    public function testActiveEventIsSetWhenSingleEvent(): void
-    {
+    public function testActiveEventIsSetWhenSingleEvent(): void {
         $pdo = $this->createPdo();
         $svc = new EventService($pdo);
         $svc->saveAll([[ 'uid' => 'e1', 'name' => 'Single' ]]);
@@ -104,8 +99,7 @@ class EventServiceTest extends TestCase
         $this->assertSame('e1', $uid);
     }
 
-    public function testActiveEventNotTouchedWithMultipleEvents(): void
-    {
+    public function testActiveEventNotTouchedWithMultipleEvents(): void {
         $pdo = $this->createPdo();
         $svc = new EventService($pdo);
         $svc->saveAll([
@@ -116,8 +110,7 @@ class EventServiceTest extends TestCase
         $this->assertSame(0, $count);
     }
 
-    public function testSaveAllRespectsStarterLimit(): void
-    {
+    public function testSaveAllRespectsStarterLimit(): void {
         $pdo = $this->createPdo();
         $pdo->exec("INSERT INTO tenants(uid, subdomain, plan) VALUES('t1','sub1','starter')");
         $tenantSvc = new TenantService($pdo);
@@ -132,8 +125,7 @@ class EventServiceTest extends TestCase
         ]);
     }
 
-    public function testSaveAllRespectsStandardLimit(): void
-    {
+    public function testSaveAllRespectsStandardLimit(): void {
         $pdo = $this->createPdo();
         $pdo->exec("INSERT INTO tenants(uid, subdomain, plan) VALUES('t2','sub2','standard')");
         $tenantSvc = new TenantService($pdo);
@@ -150,8 +142,7 @@ class EventServiceTest extends TestCase
         ]);
     }
 
-    public function testCustomLimitOverridesPlan(): void
-    {
+    public function testCustomLimitOverridesPlan(): void {
         $pdo = $this->createPdo();
         $pdo->exec(
             "INSERT INTO tenants(uid, subdomain, plan, custom_limits) " .
@@ -175,8 +166,7 @@ class EventServiceTest extends TestCase
         ]);
     }
 
-    public function testSaveAllAllowsReplacementAtLimit(): void
-    {
+    public function testSaveAllAllowsReplacementAtLimit(): void {
         $pdo = $this->createPdo();
         $pdo->exec("INSERT INTO tenants(uid, subdomain, plan) VALUES('t4','sub4','professional')");
         $tenantSvc = new TenantService($pdo);
@@ -197,8 +187,7 @@ class EventServiceTest extends TestCase
         $this->assertSame(20, $count);
     }
 
-    public function testDraftEventsAreIgnoredOnSave(): void
-    {
+    public function testDraftEventsAreIgnoredOnSave(): void {
         $pdo = $this->createPdo();
         $service = new EventService($pdo);
 
@@ -213,8 +202,7 @@ class EventServiceTest extends TestCase
         ], $rows);
     }
 
-    public function testDraftOnlyPayloadKeepsExistingEvents(): void
-    {
+    public function testDraftOnlyPayloadKeepsExistingEvents(): void {
         $pdo = $this->createPdo();
         $service = new EventService($pdo);
 
@@ -233,8 +221,7 @@ class EventServiceTest extends TestCase
         ], $rows);
     }
 
-    public function testGetBySlugAndUidBySlug(): void
-    {
+    public function testGetBySlugAndUidBySlug(): void {
         $pdo = $this->createPdo();
         $service = new EventService($pdo);
         $uid = str_repeat('a', 32);

--- a/tests/Service/ImageUploadServiceTest.php
+++ b/tests/Service/ImageUploadServiceTest.php
@@ -11,8 +11,7 @@ use Tests\TestCase;
 
 class ImageUploadServiceTest extends TestCase
 {
-    public function testReadImageScalesDownLargeImages(): void
-    {
+    public function testReadImageScalesDownLargeImages(): void {
         $service = new ImageUploadService();
         $file = tempnam(sys_get_temp_dir(), 'img');
         $image = imagecreatetruecolor(6000, 4000);

--- a/tests/Service/LandingMediaReferenceServiceTest.php
+++ b/tests/Service/LandingMediaReferenceServiceTest.php
@@ -17,8 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class LandingMediaReferenceServiceTest extends TestCase
 {
-    public function testCollectAggregatesLandingReferences(): void
-    {
+    public function testCollectAggregatesLandingReferences(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE pages (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, content TEXT)');
@@ -114,8 +113,7 @@ class LandingMediaReferenceServiceTest extends TestCase
         }
     }
 
-    public function testNormalizeFilePath(): void
-    {
+    public function testNormalizeFilePath(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE pages (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, content TEXT)');

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -16,8 +16,7 @@ use PDO;
 
 class MailServiceTest extends TestCase
 {
-    protected function setUp(): void
-    {
+    protected function setUp(): void {
         $pdo = $this->createDatabase();
         $this->setDatabase($pdo);
         $pdo->exec(
@@ -29,8 +28,7 @@ class MailServiceTest extends TestCase
         unset($_ENV['MAILER_DSN']);
     }
 
-    public function testIsConfiguredTrue(): void
-    {
+    public function testIsConfiguredTrue(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -41,8 +39,7 @@ class MailServiceTest extends TestCase
         $this->assertTrue(MailService::isConfigured());
     }
 
-    public function testIsConfiguredTrueWithMailerDsn(): void
-    {
+    public function testIsConfiguredTrueWithMailerDsn(): void {
         putenv('SMTP_HOST');
         putenv('SMTP_USER');
         putenv('SMTP_PASS');
@@ -57,8 +54,7 @@ class MailServiceTest extends TestCase
     /**
      * @dataProvider missingEnvProvider
      */
-    public function testIsConfiguredFalseIfMissing(string $var): void
-    {
+    public function testIsConfiguredFalseIfMissing(string $var): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -72,8 +68,7 @@ class MailServiceTest extends TestCase
         $this->assertFalse(MailService::isConfigured());
     }
 
-    public function testUsesSmtpUserAsFrom(): void
-    {
+    public function testUsesSmtpUserAsFrom(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -97,8 +92,7 @@ class MailServiceTest extends TestCase
         $this->assertSame('Example Org <user@example.org>', $from);
     }
 
-    public function testUsesFromOverride(): void
-    {
+    public function testUsesFromOverride(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -130,8 +124,7 @@ class MailServiceTest extends TestCase
     /**
      * @dataProvider missingEnvProvider
      */
-    public function testMissingEnvThrows(string $var): void
-    {
+    public function testMissingEnvThrows(string $var): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -155,8 +148,7 @@ class MailServiceTest extends TestCase
         new MailService($twig);
     }
 
-    public function testMissingMultipleEnvThrows(): void
-    {
+    public function testMissingMultipleEnvThrows(): void {
         putenv('SMTP_HOST');
         putenv('SMTP_USER');
         putenv('SMTP_PASS=secret');
@@ -178,8 +170,7 @@ class MailServiceTest extends TestCase
     /**
      * @return array<string[]>
      */
-    public function missingEnvProvider(): array
-    {
+    public function missingEnvProvider(): array {
         return [
             ['SMTP_HOST'],
             ['SMTP_USER'],
@@ -187,8 +178,7 @@ class MailServiceTest extends TestCase
         ];
     }
 
-    public function testDsnWithEncryption(): void
-    {
+    public function testDsnWithEncryption(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -208,8 +198,7 @@ class MailServiceTest extends TestCase
         $svc = new class ($twig) extends MailService {
             public string $dsn = '';
 
-            protected function createTransport(string $dsn): MailerInterface
-            {
+            protected function createTransport(string $dsn): MailerInterface {
                 $this->dsn = $dsn;
 
                 return parent::createTransport($dsn);
@@ -228,8 +217,7 @@ class MailServiceTest extends TestCase
         unset($_ENV['SMTP_FROM'], $_ENV['SMTP_FROM_NAME']);
     }
 
-    public function testMailerDsnIsPassedThrough(): void
-    {
+    public function testMailerDsnIsPassedThrough(): void {
         putenv('SMTP_HOST');
         putenv('SMTP_USER');
         putenv('SMTP_PASS');
@@ -253,8 +241,7 @@ class MailServiceTest extends TestCase
         $svc = new class ($twig) extends MailService {
             public string $dsn = '';
 
-            protected function createTransport(string $dsn): MailerInterface
-            {
+            protected function createTransport(string $dsn): MailerInterface {
                 $this->dsn = $dsn;
 
                 return parent::createTransport($dsn);
@@ -269,8 +256,7 @@ class MailServiceTest extends TestCase
         unset($_ENV['SMTP_FROM']);
     }
 
-    public function testMailerDsnRequiresFrom(): void
-    {
+    public function testMailerDsnRequiresFrom(): void {
         putenv('SMTP_HOST');
         putenv('SMTP_USER');
         putenv('SMTP_PASS');
@@ -297,8 +283,7 @@ class MailServiceTest extends TestCase
         new MailService($twig);
     }
 
-    public function testSendContactSendsCopyToUser(): void
-    {
+    public function testSendContactSendsCopyToUser(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -317,13 +302,11 @@ class MailServiceTest extends TestCase
             /** @var Email[] */
             public array $messages = [];
 
-            protected function createTransport(string $dsn): MailerInterface
-            {
+            protected function createTransport(string $dsn): MailerInterface {
                 return new class ($this) implements MailerInterface {
                     private $outer;
 
-                    public function __construct($outer)
-                    {
+                    public function __construct($outer) {
                         $this->outer = $outer;
                     }
 
@@ -346,8 +329,7 @@ class MailServiceTest extends TestCase
         $this->assertSame('john@example.org', $svc->messages[1]->getTo()[0]->getAddress());
     }
 
-    public function testSendContactUsesTemplates(): void
-    {
+    public function testSendContactUsesTemplates(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -366,13 +348,11 @@ class MailServiceTest extends TestCase
             /** @var Email[] */
             public array $messages = [];
 
-            protected function createTransport(string $dsn): MailerInterface
-            {
+            protected function createTransport(string $dsn): MailerInterface {
                 return new class ($this) implements MailerInterface {
                     private $outer;
 
-                    public function __construct($outer)
-                    {
+                    public function __construct($outer) {
                         $this->outer = $outer;
                     }
 
@@ -417,8 +397,7 @@ class MailServiceTest extends TestCase
         $this->assertStringContainsString('Domain Team', (string) $copy->getHtmlBody());
     }
 
-    public function testSendWelcomeContainsCatalogAndPasswordLinks(): void
-    {
+    public function testSendWelcomeContainsCatalogAndPasswordLinks(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -437,13 +416,11 @@ class MailServiceTest extends TestCase
             /** @var Email[] */
             public array $messages = [];
 
-            protected function createTransport(string $dsn): MailerInterface
-            {
+            protected function createTransport(string $dsn): MailerInterface {
                 return new class ($this) implements MailerInterface {
                     private $outer;
 
-                    public function __construct($outer)
-                    {
+                    public function __construct($outer) {
                         $this->outer = $outer;
                     }
 
@@ -468,8 +445,7 @@ class MailServiceTest extends TestCase
         $this->assertCount(1, $svc->messages);
     }
 
-    public function testSendContactUsesDomainDsnOverride(): void
-    {
+    public function testSendContactUsesDomainDsnOverride(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -489,15 +465,13 @@ class MailServiceTest extends TestCase
             public array $messages = [];
             public array $dsns = [];
 
-            protected function createTransport(string $dsn): MailerInterface
-            {
+            protected function createTransport(string $dsn): MailerInterface {
                 $this->dsns[] = $dsn;
 
                 return new class ($this) implements MailerInterface {
                     private $outer;
 
-                    public function __construct($outer)
-                    {
+                    public function __construct($outer) {
                         $this->outer = $outer;
                     }
 
@@ -526,8 +500,7 @@ class MailServiceTest extends TestCase
         $this->assertSame('smtp://override-user:pass@custom-host:2525', $svc->dsns[1]);
     }
 
-    public function testSendContactUsesDomainSmtpSettings(): void
-    {
+    public function testSendContactUsesDomainSmtpSettings(): void {
         putenv('SMTP_HOST=localhost');
         putenv('SMTP_USER=user@example.org');
         putenv('SMTP_PASS=secret');
@@ -547,15 +520,13 @@ class MailServiceTest extends TestCase
             public array $messages = [];
             public array $dsns = [];
 
-            protected function createTransport(string $dsn): MailerInterface
-            {
+            protected function createTransport(string $dsn): MailerInterface {
                 $this->dsns[] = $dsn;
 
                 return new class ($this) implements MailerInterface {
                     private $outer;
 
-                    public function __construct($outer)
-                    {
+                    public function __construct($outer) {
                         $this->outer = $outer;
                     }
 

--- a/tests/Service/MediaLibraryServiceTest.php
+++ b/tests/Service/MediaLibraryServiceTest.php
@@ -20,8 +20,7 @@ class MediaLibraryServiceTest extends TestCase
 {
     private string $tempDir;
 
-    protected function setUp(): void
-    {
+    protected function setUp(): void {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/media-lib-' . uniqid('', true);
         if (!is_dir($this->tempDir) && !mkdir($this->tempDir, 0775, true) && !is_dir($this->tempDir)) {
@@ -29,14 +28,12 @@ class MediaLibraryServiceTest extends TestCase
         }
     }
 
-    protected function tearDown(): void
-    {
+    protected function tearDown(): void {
         $this->removeDir($this->tempDir);
         parent::tearDown();
     }
 
-    public function testMetadataPersistenceRoundTrip(): void
-    {
+    public function testMetadataPersistenceRoundTrip(): void {
         [$service, $config, $images] = $this->createService();
 
         $tmp = tempnam($this->tempDir, 'img');
@@ -87,8 +84,7 @@ class MediaLibraryServiceTest extends TestCase
         $this->assertTrue($images->saveCalled, 'Raster uploads should be processed via ImageUploadService');
     }
 
-    public function testSvgUploadBypassesRasterProcessing(): void
-    {
+    public function testSvgUploadBypassesRasterProcessing(): void {
         [$service, $config, $images] = $this->createService();
 
         $svg = <<<SVG
@@ -111,8 +107,7 @@ SVG;
         $this->assertStringEqualsFile($storedPath, $svg);
     }
 
-    public function testPdfUploadBypassesRasterProcessing(): void
-    {
+    public function testPdfUploadBypassesRasterProcessing(): void {
         [$service, $config, $images] = $this->createService();
 
         $pdf = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF\n";
@@ -133,8 +128,7 @@ SVG;
         $this->assertStringEqualsFile($storedPath, $pdf);
     }
 
-    private function removeDir(string $dir): void
-    {
+    private function removeDir(string $dir): void {
         if (!is_dir($dir)) {
             return;
         }
@@ -158,37 +152,31 @@ SVG;
     /**
      * @return array{0:MediaLibraryService,1:ConfigService,2:ImageUploadService}
      */
-    private function createService(): array
-    {
+    private function createService(): array {
         $pdo = new PDO('sqlite::memory:');
 
         $config = new class ($pdo, $this->tempDir) extends ConfigService {
             private string $baseDir;
             private string $activeUid = 'event-test';
 
-            public function __construct(PDO $pdo, string $baseDir)
-            {
+            public function __construct(PDO $pdo, string $baseDir) {
                 $this->baseDir = $baseDir;
                 parent::__construct($pdo);
             }
 
-            public function setActiveEventUid(string $uid): void
-            {
+            public function setActiveEventUid(string $uid): void {
                 $this->activeUid = $uid;
             }
 
-            public function getActiveEventUid(): string
-            {
+            public function getActiveEventUid(): string {
                 return $this->activeUid;
             }
 
-            public function getGlobalUploadsPath(): string
-            {
+            public function getGlobalUploadsPath(): string {
                 return '/uploads';
             }
 
-            public function getGlobalUploadsDir(): string
-            {
+            public function getGlobalUploadsDir(): string {
                 $dir = $this->baseDir . '/uploads';
                 if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
                     throw new RuntimeException('unable to create uploads directory');
@@ -196,14 +184,12 @@ SVG;
                 return $dir;
             }
 
-            public function getEventImagesPath(?string $uid = null): string
-            {
+            public function getEventImagesPath(?string $uid = null): string {
                 $uid = $uid ?? $this->activeUid;
                 return '/events/' . $uid . '/images';
             }
 
-            public function getEventImagesDir(?string $uid = null): string
-            {
+            public function getEventImagesDir(?string $uid = null): string {
                 $uid = $uid ?? $this->activeUid;
                 $dir = $this->baseDir . '/events/' . $uid . '/images';
                 if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
@@ -217,8 +203,7 @@ SVG;
             public bool $saveCalled = false;
             private string $baseDir;
 
-            public function __construct(string $baseDir)
-            {
+            public function __construct(string $baseDir) {
                 $this->baseDir = rtrim($baseDir, '/');
             }
 

--- a/tests/Service/NginxServiceTest.php
+++ b/tests/Service/NginxServiceTest.php
@@ -11,8 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class NginxServiceTest extends TestCase
 {
-    public function testReloadViaWebhook(): void
-    {
+    public function testReloadViaWebhook(): void {
         $dir = sys_get_temp_dir() . '/vhost' . uniqid();
         mkdir($dir);
         $client = $this->createMock(ClientInterface::class);
@@ -22,8 +21,7 @@ class NginxServiceTest extends TestCase
             ->willReturn(new Response(200));
         $svc = new class ($dir, 'example.com', '1m', true, 'http://webhook', 'tok', $client) extends NginxService {
             public bool $called = false;
-            public function reload(): void
-            {
+            public function reload(): void {
                 $this->called = true;
                 parent::reload();
             }
@@ -33,8 +31,7 @@ class NginxServiceTest extends TestCase
         $this->assertFileExists("$dir/test.example.com");
     }
 
-    public function testCreateVhostFailsOnUnwritableDir(): void
-    {
+    public function testCreateVhostFailsOnUnwritableDir(): void {
         $svc = new NginxService('/proc/sys', 'example.com', '1m', false);
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Vhost directory not writable');

--- a/tests/Service/NullRedirectManager.php
+++ b/tests/Service/NullRedirectManager.php
@@ -8,11 +8,9 @@ use App\Application\Routing\RedirectManager;
 
 class NullRedirectManager extends RedirectManager
 {
-    public function __construct()
-    {
+    public function __construct() {
     }
 
-    public function register(string $from, string $to, int $status = 301): void
-    {
+    public function register(string $from, string $to, int $status = 301): void {
     }
 }

--- a/tests/Service/PageSeoConfigServiceTest.php
+++ b/tests/Service/PageSeoConfigServiceTest.php
@@ -13,8 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class PageSeoConfigServiceTest extends TestCase
 {
-    public function testValidateLimitsAndUrl(): void
-    {
+    public function testValidateLimitsAndUrl(): void {
         $pdo = new PDO('sqlite::memory:');
         $redirects = new NullRedirectManager();
         $service = new PageSeoConfigService($pdo, $redirects);
@@ -29,8 +28,7 @@ class PageSeoConfigServiceTest extends TestCase
         $this->assertArrayHasKey('canonicalUrl', $errors);
     }
 
-    public function testCacheInvalidatedOnSave(): void
-    {
+    public function testCacheInvalidatedOnSave(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -65,8 +63,7 @@ class PageSeoConfigServiceTest extends TestCase
         $this->assertSame('changed', $row['slug']);
     }
 
-    public function testSlugAllowsSlashesAndUnderscores(): void
-    {
+    public function testSlugAllowsSlashesAndUnderscores(): void {
         $pdo = new PDO('sqlite::memory:');
         $redirects = new NullRedirectManager();
         $service = new PageSeoConfigService($pdo, $redirects);
@@ -76,8 +73,7 @@ class PageSeoConfigServiceTest extends TestCase
         $this->assertArrayHasKey('slug', $invalid);
     }
 
-    public function testEmptySchemaJsonSavedAsNull(): void
-    {
+    public function testEmptySchemaJsonSavedAsNull(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -106,8 +102,7 @@ class PageSeoConfigServiceTest extends TestCase
         $this->assertNull($row['schema_json']);
     }
 
-    public function testCanonicalAndRobotsUpdatedOnUpsert(): void
-    {
+    public function testCanonicalAndRobotsUpdatedOnUpsert(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -154,8 +149,7 @@ class PageSeoConfigServiceTest extends TestCase
         $this->assertSame('noindex, follow', $row['robots_meta']);
     }
 
-    public function testFaviconPathStoredAndValidated(): void
-    {
+    public function testFaviconPathStoredAndValidated(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(

--- a/tests/Service/PageVariableServiceTest.php
+++ b/tests/Service/PageVariableServiceTest.php
@@ -9,8 +9,7 @@ use App\Service\PageVariableService;
 
 class PageVariableServiceTest extends TestCase
 {
-    public function testApplyReplacesPlaceholders(): void
-    {
+    public function testApplyReplacesPlaceholders(): void {
         $html = '<p>[NAME], [STREET], [ZIP] [CITY], [EMAIL]</p>';
         $result = PageVariableService::apply($html);
         $this->assertStringNotContainsString('[NAME]', $result);

--- a/tests/Service/PasswordResetServiceTest.php
+++ b/tests/Service/PasswordResetServiceTest.php
@@ -10,8 +10,7 @@ use Tests\TestCase;
 
 class PasswordResetServiceTest extends TestCase
 {
-    public function testCreateAndConsumeToken(): void
-    {
+    public function testCreateAndConsumeToken(): void {
         $pdo = $this->createDatabase();
         $users = new UserService($pdo);
         $users->create('alice', 'secret', 'alice@example.com');
@@ -32,8 +31,7 @@ class PasswordResetServiceTest extends TestCase
         $this->assertTrue($logger->has('warning', 'Password reset token not found'));
     }
 
-    public function testTokenExpires(): void
-    {
+    public function testTokenExpires(): void {
         $pdo = $this->createDatabase();
         $users = new UserService($pdo);
         $users->create('bob', 'secret', 'bob@example.com');
@@ -50,8 +48,7 @@ class PasswordResetServiceTest extends TestCase
         );
     }
 
-    public function testOldTokenInvalidated(): void
-    {
+    public function testOldTokenInvalidated(): void {
         $pdo = $this->createDatabase();
         $users = new UserService($pdo);
         $users->create('carol', 'secret', 'carol@example.com');

--- a/tests/Service/PhotoConsentServiceTest.php
+++ b/tests/Service/PhotoConsentServiceTest.php
@@ -11,8 +11,7 @@ use Tests\TestCase;
 
 class PhotoConsentServiceTest extends TestCase
 {
-    public function testAddConsentAppendsEntry(): void
-    {
+    public function testAddConsentAppendsEntry(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -38,8 +37,7 @@ class PhotoConsentServiceTest extends TestCase
         $this->assertSame(456, (int)$data[1]['time']);
     }
 
-    public function testGetAllReturnsStoredConsents(): void
-    {
+    public function testGetAllReturnsStoredConsents(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -65,8 +63,7 @@ class PhotoConsentServiceTest extends TestCase
         $this->assertSame(2, (int)$data[1]['time']);
     }
 
-    public function testAddStoresEventUid(): void
-    {
+    public function testAddStoresEventUid(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -88,8 +85,7 @@ class PhotoConsentServiceTest extends TestCase
         $this->assertSame('ev1', $uid);
     }
 
-    public function testGetAllFiltersByEventUid(): void
-    {
+    public function testGetAllFiltersByEventUid(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -113,8 +109,7 @@ class PhotoConsentServiceTest extends TestCase
         $this->assertSame('A', $rows[0]['team']);
     }
 
-    public function testSaveAllReplacesOnlyCurrentEvent(): void
-    {
+    public function testSaveAllReplacesOnlyCurrentEvent(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(

--- a/tests/Service/QrCodeServiceTest.php
+++ b/tests/Service/QrCodeServiceTest.php
@@ -9,8 +9,7 @@ use Tests\TestCase;
 
 class QrCodeServiceTest extends TestCase
 {
-    public function testPunchOutCanBeToggled(): void
-    {
+    public function testPunchOutCanBeToggled(): void {
         $svc = new QrCodeService();
 
         // create transparent logo for first call
@@ -47,8 +46,7 @@ class QrCodeServiceTest extends TestCase
         $this->assertNotSame($with['body'], $without['body']);
     }
 
-    public function testSvgPunchOutAddsRectBehindLogo(): void
-    {
+    public function testSvgPunchOutAddsRectBehindLogo(): void {
         $svc = new QrCodeService();
 
         $dir = dirname(__DIR__, 2) . '/data';
@@ -76,8 +74,7 @@ class QrCodeServiceTest extends TestCase
         $this->assertMatchesRegularExpression('/<rect[^>]*fill="#ffffff"/i', $svg);
     }
 
-    public function testSvgLogoKeepsAspectRatio(): void
-    {
+    public function testSvgLogoKeepsAspectRatio(): void {
         $svc = new QrCodeService();
 
         $dir = dirname(__DIR__, 2) . '/data';

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -11,8 +11,7 @@ use Tests\TestCase;
 
 class ResultServiceTest extends TestCase
 {
-    public function testAddIncrementsAttemptForSameCatalog(): void
-    {
+    public function testAddIncrementsAttemptForSameCatalog(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -47,8 +46,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame(2, $second['attempt']);
     }
 
-    public function testAddDoesNotIncrementAcrossCatalogs(): void
-    {
+    public function testAddDoesNotIncrementAcrossCatalogs(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -83,8 +81,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame(1, $other['attempt']);
     }
 
-    public function testExistsChecksPlayerCatalogPair(): void
-    {
+    public function testExistsChecksPlayerCatalogPair(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -115,8 +112,7 @@ class ResultServiceTest extends TestCase
         $this->assertFalse($service->exists('TeamB', 'cat1'));
     }
 
-    public function testMarkPuzzleUpdatesEntry(): void
-    {
+    public function testMarkPuzzleUpdatesEntry(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -152,8 +148,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame($ts, (int)$stmt->fetchColumn());
     }
 
-    public function testMarkPuzzleReturnsTrueIfAlreadySolved(): void
-    {
+    public function testMarkPuzzleReturnsTrueIfAlreadySolved(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -188,8 +183,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame(123, (int)$stmt->fetchColumn());
     }
 
-    public function testSetPhotoUpdatesEntry(): void
-    {
+    public function testSetPhotoUpdatesEntry(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -223,8 +217,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame('/photo/test.jpg', $stmt->fetchColumn());
     }
 
-    public function testAddStoresQuestionResults(): void
-    {
+    public function testAddStoresQuestionResults(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -300,8 +293,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame('0', (string)$rows[1]['correct']);
     }
 
-    public function testClearRemovesResultsAndQuestionResults(): void
-    {
+    public function testClearRemovesResultsAndQuestionResults(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -352,8 +344,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame(0, $qresCount);
     }
 
-    public function testPhotoAttachedAfterEventUidChange(): void
-    {
+    public function testPhotoAttachedAfterEventUidChange(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -437,8 +428,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame('ev1', $row['event_uid']);
     }
 
-    public function testGetAllAssociatesCatalogNameWithEvent(): void
-    {
+    public function testGetAllAssociatesCatalogNameWithEvent(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -478,8 +468,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame('Catalog 1', $rows[0]['catalogName']);
     }
 
-    public function testGetQuestionResultsAssociatesCatalogNameWithEvent(): void
-    {
+    public function testGetQuestionResultsAssociatesCatalogNameWithEvent(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
@@ -539,8 +528,7 @@ class ResultServiceTest extends TestCase
         $this->assertSame('Catalog 2', $rows[1]['catalogName']);
     }
 
-    public function testQueriesReturnEmptyWithoutActiveEvent(): void
-    {
+    public function testQueriesReturnEmptyWithoutActiveEvent(): void {
         $pdo = new PDO('sqlite::memory:');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec(

--- a/tests/Service/SessionServiceTest.php
+++ b/tests/Service/SessionServiceTest.php
@@ -9,8 +9,7 @@ use Tests\TestCase;
 
 class SessionServiceTest extends TestCase
 {
-    public function testInvalidateRemovesSessions(): void
-    {
+    public function testInvalidateRemovesSessions(): void {
         $pdo = $this->createDatabase();
         $pdo->exec('CREATE TABLE IF NOT EXISTS user_sessions(user_id INTEGER NOT NULL, session_id TEXT PRIMARY KEY)');
 

--- a/tests/Service/SettingsServiceTest.php
+++ b/tests/Service/SettingsServiceTest.php
@@ -9,8 +9,7 @@ use Tests\TestCase;
 
 class SettingsServiceTest extends TestCase
 {
-    public function testReadWriteSettings(): void
-    {
+    public function testReadWriteSettings(): void {
         $pdo = $this->createDatabase();
         $svc = new SettingsService($pdo);
         $svc->save(['home_page' => 'events']);

--- a/tests/Service/StripeServiceStub.php
+++ b/tests/Service/StripeServiceStub.php
@@ -8,32 +8,26 @@ class StripeService
 {
     public static array $calls = [];
 
-    public function __construct()
-    {
+    public function __construct() {
     }
 
-    public function findCustomerIdByEmail(string $email): ?string
-    {
+    public function findCustomerIdByEmail(string $email): ?string {
         return null;
     }
 
-    public function createCustomer(string $email, ?string $name = null): string
-    {
+    public function createCustomer(string $email, ?string $name = null): string {
         return 'cus_test';
     }
 
-    public function updateSubscriptionForCustomer(string $customerId, string $priceId): void
-    {
+    public function updateSubscriptionForCustomer(string $customerId, string $priceId): void {
         self::$calls[] = ['update', $customerId, $priceId];
     }
 
-    public function cancelSubscriptionForCustomer(string $customerId): void
-    {
+    public function cancelSubscriptionForCustomer(string $customerId): void {
         self::$calls[] = ['cancel', $customerId];
     }
 
-    public static function isConfigured(): array
-    {
+    public static function isConfigured(): array {
         return ['ok' => true, 'missing' => [], 'warnings' => []];
     }
 }

--- a/tests/Service/SummaryPhotoServiceTest.php
+++ b/tests/Service/SummaryPhotoServiceTest.php
@@ -11,8 +11,7 @@ use Tests\TestCase;
 
 class SummaryPhotoServiceTest extends TestCase
 {
-    public function testAddAndGetAll(): void
-    {
+    public function testAddAndGetAll(): void {
         $pdo = $this->createDatabase();
         $cfg = new ConfigService($pdo);
         $cfg->saveConfig(['event_uid' => 'ev1']);

--- a/tests/Service/TeamServiceTest.php
+++ b/tests/Service/TeamServiceTest.php
@@ -12,8 +12,7 @@ use Tests\TestCase;
 
 class TeamServiceTest extends TestCase
 {
-    public function testSaveAllStoresUid(): void
-    {
+    public function testSaveAllStoresUid(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('ev1','ev1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('ev1')");
@@ -31,8 +30,7 @@ class TeamServiceTest extends TestCase
         $this->assertNotSame($rows[0]['uid'], $rows[1]['uid']);
     }
 
-    public function testSaveAllWithoutEvent(): void
-    {
+    public function testSaveAllWithoutEvent(): void {
         $pdo = $this->createDatabase();
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('');
@@ -44,8 +42,7 @@ class TeamServiceTest extends TestCase
         $this->assertNull($row['event_uid']);
     }
 
-    public function testGetAllWithoutActiveEventReturnsEmpty(): void
-    {
+    public function testGetAllWithoutActiveEventReturnsEmpty(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event1')");
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e2','e2','Event2')");
@@ -57,8 +54,7 @@ class TeamServiceTest extends TestCase
         $this->assertSame([], $svc->getAll());
     }
 
-    public function testSaveAllRespectsTeamLimit(): void
-    {
+    public function testSaveAllRespectsTeamLimit(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('e1')");
@@ -75,8 +71,7 @@ class TeamServiceTest extends TestCase
         $svc->saveAll(['A', 'B', 'C', 'D', 'E', 'F']);
     }
 
-    public function testSaveAllRespectsStandardTeamLimit(): void
-    {
+    public function testSaveAllRespectsStandardTeamLimit(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('e1')");
@@ -98,8 +93,7 @@ class TeamServiceTest extends TestCase
         $svc->saveAll($teams);
     }
 
-    public function testCustomLimitOverridesTeamLimit(): void
-    {
+    public function testCustomLimitOverridesTeamLimit(): void {
         $pdo = $this->createDatabase();
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event1')");
         $pdo->exec("INSERT INTO config(event_uid) VALUES('e1')");

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -10,8 +10,7 @@ use Tests\TestCase;
 
 class UserServiceTest extends TestCase
 {
-    public function testSaveAllStoresPositionAndReturnsOrdered(): void
-    {
+    public function testSaveAllStoresPositionAndReturnsOrdered(): void {
         $pdo = $this->createDatabase();
         $svc = new UserService($pdo);
 

--- a/tests/SessionDependentMiddlewareTest.php
+++ b/tests/SessionDependentMiddlewareTest.php
@@ -17,8 +17,7 @@ use Slim\Psr7\Response;
 
 class SessionDependentMiddlewareTest extends TestCase
 {
-    protected function tearDown(): void
-    {
+    protected function tearDown(): void {
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_unset();
             session_destroy();
@@ -26,8 +25,7 @@ class SessionDependentMiddlewareTest extends TestCase
         parent::tearDown();
     }
 
-    public function testCsrfMiddlewareSetsAndValidatesToken(): void
-    {
+    public function testCsrfMiddlewareSetsAndValidatesToken(): void {
         $app = AppFactory::create();
         $app->add(new SessionMiddleware());
         $app->map(['GET', 'POST'], '/csrf', fn (Request $request, Response $response): Response => $response)
@@ -48,8 +46,7 @@ class SessionDependentMiddlewareTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
     }
 
-    public function testCsrfMiddlewareReturnsJsonForApiPath(): void
-    {
+    public function testCsrfMiddlewareReturnsJsonForApiPath(): void {
         $app = AppFactory::create();
         $app->add(new SessionMiddleware());
         $app->post('/api/test', fn (Request $request, Response $response): Response => $response)
@@ -62,8 +59,7 @@ class SessionDependentMiddlewareTest extends TestCase
         $this->assertSame('application/json', $res->getHeaderLine('Content-Type'));
     }
 
-    public function testRateLimitMiddlewareUsesSession(): void
-    {
+    public function testRateLimitMiddlewareUsesSession(): void {
         RateLimitMiddleware::resetPersistentStorage();
         $app = AppFactory::create();
         $app->add(new SessionMiddleware());
@@ -83,8 +79,7 @@ class SessionDependentMiddlewareTest extends TestCase
         $this->assertSame(429, $res2->getStatusCode());
     }
 
-    public function testRoleAuthMiddlewareRedirectsWithoutRole(): void
-    {
+    public function testRoleAuthMiddlewareRedirectsWithoutRole(): void {
         $app = AppFactory::create();
         $app->add(new SessionMiddleware());
         $app->get('/protected', fn (Request $request, Response $response): Response => $response)
@@ -97,8 +92,7 @@ class SessionDependentMiddlewareTest extends TestCase
         $this->assertSame('/login', $res->getHeaderLine('Location'));
     }
 
-    public function testRoleAuthMiddlewareReturnsJsonForApiRequests(): void
-    {
+    public function testRoleAuthMiddlewareReturnsJsonForApiRequests(): void {
         $app = AppFactory::create();
         $app->add(new SessionMiddleware());
         $app->get('/protected', fn (Request $request, Response $response): Response => $response)
@@ -113,8 +107,7 @@ class SessionDependentMiddlewareTest extends TestCase
         $this->assertSame('application/json', $res->getHeaderLine('Content-Type'));
     }
 
-    public function testRoleAuthMiddlewareUsesApiPath(): void
-    {
+    public function testRoleAuthMiddlewareUsesApiPath(): void {
         $app = AppFactory::create();
         $app->add(new SessionMiddleware());
         $app->get('/api/protected', fn (Request $request, Response $response): Response => $response)
@@ -127,8 +120,7 @@ class SessionDependentMiddlewareTest extends TestCase
         $this->assertSame('application/json', $res->getHeaderLine('Content-Type'));
     }
 
-    public function testAdminAuthMiddlewareReturnsJsonForApiRequests(): void
-    {
+    public function testAdminAuthMiddlewareReturnsJsonForApiRequests(): void {
         $app = AppFactory::create();
         $app->add(new SessionMiddleware());
         $app->get('/api/admin', fn (Request $request, Response $response): Response => $response)
@@ -141,8 +133,7 @@ class SessionDependentMiddlewareTest extends TestCase
         $this->assertSame('application/json', $res->getHeaderLine('Content-Type'));
     }
 
-    public function testAdminAuthMiddlewareAllowsAdmin(): void
-    {
+    public function testAdminAuthMiddlewareAllowsAdmin(): void {
         $app = AppFactory::create();
         $app->add(new SessionMiddleware());
         $app->get('/set', function (Request $request, Response $response): Response {

--- a/tests/SessionMiddlewareTest.php
+++ b/tests/SessionMiddlewareTest.php
@@ -16,8 +16,7 @@ use Slim\Psr7\Uri;
 
 class SessionMiddlewareTest extends TestCase
 {
-    protected function setUp(): void
-    {
+    protected function setUp(): void {
         parent::setUp();
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_unset();
@@ -30,8 +29,7 @@ class SessionMiddlewareTest extends TestCase
         putenv('SESSION_COOKIE_SECURE');
     }
 
-    protected function tearDown(): void
-    {
+    protected function tearDown(): void {
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_unset();
             session_destroy();
@@ -42,19 +40,16 @@ class SessionMiddlewareTest extends TestCase
         parent::tearDown();
     }
 
-    private function createRequest(string $host): Request
-    {
+    private function createRequest(string $host): Request {
         $uri = new Uri('http', $host, 80, '/');
         $headers = new Headers();
         $stream = (new StreamFactory())->createStream();
         return new SlimRequest('GET', $uri, $headers, [], [], $stream);
     }
 
-    private function handle(Request $request): void
-    {
+    private function handle(Request $request): void {
         $handler = new class implements RequestHandlerInterface {
-            public function handle(Request $request): Response
-            {
+            public function handle(Request $request): Response {
                 return new Response();
             }
         };
@@ -62,32 +57,28 @@ class SessionMiddlewareTest extends TestCase
         $middleware->process($request, $handler);
     }
 
-    public function testSkipsDomainForIpAddress(): void
-    {
+    public function testSkipsDomainForIpAddress(): void {
         $request = $this->createRequest('127.0.0.1');
         $this->handle($request);
         $params = session_get_cookie_params();
         $this->assertSame('', $params['domain']);
     }
 
-    public function testSkipsDomainForLocalhost(): void
-    {
+    public function testSkipsDomainForLocalhost(): void {
         $request = $this->createRequest('localhost');
         $this->handle($request);
         $params = session_get_cookie_params();
         $this->assertSame('', $params['domain']);
     }
 
-    public function testUsesHostDomainWhenEnvEmpty(): void
-    {
+    public function testUsesHostDomainWhenEnvEmpty(): void {
         $request = $this->createRequest('example.com');
         $this->handle($request);
         $params = session_get_cookie_params();
         $this->assertSame('.example.com', $params['domain']);
     }
 
-    public function testSetsSecureFlagFromForwardedProto(): void
-    {
+    public function testSetsSecureFlagFromForwardedProto(): void {
         $uri = new Uri('http', 'example.com', 80, '/');
         $headers = new Headers(['X-Forwarded-Proto' => ['https']]);
         $stream = (new StreamFactory())->createStream();
@@ -97,8 +88,7 @@ class SessionMiddlewareTest extends TestCase
         $this->assertTrue($params['secure']);
     }
 
-    public function testSetsSecureFlagFromEnv(): void
-    {
+    public function testSetsSecureFlagFromEnv(): void {
         putenv('SESSION_COOKIE_SECURE=true');
         $_ENV['SESSION_COOKIE_SECURE'] = 'true';
         $request = $this->createRequest('example.com');

--- a/tests/Support/BasePathHelperTest.php
+++ b/tests/Support/BasePathHelperTest.php
@@ -12,16 +12,14 @@ class BasePathHelperTest extends TestCase
     /**
      * @dataProvider provideBasePaths
      */
-    public function testNormalize(?string $input, string $expected): void
-    {
+    public function testNormalize(?string $input, string $expected): void {
         self::assertSame($expected, BasePathHelper::normalize($input));
     }
 
     /**
      * @return iterable<string, array{?string, string}>
      */
-    public static function provideBasePaths(): iterable
-    {
+    public static function provideBasePaths(): iterable {
         yield 'null' => [null, ''];
         yield 'empty string' => ['', ''];
         yield 'single slash' => ['/', ''];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,16 +27,14 @@ class TestCase extends PHPUnit_TestCase
     /**
      * Inject a custom PDO instance for tests that require a specific connection.
      */
-    public function setDatabase(PDO $pdo): void
-    {
+    public function setDatabase(PDO $pdo): void {
         $this->pdo = $pdo;
     }
 
     /**
      * Ensure a database connection is available and return it.
      */
-    protected function getDatabase(): PDO
-    {
+    protected function getDatabase(): PDO {
         if ($this->pdo === null) {
             $this->pdo = $this->createDatabase();
         }
@@ -48,8 +46,7 @@ class TestCase extends PHPUnit_TestCase
      * @return App
      * @throws Exception
      */
-    protected function getAppInstance(): App
-    {
+    protected function getAppInstance(): App {
         $this->getDatabase();
 
         // Load settings
@@ -136,8 +133,7 @@ class TestCase extends PHPUnit_TestCase
     /**
      * Create a database with the current schema applied.
      */
-    protected function createDatabase(): \PDO
-    {
+    protected function createDatabase(): \PDO {
         $dsn = getenv('POSTGRES_DSN') ?: '';
         $user = getenv('POSTGRES_USER') ?: 'postgres';
         $password = getenv('POSTGRES_PASSWORD') ?: 'postgres';
@@ -161,8 +157,7 @@ class TestCase extends PHPUnit_TestCase
         return $pdo;
     }
 
-    protected function tearDown(): void
-    {
+    protected function tearDown(): void {
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_unset();
             session_destroy();

--- a/tests/Uri.php
+++ b/tests/Uri.php
@@ -10,13 +10,11 @@ class Uri extends SlimUri
 {
     private string $basePath = '';
 
-    public function getBasePath(): string
-    {
+    public function getBasePath(): string {
         return $this->basePath;
     }
 
-    public function withBasePath(string $basePath): self
-    {
+    public function withBasePath(string $basePath): self {
         $clone = clone $this;
         $clone->basePath = $basePath;
         return $clone;


### PR DESCRIPTION
## Summary
- update the PHPCS ruleset to permit inline opening braces on function declarations
- convert application and test function definitions to the new `) {` brace style
- adjust a few multi-line callbacks to satisfy PHPCS formatting expectations after the style change

## Testing
- ./vendor/bin/phpcs

------
https://chatgpt.com/codex/tasks/task_e_68dab673370c832b95de1f53af3ef043