### PR TITLE
Use proc_open fallback for runSyncProcess

### DIFF
--- a/tests/Stubs/FailingProcess.php
+++ b/tests/Stubs/FailingProcess.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Process;
+
+class Process
+{
+    public function __construct(array $command)
+    {
+        throw new \RuntimeException('Stub Process failure.');
+    }
+}


### PR DESCRIPTION
## Summary
- replace the exec() fallback in runSyncProcess with a proc_open implementation that avoids shell invocation
- ensure fallback continues to capture stdout, stderr, and error cases consistently with the primary path
- extend the test suite with Process stubs to cover fallback success and failure scenarios

## Testing
- composer phpunit -- --filter runSyncProcess

------
https://chatgpt.com/codex/tasks/task_e_68db0130c664832b9da3abba9d5d1290