### PR TITLE
Fix runtime exception handling in migration script

### DIFF
--- a/scripts/run_migrations.php
+++ b/scripts/run_migrations.php
@@ -19,11 +19,10 @@ if (is_readable($envFile)) {
 }
 
 use App\Infrastructure\Migrations\MigrationScriptRunner;
-use RuntimeException;
 
 try {
     $errors = MigrationScriptRunner::run(__DIR__ . '/../migrations');
-} catch (RuntimeException $e) {
+} catch (\RuntimeException $e) {
     fwrite(STDERR, '[ERROR] ' . $e->getMessage() . PHP_EOL);
     exit(1);
 }


### PR DESCRIPTION
## Summary
- remove the unused RuntimeException import from the migration runner script
- catch the global RuntimeException class directly to avoid PHP warnings

## Testing
- POSTGRES_DSN='pgsql:host=127.0.0.1;port=5432;dbname=test' POSTGRES_USER=foo POSTGRES_PASSWORD=bar POSTGRES_CONNECT_RETRIES=0 php scripts/run_migrations.php

------
https://chatgpt.com/codex/tasks/task_e_68dc13e828d4832bbcc702c5c4f3b151