### PR TITLE
Wrap long lines in tests

### DIFF
--- a/tests/Controller/AdminCatalogControllerTest.php
+++ b/tests/Controller/AdminCatalogControllerTest.php
@@ -22,10 +22,21 @@ class AdminCatalogControllerTest extends TestCase
         $pdo = new PDO('sqlite:' . $db);
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         Migrator::migrate($pdo, dirname(__DIR__, 2) . '/migrations');
-        $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event')");
-        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('c1',1,'s1','s1.json','Cat1','e1')");
-        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('c2',2,'s2','s2.json','Cat2','e1')");
-        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('c3',3,'s3','s3.json','Cat3','e1')");
+        $pdo->exec(
+            "INSERT INTO events(uid,slug,name) VALUES('e1','e1','Event')"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) " .
+            "VALUES('c1',1,'s1','s1.json','Cat1','e1')"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) " .
+            "VALUES('c2',2,'s2','s2.json','Cat2','e1')"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) " .
+            "VALUES('c3',3,'s3','s3.json','Cat3','e1')"
+        );
 
         $cfgSvc = new ConfigService($pdo);
         $service = new CatalogService($pdo, $cfgSvc);

--- a/tests/Controller/CatalogQuestionsControllerTest.php
+++ b/tests/Controller/CatalogQuestionsControllerTest.php
@@ -50,7 +50,10 @@ class CatalogQuestionsControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES('u1',1,'station_1','station_1.json','Station 1');");
+        $pdo->exec(
+            "INSERT INTO catalogs(uid,sort_order,slug,file,name) VALUES" .
+            "('u1',1,'station_1','station_1.json','Station 1');"
+        );
         $pdo->exec("INSERT INTO questions(catalog_uid,sort_order,type,prompt) VALUES('u1',1,'text','Frage?');");
 
         $cfg = new ConfigService($pdo);

--- a/tests/Controller/CatalogStickerControllerTest.php
+++ b/tests/Controller/CatalogStickerControllerTest.php
@@ -19,14 +19,22 @@ class CatalogStickerControllerTest extends TestCase
 {
     public function testPdfWithEmptyParameters(): void {
         $pdo = $this->createDatabase();
-        $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
-        $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')");
+        $pdo->exec(
+            "INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) " .
+            "VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')"
+        );
         $config = new ConfigService($pdo);
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
             public function generateCatalog(array $q, array $cfg = []): array {
-                $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
+                $img = base64_decode(
+                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU' .
+                    '5ErkJggg=='
+                );
                 return ['mime' => 'image/png', 'body' => $img];
             }
         };
@@ -51,14 +59,22 @@ class CatalogStickerControllerTest extends TestCase
 
     public function testPdfWithValidParameters(): void {
         $pdo = $this->createDatabase();
-        $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
-        $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')");
+        $pdo->exec(
+            "INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) " .
+            "VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')"
+        );
         $config = new ConfigService($pdo);
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
             public function generateCatalog(array $q, array $cfg = []): array {
-                $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
+                $img = base64_decode(
+                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU' .
+                    '5ErkJggg=='
+                );
                 return ['mime' => 'image/png', 'body' => $img];
             }
         };
@@ -83,14 +99,22 @@ class CatalogStickerControllerTest extends TestCase
 
     public function testPdfWithAdditionalTemplate(): void {
         $pdo = $this->createDatabase();
-        $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
-        $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')");
+        $pdo->exec(
+            "INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) " .
+            "VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')"
+        );
         $config = new ConfigService($pdo);
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
             public function generateCatalog(array $q, array $cfg = []): array {
-                $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
+                $img = base64_decode(
+                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU' .
+                    '5ErkJggg=='
+                );
                 return ['mime' => 'image/png', 'body' => $img];
             }
         };
@@ -109,7 +133,9 @@ class CatalogStickerControllerTest extends TestCase
 
     public function testPdfUsesDefaultTemplateL7163(): void {
         $pdo = $this->createDatabase();
-        $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
+        $pdo->exec(
+            "INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)"
+        );
         for ($i = 0; $i < 14; $i++) {
             $uid = 'c' . $i;
             $pdo->exec(
@@ -122,7 +148,10 @@ class CatalogStickerControllerTest extends TestCase
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
             public function generateCatalog(array $q, array $cfg = []): array {
-                $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
+                $img = base64_decode(
+                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU' .
+                    '5ErkJggg=='
+                );
                 return ['mime' => 'image/png', 'body' => $img];
             }
         };
@@ -136,14 +165,22 @@ class CatalogStickerControllerTest extends TestCase
 
     public function testPdfEmbedsBackgroundImage(): void {
         $pdo = $this->createDatabase();
-        $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
-        $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')");
+        $pdo->exec(
+            "INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) " .
+            "VALUES('c1',0,'c1','c1.json','Cat','Desc','A','ev1')"
+        );
         $config = new ConfigService($pdo);
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
         $qr = new class extends QrCodeService {
             public function generateCatalog(array $q, array $cfg = []): array {
-                $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==');
+                $img = base64_decode(
+                    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU' .
+                    '5ErkJggg=='
+                );
                 return ['mime' => 'image/png', 'body' => $img];
             }
         };
@@ -159,7 +196,10 @@ class CatalogStickerControllerTest extends TestCase
         if (!is_dir($dir)) {
             mkdir($dir, 0777, true);
         }
-        $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFklEQVR4nGP8z8DAwMDAxMDAwMDAAAANHQEDasKb6QAAAABJRU5ErkJggg==');
+        $img = base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFklEQVR4nGP8z8DAwMDAxMDAwMDAAAANHQEDa' .
+            'sKb6QAAAABJRU5ErkJggg=='
+        );
         file_put_contents($bg, $img);
         try {
             $responseWithBg = $controller->pdf($request, new Response());
@@ -174,8 +214,14 @@ class CatalogStickerControllerTest extends TestCase
 
     public function testGetSettingsProvidesPreviewFields(): void {
         $pdo = $this->createDatabase();
-        $pdo->exec("INSERT INTO events(uid, slug, name, description, published, sort_order) VALUES('ev1','ev1','EventTitle','EventDesc',1,0)");
-        $pdo->exec("INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) VALUES('c1',0,'c1','c1.json','CatName','CatDesc','A','ev1')");
+        $pdo->exec(
+            "INSERT INTO events(uid, slug, name, description, published, sort_order) " .
+            "VALUES('ev1','ev1','EventTitle','EventDesc',1,0)"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid, sort_order, slug, file, name, description, raetsel_buchstabe, event_uid) " .
+            "VALUES('c1',0,'c1','c1.json','CatName','CatDesc','A','ev1')"
+        );
         $config = new ConfigService($pdo);
         $config->saveConfig([
             'event_uid' => 'ev1',
@@ -205,7 +251,9 @@ class CatalogStickerControllerTest extends TestCase
 
     public function testUploadBackgroundStoresImageAndConfig(): void {
         $pdo = $this->createDatabase();
-        $pdo->exec("INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)");
+        $pdo->exec(
+            "INSERT INTO events(uid, slug, name, published, sort_order) VALUES('ev1','ev1','Event',1,0)"
+        );
         $config = new ConfigService($pdo);
         $events = new EventService($pdo);
         $catalogs = new CatalogService($pdo, $config);
@@ -214,7 +262,10 @@ class CatalogStickerControllerTest extends TestCase
         $controller = new CatalogStickerController($config, $events, $catalogs, $qr, $images);
 
         $filePath = sys_get_temp_dir() . '/bg.png';
-        $img = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAADElEQVQImWNgYGAAAAAEAAGjChXjAAAAAElFTkSuQmCC');
+        $img = base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAADElEQVQI' .
+            'mWNgYGAAAAAEAAGjChXjAAAAAElFTkSuQmCC'
+        );
         file_put_contents($filePath, $img);
         $stream = fopen($filePath, 'rb');
         $uploaded = new UploadedFile(new Stream($stream), 'bg.png', 'image/png', filesize($filePath), UPLOAD_ERR_OK);

--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -54,19 +54,20 @@ class ContactControllerTest extends TestCase
 
             $pdo = $this->getDatabase();
             $stmt = $pdo->prepare(
-                'INSERT INTO domain_start_pages(domain, start_page, email) VALUES(?, ?, ?)
-                 ON CONFLICT(domain) DO UPDATE SET start_page = excluded.start_page, email = excluded.email'
+                'INSERT INTO domain_start_pages(domain, start_page, email) VALUES(?, ?, ?)' .
+                ' ON CONFLICT(domain) DO UPDATE SET start_page = excluded.start_page, email = excluded.email'
             );
             $stmt->execute(['main.test', 'landing', 'contact@main.test']);
             $pdo->prepare(
-                'INSERT INTO domain_contact_templates(domain, sender_name, recipient_html, recipient_text, sender_html, sender_text)
-                 VALUES(?, ?, ?, ?, ?, ?)
-                 ON CONFLICT(domain) DO UPDATE SET
-                    sender_name = excluded.sender_name,
-                    recipient_html = excluded.recipient_html,
-                    recipient_text = excluded.recipient_text,
-                    sender_html = excluded.sender_html,
-                    sender_text = excluded.sender_text'
+                'INSERT INTO domain_contact_templates(' .
+                'domain, sender_name, recipient_html, recipient_text, sender_html, sender_text)' .
+                ' VALUES(?, ?, ?, ?, ?, ?)' .
+                ' ON CONFLICT(domain) DO UPDATE SET' .
+                '     sender_name = excluded.sender_name,' .
+                '     recipient_html = excluded.recipient_html,' .
+                '     recipient_text = excluded.recipient_text,' .
+                '     sender_html = excluded.sender_html,' .
+                '     sender_text = excluded.sender_text'
             )->execute([
                 'main.test',
                 'Main Contact',

--- a/tests/Controller/EventImageControllerTest.php
+++ b/tests/Controller/EventImageControllerTest.php
@@ -21,7 +21,9 @@ class EventImageControllerTest extends TestCase
 
         $app = $this->getAppInstance();
         $request = $this->createRequest('GET', '/events/evimg/images/sticker-bg.png');
-        $request = $request->withUri(new \Slim\Psr7\Uri('http', 'localhost', 80, '/events/evimg/images/sticker-bg.png'));
+        $request = $request->withUri(
+            new \Slim\Psr7\Uri('http', 'localhost', 80, '/events/evimg/images/sticker-bg.png')
+        );
         $response = $app->handle($request);
 
         $this->assertSame(200, $response->getStatusCode());

--- a/tests/Controller/HelpControllerTest.php
+++ b/tests/Controller/HelpControllerTest.php
@@ -49,17 +49,18 @@ class HelpControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, description TEXT, ' .
-            'sort_order INTEGER DEFAULT 0);'
+            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
+            ');'
         );
         $pdo->exec(
             "INSERT INTO events(uid,slug,name,start_date,end_date,description) " .
             "VALUES('1','event','Event','2024-01-01T10:00','2024-01-01T12:00','Desc')"
         );
         $pdo->exec(
-            "INSERT INTO config(inviteText, event_uid) VALUES(" .
+            'INSERT INTO config(inviteText, event_uid) VALUES(' .
             "'Hallo [Team], willkommen zu [EVENT_NAME] am [EVENT_START] " .
-            "bis [EVENT_END] - [EVENT_DESCRIPTION]!','1')"
+            "bis [EVENT_END] - [EVENT_DESCRIPTION]!', '1')"
         );
 
         putenv('POSTGRES_DSN=sqlite:' . $dbFile);

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -193,7 +193,9 @@ class HomeControllerTest extends TestCase
         $pdo = \App\Infrastructure\Database::connectFromEnv();
         \App\Infrastructure\Migrations\Migrator::migrate($pdo, dirname(__DIR__, 2) . '/migrations');
         (new \App\Service\SettingsService($pdo))->save(['home_page' => 'landing']);
-        $pdo->exec("INSERT INTO pages(slug,title,content) VALUES('landing','Landing','Trete gegen Freunde und Kollegen an')");
+        $pdo->exec(
+            "INSERT INTO pages(slug,title,content) VALUES('landing','Landing','Trete gegen Freunde und Kollegen an')"
+        );
         $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('1','event','Event')");
         $pdo->exec(
             "INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) " .

--- a/tests/Controller/LogoControllerTest.php
+++ b/tests/Controller/LogoControllerTest.php
@@ -136,7 +136,9 @@ class LogoControllerTest extends TestCase
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $pdo->exec(
-            'CREATE TABLE events(uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, sort_order INTEGER DEFAULT 0);'
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, sort_order INTEGER DEFAULT 0' .
+            ');'
         );
         $pdo->exec(
             'CREATE TABLE active_event(event_uid TEXT PRIMARY KEY);'
@@ -243,7 +245,11 @@ class LogoControllerTest extends TestCase
     public function testGetLogoForSpecificEventWhileAnotherActive(): void {
         $pdo = new \PDO('sqlite::memory:');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, sort_order INTEGER DEFAULT 0);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, sort_order INTEGER DEFAULT 0' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE active_event(event_uid TEXT PRIMARY KEY);');
         $pdo->exec(
             <<<'SQL'

--- a/tests/Controller/PlayerProfileTest.php
+++ b/tests/Controller/PlayerProfileTest.php
@@ -11,7 +11,9 @@ class PlayerProfileTest extends TestCase
 {
     public function testProfilePageAndApiPlayers(): void {
         $pdo = $this->getDatabase();
-        $pdo->exec("INSERT INTO events(uid, slug, name) VALUES('ev1','ev1','Test')");
+        $pdo->exec(
+            "INSERT INTO events(uid, slug, name) VALUES('ev1','ev1','Test')"
+        );
 
         $app = $this->getAppInstance();
 
@@ -27,7 +29,9 @@ class PlayerProfileTest extends TestCase
         $res = $app->handle($request);
         $this->assertSame(204, $res->getStatusCode());
 
-        $name = $pdo->query("SELECT player_name FROM players WHERE event_uid='ev1' AND player_uid='uid1'")?->fetchColumn();
+        $name = $pdo->query(
+            "SELECT player_name FROM players WHERE event_uid='ev1' AND player_uid='uid1'"
+        )?->fetchColumn();
         $this->assertSame('Alice', $name);
 
         $getReq = $this->createRequest('GET', '/api/players?event_uid=ev1&player_uid=uid1');

--- a/tests/Controller/QrControllerTest.php
+++ b/tests/Controller/QrControllerTest.php
@@ -191,10 +191,13 @@ class QrControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, description TEXT, ' .
-            'sort_order INTEGER DEFAULT 0);'
+            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
+            ');'
         );
-        $pdo->exec("INSERT INTO events(uid,slug,name,description) VALUES('1','event','Event','Sub')");
+        $pdo->exec(
+            "INSERT INTO events(uid,slug,name,description) VALUES('1','event','Event','Sub')"
+        );
         $cfg = new \App\Service\ConfigService($pdo);
         $cfg->setActiveEventUid('1');
         $teams = new \App\Service\TeamService($pdo, $cfg);
@@ -440,10 +443,13 @@ class QrControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, description TEXT, sort_order INTEGER DEFAULT 0' .
+            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
             ');'
         );
-        $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('1','event','Event')");
+        $pdo->exec(
+            "INSERT INTO events(uid,slug,name) VALUES('1','event','Event')"
+        );
         $pdo->exec(
             'CREATE TABLE teams(' .
             'sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY, event_uid TEXT' .
@@ -502,11 +508,31 @@ class QrControllerTest extends TestCase
             );
             SQL
         );
-        $pdo->exec('CREATE TABLE events(uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, description TEXT, sort_order INTEGER DEFAULT 0);');
-        $pdo->exec("INSERT INTO events(uid,slug,name) VALUES('1','event','Event')");
-        $pdo->exec('CREATE TABLE teams(sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY, event_uid TEXT);');
-        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT);');
-        $pdo->exec('CREATE TABLE results(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, catalog TEXT, attempt INTEGER, correct INTEGER, total INTEGER, time INTEGER, puzzleTime INTEGER, photo TEXT, event_uid TEXT);');
+        $pdo->exec(
+            'CREATE TABLE events(' .
+            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
+            ');'
+        );
+        $pdo->exec(
+            "INSERT INTO events(uid,slug,name) VALUES('1','event','Event')"
+        );
+        $pdo->exec(
+            'CREATE TABLE teams(' .
+            'sort_order INTEGER UNIQUE NOT NULL, name TEXT NOT NULL, uid TEXT PRIMARY KEY, event_uid TEXT' .
+            ');'
+        );
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
+        );
+        $pdo->exec(
+            'CREATE TABLE results(' .
+            'id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, catalog TEXT, attempt INTEGER, correct INTEGER, ' .
+            'total INTEGER, time INTEGER, puzzleTime INTEGER, photo TEXT, event_uid TEXT' .
+            ');'
+        );
 
         $cfg = new \App\Service\ConfigService($pdo);
         $cfg->setActiveEventUid('1');
@@ -561,7 +587,10 @@ class QrControllerTest extends TestCase
             'description TEXT, sort_order INTEGER DEFAULT 0' .
             ');'
         );
-        $pdo->exec("INSERT INTO events(uid,slug,name,description) VALUES('1','one','First','A'),('2','two','Second','B')");
+        $pdo->exec(
+            "INSERT INTO events(uid,slug,name,description) VALUES" .
+            "('1','one','First','A'),('2','two','Second','B')"
+        );
 
         $cfg = new \App\Service\ConfigService($pdo);
         $teams = new \App\Service\TeamService($pdo, $cfg);

--- a/tests/Controller/ResultControllerTest.php
+++ b/tests/Controller/ResultControllerTest.php
@@ -54,10 +54,13 @@ class ResultControllerTest extends TestCase
         );
         $pdo->exec(
             'CREATE TABLE events(' .
-            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, description TEXT, ' .
-            'sort_order INTEGER DEFAULT 0);'
+            'uid TEXT PRIMARY KEY, slug TEXT UNIQUE NOT NULL, name TEXT, start_date TEXT, end_date TEXT, ' .
+            'description TEXT, sort_order INTEGER DEFAULT 0' .
+            ');'
         );
-        $pdo->exec("INSERT INTO events(uid,slug,name,description) VALUES('1','1','Event','Sub')");
+        $pdo->exec(
+            "INSERT INTO events(uid,slug,name,description) VALUES('1','1','Event','Sub')"
+        );
         $pdo->exec(
             'CREATE TABLE catalogs(' .
             'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, description TEXT,' .

--- a/tests/Controller/StripeCheckoutControllerTest.php
+++ b/tests/Controller/StripeCheckoutControllerTest.php
@@ -83,7 +83,10 @@ class StripeCheckoutControllerTest extends TestCase
         $this->assertNull($service->args['create'][5] ?? null);
         $this->assertSame('tenant1', $service->args['create'][6] ?? null);
         $this->assertSame(7, $service->args['create'][7] ?? null);
-        $this->assertStringContainsString('/onboarding/checkout/{CHECKOUT_SESSION_ID}', $service->args['create'][1] ?? '');
+        $this->assertStringContainsString(
+            '/onboarding/checkout/{CHECKOUT_SESSION_ID}',
+            $service->args['create'][1] ?? ''
+        );
     }
 
     public function testPostReturnsCheckoutUrl(): void {

--- a/tests/Service/LandingMediaReferenceServiceTest.php
+++ b/tests/Service/LandingMediaReferenceServiceTest.php
@@ -29,13 +29,20 @@ class LandingMediaReferenceServiceTest extends TestCase
             'updated_at TEXT DEFAULT CURRENT_TIMESTAMP)'
         );
         $stmt = $pdo->prepare('INSERT INTO pages (slug, title, content) VALUES (?, ?, ?)');
-        $stmt->execute(['landing', 'Landing', '<img src="{{ basePath }}/uploads/landing/hero.webp"><img src="/uploads/landing/missing.avif">']);
+        $stmt->execute([
+            'landing',
+            'Landing',
+            '<img src="{{ basePath }}/uploads/landing/hero.webp">' .
+            '<img src="/uploads/landing/missing.avif">',
+        ]);
         $landingId = (int) $pdo->lastInsertId();
         $stmt->execute(['impressum', 'Impressum', '<img src="/uploads/landing/ignore.webp">']);
 
         $seoInsert = $pdo->prepare(
-            'INSERT INTO page_seo_config (page_id, slug, domain, meta_title, meta_description, canonical_url, robots_meta, ' .
-            'og_title, og_description, og_image, favicon_path, schema_json, hreflang) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+            'INSERT INTO page_seo_config (' .
+            'page_id, slug, domain, meta_title, meta_description, canonical_url, robots_meta, ' .
+            'og_title, og_description, og_image, favicon_path, schema_json, hreflang) ' .
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
         );
         $seoInsert->execute([
             $landingId,
@@ -118,9 +125,10 @@ class LandingMediaReferenceServiceTest extends TestCase
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->exec('CREATE TABLE pages (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT, title TEXT, content TEXT)');
         $pdo->exec(
-            'CREATE TABLE page_seo_config (page_id INTEGER PRIMARY KEY, slug TEXT, domain TEXT, meta_title TEXT, ' .
-            'meta_description TEXT, canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, og_image TEXT, ' .
-            'favicon_path TEXT, schema_json TEXT, hreflang TEXT, created_at TEXT, updated_at TEXT)'
+            'CREATE TABLE page_seo_config (' .
+            'page_id INTEGER PRIMARY KEY, slug TEXT, domain TEXT, meta_title TEXT, ' .
+            'meta_description TEXT, canonical_url TEXT, robots_meta TEXT, og_title TEXT, og_description TEXT, ' .
+            'og_image TEXT, favicon_path TEXT, schema_json TEXT, hreflang TEXT, created_at TEXT, updated_at TEXT)'
         );
         $config = new ConfigService($pdo);
         $pageService = new PageService($pdo);
@@ -133,10 +141,21 @@ class LandingMediaReferenceServiceTest extends TestCase
         );
         $service = new LandingMediaReferenceService($pageService, $seoService, $config);
 
-        $this->assertSame('uploads/landing/hero.webp', $service->normalizeFilePath('{{ basePath }}/uploads/landing/hero.webp'));
-        $this->assertSame('uploads/landing/hero.webp', $service->normalizeFilePath('/uploads/landing/hero.webp'));
-        $this->assertSame('uploads/landing/hero.webp', $service->normalizeFilePath('uploads/landing/hero.webp'));
-        $this->assertNull($service->normalizeFilePath('https://example.com/uploads/landing/hero.webp'));
+        $this->assertSame(
+            'uploads/landing/hero.webp',
+            $service->normalizeFilePath('{{ basePath }}/uploads/landing/hero.webp')
+        );
+        $this->assertSame(
+            'uploads/landing/hero.webp',
+            $service->normalizeFilePath('/uploads/landing/hero.webp')
+        );
+        $this->assertSame(
+            'uploads/landing/hero.webp',
+            $service->normalizeFilePath('uploads/landing/hero.webp')
+        );
+        $this->assertNull(
+            $service->normalizeFilePath('https://example.com/uploads/landing/hero.webp')
+        );
         $this->assertNull($service->normalizeFilePath('/images/hero.webp'));
     }
 }

--- a/tests/Service/MailServiceTest.php
+++ b/tests/Service/MailServiceTest.php
@@ -388,7 +388,10 @@ class MailServiceTest extends TestCase
         $this->assertSame('contact@example.org', $first->getFrom()[0]->getAddress());
         $this->assertSame('Kontaktanfrage', $first->getSubject());
         $this->assertStringContainsString('<p>Jane Doe</p>', (string) $first->getHtmlBody());
-        $this->assertStringContainsString('&lt;b&gt;World&lt;/b&gt;<br />' . PHP_EOL . 'Line', (string) $first->getHtmlBody());
+        $this->assertStringContainsString(
+            '&lt;b&gt;World&lt;/b&gt;<br />' . PHP_EOL . 'Line',
+            (string) $first->getHtmlBody()
+        );
         $this->assertSame("Plain: Hello <b>World</b>\nLine", $first->getTextBody());
 
         $copy = $svc->messages[1];

--- a/tests/Service/MediaLibraryServiceTest.php
+++ b/tests/Service/MediaLibraryServiceTest.php
@@ -15,6 +15,7 @@ use RecursiveIteratorIterator;
 use RuntimeException;
 use Slim\Psr7\Factory\StreamFactory;
 use Slim\Psr7\UploadedFile;
+
 use function json_encode;
 
 class MediaLibraryServiceTest extends TestCase
@@ -386,8 +387,11 @@ SVG;
         return [new MediaLibraryService($config, $images), $config, $images];
     }
 
-    private function createConversionService(ConfigService $config, ImageUploadService $images, bool $hasAudio): MediaLibraryService
-    {
+    private function createConversionService(
+        ConfigService $config,
+        ImageUploadService $images,
+        bool $hasAudio
+    ): MediaLibraryService {
         return new class ($config, $images, $hasAudio) extends MediaLibraryService {
             /** @var list<array{0:string,1:list<string>}> */
             public array $processCalls = [];

--- a/tests/Service/ResultServiceTest.php
+++ b/tests/Service/ResultServiceTest.php
@@ -457,11 +457,23 @@ class ResultServiceTest extends TestCase
         $cfg->setActiveEventUid('ev1');
         $service = new ResultService($pdo);
 
-        $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time,event_uid) VALUES('Team1','cat',1,0,0,0,'ev1')");
-        $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time,event_uid) VALUES('Team2','cat',1,0,0,0,'ev2')");
+        $pdo->exec(
+            "INSERT INTO results(name,catalog,attempt,correct,total,time,event_uid) " .
+            "VALUES('Team1','cat',1,0,0,0,'ev1')"
+        );
+        $pdo->exec(
+            "INSERT INTO results(name,catalog,attempt,correct,total,time,event_uid) " .
+            "VALUES('Team2','cat',1,0,0,0,'ev2')"
+        );
 
-        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('u1',1,'cat','c.json','Catalog 1','ev1')");
-        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('u2',2,'cat','c.json','Catalog 2','ev2')");
+        $pdo->exec(
+            "INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) " .
+            "VALUES('u1',1,'cat','c.json','Catalog 1','ev1')"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) " .
+            "VALUES('u2',2,'cat','c.json','Catalog 2','ev2')"
+        );
 
         $rows = $service->getAll();
         $this->assertCount(1, $rows);
@@ -516,11 +528,23 @@ class ResultServiceTest extends TestCase
 
         $pdo->exec("INSERT INTO questions(id,catalog_uid,sort_order,type,prompt) VALUES(1,'u1',1,'text','Q1')");
 
-        $pdo->exec("INSERT INTO question_results(name,catalog,question_id,attempt,correct,event_uid) VALUES('Team1','cat',1,1,1,'ev1')");
-        $pdo->exec("INSERT INTO question_results(name,catalog,question_id,attempt,correct,event_uid) VALUES('Team2','cat',1,1,1,'ev2')");
+        $pdo->exec(
+            "INSERT INTO question_results(name,catalog,question_id,attempt,correct,event_uid) " .
+            "VALUES('Team1','cat',1,1,1,'ev1')"
+        );
+        $pdo->exec(
+            "INSERT INTO question_results(name,catalog,question_id,attempt,correct,event_uid) " .
+            "VALUES('Team2','cat',1,1,1,'ev2')"
+        );
 
-        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('u1',1,'cat','c.json','Catalog 1','ev1')");
-        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('u2',2,'cat','c.json','Catalog 2','ev2')");
+        $pdo->exec(
+            "INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) " .
+            "VALUES('u1',1,'cat','c.json','Catalog 1','ev1')"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) " .
+            "VALUES('u2',2,'cat','c.json','Catalog 2','ev2')"
+        );
 
         $rows = $service->getQuestionResults();
         $this->assertCount(2, $rows);
@@ -568,13 +592,27 @@ class ResultServiceTest extends TestCase
             'prompt TEXT NOT NULL' .
             ')'
         );
-        $pdo->exec('CREATE TABLE catalogs(uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT);');
+        $pdo->exec(
+            'CREATE TABLE catalogs(' .
+            'uid TEXT PRIMARY KEY, sort_order INTEGER, slug TEXT, file TEXT, name TEXT, event_uid TEXT' .
+            ');'
+        );
         $pdo->exec('CREATE TABLE config(event_uid TEXT);');
 
-        $pdo->exec("INSERT INTO results(name,catalog,attempt,correct,total,time,event_uid) VALUES('T','c',1,1,1,1,'ev1')");
-        $pdo->exec("INSERT INTO question_results(name,catalog,question_id,attempt,correct,event_uid) VALUES('T','c',1,1,1,'ev1')");
-        $pdo->exec("INSERT INTO questions(id,catalog_uid,sort_order,type,prompt) VALUES(1,'c',1,'text','Q')");
-        $pdo->exec("INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('c',1,'c','c.json','C','ev1')");
+        $pdo->exec(
+            "INSERT INTO results(name,catalog,attempt,correct,total,time,event_uid) " .
+            "VALUES('T','c',1,1,1,1,'ev1')"
+        );
+        $pdo->exec(
+            "INSERT INTO question_results(name,catalog,question_id,attempt,correct,event_uid) " .
+            "VALUES('T','c',1,1,1,'ev1')"
+        );
+        $pdo->exec(
+            "INSERT INTO questions(id,catalog_uid,sort_order,type,prompt) VALUES(1,'c',1,'text','Q')"
+        );
+        $pdo->exec(
+            "INSERT INTO catalogs(uid,sort_order,slug,file,name,event_uid) VALUES('c',1,'c','c.json','C','ev1')"
+        );
 
         $cfg = new ConfigService($pdo);
         $cfg->setActiveEventUid('');


### PR DESCRIPTION
## Summary
- wrap lengthy SQL statements and assertions in service-layer tests to keep lines under the PHPCS 120-character limit
- reformat controller integration tests to break long literals and base64 fixtures without altering behaviour

## Testing
- vendor/bin/phpcs tests

------
https://chatgpt.com/codex/tasks/task_e_68dae2a15cc8832bbb5a2696e7f0b630