### PR TITLE
Remove card wrapper from calServer testimonials widget

### DIFF
--- a/migrations/20250930_add_calserver_proseal_widget.sql
+++ b/migrations/20250930_add_calserver_proseal_widget.sql
@@ -1231,26 +1231,23 @@ VALUES (
                 </div>
               </div>
               <div>
-                <div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
-                  <p class="uk-margin-small-bottom uk-text-large">Kundenstimmen</p>
-                  <div
-                    class="calserver-proseal"
-                    data-calserver-proseal
-                    data-widget-id="1503aa9a-ae86-41d0-8ce9-05ed6f0a4856"
-                    data-widget-language="de-DE">
-                    <div class="calserver-proseal__placeholder" data-calserver-proseal-placeholder>
-                      <p class="uk-text-small uk-margin-small-bottom">Bewertungen werden geladen, sobald du Marketing-Cookies erlaubst.</p>
-                      <button class="uk-button uk-button-primary uk-button-small" type="button" data-calserver-proseal-consent>Bewertungen anzeigen</button>
-                      <p class="uk-text-meta uk-margin-small-top">Du kannst deine Auswahl jederzeit in den Cookie-Einstellungen ändern.</p>
-                      <p class="uk-text-meta uk-margin-small-top calserver-proseal__error" data-calserver-proseal-error hidden>Bewertungen konnten nicht geladen werden. Bitte versuche es später erneut.</p>
-                    </div>
-                    <div class="calserver-proseal__embed" id="proSealWidget" data-proseal-target hidden></div>
-                    <noscript>
-                      <p class="uk-text-small uk-margin-small-top">
-                        <a class="uk-link-muted" href="https://www.provenexpert.com/calhelp/?utm_source=seals&amp;utm_campaign=embedded-proseal&amp;utm_medium=profile&amp;utm_content=1503aa9a-ae86-41d0-8ce9-05ed6f0a4856" rel="noopener" target="_blank">Kundenbewertungen auf ProvenExpert ansehen</a>
-                      </p>
-                    </noscript>
+                <div
+                  class="calserver-proseal"
+                  data-calserver-proseal
+                  data-widget-id="1503aa9a-ae86-41d0-8ce9-05ed6f0a4856"
+                  data-widget-language="de-DE">
+                  <div class="calserver-proseal__placeholder" data-calserver-proseal-placeholder>
+                    <p class="uk-text-small uk-margin-small-bottom">Bewertungen werden geladen, sobald du Marketing-Cookies erlaubst.</p>
+                    <button class="uk-button uk-button-primary uk-button-small" type="button" data-calserver-proseal-consent>Bewertungen anzeigen</button>
+                    <p class="uk-text-meta uk-margin-small-top">Du kannst deine Auswahl jederzeit in den Cookie-Einstellungen ändern.</p>
+                    <p class="uk-text-meta uk-margin-small-top calserver-proseal__error" data-calserver-proseal-error hidden>Bewertungen konnten nicht geladen werden. Bitte versuche es später erneut.</p>
                   </div>
+                  <div class="calserver-proseal__embed" id="proSealWidget" data-proseal-target hidden></div>
+                  <noscript>
+                    <p class="uk-text-small uk-margin-small-top">
+                      <a class="uk-link-muted" href="https://www.provenexpert.com/calhelp/?utm_source=seals&amp;utm_campaign=embedded-proseal&amp;utm_medium=profile&amp;utm_content=1503aa9a-ae86-41d0-8ce9-05ed6f0a4856" rel="noopener" target="_blank">Kundenbewertungen auf ProvenExpert ansehen</a>
+                    </p>
+                  </noscript>
                 </div>
               </div>
             </div>
@@ -2344,8 +2341,6 @@ VALUES (
 </div>
 </div>
 <div>
-<div class="uk-card uk-card-default uk-card-body uk-text-left padding-30px contact-card">
-<p class="uk-margin-small-bottom uk-text-large">Customer reviews</p>
 <div
   class="calserver-proseal"
   data-calserver-proseal
@@ -2363,7 +2358,6 @@ VALUES (
       <a class="uk-link-muted" href="https://www.provenexpert.com/calhelp/?utm_source=seals&amp;utm_campaign=embedded-proseal&amp;utm_medium=profile&amp;utm_content=1503aa9a-ae86-41d0-8ce9-05ed6f0a4856" rel="noopener" target="_blank">View customer reviews on ProvenExpert</a>
     </p>
   </noscript>
-</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
- embed the ProvenExpert testimonials widget in the calServer contact section without the surrounding card wrapper or heading
- mirror the same direct embed in the English content block so both locales render the widget consistently

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dab6befaf0832ba827dad4ad8666ee