### PR TITLE
Ensure migrations run on public schema

### DIFF
--- a/scripts/run_migrations.php
+++ b/scripts/run_migrations.php
@@ -18,70 +18,20 @@ if (is_readable($envFile)) {
     }
 }
 
-use App\Infrastructure\Database;
-use App\Infrastructure\Migrations\Migrator;
-
-$availableDrivers = PDO::getAvailableDrivers();
+use App\Infrastructure\Migrations\MigrationScriptRunner;
+use RuntimeException;
 
 try {
-    $base = Database::connectFromEnv();
-} catch (PDOException $e) {
-    $dsn = getenv('POSTGRES_DSN') ?: '';
-    $driver = strtolower($dsn !== '' ? explode(':', $dsn, 2)[0] : '');
-    if ($driver === '') {
-        $driver = 'unknown';
-    }
-
-    $message = $e->getMessage();
-
-    if ($driver !== 'unknown' && !in_array($driver, $availableDrivers, true)) {
-        $message = sprintf(
-            "PDO driver '%s' is not available. Enable the extension for this driver or adjust POSTGRES_DSN (current: %s).",
-            $driver,
-            $dsn === '' ? '[empty]' : $dsn
-        );
-    }
-
-    fwrite(STDERR, '[ERROR] ' . $message . PHP_EOL);
-    exit(1);
-}
-Migrator::migrate($base, __DIR__ . '/../migrations');
-
-try {
-    $stmt = $base->query('SELECT subdomain FROM tenants');
-    if ($stmt === false) {
-        throw new RuntimeException('Unable to query tenant subdomains.');
-    }
-
-    $tenants = $stmt->fetchAll(PDO::FETCH_COLUMN);
-} catch (Throwable $e) {
-    fwrite(STDERR, '[ERROR] Failed to retrieve tenant schemas: ' . $e->getMessage() . PHP_EOL);
+    $errors = MigrationScriptRunner::run(__DIR__ . '/../migrations');
+} catch (RuntimeException $e) {
+    fwrite(STDERR, '[ERROR] ' . $e->getMessage() . PHP_EOL);
     exit(1);
 }
 
-$schemas = [];
-foreach ($tenants as $subdomain) {
-    $schema = trim((string) $subdomain);
-    if ($schema === '' || $schema === 'public' || $schema === 'main') {
-        $schema = 'public';
+if ($errors !== []) {
+    foreach ($errors as $message) {
+        fwrite(STDERR, '[ERROR] ' . $message . PHP_EOL);
     }
 
-    $schemas[$schema] = true;
-}
-
-unset($schemas['public']);
-
-$hasErrors = false;
-foreach (array_keys($schemas) as $schema) {
-    try {
-        $tenant = Database::connectWithSchema($schema);
-        Migrator::migrate($tenant, __DIR__ . '/../migrations');
-    } catch (Throwable $e) {
-        $hasErrors = true;
-        fwrite(STDERR, sprintf('[ERROR] Migration failed for schema "%s": %s', $schema, $e->getMessage()) . PHP_EOL);
-    }
-}
-
-if ($hasErrors) {
     exit(1);
 }

--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -6,12 +6,19 @@ namespace App\Infrastructure;
 
 use PDO;
 use PDOException;
+use RuntimeException;
 
 /**
  * Utility class for creating database connections.
  */
 class Database
 {
+    /** @var callable|null */
+    private static $factory = null;
+
+    /** @var callable|null */
+    private static $connectHook = null;
+
     /**
      * Create a PDO connection using credentials from environment variables.
      *
@@ -21,6 +28,15 @@ class Database
      * after each failed attempt to give the database more time to recover.
      */
     public static function connectFromEnv(int $retries = 5, int $delay = 1): PDO {
+        if (self::$factory !== null) {
+            $pdo = (self::$factory)();
+            if (!$pdo instanceof PDO) {
+                throw new RuntimeException('Database factory must return a PDO instance.');
+            }
+
+            return $pdo;
+        }
+
         $envRetries = getenv('POSTGRES_CONNECT_RETRIES');
         if ($envRetries !== false) {
             $retries = (int) $envRetries;
@@ -81,6 +97,24 @@ class Database
             $pdo->exec('SET search_path TO ' . $pdo->quote($schema));
         }
 
+        if (self::$connectHook !== null) {
+            (self::$connectHook)($schema, $pdo);
+        }
+
         return $pdo;
+    }
+
+    /**
+     * Override the connection factory for testing purposes.
+     */
+    public static function setFactory(?callable $factory): void {
+        self::$factory = $factory;
+    }
+
+    /**
+     * Attach a hook that receives every schema-specific connection.
+     */
+    public static function setConnectHook(?callable $hook): void {
+        self::$connectHook = $hook;
     }
 }

--- a/src/Infrastructure/Migrations/MigrationScriptRunner.php
+++ b/src/Infrastructure/Migrations/MigrationScriptRunner.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Migrations;
+
+use App\Infrastructure\Database;
+use PDO;
+use PDOException;
+use RuntimeException;
+use Throwable;
+
+class MigrationScriptRunner
+{
+    /**
+     * Execute the migration runner and return any tenant-specific errors.
+     *
+     * @return list<string>
+     */
+    public static function run(string $migrationsPath): array
+    {
+        $availableDrivers = PDO::getAvailableDrivers();
+
+        try {
+            $base = Database::connectWithSchema('public');
+        } catch (Throwable $e) {
+            throw self::connectionException($e, $availableDrivers);
+        }
+
+        Migrator::migrate($base, $migrationsPath);
+
+        try {
+            $stmt = $base->query('SELECT subdomain FROM tenants');
+            if ($stmt === false) {
+                throw new RuntimeException('Unable to query tenant subdomains.');
+            }
+
+            /** @var list<string> $tenants */
+            $tenants = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        } catch (Throwable $e) {
+            throw new RuntimeException('Failed to retrieve tenant schemas: ' . $e->getMessage(), 0, $e);
+        }
+
+        $schemas = [];
+        foreach ($tenants as $subdomain) {
+            $schema = trim((string) $subdomain);
+            if ($schema === '' || $schema === 'public' || $schema === 'main') {
+                $schema = 'public';
+            }
+
+            $schemas[$schema] = true;
+        }
+
+        unset($schemas['public']);
+
+        $errors = [];
+        foreach (array_keys($schemas) as $schema) {
+            try {
+                $tenant = Database::connectWithSchema($schema);
+                Migrator::migrate($tenant, $migrationsPath);
+            } catch (Throwable $e) {
+                $errors[] = sprintf('Migration failed for schema "%s": %s', $schema, $e->getMessage());
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param list<string> $availableDrivers
+     */
+    private static function connectionException(Throwable $e, array $availableDrivers): RuntimeException
+    {
+        $dsn = getenv('POSTGRES_DSN') ?: '';
+        $driver = strtolower($dsn !== '' ? explode(':', $dsn, 2)[0] : '');
+        if ($driver === '') {
+            $driver = 'unknown';
+        }
+
+        $message = $e->getMessage();
+
+        if ($driver !== 'unknown' && !in_array($driver, $availableDrivers, true) && $e instanceof PDOException) {
+            $message = sprintf(
+                "PDO driver '%s' is not available. Enable the extension for this driver or adjust POSTGRES_DSN (current: %s).",
+                $driver,
+                $dsn === '' ? '[empty]' : $dsn
+            );
+        }
+
+        return new RuntimeException($message, 0, $e);
+    }
+}

--- a/tests/RunMigrationsScriptTest.php
+++ b/tests/RunMigrationsScriptTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Infrastructure\Database;
+use App\Infrastructure\Migrations\Migrator;
+use App\Infrastructure\Migrations\MigrationScriptRunner;
+use PDO;
+use PDOStatement;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class RunMigrationsScriptTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Database::setFactory(null);
+        Database::setConnectHook(null);
+        Migrator::setHook(null);
+        parent::tearDown();
+    }
+
+    public function testScriptPinsBaseConnectionToPublicSchema(): void
+    {
+        $schemas = [];
+        $migratorCalls = [];
+        $basePdo = new SpyPDO();
+
+        $connections = [$basePdo];
+        $factoryCalls = 0;
+        Database::setFactory(static function () use (&$connections, &$factoryCalls) {
+            $factoryCalls++;
+            if ($connections === []) {
+                throw new RuntimeException('Unexpected database connection request.');
+            }
+
+            return array_shift($connections);
+        });
+
+        Database::setConnectHook(static function (string $schema, PDO $pdo) use (&$schemas): void {
+            $schemas[] = [
+                'schema' => $schema,
+                'pdo' => spl_object_id($pdo),
+            ];
+        });
+
+        Migrator::setHook(static function (PDO $pdo, string $dir) use (&$migratorCalls): bool {
+            $migratorCalls[] = [
+                'pdo' => spl_object_id($pdo),
+                'dir' => $dir,
+            ];
+
+            return false;
+        });
+
+        $originalEnv = $this->captureEnv(['POSTGRES_DSN', 'POSTGRES_USER', 'POSTGRES_PASSWORD']);
+
+        try {
+            $dsn = 'pgsql:host=localhost;options=--search_path=main';
+            $this->setEnv('POSTGRES_DSN', $dsn);
+            $this->setEnv('POSTGRES_USER', 'test-user');
+            $this->setEnv('POSTGRES_PASSWORD', 'test-pass');
+
+            $errors = MigrationScriptRunner::run(dirname(__DIR__) . '/migrations');
+        } finally {
+            $this->restoreEnv($originalEnv);
+        }
+
+        $this->assertSame(1, $factoryCalls, 'Expected exactly one base connection.');
+        $this->assertNotEmpty($schemas, 'Expected at least one schema-bound connection.');
+        $this->assertSame('public', $schemas[0]['schema']);
+        $this->assertSame(spl_object_id($basePdo), $schemas[0]['pdo']);
+
+        $this->assertNotEmpty($migratorCalls, 'Migrator should be invoked for the base connection.');
+        $this->assertSame(spl_object_id($basePdo), $migratorCalls[0]['pdo']);
+        $this->assertContains('SELECT subdomain FROM tenants', $basePdo->queries);
+        $this->assertSame([], $errors, 'Tenant migrations should not report errors.');
+    }
+
+    /**
+     * @param array<string|null> $keys
+     * @return array<string, string|null>
+     */
+    private function captureEnv(array $keys): array
+    {
+        $values = [];
+        foreach ($keys as $key) {
+            $value = getenv($key);
+            $values[$key] = $value === false ? null : $value;
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array<string, string|null> $values
+     */
+    private function restoreEnv(array $values): void
+    {
+        foreach ($values as $key => $value) {
+            if ($value === null) {
+                putenv($key);
+                unset($_ENV[$key]);
+            } else {
+                putenv($key . '=' . $value);
+                $_ENV[$key] = $value;
+            }
+        }
+    }
+
+    private function setEnv(string $key, string $value): void
+    {
+        putenv($key . '=' . $value);
+        $_ENV[$key] = $value;
+    }
+}
+
+class SpyPDO extends PDO
+{
+    /** @var list<string> */
+    public array $queries = [];
+    /** @var list<string> */
+    public array $execStatements = [];
+    /** @var list<string> */
+    private array $tenantRows;
+
+    /**
+     * @param list<string> $tenantRows
+     */
+    public function __construct(array $tenantRows = [])
+    {
+        parent::__construct('sqlite::memory:');
+        $this->tenantRows = $tenantRows;
+    }
+
+    public function exec(string $statement): int|false
+    {
+        $this->execStatements[] = $statement;
+
+        return 0;
+    }
+
+    public function query(string $statement, ?int $fetchMode = null, mixed ...$fetchModeArgs): PDOStatement|false
+    {
+        $this->queries[] = $statement;
+
+        if ($statement === 'SELECT subdomain FROM tenants') {
+            $rows = array_map(static fn (string $value): array => [$value], $this->tenantRows);
+
+            return FakeStatement::create($rows);
+        }
+
+        return FakeStatement::create([]);
+    }
+
+    public function getAttribute(int $attribute): mixed
+    {
+        if ($attribute === PDO::ATTR_DRIVER_NAME) {
+            return 'pgsql';
+        }
+
+        return null;
+    }
+
+    public function prepare(string $statement, array $driverOptions = []): PDOStatement|false
+    {
+        return FakeStatement::create([]);
+    }
+
+    /**
+     * @param list<string> $rows
+     */
+    public function setTenantRows(array $rows): void
+    {
+        $this->tenantRows = $rows;
+    }
+}
+
+class FakeStatement extends PDOStatement
+{
+    /** @var array<int, array<int, mixed>> */
+    private array $rows;
+
+    /**
+     * @param array<int, array<int, mixed>> $rows
+     */
+    private function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    /**
+     * @param array<int, array<int, mixed>> $rows
+     */
+    public static function create(array $rows): self
+    {
+        return new self($rows);
+    }
+
+    public function fetchAll(int $mode = PDO::ATTR_DEFAULT_FETCH_MODE, mixed ...$args): array
+    {
+        if ($mode === PDO::FETCH_COLUMN) {
+            return array_map(static fn (array $row): mixed => $row[0] ?? null, $this->rows);
+        }
+
+        return $this->rows;
+    }
+
+    public function execute(?array $params = null): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize migration execution in a new `MigrationScriptRunner` that always connects using the public schema before running tenant migrations
- add hookable connection and migrator helpers to ease testing and reuse
- cover the regression with a PHPUnit test that simulates a DSN overriding the search path

## Testing
- `./vendor/bin/phpunit tests/RunMigrationsScriptTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68db99e82634832baa10d2591d4b6301