### PR TITLE
Switch calServer module visuals to MP4 videos

### DIFF
--- a/migrations/20250928_add_calserver_en_page.sql
+++ b/migrations/20250928_add_calserver_en_page.sql
@@ -484,7 +484,11 @@ VALUES (
 <ul class="uk-switcher calserver-modules-switcher" id="calserver-modules-switcher">
 <li>
 <figure class="calserver-module-figure" id="module-device-management">
-<img alt="Screenshot of the calServer device management with device files, history and measured values" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-device-management.webp" width="1200"/>
+<video aria-label="Screenshot of the calServer device management with device files, history and measured values" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+<source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>
 <figcaption>
 <h3 class="uk-h3">Device management &amp; history</h3>
 <p class="muted">Device files, attachments and history in one interface — including measurement values.</p>
@@ -498,7 +502,11 @@ VALUES (
 </li>
 <li>
 <figure class="calserver-module-figure" id="module-calendar-resources">
-<img alt="Screenshot of the calServer calendar with resource and scheduling" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp" width="1200"/>
+<video aria-label="Screenshot of the calServer calendar with resource and scheduling" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+<source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>
 <figcaption>
 <h3 class="uk-h3">Calendar &amp; resources</h3>
 <p class="muted">Plan appointments, loan devices and staff in a single view.</p>
@@ -512,7 +520,11 @@ VALUES (
 </li>
 <li>
 <figure class="calserver-module-figure" id="module-order-ticketing">
-<img alt="Screenshot of the calServer mandate and ticket management with workflow status" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp" width="1200"/>
+<video aria-label="Screenshot of the calServer mandate and ticket management with workflow status" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+<source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>
 <figcaption>
 <h3 class="uk-h3">Order &amp; ticket management</h3>
 <p class="muted">From order to invoice — with clear statuses, workflows and documents.</p>
@@ -526,7 +538,11 @@ VALUES (
 </li>
 <li>
 <figure class="calserver-module-figure" id="module-self-service">
-<img alt="Screenshot of the calServer self-service portal with customer view and certificates" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-self-service.webp" width="1200"/>
+<video aria-label="Screenshot of the calServer self-service portal with customer view and certificates" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+<source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>
 <figcaption>
 <h3 class="uk-h3">Self-service &amp; extranet</h3>
 <p class="muted">Provide customers &amp; partners with instrument details, certificates and forms.</p>

--- a/migrations/20250930_add_calserver_proseal_widget.sql
+++ b/migrations/20250930_add_calserver_proseal_widget.sql
@@ -531,12 +531,21 @@ VALUES (
             <ul id="calserver-modules-switcher" class="uk-switcher calserver-modules-switcher">
                               <li>
                   <figure id="module-device-management" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver-module-device-management.webp"
-                         width="1200"
-                         height="675"
-                         loading="lazy"
-                         decoding="async"
-                         alt="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
+                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
+                      <source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>
                     <figcaption>
                       <h3 class="uk-h3">Geräteverwaltung & Historie</h3>
                       <p class="muted">Geräteakten, Anhänge und Historie in einer Oberfläche – inklusive Messwerten.</p>
@@ -550,12 +559,21 @@ VALUES (
                 </li>
                               <li>
                   <figure id="module-calendar-resources" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
-                         width="1200"
-                         height="675"
-                         loading="lazy"
-                         decoding="async"
-                         alt="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
+                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
+                      <source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>
                     <figcaption>
                       <h3 class="uk-h3">Kalender & Ressourcen</h3>
                       <p class="muted">Planung von Terminen, Leihgeräten und Personal in einer Ansicht.</p>
@@ -569,12 +587,21 @@ VALUES (
                 </li>
                               <li>
                   <figure id="module-order-ticketing" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
-                         width="1200"
-                         height="675"
-                         loading="lazy"
-                         decoding="async"
-                         alt="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
+                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
+                      <source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>
                     <figcaption>
                       <h3 class="uk-h3">Auftrags- & Ticketverwaltung</h3>
                       <p class="muted">Vom Auftrag bis zur Rechnung – mit klaren Status, Workflows und Dokumenten.</p>
@@ -588,12 +615,21 @@ VALUES (
                 </li>
                               <li>
                   <figure id="module-self-service" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver-module-self-service.webp"
-                         width="1200"
-                         height="675"
-                         loading="lazy"
-                         decoding="async"
-                         alt="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
+                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
+                      <source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>
                     <figcaption>
                       <h3 class="uk-h3">Self-Service & Extranet</h3>
                       <p class="muted">Stellen Sie Kunden & Partnern Geräteinfos, Zertifikate und Formulare bereit.</p>

--- a/migrations/20251001_update_calserver_module_videos.sql
+++ b/migrations/20251001_update_calserver_module_videos.sql
@@ -1,0 +1,123 @@
+UPDATE pages
+SET content = REPLACE(
+    REPLACE(
+        REPLACE(
+            REPLACE(content,
+$$                    <img src="{{ basePath }}/uploads/calserver-module-device-management.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">$$,
+$$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
+                      <source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+            $$                    <img src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">$$,
+$$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
+                      <source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+        $$                    <img src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">$$,
+$$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
+                      <source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+    $$                    <img src="{{ basePath }}/uploads/calserver-module-self-service.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">$$,
+$$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
+                      <source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+    updated_at = CURRENT_TIMESTAMP
+WHERE slug = 'calserver';
+
+UPDATE pages
+SET content = REPLACE(
+    REPLACE(
+        REPLACE(
+            REPLACE(content,
+$$<img alt="Screenshot of the calServer device management with device files, history and measured values" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-device-management.webp" width="1200"/>$$,
+$$<video aria-label="Screenshot of the calServer device management with device files, history and measured values" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+<source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+            $$<img alt="Screenshot of the calServer calendar with resource and scheduling" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp" width="1200"/>$$,
+$$<video aria-label="Screenshot of the calServer calendar with resource and scheduling" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+<source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+        $$<img alt="Screenshot of the calServer mandate and ticket management with workflow status" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp" width="1200"/>$$,
+$$<video aria-label="Screenshot of the calServer mandate and ticket management with workflow status" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+<source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+    $$<img alt="Screenshot of the calServer self-service portal with customer view and certificates" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-self-service.webp" width="1200"/>$$,
+$$<video aria-label="Screenshot of the calServer self-service portal with customer view and certificates" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+<source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+    updated_at = CURRENT_TIMESTAMP
+WHERE slug = 'calserver-en';

--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1728,18 +1728,24 @@ body.qr-landing.calserver-theme .calserver-module-figure::before {
 }
 
 body.qr-landing.calserver-theme .calserver-module-figure img,
+body.qr-landing.calserver-theme .calserver-module-figure video,
 body.qr-landing.calserver-theme .calserver-module-figure figcaption {
     position: relative;
     z-index: 1;
 }
 
-body.qr-landing.calserver-theme .calserver-module-figure img {
+body.qr-landing.calserver-theme .calserver-module-figure img,
+body.qr-landing.calserver-theme .calserver-module-figure video {
     display: block;
     width: 100%;
     height: auto;
     object-fit: cover;
     border-radius: 0;
     box-shadow: 0 18px 32px -24px rgba(15, 23, 42, 0.45);
+}
+
+body.qr-landing.calserver-theme .calserver-module-figure video {
+    background: #000;
 }
 
 body.qr-landing.calserver-theme .calserver-module-figure figcaption {

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -880,12 +880,21 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             <ul id="calserver-modules-switcher" class="uk-switcher calserver-modules-switcher">
                               <li>
                   <figure id="module-device-management" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver-module-device-management.webp"
-                         width="1200"
-                         height="675"
-                         loading="lazy"
-                         decoding="async"
-                         alt="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
+                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
+                      <source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>
                     <figcaption>
                       <h3 class="uk-h3">Geräteverwaltung & Historie</h3>
                       <p class="muted">Geräteakten, Anhänge und Historie in einer Oberfläche – inklusive Messwerten.</p>
@@ -899,12 +908,21 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 </li>
                               <li>
                   <figure id="module-calendar-resources" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
-                         width="1200"
-                         height="675"
-                         loading="lazy"
-                         decoding="async"
-                         alt="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
+                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
+                      <source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>
                     <figcaption>
                       <h3 class="uk-h3">Kalender & Ressourcen</h3>
                       <p class="muted">Planung von Terminen, Leihgeräten und Personal in einer Ansicht.</p>
@@ -918,12 +936,21 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 </li>
                               <li>
                   <figure id="module-order-ticketing" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
-                         width="1200"
-                         height="675"
-                         loading="lazy"
-                         decoding="async"
-                         alt="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
+                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
+                      <source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>
                     <figcaption>
                       <h3 class="uk-h3">Auftrags- & Ticketverwaltung</h3>
                       <p class="muted">Vom Auftrag bis zur Rechnung – mit klaren Status, Workflows und Dokumenten.</p>
@@ -937,12 +964,21 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 </li>
                               <li>
                   <figure id="module-self-service" class="calserver-module-figure">
-                    <img src="{{ basePath }}/uploads/calserver-module-self-service.webp"
-                         width="1200"
-                         height="675"
-                         loading="lazy"
-                         decoding="async"
-                         alt="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
+                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           aria-label="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
+                      <source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>
                     <figcaption>
                       <h3 class="uk-h3">Self-Service & Extranet</h3>
                       <p class="muted">Stellen Sie Kunden & Partnern Geräteinfos, Zertifikate und Formulare bereit.</p>


### PR DESCRIPTION
## Summary
- replace the four calServer module images with looping MP4 videos in both DE and EN page content
- ensure sqlite seed schema and new migration update existing installations to the video markup
- adjust calServer styles so module videos inherit the same presentation as images and add a fallback background

## Testing
- not run (static content updates only)


------
https://chatgpt.com/codex/tasks/task_e_68dae1ab1528832b862a795960f9bd34