### PR TITLE
Use local Software Made in Germany badge for calServer

### DIFF
--- a/migrations/20251007_update_calserver_contact_seals.sql
+++ b/migrations/20251007_update_calserver_contact_seals.sql
@@ -45,7 +45,7 @@ $$          <div>
                 <div class="calserver-proof-seals uk-margin-small-top">
                   <a class="calserver-proof-seals__badge-link" href="https://www.software-made-in-germany.org/produkt/calserver/?asp_highlight=calserver&amp;p_asid=10" target="_blank" rel="noopener">
                     <img
-                      src="https://www.software-made-in-germany.org/wp-content/uploads/2021/06/Software-Made-in-Germany-Siegel.webp"
+                      src="/uploads/software-made-in-germany-siegel.webp"
                       alt="Software Made in Germany Siegel"
                       loading="lazy"
                       decoding="async"
@@ -170,7 +170,7 @@ $$          <div>
                 <div class="calserver-proof-seals uk-margin-small-top">
                   <a class="calserver-proof-seals__badge-link" href="https://www.software-made-in-germany.org/produkt/calserver/?asp_highlight=calserver&amp;p_asid=10" target="_blank" rel="noopener">
                     <img
-                      src="https://www.software-made-in-germany.org/wp-content/uploads/2021/06/Software-Made-in-Germany-Siegel.webp"
+                      src="/uploads/software-made-in-germany-siegel.webp"
                       alt="Software Made in Germany Siegel"
                       loading="lazy"
                       decoding="async"
@@ -282,7 +282,7 @@ $$<div class="uk-grid uk-child-width-1-1 uk-grid-small">
 <div class="calserver-proof-seals uk-margin-small-top">
   <a class="calserver-proof-seals__badge-link" href="https://www.software-made-in-germany.org/produkt/calserver/?asp_highlight=calserver&amp;p_asid=10" target="_blank" rel="noopener">
     <img
-      src="https://www.software-made-in-germany.org/wp-content/uploads/2021/06/Software-Made-in-Germany-Siegel.webp"
+      src="/uploads/software-made-in-germany-siegel.webp"
       alt="Software Made in Germany seal"
       loading="lazy"
       decoding="async"
@@ -393,7 +393,7 @@ $$          <div class="uk-grid uk-child-width-1-1 uk-grid-small">
               <div class="calserver-proof-seals uk-margin-small-top">
                 <a class="calserver-proof-seals__badge-link" href="https://www.software-made-in-germany.org/produkt/calserver/?asp_highlight=calserver&amp;p_asid=10" target="_blank" rel="noopener">
                   <img
-                    src="https://www.software-made-in-germany.org/wp-content/uploads/2021/06/Software-Made-in-Germany-Siegel.webp"
+                    src="/uploads/software-made-in-germany-siegel.webp"
                     alt="Software Made in Germany seal"
                     loading="lazy"
                     decoding="async"


### PR DESCRIPTION
## Summary
- update the calServer contact-page content migration to load the Software Made in Germany badge from the local uploads path instead of the external URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd9eededd8832b94c2cb64fc820e1f