### PR TITLE
Hide use case visuals on calServer page

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1875,6 +1875,7 @@ body.qr-landing.calserver-theme .testimonial-card {
 }
 
 body.qr-landing.calserver-theme .usecase-card--visual {
+    display: none;
     padding: 0;
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- hide the calServer use case visual cards so only the key facts remain visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcdbf48f68832bbaf825f1e22df13a