### PR TITLE
Add explanatory text for calServer operating modes

### DIFF
--- a/migrations/20250926_update_calserver_page.sql
+++ b/migrations/20250926_update_calserver_page.sql
@@ -956,6 +956,7 @@ VALUES (
         <ul class="uk-switcher uk-margin"
             data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
           <li>
+            <p class="uk-text-lead uk-margin-remove-top uk-margin-medium-bottom">Die Cloud-Variante betreiben wir vollständig für Sie: Updates, Monitoring und Sicherheit bleiben bei uns, damit Ihr Team sich sofort auf die Arbeit mit calServer konzentrieren kann.</p>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
               <div class="anim">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
@@ -980,6 +981,7 @@ VALUES (
             </div>
           </li>
           <li>
+            <p class="uk-text-lead uk-margin-remove-top uk-margin-medium-bottom">Mit der On-Premise-Variante läuft calServer in Ihrer Infrastruktur: Sie behalten volle Datenhoheit, wir begleiten Installation, Updates und binden bestehende Systeme nahtlos an.</p>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
               <div class="anim">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">

--- a/migrations/20250927_update_calserver_visual_assets.sql
+++ b/migrations/20250927_update_calserver_visual_assets.sql
@@ -980,6 +980,7 @@ VALUES (
         <ul class="uk-switcher uk-margin"
             data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
           <li>
+            <p class="uk-text-lead uk-margin-remove-top uk-margin-medium-bottom">Die Cloud-Variante betreiben wir vollständig für Sie: Updates, Monitoring und Sicherheit bleiben bei uns, damit Ihr Team sich sofort auf die Arbeit mit calServer konzentrieren kann.</p>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
               <div class="anim">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
@@ -1004,6 +1005,7 @@ VALUES (
             </div>
           </li>
           <li>
+            <p class="uk-text-lead uk-margin-remove-top uk-margin-medium-bottom">Mit der On-Premise-Variante läuft calServer in Ihrer Infrastruktur: Sie behalten volle Datenhoheit, wir begleiten Installation, Updates und binden bestehende Systeme nahtlos an.</p>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
               <div class="anim">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">

--- a/migrations/20250930_add_calserver_proseal_widget.sql
+++ b/migrations/20250930_add_calserver_proseal_widget.sql
@@ -1016,6 +1016,7 @@ VALUES (
         <ul class="uk-switcher uk-margin"
             data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
           <li>
+            <p class="uk-text-lead uk-margin-remove-top uk-margin-medium-bottom">Die Cloud-Variante betreiben wir vollständig für Sie: Updates, Monitoring und Sicherheit bleiben bei uns, damit Ihr Team sich sofort auf die Arbeit mit calServer konzentrieren kann.</p>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
               <div class="anim">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
@@ -1040,6 +1041,7 @@ VALUES (
             </div>
           </li>
           <li>
+            <p class="uk-text-lead uk-margin-remove-top uk-margin-medium-bottom">Mit der On-Premise-Variante läuft calServer in Ihrer Infrastruktur: Sie behalten volle Datenhoheit, wir begleiten Installation, Updates und binden bestehende Systeme nahtlos an.</p>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
               <div class="anim">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -1369,6 +1369,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
         <ul class="uk-switcher uk-margin"
             data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: .anim; delay: 75; repeat: true">
           <li>
+            <p class="uk-text-lead uk-margin-remove-top uk-margin-medium-bottom">Die Cloud-Variante betreiben wir vollständig für Sie: Updates, Monitoring und Sicherheit bleiben bei uns, damit Ihr Team sich sofort auf die Arbeit mit calServer konzentrieren kann.</p>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
               <div class="anim">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">
@@ -1393,6 +1394,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </div>
           </li>
           <li>
+            <p class="uk-text-lead uk-margin-remove-top uk-margin-medium-bottom">Mit der On-Premise-Variante läuft calServer in Ihrer Infrastruktur: Sie behalten volle Datenhoheit, wir begleiten Installation, Updates und binden bestehende Systeme nahtlos an.</p>
             <div class="uk-grid-large uk-child-width-1-2@m uk-grid-match" data-uk-grid>
               <div class="anim">
                 <div class="uk-card uk-card-default uk-card-body uk-card-hover calserver-highlight-card">


### PR DESCRIPTION
## Summary
- add descriptive lead paragraphs for the Cloud and On-Premise operating modes on the calServer page across migrations and schema

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68dd09b1fbf4832bbe4f65bb64ff7bfb