### PR TITLE
Stop tracking calServer badge asset

### DIFF
--- a/migrations/20251010_update_calserver_badge_image.sql
+++ b/migrations/20251010_update_calserver_badge_image.sql
@@ -1,0 +1,8 @@
+UPDATE pages
+SET content = REPLACE(
+    content,
+    'src="https://www.software-made-in-germany.org/wp-content/uploads/2021/06/Software-Made-in-Germany-Siegel.webp"',
+    'src="/uploads/software-made-in-germany-siegel.webp"'
+)
+WHERE slug IN ('calserver', 'calserver-en')
+  AND content LIKE '%https://www.software-made-in-germany.org/wp-content/uploads/2021/06/Software-Made-in-Germany-Siegel.webp%';

--- a/public/uploads/.gitignore
+++ b/public/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- remove the tracked Software Made in Germany badge file from `public/uploads`
- add a directory-level .gitignore so future uploads are not committed by accident

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dda310f9ac832b886db5b2d132ad73