### PR TITLE
Update German video privacy hint

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -189,7 +189,7 @@
         'videoPreviewSubtitle': 'calServer Vorstellung auf YouTube',
         'videoHint': 'Vorstellung hier laden. Mit deinem Klick werden YouTube-Inhalte nachgeladen und Google kann personenbezogene Daten verarbeiten.',
         'videoButton': 'Video laden',
-        'videoPrivacy': 'Du kannst deine Einwilligung jederzeit in deinen Browser-Einstellungen widerrufen.',
+        'videoPrivacy': 'Du kannst deine Einwilligung jederzeit in deinen Browser-Einstellungen und mit der Schaltfläche unten links widerrufen.',
         'videoNoscript': 'JavaScript ist deaktiviert. Öffne das Video direkt auf',
         'videoNoscriptLink': 'YouTube',
         'videoNoscriptSuffix': '.',


### PR DESCRIPTION
## Summary
- clarify the German video privacy hint to include the option to revoke consent via the button on the bottom left

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcd52e45f4832b85f3ff58031e7a04