### PR TITLE
chore: trim blank lines before end-of-file docblocks

### DIFF
--- a/src/Controller/AdminMediaController.php
+++ b/src/Controller/AdminMediaController.php
@@ -607,7 +607,6 @@ class AdminMediaController
 
         return $this->json($response, $payload, $status);
     }
-
     /**
      * @return array<string,mixed>
      */

--- a/src/Service/MediaLibraryService.php
+++ b/src/Service/MediaLibraryService.php
@@ -665,7 +665,6 @@ class MediaLibraryService
 
         return $normalized;
     }
-
     /**
      * @param mixed $value
      */


### PR DESCRIPTION
## Summary
- remove the superfluous blank line before the final docblock in `AdminMediaController`
- trim the corresponding blank line before the trailing docblock in `MediaLibraryService`

## Testing
- vendor/bin/phpcs src/Controller/AdminMediaController.php src/Service/MediaLibraryService.php

------
https://chatgpt.com/codex/tasks/task_e_68dabc8186bc832baefd5a269d3da95c