### PR TITLE
Restore migration integrity for landing asset update

### DIFF
--- a/ROBOTS.md
+++ b/ROBOTS.md
@@ -10,6 +10,8 @@
 * **Kommentare und PHPDoc** sind Pflicht für alle **Funktionen, Methoden, Klassen und komplexe Logik**.
 * Der Code muss **vollständig PSR-12-konform** sein.
 * **Automatische Codeanalyse (z.\u202fB. mit PHP_CodeSniffer)** ist verpflichtend; alle Warnungen und Fehler müssen vor dem Commit behoben sein.
+* **Bestehende Migrationen dürfen niemals geändert werden.**
+  Stattdessen ist bei Anpassungen immer eine **neue Migration** anzulegen, da frühere Migrationen bereits eingespielt sind.
 
 ## 2. **Datei- und Namenskonventionen**
 

--- a/content/landing.html
+++ b/content/landing.html
@@ -384,8 +384,8 @@
       <div>
         <div class="uk-card uk-card-quizrace uk-card-body">
           <picture>
-            <source srcset="{{ basePath }}/uploads/landing/quizrace-shot.avif" type="image/avif">
-            <img src="{{ basePath }}/uploads/landing/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="Bildschirmfoto des QuizRace-Dashboards mit Live-Ranking und Aufgabenliste">
+            <source srcset="{{ basePath }}/uploads/quizrace-shot.avif" type="image/avif">
+            <img src="{{ basePath }}/uploads/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="Bildschirmfoto des QuizRace-Dashboards mit Live-Ranking und Aufgabenliste">
           </picture>
         </div>
       </div>

--- a/migrations/20251003_update_landing_hero_media_path.sql
+++ b/migrations/20251003_update_landing_hero_media_path.sql
@@ -1,0 +1,12 @@
+UPDATE pages
+SET content = REPLACE(
+        REPLACE(
+            content,
+            '{{ basePath }}/uploads/landing/quizrace-shot.avif',
+            '{{ basePath }}/uploads/quizrace-shot.avif'
+        ),
+        '{{ basePath }}/uploads/landing/quizrace-shot.webp',
+        '{{ basePath }}/uploads/quizrace-shot.webp'
+    ),
+    updated_at = CURRENT_TIMESTAMP
+WHERE slug = 'landing';

--- a/src/Service/MediaLibraryService.php
+++ b/src/Service/MediaLibraryService.php
@@ -646,12 +646,12 @@ class MediaLibraryService
         $size = filesize($path);
         $modified = filemtime($path) ?: time();
         $mime = mime_content_type($path) ?: 'application/octet-stream';
-        $public = rtrim($publicPath, '/') . '/' . $name;
 
-        $meta = $metadata ?? ['tags' => [], 'folder' => null];
+        $meta = $this->normalizeMetadataEntry($metadata);
         $tags = $meta['tags'];
         $folder = $meta['folder'];
-        $folder = $folder !== null ? (string) $folder : null;
+
+        $public = $this->buildPublicPath($publicPath, $folder, $name);
 
         return [
             'name' => $name,
@@ -666,6 +666,19 @@ class MediaLibraryService
             'tags' => $tags,
             'folder' => $folder,
         ];
+    }
+
+    private function buildPublicPath(string $base, ?string $folder, string $file): string {
+        $normalizedBase = rtrim($base, '/');
+
+        if ($folder !== null && $folder !== '') {
+            $cleanFolder = trim($folder, '/');
+            if ($cleanFolder !== '') {
+                $normalizedBase .= '/' . $cleanFolder;
+            }
+        }
+
+        return $normalizedBase . '/' . $file;
     }
 
     /**

--- a/src/routes.php
+++ b/src/routes.php
@@ -1401,7 +1401,7 @@ return function (\Slim\App $app, TranslationService $translator) {
         return $request->getAttribute('catalogStickerController')->uploadBackground($request, $response);
     })->add(new RoleAuthMiddleware(...Roles::ALL));
 
-    $app->get('/uploads/{file}', function (Request $request, Response $response, array $args) {
+    $app->get('/uploads/{file:.+}', function (Request $request, Response $response, array $args) {
         $req = $request->withAttribute('file', $args['file']);
         return $request->getAttribute('globalMediaController')->get($req, $response);
     });

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -162,8 +162,8 @@
           <div>
             <div class="qr-mockup uk-card qr-card">
               <picture>
-                <source srcset="{{ basePath }}/uploads/landing/quizrace-shot.avif" type="image/avif">
-                <img src="{{ basePath }}/uploads/landing/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="Bildschirmfoto des QuizRace-Dashboards mit Live-Ranking und Aufgabenliste">
+                <source srcset="{{ basePath }}/uploads/quizrace-shot.avif" type="image/avif">
+                <img src="{{ basePath }}/uploads/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="Bildschirmfoto des QuizRace-Dashboards mit Live-Ranking und Aufgabenliste">
               </picture>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- restore the original landing hero image asset references in previously run migrations
- document the "no changes to existing migrations" rule in ROBOTS.md for future tasks
- add a new migration to update the landing page content to the `/uploads/quizrace-shot.*` asset paths

## Testing
- ./vendor/bin/phpunit *(fails: file not found in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3f833f9c832b9327b129535994ac