### PR TITLE
Default calserver marketing page to dark mode

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -414,6 +414,33 @@
   <script src="{{ basePath }}/js/custom-icons.js" defer></script>
   <script src="{{ basePath }}/js/storage.js"></script>
   <script>
+    (function () {
+      try {
+        var hasStorageHelpers = typeof STORAGE_KEYS !== 'undefined' &&
+          typeof getStored === 'function' &&
+          typeof setStored === 'function';
+        var darkKey = hasStorageHelpers ? STORAGE_KEYS.DARK_MODE : 'darkMode';
+        var storedTheme = hasStorageHelpers ? getStored(darkKey) : (function () {
+          try {
+            return (typeof localStorage !== 'undefined') ? localStorage.getItem(darkKey) : null;
+          } catch (error) {
+            return null;
+          }
+        })();
+
+        if (storedTheme === null) {
+          if (hasStorageHelpers) {
+            setStored(darkKey, 'true');
+          } else if (typeof localStorage !== 'undefined') {
+            localStorage.setItem(darkKey, 'true');
+          }
+        }
+      } catch (error) {
+        /* empty */
+      }
+    })();
+  </script>
+  <script>
     document.addEventListener('DOMContentLoaded', function () {
       document.querySelectorAll('.js-email-link').forEach(function (anchor) {
         var user = anchor.getAttribute('data-user');


### PR DESCRIPTION
## Summary
- ensure new visitors to the calServer marketing page persist a dark theme preference when no setting exists
- leave existing visitor preferences untouched by only seeding the dark-mode key when it is absent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcfc8379d4832b878c07d0eb99966f