### PR TITLE
Handle HEAD requests like GET

### DIFF
--- a/src/Application/Middleware/HeadRequestMiddleware.php
+++ b/src/Application/Middleware/HeadRequestMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Psr7\Factory\StreamFactory;
+
+final class HeadRequestMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (strtoupper($request->getMethod()) !== 'HEAD') {
+            return $handler->handle($request);
+        }
+
+        $response = $handler->handle($request->withMethod('GET'));
+        $contentLength = $response->getHeaderLine('Content-Length');
+
+        $streamFactory = new StreamFactory();
+        $response = $response->withBody($streamFactory->createStream(''));
+
+        if ($contentLength === '') {
+            return $response->withHeader('Content-Length', '0');
+        }
+
+        return $response->withHeader('Content-Length', $contentLength);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -17,6 +17,7 @@ use App\Controller\LogoutController;
 use App\Controller\ConfigController;
 use App\Controller\CatalogController;
 use App\Application\Seo\PageSeoConfigService;
+use App\Application\Middleware\HeadRequestMiddleware;
 use App\Application\Middleware\RoleAuthMiddleware;
 use App\Service\ConfigService;
 use App\Service\ConfigValidator;
@@ -390,6 +391,7 @@ return function (\Slim\App $app, TranslationService $translator) {
 
         return $handler->handle($request);
     });
+    $app->add(new HeadRequestMiddleware());
     $app->add(new LanguageMiddleware($translator));
 
     $app->map(['GET', 'HEAD'], '/healthz', function (Request $request, Response $response) {

--- a/tests/Controller/HomeControllerTest.php
+++ b/tests/Controller/HomeControllerTest.php
@@ -42,6 +42,21 @@ class HomeControllerTest extends TestCase
         unlink($db);
     }
 
+    public function testHomePageAllowsHeadRequest(): void {
+        $db = $this->setupDb();
+
+        try {
+            $app = $this->getAppInstance();
+            $request = $this->createRequest('HEAD', '/');
+            $response = $app->handle($request);
+
+            $this->assertEquals(200, $response->getStatusCode());
+            $this->assertSame('', (string) $response->getBody());
+        } finally {
+            unlink($db);
+        }
+    }
+
     public function testEventCatalogOverview(): void {
         $db = $this->setupDb();
         $this->getAppInstance();


### PR DESCRIPTION
## Summary
- add middleware that translates HEAD requests to GET handlers while returning an empty body
- register the middleware globally so all GET routes accept HEAD requests
- cover the homepage endpoint with a PHPUnit test for HEAD requests

## Testing
- ./vendor/bin/phpunit tests/Controller/HomeControllerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68ddb98186dc832bb85e728c83422729