### PR TITLE
Fix syntax error in MarketingPageController hreflang helper

### DIFF
--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -242,20 +242,11 @@ class MarketingPageController
                     'hreflang' => $lang,
                 ];
             }
+
             if ($links !== []) {
-        return $links;
-    }
-
-    private function buildNewsBasePath(Request $request, string $pageSlug): string
-    {
-        $path = $request->getUri()->getPath();
-        if (preg_match('~^/m/([a-z0-9-]+)~', $path) === 1) {
-            return sprintf('/m/%s/news', $pageSlug);
+                return $links;
+            }
         }
-
-        return sprintf('/%s/news', $pageSlug);
-    }
-}
 
         $codes = preg_split('/[\s,;|]+/', $hreflang, -1, PREG_SPLIT_NO_EMPTY);
         if (!is_array($codes)) {
@@ -275,6 +266,16 @@ class MarketingPageController
         }
 
         return $links;
+    }
+
+    private function buildNewsBasePath(Request $request, string $pageSlug): string
+    {
+        $path = $request->getUri()->getPath();
+        if (preg_match('~^/m/([a-z0-9-]+)~', $path) === 1) {
+            return sprintf('/m/%s/news', $pageSlug);
+        }
+
+        return sprintf('/%s/news', $pageSlug);
     }
 
     private function resolveLocalizedSlug(string $baseSlug, string $locale): string {


### PR DESCRIPTION
## Summary
- restore the braces in `buildHreflangLinks` so the method returns early when decoded hreflang data is valid
- keep the fallback parsing logic and helper methods inside the controller class to avoid syntax errors

## Testing
- php -l src/Controller/Marketing/MarketingPageController.php

------
https://chatgpt.com/codex/tasks/task_e_68dd9f55f840832b8f85a0d4a28d37ad