### PR TITLE
Remove card wrapper from calServer testimonials widget

### DIFF
--- a/public/js/calserver.js
+++ b/public/js/calserver.js
@@ -394,10 +394,38 @@
     document.head.appendChild(script);
   }
 
+  function unwrapProSealCard(container) {
+    if (!container) {
+      return;
+    }
+
+    const card = container.closest('.contact-card');
+    if (!card) {
+      return;
+    }
+
+    const parent = card.parentElement;
+    if (!parent) {
+      return;
+    }
+
+    const heading = card.querySelector('.uk-text-large');
+    if (heading) {
+      const text = heading.textContent.trim().toLowerCase();
+      if (text.includes('kundenstimmen') || text.includes('customer voices')) {
+        heading.remove();
+      }
+    }
+
+    parent.replaceChild(container, card);
+  }
+
   function setupProSealContainer(container) {
     if (!container) {
       return;
     }
+
+    unwrapProSealCard(container);
 
     const target = container.querySelector('[data-proseal-target]');
     if (!target) {


### PR DESCRIPTION
## Summary
- unwrap the ProvenExpert testimonials widget from the Kundenstimmen card on the calServer marketing page
- remove the Kundenstimmen / Customer voices heading when unwrapping so the ProvenExpert embed renders inline

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daed23ede8832bb4c68cb689fe2b0d