### PR TITLE
Fix migration runner imports

### DIFF
--- a/scripts/run_migrations.php
+++ b/scripts/run_migrations.php
@@ -18,12 +18,9 @@ if (is_readable($envFile)) {
     }
 }
 
-use App\Infrastructure\Migrations\MigrationScriptRunner;
-use RuntimeException;
-
 try {
-    $errors = MigrationScriptRunner::run(__DIR__ . '/../migrations');
-} catch (RuntimeException $e) {
+    $errors = \App\Infrastructure\Migrations\MigrationScriptRunner::run(__DIR__ . '/../migrations');
+} catch (\RuntimeException $e) {
     fwrite(STDERR, '[ERROR] ' . $e->getMessage() . PHP_EOL);
     exit(1);
 }


### PR DESCRIPTION
## Summary
- call the migration runner and exception classes via fully qualified names to avoid misplaced use statements

## Testing
- POSTGRES_DSN=sqlite::memory: POSTGRES_USER= POSTGRES_PASSWORD= POSTGRES_CONNECT_RETRIES=0 php scripts/run_migrations.php

------
https://chatgpt.com/codex/tasks/task_e_68dd23fe94a0832b8724b9b01e8b64fd