### PR TITLE
Allow MP4 and WEBM uploads in media library

### DIFF
--- a/src/Service/MediaLibraryService.php
+++ b/src/Service/MediaLibraryService.php
@@ -20,7 +20,10 @@ class MediaLibraryService
     public const MAX_UPLOAD_SIZE = 5 * 1024 * 1024;
 
     /** @var list<string> */
-    public const ALLOWED_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp', 'svg', 'pdf'];
+    public const ALLOWED_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp', 'svg', 'pdf', 'mp4', 'webm'];
+
+    /** @var list<string> */
+    private const RAW_EXTENSIONS = ['svg', 'pdf', 'mp4', 'webm'];
 
     /** @var list<string> */
     public const ALLOWED_MIME_TYPES = [
@@ -29,6 +32,8 @@ class MediaLibraryService
         'image/webp',
         'image/svg+xml',
         'application/pdf',
+        'video/mp4',
+        'video/webm',
     ];
 
     private const METADATA_FILE = '.media-metadata.json';
@@ -123,7 +128,7 @@ class MediaLibraryService
         }
 
         $unique = $this->uniqueBaseName($dir, $baseName, $extension);
-        if (in_array($extension, ['svg', 'pdf'], true)) {
+        if (in_array($extension, self::RAW_EXTENSIONS, true)) {
             $storedPath = $this->storeRawUpload($file, $dir, $relative, $unique, $extension);
         } else {
             $storedPath = $this->images->saveUploadedFile(
@@ -203,7 +208,7 @@ class MediaLibraryService
 
         $baseName = (string) pathinfo($name, PATHINFO_FILENAME);
 
-        if (in_array($targetExtension, ['svg', 'pdf'], true)) {
+        if (in_array($targetExtension, self::RAW_EXTENSIONS, true)) {
             $this->storeRawUpload($file, $dir, $relative, $baseName, $targetExtension);
         } else {
             $this->images->saveUploadedFile(

--- a/tests/Service/MediaLibraryServiceTest.php
+++ b/tests/Service/MediaLibraryServiceTest.php
@@ -128,6 +128,48 @@ SVG;
         $this->assertStringEqualsFile($storedPath, $pdf);
     }
 
+    public function testMp4UploadBypassesRasterProcessing(): void {
+        [$service, $config, $images] = $this->createService();
+
+        $video = str_repeat('mp4-video', 32);
+
+        $tmp = tempnam($this->tempDir, 'mp4');
+        file_put_contents($tmp, $video);
+        $stream = (new StreamFactory())->createStreamFromFile($tmp);
+        $uploaded = new UploadedFile($stream, 'teaser.mp4', 'video/mp4', $stream->getSize(), UPLOAD_ERR_OK);
+
+        $info = $service->uploadFile(MediaLibraryService::SCOPE_GLOBAL, $uploaded);
+
+        $this->assertSame('teaser.mp4', $info['name']);
+        $this->assertSame('mp4', $info['extension']);
+        $this->assertFalse($images->saveCalled, 'MP4 uploads must not invoke ImageUploadService');
+
+        $storedPath = $config->getGlobalUploadsDir() . DIRECTORY_SEPARATOR . 'teaser.mp4';
+        $this->assertFileExists($storedPath);
+        $this->assertStringEqualsFile($storedPath, $video);
+    }
+
+    public function testWebmUploadBypassesRasterProcessing(): void {
+        [$service, $config, $images] = $this->createService();
+
+        $video = str_repeat('webm-video', 32);
+
+        $tmp = tempnam($this->tempDir, 'webm');
+        file_put_contents($tmp, $video);
+        $stream = (new StreamFactory())->createStreamFromFile($tmp);
+        $uploaded = new UploadedFile($stream, 'clip.webm', 'video/webm', $stream->getSize(), UPLOAD_ERR_OK);
+
+        $info = $service->uploadFile(MediaLibraryService::SCOPE_GLOBAL, $uploaded);
+
+        $this->assertSame('clip.webm', $info['name']);
+        $this->assertSame('webm', $info['extension']);
+        $this->assertFalse($images->saveCalled, 'WEBM uploads must not invoke ImageUploadService');
+
+        $storedPath = $config->getGlobalUploadsDir() . DIRECTORY_SEPARATOR . 'clip.webm';
+        $this->assertFileExists($storedPath);
+        $this->assertStringEqualsFile($storedPath, $video);
+    }
+
     private function removeDir(string $dir): void {
         if (!is_dir($dir)) {
             return;


### PR DESCRIPTION
## Summary
- allow the media manager to accept mp4 and webm uploads alongside existing image and pdf formats
- update upload validation to include new video mime types and bypass raster processing for video files
- add regression tests to cover mp4 and webm handling in the media library service

## Testing
- vendor/bin/phpunit --filter MediaLibraryServiceTest

------
https://chatgpt.com/codex/tasks/task_e_68dacf565408832b9d15f2b1933cf63f