### PR TITLE
Improve typing for rate limiting and media helpers

### DIFF
--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -365,14 +365,12 @@ class DomainStartPageService
      * @return array{smtp_host:?string,smtp_user:?string,smtp_pass:?string,smtp_port:?int,smtp_encryption:?string,smtp_dsn:?string,update_pass:bool}
      */
     private function normalizeSmtpConfig(array $smtpConfig, ?array $existing): array {
-        $host = isset($existing['smtp_host']) && $existing['smtp_host'] !== null ? (string) $existing['smtp_host'] : null;
-        $user = isset($existing['smtp_user']) && $existing['smtp_user'] !== null ? (string) $existing['smtp_user'] : null;
-        $port = isset($existing['smtp_port']) && $existing['smtp_port'] !== null ? (int) $existing['smtp_port'] : null;
-        $encryption = isset($existing['smtp_encryption']) && $existing['smtp_encryption'] !== null
-            ? (string) $existing['smtp_encryption']
-            : null;
-        $dsn = isset($existing['smtp_dsn']) && $existing['smtp_dsn'] !== null ? (string) $existing['smtp_dsn'] : null;
-        $pass = isset($existing['smtp_pass']) && $existing['smtp_pass'] !== null ? (string) $existing['smtp_pass'] : null;
+        $host = $this->readExistingString($existing, 'smtp_host');
+        $user = $this->readExistingString($existing, 'smtp_user');
+        $port = $this->readExistingInt($existing, 'smtp_port');
+        $encryption = $this->readExistingString($existing, 'smtp_encryption');
+        $dsn = $this->readExistingString($existing, 'smtp_dsn');
+        $pass = $this->readExistingString($existing, 'smtp_pass');
 
         if (array_key_exists('smtp_host', $smtpConfig)) {
             $value = trim((string) $smtpConfig['smtp_host']);
@@ -465,5 +463,31 @@ class DomainStartPageService
             'smtp_dsn' => $dsn,
             'update_pass' => $updatePass,
         ];
+    }
+
+    /**
+     * @param array<string,mixed>|null $existing
+     */
+    private function readExistingString(?array $existing, string $key): ?string {
+        if ($existing === null || !array_key_exists($key, $existing)) {
+            return null;
+        }
+
+        $value = $existing[$key];
+
+        return $value === null ? null : (string) $value;
+    }
+
+    /**
+     * @param array<string,mixed>|null $existing
+     */
+    private function readExistingInt(?array $existing, string $key): ?int {
+        if ($existing === null || !array_key_exists($key, $existing)) {
+            return null;
+        }
+
+        $value = $existing[$key];
+
+        return $value === null ? null : (int) $value;
     }
 }

--- a/src/Service/ProvenExpertRatingService.php
+++ b/src/Service/ProvenExpertRatingService.php
@@ -36,6 +36,9 @@ use const CURLOPT_TIMEOUT;
 use const CURLOPT_URL;
 use const CURLOPT_USERPWD;
 
+/**
+ * @phpstan-type ProvenExpertCache array<string,mixed>
+ */
 class ProvenExpertRatingService
 {
     private const API_URL = 'https://www.provenexpert.com/api_rating_v2.json';
@@ -159,6 +162,9 @@ class ProvenExpertRatingService
         return $data;
     }
 
+    /**
+     * @return ProvenExpertCache|null
+     */
     private function readCache(): ?array {
         if (!file_exists($this->cacheFile)) {
             return null;
@@ -170,9 +176,17 @@ class ProvenExpertRatingService
         }
 
         $decoded = json_decode($contents, true);
-        return is_array($decoded) ? $decoded : null;
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        /** @var ProvenExpertCache $decoded */
+        return $decoded;
     }
 
+    /**
+     * @param ProvenExpertCache $data
+     */
     private function writeCache(array $data): void {
         if (!is_writable($this->cacheFile) && !is_writable(dirname($this->cacheFile))) {
             return;


### PR DESCRIPTION
## Summary
- make the rate limit middleware and stores rely on typed local state so PHPStan can infer rate limiting entries
- streamline SMTP configuration normalization by sharing helpers that respect nullable existing values
- document media reference and caching payload shapes to tighten PHPStan expectations without affecting behaviour

## Testing
- php -l src/Application/Middleware/RateLimitMiddleware.php
- php -l src/Application/RateLimiting/ApcuRateLimitStore.php
- php -l src/Application/RateLimiting/FilesystemRateLimitStore.php
- php -l src/Service/DomainStartPageService.php
- php -l src/Service/LandingMediaReferenceService.php
- php -l src/Service/ProvenExpertRatingService.php

------
https://chatgpt.com/codex/tasks/task_e_68dab9f1baa0832bab27ce076896990a