### PR TITLE
Add calServer module video fallbacks for iPad playback

### DIFF
--- a/migrations/20251001_update_calserver_module_videos.sql
+++ b/migrations/20251001_update_calserver_module_videos.sql
@@ -17,6 +17,7 @@ $$                    <video class="calserver-module-figure__video"
                            loop
                            playsinline
                            preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-device-management.webp"
                            aria-label="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
                       <source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -38,6 +39,7 @@ $$                    <video class="calserver-module-figure__video"
                            loop
                            playsinline
                            preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
                            aria-label="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
                       <source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -59,6 +61,7 @@ $$                    <video class="calserver-module-figure__video"
                            loop
                            playsinline
                            preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
                            aria-label="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
                       <source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -80,6 +83,7 @@ $$                    <video class="calserver-module-figure__video"
                            loop
                            playsinline
                            preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-self-service.webp"
                            aria-label="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
                       <source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -96,25 +100,25 @@ SET content = REPLACE(
         REPLACE(
             REPLACE(content,
 $$<img alt="Screenshot of the calServer device management with device files, history and measured values" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-device-management.webp" width="1200"/>$$,
-$$<video aria-label="Screenshot of the calServer device management with device files, history and measured values" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+$$<video aria-label="Screenshot of the calServer device management with device files, history and measured values" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-device-management.webp">
 <source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4"/>
 Your browser does not support HTML5 video.
 <a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">Download video</a>.
 </video>$$),
             $$<img alt="Screenshot of the calServer calendar with resource and scheduling" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp" width="1200"/>$$,
-$$<video aria-label="Screenshot of the calServer calendar with resource and scheduling" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+$$<video aria-label="Screenshot of the calServer calendar with resource and scheduling" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp">
 <source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4"/>
 Your browser does not support HTML5 video.
 <a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">Download video</a>.
 </video>$$),
         $$<img alt="Screenshot of the calServer mandate and ticket management with workflow status" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp" width="1200"/>$$,
-$$<video aria-label="Screenshot of the calServer mandate and ticket management with workflow status" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+$$<video aria-label="Screenshot of the calServer mandate and ticket management with workflow status" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp">
 <source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4"/>
 Your browser does not support HTML5 video.
 <a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">Download video</a>.
 </video>$$),
     $$<img alt="Screenshot of the calServer self-service portal with customer view and certificates" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-self-service.webp" width="1200"/>$$,
-$$<video aria-label="Screenshot of the calServer self-service portal with customer view and certificates" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto">
+$$<video aria-label="Screenshot of the calServer self-service portal with customer view and certificates" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-self-service.webp">
 <source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4"/>
 Your browser does not support HTML5 video.
 <a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">Download video</a>.

--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1748,6 +1748,15 @@ body.qr-landing.calserver-theme .calserver-module-figure video {
     background: #000;
 }
 
+body.qr-landing.calserver-theme .calserver-module-figure__video--manual {
+    cursor: pointer;
+}
+
+body.qr-landing.calserver-theme .calserver-module-figure--manual .calserver-module-figure__fullscreen-button {
+    top: 14px;
+    right: 14px;
+}
+
 body.qr-landing.calserver-theme .calserver-module-figure__fullscreen-button {
     position: absolute;
     top: 18px;

--- a/public/js/calserver.js
+++ b/public/js/calserver.js
@@ -203,6 +203,58 @@
     }
   }
 
+  function disableModuleVideoAutoplay(video, figure) {
+    if (!video || video.dataset.calserverAutoplay === 'manual') {
+      return;
+    }
+
+    try {
+      video.pause();
+    } catch (error) {
+      /* empty */
+    }
+
+    video.dataset.calserverAutoplay = 'manual';
+    video.autoplay = false;
+    video.removeAttribute('autoplay');
+
+    video.muted = false;
+    video.removeAttribute('muted');
+
+    video.controls = true;
+    video.setAttribute('controls', '');
+    video.setAttribute('controlslist', 'nodownload');
+
+    if (video.classList) {
+      video.classList.add('calserver-module-figure__video--manual');
+    }
+
+    if (figure && figure.classList) {
+      figure.classList.add('calserver-module-figure--manual');
+    }
+  }
+
+  function attemptModuleVideoAutoplay(video, figure) {
+    if (!video || typeof video.play !== 'function') {
+      return;
+    }
+
+    let playResult = null;
+
+    try {
+      playResult = video.play();
+    } catch (error) {
+      disableModuleVideoAutoplay(video, figure);
+      return;
+    }
+
+    if (playResult && typeof playResult.catch === 'function') {
+      playResult.catch(function () {
+        disableModuleVideoAutoplay(video, figure);
+      });
+    }
+  }
+
   function syncModuleVideoStates() {
     moduleVideoControls.forEach(function (entry) {
       updateModuleVideoState(entry, isModuleVideoFullscreen(entry.video));
@@ -327,6 +379,8 @@
     video.addEventListener('webkitendfullscreen', function () {
       updateModuleVideoState(entry, false);
     });
+
+    attemptModuleVideoAutoplay(video, figure);
   }
 
   function initModuleVideoFullscreen() {

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -888,6 +888,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                            loop
                            playsinline
                            preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-device-management.webp"
                            aria-label="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
                       <source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -916,6 +917,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                            loop
                            playsinline
                            preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
                            aria-label="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
                       <source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -944,6 +946,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                            loop
                            playsinline
                            preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
                            aria-label="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
                       <source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -972,6 +975,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                            loop
                            playsinline
                            preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-self-service.webp"
                            aria-label="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
                       <source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.


### PR DESCRIPTION
## Summary
- add poster images to calServer module videos so a preview is visible when autoplay is blocked
- detect autoplay failures on calServer module videos and enable manual playback controls
- tweak the calServer module styling for videos shown with manual controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc610d33d4832b99c61540788b4625