### PR TITLE
Update calServer badge image source

### DIFF
--- a/migrations/20251010_update_calserver_badge_image.sql
+++ b/migrations/20251010_update_calserver_badge_image.sql
@@ -1,0 +1,8 @@
+UPDATE pages
+SET content = REPLACE(
+    content,
+    'src="https://www.software-made-in-germany.org/wp-content/uploads/2021/06/Software-Made-in-Germany-Siegel.webp"',
+    'src="/uploads/software-made-in-germany-siegel.webp"'
+)
+WHERE slug IN ('calserver', 'calserver-en')
+  AND content LIKE '%https://www.software-made-in-germany.org/wp-content/uploads/2021/06/Software-Made-in-Germany-Siegel.webp%';


### PR DESCRIPTION
## Summary
- add a migration that updates the calServer marketing page to use the local Software Made in Germany seal asset instead of the remote URL

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dda310f9ac832b886db5b2d132ad73