### PR TITLE
Handle OPTIONS requests for AJAX preflights

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -96,6 +96,7 @@ use App\Service\MediaLibraryService;
 use App\Service\LandingMediaReferenceService;
 use App\Service\LandingNewsService;
 use Slim\Views\Twig;
+use Slim\Psr7\Response as SlimResponse;
 use GuzzleHttp\Client;
 use Psr\Log\NullLogger;
 use App\Controller\BackupController;
@@ -378,6 +379,14 @@ return function (\Slim\App $app, TranslationService $translator) {
             ->withAttribute('translator', $translator)
             ->withAttribute('lang', $translator->getLocale())
             ->withAttribute('playerService', $playerService);
+
+        return $handler->handle($request);
+    });
+
+    $app->add(static function (Request $request, RequestHandlerInterface $handler): Response {
+        if ($request->getMethod() === 'OPTIONS') {
+            return (new SlimResponse())->withStatus(204);
+        }
 
         return $handler->handle($request);
     });

--- a/tests/Application/OptionsRequestTest.php
+++ b/tests/Application/OptionsRequestTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application;
+
+use Tests\TestCase;
+
+class OptionsRequestTest extends TestCase
+{
+    public function testOptionsRequestReturnsNoContent(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest(
+            'OPTIONS',
+            '/onboarding/tenants/example',
+            [
+                'Origin' => 'https://example.com',
+                'Access-Control-Request-Method' => 'GET',
+                'Access-Control-Request-Headers' => 'X-Requested-With',
+            ]
+        );
+
+        $response = $app->handle($request);
+
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertSame('', (string) $response->getBody());
+    }
+}


### PR DESCRIPTION
## Summary
- add an application middleware that returns 204 for OPTIONS requests so preflight checks stop failing with 405 errors
- add a PHPUnit test that exercises an OPTIONS call against a marketing endpoint

## Testing
- vendor/bin/phpunit tests/Application/OptionsRequestTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dda5c5f2a0832bb6d9e9b20425034f