### PR TITLE
Fix duplicate landing labels in media manager

### DIFF
--- a/public/js/media-manager.js
+++ b/public/js/media-manager.js
@@ -371,6 +371,17 @@ ready(() => {
       if (!previewLanding || !previewLandingList) return;
       previewLandingList.innerHTML = '';
       const references = Array.isArray(file?.landing) ? file.landing : [];
+      const titleCounts = references.reduce((accumulator, reference) => {
+        if (!reference || typeof reference !== 'object') {
+          return accumulator;
+        }
+        const rawTitle = typeof reference.title === 'string' ? reference.title.trim() : '';
+        if (!rawTitle) {
+          return accumulator;
+        }
+        accumulator[rawTitle] = (accumulator[rawTitle] || 0) + 1;
+        return accumulator;
+      }, {});
       if (!references.length) {
         previewLanding.hidden = true;
         return;
@@ -384,8 +395,14 @@ ready(() => {
         item.className = 'media-landing-preview-item';
         const title = document.createElement('div');
         title.className = 'uk-text-small uk-text-bold';
-        const label = reference.title || reference.slug || '';
-        title.textContent = label || (reference.slug ? String(reference.slug) : '');
+        const rawTitle = typeof reference.title === 'string' ? reference.title.trim() : '';
+        const slug = typeof reference.slug === 'string' ? reference.slug : '';
+        const hasDuplicateTitle = rawTitle && titleCounts[rawTitle] > 1;
+        let label = rawTitle || slug || '';
+        if (hasDuplicateTitle && slug) {
+          label = `${rawTitle} (${slug})`;
+        }
+        title.textContent = label || (slug ? String(slug) : '');
         item.appendChild(title);
         const meta = document.createElement('div');
         meta.className = 'uk-text-meta';

--- a/templates/admin/media.twig
+++ b/templates/admin/media.twig
@@ -5,6 +5,13 @@
 {% set sizeMb = (limits.maxSize|default(0) / 1048576)|number_format(1, '.', '') %}
 {% set limitText = t('text_media_limits')|format(sizeMb, allowedExtensions|join(', ')) %}
 {% set landingSlugs = mediaLandingSlugs|default([]) %}
+{% set landingTitleCounts = {} %}
+{% for landing in landingSlugs %}
+  {% set titleKey = landing.title|default(landing.slug)|default('') %}
+  {% if titleKey is not empty %}
+    {% set landingTitleCounts = landingTitleCounts|merge({ (titleKey): landingTitleCounts[titleKey]|default(0) + 1 }) %}
+  {% endif %}
+{% endfor %}
 {% set translations = {
   'renamePrompt': t('prompt_media_rename'),
   'deleteConfirm': t('confirm_media_delete'),
@@ -101,7 +108,10 @@
               >
                 <option value="">{{ t('option_media_all_landings') }}</option>
                 {% for landing in landingSlugs %}
-                  <option value="{{ landing.slug|e }}">{{ landing.title|default(landing.slug)|e }}</option>
+                  {% set baseTitle = landing.title|default(landing.slug)|default('') %}
+                  {% set showSlug = landingTitleCounts[baseTitle]|default(0) > 1 %}
+                  {% set optionLabel = showSlug ? baseTitle ~ ' (' ~ landing.slug|default('') ~ ')' : baseTitle %}
+                  <option value="{{ landing.slug|e }}">{{ optionLabel|e }}</option>
                 {% endfor %}
               </select>
             </div>


### PR DESCRIPTION
## Summary
- append landing slugs to duplicate-titled entries in the media manager filter dropdown
- include landing slugs in preview labels when multiple landing references share the same title

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dae8113ad8832b8009bea5633aeae8