### PR TITLE
Allow HEAD requests for health check endpoint

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -383,7 +383,7 @@ return function (\Slim\App $app, TranslationService $translator) {
     });
     $app->add(new LanguageMiddleware($translator));
 
-    $app->get('/healthz', function (Request $request, Response $response) {
+    $app->map(['GET', 'HEAD'], '/healthz', function (Request $request, Response $response) {
         $version = getenv('APP_VERSION');
         if ($version === false || $version === '') {
             $version = (new VersionService())->getCurrentVersion();
@@ -394,7 +394,11 @@ return function (\Slim\App $app, TranslationService $translator) {
             'version' => $version,
             'time'    => gmdate('c'),
         ];
-        $response->getBody()->write(json_encode($payload));
+        $payloadJson = json_encode($payload);
+
+        if (strtoupper($request->getMethod()) !== 'HEAD') {
+            $response->getBody()->write($payloadJson);
+        }
 
         $response = $response
             ->withHeader('Content-Type', 'application/json')

--- a/tests/HealthzEndpointTest.php
+++ b/tests/HealthzEndpointTest.php
@@ -115,4 +115,14 @@ class HealthzEndpointTest extends TestCase
             }
         }
     }
+
+    public function testHealthzEndpointAllowsHeadRequests(): void {
+        $app = $this->getAppInstance();
+
+        $response = $app->handle($this->createRequest('HEAD', '/healthz'));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('', (string) $response->getBody());
+    }
 }


### PR DESCRIPTION
## Summary
- allow the /healthz route to handle both GET and HEAD requests
- avoid writing a response body for HEAD while keeping JSON headers
- cover the new behaviour with a dedicated PHPUnit test

## Testing
- ./vendor/bin/phpunit --filter HealthzEndpointTest

------
https://chatgpt.com/codex/tasks/task_e_68dda4015800832b9a11250ee09ef7f4