### PR TITLE
Adjust array_map formatting in AdminMediaController

### DIFF
--- a/src/Controller/AdminMediaController.php
+++ b/src/Controller/AdminMediaController.php
@@ -140,7 +140,10 @@ class AdminMediaController
         }
 
         $rawTagFilters = $this->normalizeTags($params['tags'] ?? []);
-        $activeTagFilters = array_map(static fn(string $tag): string => mb_strtolower($tag), $rawTagFilters);
+        $activeTagFilters = array_map(
+            static fn(string $tag): string => mb_strtolower($tag),
+            $rawTagFilters
+        );
         if ($activeTagFilters !== []) {
             $files = array_values(
                 array_filter(
@@ -148,7 +151,10 @@ class AdminMediaController
                     static function (array $file) use ($activeTagFilters): bool {
                         $fileTags = array_map(
                             static fn(string $tag): string => mb_strtolower($tag),
-                            array_map('strval', $file['tags'] ?? [])
+                            array_map(
+                                'strval',
+                                $file['tags'] ?? []
+                            )
                         );
                         foreach ($activeTagFilters as $tag) {
                             if (!in_array($tag, $fileTags, true)) {


### PR DESCRIPTION
## Summary
- format the array_map calls in AdminMediaController to place arguments on separate lines for PSR-12 compliance

## Testing
- ./vendor/bin/phpcs

------
https://chatgpt.com/codex/tasks/task_e_68dab92949f4832b8a96babcd57d5461