### PR TITLE
Fix PHPStan issues across services

### DIFF
--- a/src/Application/RateLimiting/ApcuRateLimitStore.php
+++ b/src/Application/RateLimiting/ApcuRateLimitStore.php
@@ -79,7 +79,7 @@ class ApcuRateLimitStore implements RateLimitStore
      * @param RateLimitEntry $entry
      */
     private function isExpired(array $entry, int $now, int $windowSeconds): bool {
-        $start = (int) ($entry['start'] ?? 0);
+        $start = (int) $entry['start'];
 
         return $start === 0 || ($now - $start) > $windowSeconds;
     }

--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -198,16 +198,34 @@ class DomainStartPageService
                 $smtpPort = (int) $row['smtp_port'];
             }
 
+            $smtpHost = null;
+            if (array_key_exists('smtp_host', $row) && $row['smtp_host'] !== null) {
+                $smtpHost = (string) $row['smtp_host'];
+            }
+
+            $smtpUser = null;
+            if (array_key_exists('smtp_user', $row) && $row['smtp_user'] !== null) {
+                $smtpUser = (string) $row['smtp_user'];
+            }
+
+            $smtpEncryption = null;
+            if (array_key_exists('smtp_encryption', $row) && $row['smtp_encryption'] !== null) {
+                $smtpEncryption = (string) $row['smtp_encryption'];
+            }
+
+            $smtpDsn = null;
+            if (array_key_exists('smtp_dsn', $row) && $row['smtp_dsn'] !== null) {
+                $smtpDsn = (string) $row['smtp_dsn'];
+            }
+
             $mappings[$domain] = [
                 'start_page' => $page,
                 'email' => $email,
-                'smtp_host' => isset($row['smtp_host']) && $row['smtp_host'] !== null ? (string) $row['smtp_host'] : null,
-                'smtp_user' => isset($row['smtp_user']) && $row['smtp_user'] !== null ? (string) $row['smtp_user'] : null,
+                'smtp_host' => $smtpHost,
+                'smtp_user' => $smtpUser,
                 'smtp_port' => $smtpPort,
-                'smtp_encryption' => isset($row['smtp_encryption']) && $row['smtp_encryption'] !== null
-                    ? (string) $row['smtp_encryption']
-                    : null,
-                'smtp_dsn' => isset($row['smtp_dsn']) && $row['smtp_dsn'] !== null ? (string) $row['smtp_dsn'] : null,
+                'smtp_encryption' => $smtpEncryption,
+                'smtp_dsn' => $smtpDsn,
                 'has_smtp_pass' => ((int) ($row['has_smtp_pass'] ?? 0)) === 1,
             ];
         }
@@ -258,17 +276,35 @@ class DomainStartPageService
 
         $hasPass = $smtpPass !== null && $smtpPass !== '';
 
+        $smtpHost = null;
+        if (array_key_exists('smtp_host', $row) && $row['smtp_host'] !== null) {
+            $smtpHost = (string) $row['smtp_host'];
+        }
+
+        $smtpUser = null;
+        if (array_key_exists('smtp_user', $row) && $row['smtp_user'] !== null) {
+            $smtpUser = (string) $row['smtp_user'];
+        }
+
+        $smtpEncryption = null;
+        if (array_key_exists('smtp_encryption', $row) && $row['smtp_encryption'] !== null) {
+            $smtpEncryption = (string) $row['smtp_encryption'];
+        }
+
+        $smtpDsn = null;
+        if (array_key_exists('smtp_dsn', $row) && $row['smtp_dsn'] !== null) {
+            $smtpDsn = (string) $row['smtp_dsn'];
+        }
+
         return [
             'domain' => $normalized,
             'start_page' => $startPage,
             'email' => $email,
-            'smtp_host' => isset($row['smtp_host']) && $row['smtp_host'] !== null ? (string) $row['smtp_host'] : null,
-            'smtp_user' => isset($row['smtp_user']) && $row['smtp_user'] !== null ? (string) $row['smtp_user'] : null,
+            'smtp_host' => $smtpHost,
+            'smtp_user' => $smtpUser,
             'smtp_port' => $smtpPort,
-            'smtp_encryption' => isset($row['smtp_encryption']) && $row['smtp_encryption'] !== null
-                ? (string) $row['smtp_encryption']
-                : null,
-            'smtp_dsn' => isset($row['smtp_dsn']) && $row['smtp_dsn'] !== null ? (string) $row['smtp_dsn'] : null,
+            'smtp_encryption' => $smtpEncryption,
+            'smtp_dsn' => $smtpDsn,
             'has_smtp_pass' => $hasPass,
             'smtp_pass' => $includeSensitive ? $smtpPass : null,
         ];

--- a/src/Service/MediaLibraryService.php
+++ b/src/Service/MediaLibraryService.php
@@ -366,8 +366,8 @@ class MediaLibraryService
             return $metadata;
         }
 
-        $tags = array_values(array_map('strval', $sourceMeta['tags'] ?? []));
-        $folderValue = $sourceMeta['folder'] ?? null;
+        $tags = $sourceMeta['tags'];
+        $folderValue = $sourceMeta['folder'];
         $folder = is_string($folderValue) && $folderValue !== '' ? $folderValue : null;
 
         return $this->applyMetadata(
@@ -588,8 +588,8 @@ class MediaLibraryService
         $public = rtrim($publicPath, '/') . '/' . $name;
 
         $meta = $metadata ?? ['tags' => [], 'folder' => null];
-        $tags = array_values(array_map('strval', $meta['tags'] ?? []));
-        $folder = $meta['folder'] ?? null;
+        $tags = $meta['tags'];
+        $folder = $meta['folder'];
         $folder = $folder !== null ? (string) $folder : null;
 
         return [

--- a/src/Service/ProvenExpertRatingService.php
+++ b/src/Service/ProvenExpertRatingService.php
@@ -72,10 +72,6 @@ class ProvenExpertRatingService
 
     public function getAggregateRatingMarkup(): string {
         $data = $this->loadData();
-        if ($data === null) {
-            return '';
-        }
-
         if (($data['status'] ?? null) === 'success' && isset($data['aggregateRating'])) {
             $markup = (string) $data['aggregateRating'];
             if ($markup !== '') {
@@ -87,9 +83,9 @@ class ProvenExpertRatingService
     }
 
     /**
-     * @return array<string,mixed>|null
+     * @return array<string,mixed>
      */
-    private function loadData(): ?array {
+    private function loadData(): array {
         $cached = $this->readCache();
         $cacheFresh = $this->isCacheFresh();
 


### PR DESCRIPTION
## Summary
- remove redundant null checks in the rate limiter and landing/media services to satisfy PHPStan
- streamline domain SMTP configuration extraction to avoid impossible null comparisons
- make the ProvenExpert rating loader always return an array and adjust callers accordingly

## Testing
- `vendor/bin/phpstan --no-progress --memory-limit=512M`


------
https://chatgpt.com/codex/tasks/task_e_68dad331356c832b972b9d909afbef03