### PR TITLE
Include admin assets on landing news pages

### DIFF
--- a/templates/admin/landing_news/form.twig
+++ b/templates/admin/landing_news/form.twig
@@ -130,6 +130,8 @@
 {% endblock %}
 
 {% block scripts %}
+  <script src="{{ basePath }}/js/storage.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
   <script>
     (function() {
       const initEditor = function(selector) {

--- a/templates/admin/landing_news/index.twig
+++ b/templates/admin/landing_news/index.twig
@@ -2,6 +2,12 @@
 
 {% block title %}{{ t('heading_landing_news') }}{% endblock %}
 
+{% block head %}
+  <link rel="stylesheet" href="{{ basePath }}/css/main.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/dark.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+{% endblock %}
+
 {% block body_class %}uk-background-muted uk-padding admin-page{% endblock %}
 
 {% block body %}
@@ -108,4 +114,9 @@
       </div>
     </main>
   </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ basePath }}/js/storage.js"></script>
+  <script src="{{ basePath }}/js/app.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add the standard admin CSS bundle to the landing news index page
- load storage.js and app.js on the landing news overview and form so UI toggles respond

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dda46de128832b97240f9021d1ca6f