### PR TITLE
Improve error handling for background process helper

### DIFF
--- a/src/process_helpers.php
+++ b/src/process_helpers.php
@@ -36,8 +36,20 @@ function runBackgroundProcess(string $script, array $args = []): void {
         $process->start();
         return;
     } catch (\Throwable $e) {
-        error_log('runBackgroundProcess failed: ' . $e->getMessage());
-        exec($commandLine . ' &');
+        $message = sprintf(
+            'runBackgroundProcess failed to start "%s": %s',
+            $escapedCommand,
+            $e->getMessage()
+        );
+
+        error_log($message);
+        file_put_contents(
+            $logFile,
+            '[' . date('c') . '] ERROR ' . $message . PHP_EOL,
+            FILE_APPEND
+        );
+
+        throw $e instanceof \RuntimeException ? $e : new \RuntimeException($message, 0, $e);
     }
 }
 


### PR DESCRIPTION
## Summary
- stop falling back to shell exec when background processes fail to start
- record detailed failure information in the onboarding log and rethrow the original exception

## Testing
- composer phpunit -- --filter OnboardingScriptTest

------
https://chatgpt.com/codex/tasks/task_e_68daf356dd50832bbd6eade9522e5ae6