### PR TITLE
Update ZF SSO description on calServer page

### DIFF
--- a/migrations/20251005_update_calserver_zf_sso.sql
+++ b/migrations/20251005_update_calserver_zf_sso.sql
@@ -1,0 +1,8 @@
+UPDATE pages
+SET content = REPLACE(
+        content,
+        'SSO (z. B. EntraID/Google) für nahtlosen Zugriff',
+        'SSO (EntraID/Active Directory) für nahtlosen Zugriff'
+    ),
+    updated_at = CURRENT_TIMESTAMP
+WHERE slug = 'calserver';

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -1237,7 +1237,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 <p>Messwerte fließen über Microservices automatisiert ein; Geräte, Zertifikate und Auswertungen bleiben im Zugriff der berechtigten Teams. Single Sign-On vereinfacht den Zugang, die bidirektionale Synchronisation mit Fluke MET/TEAM und MET/CAL stellt durchgehend konsistente Kalibrierdaten sicher.</p>
                 <ul class="uk-list uk-list-bullet muted">
                   <li>API-Ingestion von Messwerten (Microservices/Kubernetes)</li>
-                  <li>SSO (z. B. EntraID/Google) für nahtlosen Zugriff</li>
+                  <li>SSO (EntraID/Active Directory) für nahtlosen Zugriff</li>
                   <li>Bidirektionale MET/TEAM- &amp; MET/CAL-Synchronisation</li>
                 </ul>
               </div>


### PR DESCRIPTION
## Summary
- update the calServer page seed content so the ZF Friedrichshafen story now mentions EntraID/Active Directory SSO
- add a targeted migration that replaces the old EntraID/Google SSO wording for existing calServer content

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68dd470ddd34832bb7414965fc60ebc0