### PR TITLE
Improve guidance when PDO driver is missing

### DIFF
--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -40,6 +40,25 @@ class Database
             try {
                 return new PDO($dsn, $user, $pass, $options);
             } catch (PDOException $e) {
+                if (stripos($e->getMessage(), 'could not find driver') !== false) {
+                    $driver = strtolower($dsn !== '' ? explode(':', $dsn, 2)[0] : '');
+                    if ($driver === '') {
+                        $driver = 'unknown';
+                    }
+                    $hint = 'Enable the corresponding PDO extension for the "' . $driver . '" driver';
+                    if ($driver === 'pgsql') {
+                        $hint .= ' (for example: install the "pdo_pgsql" extension).';
+                    } else {
+                        $hint .= '.';
+                    }
+
+                    throw new PDOException(
+                        $hint . ' Current DSN: ' . ($dsn === '' ? '[empty]' : $dsn),
+                        (int) $e->getCode(),
+                        $e
+                    );
+                }
+
                 if ($retries-- <= 0) {
                     throw $e;
                 }


### PR DESCRIPTION
## Summary
- add a dedicated hint when the configured PDO driver is not available
- keep the existing retry behaviour for other connection failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db01267658832b9645a05424228499