### PR TITLE
Integrate landing news admin pages into admin layout

### DIFF
--- a/src/Controller/Admin/LandingNewsController.php
+++ b/src/Controller/Admin/LandingNewsController.php
@@ -49,6 +49,9 @@ class LandingNewsController
             'entries' => $entries,
             'status' => $status,
             'csrfToken' => $_SESSION['csrf_token'] ?? '',
+            'role' => $_SESSION['user']['role'] ?? '',
+            'currentPath' => $request->getUri()->getPath(),
+            'domainType' => $request->getAttribute('domainType'),
         ]);
     }
 
@@ -154,6 +157,9 @@ class LandingNewsController
             'pages' => $pages,
             'error' => $error,
             'csrfToken' => $_SESSION['csrf_token'] ?? '',
+            'role' => $_SESSION['user']['role'] ?? '',
+            'currentPath' => $request->getUri()->getPath(),
+            'domainType' => $request->getAttribute('domainType'),
         ];
 
         if ($override !== null) {

--- a/templates/admin/landing_news/form.twig
+++ b/templates/admin/landing_news/form.twig
@@ -22,67 +22,110 @@
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 {% endblock %}
 
-{% block body_class %}uk-background-muted uk-padding{% endblock %}
+{% block body_class %}uk-background-muted uk-padding admin-page{% endblock %}
 
 {% block body %}
-  <div class="uk-container uk-container-expand">
-    <h1 class="uk-heading-bullet">{{ isEdit ? t('heading_news_edit') : t('heading_news_create') }}</h1>
-    <form method="post" class="uk-form-stacked uk-grid-small" uk-grid>
-      <input type="hidden" name="_token" value="{{ csrfToken }}">
-      <div class="uk-width-1-1 uk-width-1-2@m">
-        <label class="uk-form-label" for="landingPage">{{ t('label_news_page') }}</label>
-        <div class="uk-form-controls">
-          <select id="landingPage" name="page_id" class="uk-select" required>
-            <option value="">{{ t('placeholder_select_page') }}</option>
-            {% for page in pages %}
-              <option value="{{ page.id }}" {% if page.id == pageId %}selected{% endif %}>{{ page.title }} ({{ page.slug }})</option>
-            {% endfor %}
-          </select>
+  {% embed 'topbar.twig' %}
+    {% block left %}
+      <button
+        id="sidebarToggle"
+        type="button"
+        class="uk-navbar-toggle uk-visible@m uk-margin-small-right git-btn"
+        aria-controls="adminSidebar"
+        aria-expanded="true"
+        aria-pressed="false"
+        aria-label="{{ t('menu') }}"
+      >
+        <span uk-navbar-toggle-icon></span>
+      </button>
+      <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">
+        QuizRace Admin
+      </a>
+    {% endblock %}
+    {% block offcanvas %}
+      <div id="qr-offcanvas" uk-offcanvas="overlay: true">
+        <div class="uk-offcanvas-bar">
+          <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
+          <h3 class="uk-margin-small">QuizRace</h3>
+          {% include 'admin/_nav.twig' %}
         </div>
       </div>
-      <div class="uk-width-1-1 uk-width-1-2@m">
-        <label class="uk-form-label" for="newsSlug">{{ t('label_news_slug') }}</label>
-        <div class="uk-form-controls">
-          <input id="newsSlug" class="uk-input" type="text" name="slug" value="{{ slug|e }}" required pattern="[a-z0-9\-]+" maxlength="100">
+    {% endblock %}
+    {% block headerbar %}
+      <div class="uk-container uk-container-large">
+        <div class="uk-padding-small uk-padding-remove-horizontal">
+          <h1 class="uk-heading-bullet uk-margin-remove">{{ isEdit ? t('heading_news_edit') : t('heading_news_create') }}</h1>
         </div>
       </div>
-      <div class="uk-width-1-1">
-        <label class="uk-form-label" for="newsTitle">{{ t('label_news_title') }}</label>
-        <div class="uk-form-controls">
-          <input id="newsTitle" class="uk-input" type="text" name="title" value="{{ titleValue|e }}" required>
-        </div>
+    {% endblock %}
+  {% endembed %}
+
+  <div class="uk-grid-collapse" uk-grid>
+    <aside id="adminSidebar" class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
+      <div class="uk-card qr-card uk-card-body qr-sidebar-card">
+        {% include 'admin/_nav.twig' %}
       </div>
-      <div class="uk-width-1-1">
-        <label class="uk-form-label" for="newsExcerpt">{{ t('label_news_excerpt') }}</label>
-        <div class="uk-form-controls">
-          <textarea id="newsExcerpt" class="uk-textarea" name="excerpt" rows="4">{{ excerptValue|e }}</textarea>
-        </div>
+    </aside>
+    <main class="uk-width-expand uk-padding-small@xs uk-padding">
+      <div class="uk-container uk-container-expand">
+        <form method="post" class="uk-form-stacked uk-grid-small" uk-grid>
+          <input type="hidden" name="_token" value="{{ csrfToken }}">
+          <div class="uk-width-1-1 uk-width-1-2@m">
+            <label class="uk-form-label" for="landingPage">{{ t('label_news_page') }}</label>
+            <div class="uk-form-controls">
+              <select id="landingPage" name="page_id" class="uk-select" required>
+                <option value="">{{ t('placeholder_select_page') }}</option>
+                {% for page in pages %}
+                  <option value="{{ page.id }}" {% if page.id == pageId %}selected{% endif %}>{{ page.title }} ({{ page.slug }})</option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="uk-width-1-1 uk-width-1-2@m">
+            <label class="uk-form-label" for="newsSlug">{{ t('label_news_slug') }}</label>
+            <div class="uk-form-controls">
+              <input id="newsSlug" class="uk-input" type="text" name="slug" value="{{ slug|e }}" required pattern="[a-z0-9\-]+" maxlength="100">
+            </div>
+          </div>
+          <div class="uk-width-1-1">
+            <label class="uk-form-label" for="newsTitle">{{ t('label_news_title') }}</label>
+            <div class="uk-form-controls">
+              <input id="newsTitle" class="uk-input" type="text" name="title" value="{{ titleValue|e }}" required>
+            </div>
+          </div>
+          <div class="uk-width-1-1">
+            <label class="uk-form-label" for="newsExcerpt">{{ t('label_news_excerpt') }}</label>
+            <div class="uk-form-controls">
+              <textarea id="newsExcerpt" class="uk-textarea" name="excerpt" rows="4">{{ excerptValue|e }}</textarea>
+            </div>
+          </div>
+          <div class="uk-width-1-1">
+            <label class="uk-form-label" for="newsContent">{{ t('label_news_content') }}</label>
+            <div class="uk-form-controls">
+              <textarea id="newsContent" class="uk-textarea" name="content" rows="12" required>{{ contentValue|e }}</textarea>
+            </div>
+          </div>
+          <div class="uk-width-1-1 uk-width-1-3@m">
+            <label class="uk-form-label" for="newsPublishedAt">{{ t('label_news_published_at') }}</label>
+            <div class="uk-form-controls">
+              <input id="newsPublishedAt" class="uk-input" type="datetime-local" name="published_at" value="{{ publishedAt|e }}">
+            </div>
+          </div>
+          <div class="uk-width-1-1 uk-width-1-3@m uk-flex uk-flex-middle">
+            <label><input class="uk-checkbox" type="checkbox" name="is_published" value="1" {% if published %}checked{% endif %}> {{ t('label_news_is_published') }}</label>
+          </div>
+          <div class="uk-width-1-1 uk-margin-top">
+            <button type="submit" class="uk-button uk-button-primary">{{ t('button_save') }}</button>
+            <a class="uk-button uk-button-default" href="{{ basePath }}/admin/landing-news">{{ t('button_cancel') }}</a>
+          </div>
+          {% if error %}
+            <div class="uk-width-1-1">
+              <div class="uk-alert-danger" uk-alert>{{ error }}</div>
+            </div>
+          {% endif %}
+        </form>
       </div>
-      <div class="uk-width-1-1">
-        <label class="uk-form-label" for="newsContent">{{ t('label_news_content') }}</label>
-        <div class="uk-form-controls">
-          <textarea id="newsContent" class="uk-textarea" name="content" rows="12" required>{{ contentValue|e }}</textarea>
-        </div>
-      </div>
-      <div class="uk-width-1-1 uk-width-1-3@m">
-        <label class="uk-form-label" for="newsPublishedAt">{{ t('label_news_published_at') }}</label>
-        <div class="uk-form-controls">
-          <input id="newsPublishedAt" class="uk-input" type="datetime-local" name="published_at" value="{{ publishedAt|e }}">
-        </div>
-      </div>
-      <div class="uk-width-1-1 uk-width-1-3@m uk-flex uk-flex-middle">
-        <label><input class="uk-checkbox" type="checkbox" name="is_published" value="1" {% if published %}checked{% endif %}> {{ t('label_news_is_published') }}</label>
-      </div>
-      <div class="uk-width-1-1 uk-margin-top">
-        <button type="submit" class="uk-button uk-button-primary">{{ t('button_save') }}</button>
-        <a class="uk-button uk-button-default" href="{{ basePath }}/admin/landing-news">{{ t('button_cancel') }}</a>
-      </div>
-      {% if error %}
-        <div class="uk-width-1-1">
-          <div class="uk-alert-danger" uk-alert>{{ error }}</div>
-        </div>
-      {% endif %}
-    </form>
+    </main>
   </div>
 {% endblock %}
 

--- a/templates/admin/landing_news/index.twig
+++ b/templates/admin/landing_news/index.twig
@@ -2,70 +2,110 @@
 
 {% block title %}{{ t('heading_landing_news') }}{% endblock %}
 
-{% block body_class %}uk-background-muted uk-padding{% endblock %}
+{% block body_class %}uk-background-muted uk-padding admin-page{% endblock %}
 
 {% block body %}
-  <div class="uk-container uk-container-expand">
-    <div class="uk-flex uk-flex-between uk-flex-middle">
-      <h1 class="uk-heading-bullet">{{ t('heading_landing_news') }}</h1>
-      <a class="uk-button uk-button-primary" href="{{ basePath }}/admin/landing-news/create">{{ t('button_add_news') }}</a>
-    </div>
+  {% embed 'topbar.twig' %}
+    {% block left %}
+      <button
+        id="sidebarToggle"
+        type="button"
+        class="uk-navbar-toggle uk-visible@m uk-margin-small-right git-btn"
+        aria-controls="adminSidebar"
+        aria-expanded="true"
+        aria-pressed="false"
+        aria-label="{{ t('menu') }}"
+      >
+        <span uk-navbar-toggle-icon></span>
+      </button>
+      <a href="{{ basePath }}/admin/summary" class="uk-navbar-item uk-logo uk-margin-small-left uk-visible@s">
+        QuizRace Admin
+      </a>
+    {% endblock %}
+    {% block offcanvas %}
+      <div id="qr-offcanvas" uk-offcanvas="overlay: true">
+        <div class="uk-offcanvas-bar">
+          <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
+          <h3 class="uk-margin-small">QuizRace</h3>
+          {% include 'admin/_nav.twig' %}
+        </div>
+      </div>
+    {% endblock %}
+    {% block headerbar %}
+      <div class="uk-container uk-container-large">
+        <div class="uk-flex uk-flex-between uk-flex-middle uk-padding-small uk-padding-remove-horizontal">
+          <h1 class="uk-heading-bullet uk-margin-remove">{{ t('heading_landing_news') }}</h1>
+          <a class="uk-button uk-button-primary" href="{{ basePath }}/admin/landing-news/create">{{ t('button_add_news') }}</a>
+        </div>
+      </div>
+    {% endblock %}
+  {% endembed %}
 
-    {% if status == 'created' %}
-      <div class="uk-alert-success" uk-alert>{{ t('message_news_created') }}</div>
-    {% elseif status == 'updated' %}
-      <div class="uk-alert-success" uk-alert>{{ t('message_news_updated') }}</div>
-    {% elseif status == 'deleted' %}
-      <div class="uk-alert-success" uk-alert>{{ t('message_news_deleted') }}</div>
-    {% endif %}
+  <div class="uk-grid-collapse" uk-grid>
+    <aside id="adminSidebar" class="uk-width-1-4@m uk-width-1-5@l uk-visible@m qr-sidebar">
+      <div class="uk-card qr-card uk-card-body qr-sidebar-card">
+        {% include 'admin/_nav.twig' %}
+      </div>
+    </aside>
+    <main class="uk-width-expand uk-padding-small@xs uk-padding">
+      <div class="uk-container uk-container-expand">
+        {% if status == 'created' %}
+          <div class="uk-alert-success" uk-alert>{{ t('message_news_created') }}</div>
+        {% elseif status == 'updated' %}
+          <div class="uk-alert-success" uk-alert>{{ t('message_news_updated') }}</div>
+        {% elseif status == 'deleted' %}
+          <div class="uk-alert-success" uk-alert>{{ t('message_news_deleted') }}</div>
+        {% endif %}
 
-    <div class="uk-overflow-auto">
-      <table class="uk-table uk-table-divider uk-table-striped">
-        <thead>
-          <tr>
-            <th>{{ t('column_title') }}</th>
-            <th>{{ t('column_page') }}</th>
-            <th>{{ t('column_status') }}</th>
-            <th>{{ t('column_published') }}</th>
-            <th>{{ t('column_actions') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for entry in entries %}
-            <tr>
-              <td>{{ entry.title }}</td>
-              <td>{{ entry.pageTitle }}</td>
-              <td>
-                {% if entry.isPublished %}
-                  <span class="uk-label uk-label-success">{{ t('status_published') }}</span>
-                {% else %}
-                  <span class="uk-label">{{ t('status_draft') }}</span>
-                {% endif %}
-              </td>
-              <td>
-                {% if entry.publishedAt %}
-                  {{ entry.publishedAt|date('d.m.Y H:i') }}
-                {% else %}
-                  &mdash;
-                {% endif %}
-              </td>
-              <td>
-                <div class="uk-flex uk-flex-middle" style="gap: 12px;">
-                  <a class="uk-button uk-button-text" href="{{ basePath }}/admin/landing-news/{{ entry.id }}">{{ t('action_edit') }}</a>
-                  <form method="post" action="{{ basePath }}/admin/landing-news/{{ entry.id }}/delete" onsubmit="return confirm('{{ t('confirm_news_delete') }}');">
-                    <input type="hidden" name="_token" value="{{ csrfToken }}">
-                    <button type="submit" class="uk-button uk-button-text uk-text-danger">{{ t('action_delete') }}</button>
-                  </form>
-                </div>
-              </td>
-            </tr>
-          {% else %}
-            <tr>
-              <td colspan="5" class="uk-text-center">{{ t('message_news_empty') }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
+        <div class="uk-overflow-auto uk-margin-top">
+          <table class="uk-table uk-table-divider uk-table-striped">
+            <thead>
+              <tr>
+                <th>{{ t('column_title') }}</th>
+                <th>{{ t('column_page') }}</th>
+                <th>{{ t('column_status') }}</th>
+                <th>{{ t('column_published') }}</th>
+                <th>{{ t('column_actions') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for entry in entries %}
+                <tr>
+                  <td>{{ entry.title }}</td>
+                  <td>{{ entry.pageTitle }}</td>
+                  <td>
+                    {% if entry.isPublished %}
+                      <span class="uk-label uk-label-success">{{ t('status_published') }}</span>
+                    {% else %}
+                      <span class="uk-label">{{ t('status_draft') }}</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if entry.publishedAt %}
+                      {{ entry.publishedAt|date('d.m.Y H:i') }}
+                    {% else %}
+                      &mdash;
+                    {% endif %}
+                  </td>
+                  <td>
+                    <div class="uk-flex uk-flex-middle" style="gap: 12px;">
+                      <a class="uk-button uk-button-text" href="{{ basePath }}/admin/landing-news/{{ entry.id }}">{{ t('action_edit') }}</a>
+                      <form method="post" action="{{ basePath }}/admin/landing-news/{{ entry.id }}/delete" onsubmit="return confirm('{{ t('confirm_news_delete') }}');">
+                        <input type="hidden" name="_token" value="{{ csrfToken }}">
+                        <button type="submit" class="uk-button uk-button-text uk-text-danger">{{ t('action_delete') }}</button>
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="5" class="uk-text-center">{{ t('message_news_empty') }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </main>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- embed the landing news index and form views inside the shared admin frame with topbar and sidebar navigation
- supply role, path, and domain context from the controller so the admin navigation highlights correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda0ae3fdc832b8e83342d1f44052b