### PR TITLE
Fix admin seed migration for schema-specific runs

### DIFF
--- a/migrations/20250305_seed_admin_user.sql
+++ b/migrations/20250305_seed_admin_user.sql
@@ -1,14 +1,18 @@
--- Ensure the default admin user exists
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 
 DO $$
 DECLARE
     new_pass TEXT;
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM users WHERE username = 'admin') THEN
-        new_pass := encode(gen_random_bytes(16), 'hex');
+        new_pass := encode(public.gen_random_bytes(16), 'hex');
         INSERT INTO users (username, password, role, active)
-        VALUES ('admin', crypt(new_pass, gen_salt('bf')), 'admin', TRUE);
+        VALUES (
+            'admin',
+            public.crypt(new_pass, public.gen_salt('bf')),
+            'admin',
+            TRUE
+        );
         RAISE NOTICE 'Created admin user with password: %', new_pass;
     END IF;
 END $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- ensure the pgcrypto extension is installed into the public schema during the admin seed migration
- fully qualify pgcrypto function calls so the migration works when run against schema-specific search paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbefd99f8832bb80470c2f9691ae1