### PR TITLE
Ensure tenant schema connections keep public search path

### DIFF
--- a/src/Infrastructure/Database.php
+++ b/src/Infrastructure/Database.php
@@ -94,7 +94,13 @@ class Database
     public static function connectWithSchema(string $schema): PDO {
         $pdo = self::connectFromEnv();
         if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
-            $pdo->exec('SET search_path TO ' . $pdo->quote($schema));
+            $quotedSchema = $pdo->quote($schema);
+
+            if ($schema === 'public') {
+                $pdo->exec('SET search_path TO ' . $quotedSchema);
+            } else {
+                $pdo->exec(sprintf('SET search_path TO %s, public', $quotedSchema));
+            }
         }
 
         if (self::$connectHook !== null) {


### PR DESCRIPTION
## Summary
- ensure PostgreSQL connections for tenant schemas retain the public schema in the search_path so extensions remain accessible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbbe2e9664832b9e14e629c5cb231a