### PR TITLE
Fix landing hero gallery asset paths

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -574,6 +574,45 @@ body.dark-mode .qr-landing .qr-badge{
   overflow:hidden;
 }
 .qr-landing .qr-mockup img{ display:block; width:100%; height:auto; }
+.qr-landing .qr-hero-gallery{
+  position:relative;
+  width:100%;
+  overflow:hidden;
+  border-radius:inherit;
+}
+.qr-landing .qr-hero-gallery::before{
+  content:"";
+  display:block;
+  padding-bottom:56.25%;
+}
+.qr-landing .qr-hero-gallery__item{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  opacity:0;
+  animation:qrHeroGalleryFade 12s ease-in-out infinite;
+}
+.qr-landing .qr-hero-gallery__item:first-child{ opacity:1; }
+.qr-landing .qr-hero-gallery__item:nth-child(2){ animation-delay:6s; }
+.qr-landing .qr-hero-gallery img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+}
+@keyframes qrHeroGalleryFade{
+  0%,40%{ opacity:1; }
+  50%,100%{ opacity:0; }
+}
+@media (prefers-reduced-motion: reduce){
+  .qr-landing .qr-hero-gallery__item{
+    animation:none;
+    opacity:1;
+  }
+  .qr-landing .qr-hero-gallery__item:nth-child(n+2){
+    display:none;
+  }
+}
 .qr-landing .marker-text::after{ /* vorhandene Unterstreichung beibehalten */ }
 
 /* Buttons, Links, Sections, Cards */

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -161,10 +161,16 @@
           </div>
           <div>
             <div class="qr-mockup uk-card qr-card">
-              <picture>
-                <source srcset="{{ basePath }}/uploads/quizrace-shot.avif" type="image/avif">
-                <img src="{{ basePath }}/uploads/quizrace-shot.webp" width="960" height="540" loading="lazy" alt="Bildschirmfoto des QuizRace-Dashboards mit Live-Ranking und Aufgabenliste">
-              </picture>
+              <div class="qr-hero-gallery">
+                <picture class="qr-hero-gallery__item">
+                  <source srcset="{{ basePath }}/uploads/landing/quizrace-shot-backend.avif" type="image/avif">
+                  <img src="{{ basePath }}/uploads/landing/quizrace-shot-backend.webp" width="960" height="540" loading="lazy" alt="Screenshot des QuizRace-Backends mit Aufgabenverwaltung und Teamübersicht">
+                </picture>
+                <picture class="qr-hero-gallery__item">
+                  <source srcset="{{ basePath }}/uploads/landing/quizrace-shot-frontend.avif" type="image/avif">
+                  <img src="{{ basePath }}/uploads/landing/quizrace-shot-frontend.webp" width="960" height="540" loading="lazy" alt="Screenshot der QuizRace-Frontend-Ansicht für Teilnehmende mit Live-Ranking">
+                </picture>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- update the landing hero gallery sources to use the /uploads/landing asset paths so the images resolve correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd45383278832b960443d52aff19ef