### PR TITLE
Fix phpstan warning for media library metadata tags

### DIFF
--- a/src/Service/MediaLibraryService.php
+++ b/src/Service/MediaLibraryService.php
@@ -371,7 +371,7 @@ class MediaLibraryService
             return $metadata;
         }
 
-        $tags = array_values(array_map('strval', $sourceMeta['tags'] ?? []));
+        $tags = array_values(array_map('strval', $sourceMeta['tags']));
         $folderValue = $sourceMeta['folder'] ?? null;
         $folder = is_string($folderValue) && $folderValue !== '' ? $folderValue : null;
 


### PR DESCRIPTION
## Summary
- remove the unnecessary null-coalescing fallback when reading the tags from media metadata so phpstan recognizes the offset is always present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dade345c38832b8cf3a04cd613efc1