### PR TITLE
Wrap long lines to satisfy coding standard

### DIFF
--- a/src/Controller/Admin/LandingpageController.php
+++ b/src/Controller/Admin/LandingpageController.php
@@ -204,7 +204,11 @@ class LandingpageController
             if ($pageDomains === [] && $fallbackHost !== '') {
                 $pageDomains[] = $fallbackHost;
             }
-            $pageDomains = array_values(array_unique(array_filter($pageDomains, static fn ($value): bool => $value !== '')));
+            $pageDomains = array_values(
+                array_unique(
+                    array_filter($pageDomains, static fn ($value): bool => $value !== '')
+                )
+            );
 
             $config = $this->seoService->load($page->getId());
             $configData = $config ? $config->jsonSerialize() : $this->seoService->defaultConfig($page->getId());
@@ -235,7 +239,11 @@ class LandingpageController
             if ($pageDomains === [] && $fallbackHost !== '') {
                 $pageDomains[] = $fallbackHost;
             }
-            $pageDomains = array_values(array_unique(array_filter($pageDomains, static fn ($value): bool => $value !== '')));
+            $pageDomains = array_values(
+                array_unique(
+                    array_filter($pageDomains, static fn ($value): bool => $value !== '')
+                )
+            );
 
             $configData = $this->seoService->defaultConfig($selected->getId());
             if (($configData['domain'] ?? null) === null && $pageDomains !== []) {

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -342,7 +342,11 @@ class AdminController
             if ($pageDomains === [] && $fallbackHost !== '') {
                 $pageDomains[] = $fallbackHost;
             }
-            $pageDomains = array_values(array_unique(array_filter($pageDomains, static fn ($value): bool => $value !== '')));
+            $pageDomains = array_values(
+                array_unique(
+                    array_filter($pageDomains, static fn ($value): bool => $value !== '')
+                )
+            );
 
             $config = $service->load($page->getId());
             $configData = $config ? $config->jsonSerialize() : $service->defaultConfig($page->getId());

--- a/src/Controller/AdminMediaController.php
+++ b/src/Controller/AdminMediaController.php
@@ -262,7 +262,12 @@ class AdminMediaController
         }
 
         try {
-            $stored = $this->media->uploadFile($scope, $file, $eventUid !== '' ? $eventUid : null, $options !== [] ? $options : null);
+            $stored = $this->media->uploadFile(
+                $scope,
+                $file,
+                $eventUid !== '' ? $eventUid : null,
+                $options !== [] ? $options : null
+            );
         } catch (RuntimeException $e) {
             return $this->jsonError($response, $e->getMessage(), 400);
         }

--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -70,7 +70,8 @@ class MarketingPageController
         if ($this->turnstileConfig->isEnabled()) {
             $siteKey = $this->turnstileConfig->getSiteKey() ?? '';
             $widgetMarkup = sprintf(
-                '<div class="cf-turnstile" data-sitekey="%s" data-callback="contactTurnstileSuccess" data-error-callback="contactTurnstileError" data-expired-callback="contactTurnstileExpired"></div>',
+                '<div class="cf-turnstile" data-sitekey="%s" data-callback="contactTurnstileSuccess" ' .
+                'data-error-callback="contactTurnstileError" data-expired-callback="contactTurnstileExpired"></div>',
                 htmlspecialchars($siteKey, ENT_QUOTES)
             );
         }

--- a/src/Service/DomainContactTemplateService.php
+++ b/src/Service/DomainContactTemplateService.php
@@ -23,7 +23,14 @@ class DomainContactTemplateService
     /**
      * Fetch a stored template configuration for the given domain.
      *
-     * @return array{domain:string,sender_name:?string,recipient_html:?string,recipient_text:?string,sender_html:?string,sender_text:?string}|null
+     * @return array{
+     *     domain:string,
+     *     sender_name:?string,
+     *     recipient_html:?string,
+     *     recipient_text:?string,
+     *     sender_html:?string,
+     *     sender_text:?string
+     * }|null
      */
     public function get(string $domain): ?array {
         $normalized = $this->normalizeDomain($domain);
@@ -43,19 +50,24 @@ class DomainContactTemplateService
 
         return [
             'domain' => $normalized,
-            'sender_name' => array_key_exists('sender_name', $row) && $row['sender_name'] !== null
+            'sender_name' => array_key_exists('sender_name', $row)
+                && $row['sender_name'] !== null
                 ? (string) $row['sender_name']
                 : null,
-            'recipient_html' => array_key_exists('recipient_html', $row) && $row['recipient_html'] !== null
+            'recipient_html' => array_key_exists('recipient_html', $row)
+                && $row['recipient_html'] !== null
                 ? (string) $row['recipient_html']
                 : null,
-            'recipient_text' => array_key_exists('recipient_text', $row) && $row['recipient_text'] !== null
+            'recipient_text' => array_key_exists('recipient_text', $row)
+                && $row['recipient_text'] !== null
                 ? (string) $row['recipient_text']
                 : null,
-            'sender_html' => array_key_exists('sender_html', $row) && $row['sender_html'] !== null
+            'sender_html' => array_key_exists('sender_html', $row)
+                && $row['sender_html'] !== null
                 ? (string) $row['sender_html']
                 : null,
-            'sender_text' => array_key_exists('sender_text', $row) && $row['sender_text'] !== null
+            'sender_text' => array_key_exists('sender_text', $row)
+                && $row['sender_text'] !== null
                 ? (string) $row['sender_text']
                 : null,
         ];
@@ -64,7 +76,14 @@ class DomainContactTemplateService
     /**
      * Convenience wrapper to load template data for a request host.
      *
-     * @return array{domain:string,sender_name:?string,recipient_html:?string,recipient_text:?string,sender_html:?string,sender_text:?string}|null
+     * @return array{
+     *     domain:string,
+     *     sender_name:?string,
+     *     recipient_html:?string,
+     *     recipient_text:?string,
+     *     sender_html:?string,
+     *     sender_text:?string
+     * }|null
      */
     public function getForHost(string $host): ?array {
         return $this->get($host);
@@ -73,7 +92,13 @@ class DomainContactTemplateService
     /**
      * Persist template content for the given domain.
      *
-     * @param array{sender_name:?string,recipient_html:?string,recipient_text:?string,sender_html:?string,sender_text:?string} $data
+     * @param array{
+     *     sender_name:?string,
+     *     recipient_html:?string,
+     *     recipient_text:?string,
+     *     sender_html:?string,
+     *     sender_text:?string
+     * } $data
      */
     public function save(string $domain, array $data): void {
         $normalized = $this->normalizeDomain($domain);
@@ -91,7 +116,8 @@ class DomainContactTemplateService
         ];
 
         $stmt = $this->pdo->prepare(
-            'INSERT INTO domain_contact_templates(domain, sender_name, recipient_html, recipient_text, sender_html, sender_text)
+            'INSERT INTO domain_contact_templates(domain, sender_name, recipient_html, recipient_text, '
+            . 'sender_html, sender_text)
              VALUES(:domain, :sender_name, :recipient_html, :recipient_text, :sender_html, :sender_text)
              ON CONFLICT(domain) DO UPDATE SET
                  sender_name = excluded.sender_name,

--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -149,7 +149,9 @@ class DomainStartPageService
                 email = excluded.email,
                 smtp_host = excluded.smtp_host,
                 smtp_user = excluded.smtp_user,
-                smtp_pass = CASE WHEN excluded.smtp_pass = ? THEN domain_start_pages.smtp_pass ELSE excluded.smtp_pass END,
+                smtp_pass = CASE WHEN excluded.smtp_pass = ? THEN domain_start_pages.smtp_pass ' .
+                "\n" .
+                '                ELSE excluded.smtp_pass END,
                 smtp_port = excluded.smtp_port,
                 smtp_encryption = excluded.smtp_encryption,
                 smtp_dsn = excluded.smtp_dsn'
@@ -172,7 +174,16 @@ class DomainStartPageService
     /**
      * Fetch all configured domain mappings.
      *
-     * @return array<string,array{start_page:string,email:?string,smtp_host:?string,smtp_user:?string,smtp_port:?int,smtp_encryption:?string,smtp_dsn:?string,has_smtp_pass:bool}> Associative array of domain => config
+     * @return array<string,array{
+     *     start_page:string,
+     *     email:?string,
+     *     smtp_host:?string,
+     *     smtp_user:?string,
+     *     smtp_port:?int,
+     *     smtp_encryption:?string,
+     *     smtp_dsn:?string,
+     *     has_smtp_pass:bool
+     * }> Associative array of domain => config
      */
     public function getAllMappings(): array {
         $stmt = $this->pdo->query(
@@ -236,7 +247,18 @@ class DomainStartPageService
     /**
      * Fetch the stored configuration for a domain.
      *
-     * @return array{domain:string,start_page:string,email:?string,smtp_host:?string,smtp_user:?string,smtp_port:?int,smtp_encryption:?string,smtp_dsn:?string,has_smtp_pass:bool,smtp_pass:?string}|null
+     * @return array{
+     *     domain:string,
+     *     start_page:string,
+     *     email:?string,
+     *     smtp_host:?string,
+     *     smtp_user:?string,
+     *     smtp_port:?int,
+     *     smtp_encryption:?string,
+     *     smtp_dsn:?string,
+     *     has_smtp_pass:bool,
+     *     smtp_pass:?string
+     * }|null
      */
     public function getDomainConfig(string $domain, bool $includeSensitive = false): ?array {
         $normalized = $this->normalizeDomain($domain);
@@ -398,7 +420,15 @@ class DomainStartPageService
      * @param array<string,mixed> $smtpConfig
      * @param array<string,mixed>|null $existing
      *
-     * @return array{smtp_host:?string,smtp_user:?string,smtp_pass:?string,smtp_port:?int,smtp_encryption:?string,smtp_dsn:?string,update_pass:bool}
+     * @return array{
+     *     smtp_host:?string,
+     *     smtp_user:?string,
+     *     smtp_pass:?string,
+     *     smtp_port:?int,
+     *     smtp_encryption:?string,
+     *     smtp_dsn:?string,
+     *     update_pass:bool
+     * }
      */
     private function normalizeSmtpConfig(array $smtpConfig, ?array $existing): array {
         $host = $this->readExistingString($existing, 'smtp_host');

--- a/src/Service/EventService.php
+++ b/src/Service/EventService.php
@@ -33,7 +33,14 @@ class EventService
     /**
      * Retrieve all events ordered by name.
      *
-     * @return list<array{uid:string,name:string,start_date:?string,end_date:?string,description:?string,published:bool}>
+     * @return list<array{
+     *     uid:string,
+     *     name:string,
+     *     start_date:?string,
+     *     end_date:?string,
+     *     description:?string,
+     *     published:bool
+     * }>
      */
     public function getAll(): array {
         $sql = 'SELECT uid,name,start_date,end_date,description,published,sort_order FROM events ORDER BY sort_order';

--- a/src/Service/LandingMediaReferenceService.php
+++ b/src/Service/LandingMediaReferenceService.php
@@ -119,7 +119,13 @@ class LandingMediaReferenceService
 
                 $absolute = $this->resolveAbsolutePath($path);
                 if (!is_file($absolute)) {
-                    $missingKey = sprintf('%s|%s|%s|%s', $reference['slug'], $path, $reference['type'], $reference['field']);
+                    $missingKey = sprintf(
+                        '%s|%s|%s|%s',
+                        $reference['slug'],
+                        $path,
+                        $reference['type'],
+                        $reference['field']
+                    );
                     if (!isset($seenMissing[$missingKey])) {
                         $missing[] = $this->buildMissingEntry($reference, $path);
                         $seenMissing[$missingKey] = true;

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -353,7 +353,12 @@ class MailService
     }
 
     private function buildDefaultSenderText(string $name, string $message): string {
-        return sprintf("Hallo %s,\n\n%s\n\n%s", $name, 'vielen Dank für Ihre Nachricht. Hier ist eine Kopie Ihrer Anfrage:', $message);
+        return sprintf(
+            "Hallo %s,\n\n%s\n\n%s",
+            $name,
+            'vielen Dank für Ihre Nachricht. Hier ist eine Kopie Ihrer Anfrage:',
+            $message
+        );
     }
 
     /**

--- a/src/Service/PageService.php
+++ b/src/Service/PageService.php
@@ -50,7 +50,10 @@ class PageService
         }
 
         if (!preg_match('/^[a-z0-9][a-z0-9\-]{0,99}$/', $normalizedSlug)) {
-            throw new InvalidArgumentException('Der Slug darf nur Kleinbuchstaben, Zahlen und Bindestriche enthalten (max. 100 Zeichen).');
+            throw new InvalidArgumentException(
+                'Der Slug darf nur Kleinbuchstaben, Zahlen und Bindestriche enthalten '
+                . '(max. 100 Zeichen).'
+            );
         }
 
         $normalizedTitle = trim($title);

--- a/src/Service/ResultService.php
+++ b/src/Service/ResultService.php
@@ -197,7 +197,9 @@ class ResultService
         if ($uid === false) {
             return;
         }
-        $qStmt = $this->pdo->prepare("SELECT id FROM questions WHERE catalog_uid=? AND type<>'flip' ORDER BY sort_order");
+        $qStmt = $this->pdo->prepare(
+            "SELECT id FROM questions WHERE catalog_uid=? AND type<>'flip' ORDER BY sort_order"
+        );
         $qStmt->execute([$uid]);
         $ids = $qStmt->fetchAll(PDO::FETCH_COLUMN);
         if (!$ids) {
@@ -215,7 +217,17 @@ class ResultService
             $text = isset($ans['text']) ? (string)$ans['text'] : null;
             $photo = isset($ans['photo']) ? (string)$ans['photo'] : null;
             $consent = isset($ans['consent']) ? (int)((bool)$ans['consent']) : null;
-            $ins->execute([$name, $catalog, $qid, $attempt, $correct, $text, $photo, $consent, $eventUid]);
+            $ins->execute([
+                $name,
+                $catalog,
+                $qid,
+                $attempt,
+                $correct,
+                $text,
+                $photo,
+                $consent,
+                $eventUid,
+            ]);
         }
     }
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -113,7 +113,14 @@ class UserService
     /**
      * Retrieve all users ordered by their position.
      *
-     * @return list<array{id:int,username:string,email:?string,role:string,active:bool,position:int}>
+     * @return list<array{
+     *     id:int,
+     *     username:string,
+     *     email:?string,
+     *     role:string,
+     *     active:bool,
+     *     position:int
+     * }>
      */
     public function getAll(): array {
         $stmt = $this->pdo->query('SELECT id,username,email,role,active,position FROM users ORDER BY position');
@@ -123,7 +130,15 @@ class UserService
     /**
      * Replace the entire user list with the provided data.
      *
-     * @param list<array{id?:int,username:string,email?:?string,role:string,password?:string,active?:bool,position?:int}> $users
+     * @param list<array{
+     *     id?:int,
+     *     username:string,
+     *     email?:?string,
+     *     role:string,
+     *     password?:string,
+     *     active?:bool,
+     *     position?:int
+     * }> $users
      */
     public function saveAll(array $users): void {
         $this->pdo->beginTransaction();
@@ -132,7 +147,9 @@ class UserService
             $existing[(int) $row['id']] = true;
         }
 
-        $insert = $this->pdo->prepare('INSERT INTO users(username,password,email,role,active,position) VALUES(?,?,?,?,?,?)');
+        $insert = $this->pdo->prepare(
+            'INSERT INTO users(username,password,email,role,active,position) VALUES(?,?,?,?,?,?)'
+        );
         $update = $this->pdo->prepare('UPDATE users SET username=?,email=?,role=?,active=?,position=? WHERE id=?');
         $updatePass = $this->pdo->prepare('UPDATE users SET password=? WHERE id=?');
         $delete = $this->pdo->prepare('DELETE FROM users WHERE id=?');
@@ -153,7 +170,14 @@ class UserService
                 if ($pass === '') {
                     $pass = bin2hex(random_bytes(8));
                 }
-                $insert->execute([$username, password_hash($pass, PASSWORD_DEFAULT), $email, $role, $active, $position]);
+                $insert->execute([
+                    $username,
+                    password_hash($pass, PASSWORD_DEFAULT),
+                    $email,
+                    $role,
+                    $active,
+                    $position,
+                ]);
                 continue;
             }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -253,7 +253,14 @@ return function (\Slim\App $app, TranslationService $translator) {
         $request = $request
             ->withAttribute('plan', $plan)
             ->withAttribute('configService', $configService)
-            ->withAttribute('configController', new ConfigController($configService, new ConfigValidator(), $eventService))
+            ->withAttribute(
+                'configController',
+                new ConfigController(
+                    $configService,
+                    new ConfigValidator(),
+                    $eventService
+                )
+            )
             ->withAttribute('catalogController', new CatalogController($catalogService))
             ->withAttribute('adminCatalogController', new AdminCatalogController($catalogService))
             ->withAttribute('resultController', new ResultController(
@@ -266,7 +273,10 @@ return function (\Slim\App $app, TranslationService $translator) {
             ))
             ->withAttribute('teamController', new TeamController($teamService, $configService))
             ->withAttribute('eventController', new EventController($eventService))
-            ->withAttribute('eventConfigController', new EventConfigController($eventService, $configService, $imageUploadService))
+            ->withAttribute(
+                'eventConfigController',
+                new EventConfigController($eventService, $configService, $imageUploadService)
+            )
             ->withAttribute(
                 'tenantController',
                 new TenantController(
@@ -443,14 +453,17 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = new MarketingPageController('calserver');
         return $controller($request, $response);
     });
-    $app->get('/m/{slug:[a-z0-9-]+}', function (Request $request, Response $response, array $args) use ($resolveMarketingAccess) {
-        [$request, $allowed] = $resolveMarketingAccess($request);
-        if (!$allowed) {
-            return $response->withStatus(404);
+    $app->get(
+        '/m/{slug:[a-z0-9-]+}',
+        function (Request $request, Response $response, array $args) use ($resolveMarketingAccess) {
+            [$request, $allowed] = $resolveMarketingAccess($request);
+            if (!$allowed) {
+                return $response->withStatus(404);
+            }
+            $controller = new MarketingPageController();
+            return $controller($request, $response, $args);
         }
-        $controller = new MarketingPageController();
-        return $controller($request, $response, $args);
-    });
+    );
     $app->post('/landing/contact', ContactController::class)
         ->add(new RateLimitMiddleware(3, 3600))
         ->add(new CsrfMiddleware());
@@ -1500,7 +1513,9 @@ return function (\Slim\App $app, TranslationService $translator) {
         if ($slug === '' || !preg_match('/^[a-z0-9-]+$/', $slug)) {
             $response->getBody()->write(json_encode(['error' => 'Invalid slug']));
 
-            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+            return $response
+                ->withHeader('Content-Type', 'application/json')
+                ->withStatus(400);
         }
         $script = realpath(__DIR__ . '/../scripts/onboard_tenant.sh');
 
@@ -1820,12 +1835,15 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $response->withHeader('Location', $location)->withStatus(302);
     })->add(new RoleAuthMiddleware('admin'));
 
-    $app->get('/{slug:[a-z0-9-]+}', function (Request $request, Response $response, array $args) use ($resolveMarketingAccess) {
-        [$request, $allowed] = $resolveMarketingAccess($request);
-        if (!$allowed || $request->getAttribute('domainType') !== 'marketing') {
-            return $response->withStatus(404);
+    $app->get(
+        '/{slug:[a-z0-9-]+}',
+        function (Request $request, Response $response, array $args) use ($resolveMarketingAccess) {
+            [$request, $allowed] = $resolveMarketingAccess($request);
+            if (!$allowed || $request->getAttribute('domainType') !== 'marketing') {
+                return $response->withStatus(404);
+            }
+            $controller = new MarketingPageController();
+            return $controller($request, $response, $args);
         }
-        $controller = new MarketingPageController();
-        return $controller($request, $response, $args);
-    });
+    );
 };


### PR DESCRIPTION
## Summary
- wrap long HTML strings and method chains in controllers so each line stays within the 120-character limit
- expand structured phpdoc array annotations onto multiple lines to comply with the formatting requirement
- split long SQL fragments and argument lists across services and routes without changing behavior

## Testing
- vendor/bin/phpcs src

------
https://chatgpt.com/codex/tasks/task_e_68dae294f8c4832bb55987a6e285b19f