### PR TITLE
Add Future is Green marketing landing page

### DIFF
--- a/migrations/20251031_add_future_is_green_page.sql
+++ b/migrations/20251031_add_future_is_green_page.sql
@@ -1,0 +1,364 @@
+INSERT INTO pages (slug, title, content)
+VALUES (
+    'future-is-green',
+    'Future is Green',
+    $$<section id="benefits" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Wirkung im Quartier</h2>
+      <p>Unsere Pilotgebiete zeigen: Klimaschutz, Lebensqualität und Liefertempo schließen sich nicht aus. Future is Green reduziert Verkehr und macht Same-Day-Lieferungen nachhaltiger – für Menschen, Umwelt und lokale Wirtschaft.</p>
+    </div>
+    <div class="fig-benefits-grid" role="list" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 120">
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">0</span>
+        <p class="fig-benefit-card__label">Emissionen im Quartier</p>
+        <p class="fig-benefit-card__desc">Vollelektrische Flotten und Ökostrom senken lokale Emissionen auf null.</p>
+      </article>
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">60%</span>
+        <p class="fig-benefit-card__label">weniger Lieferfahrten</p>
+        <p class="fig-benefit-card__desc">Mikrohubs bündeln Warenströme – weniger Staus, weniger doppelte Wege.</p>
+      </article>
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">+24%</span>
+        <p class="fig-benefit-card__label">schnellere Same-Day-Zustellung</p>
+        <p class="fig-benefit-card__desc">KI-gestützte Tourenplanung priorisiert Zeitfenster und sorgt für pünktliche Lieferungen.</p>
+      </article>
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">100%</span>
+        <p class="fig-benefit-card__label">lokal &amp; fair</p>
+        <p class="fig-benefit-card__desc">Faire Konditionen für Rider, lokale Händler:innen und urbane Wertschöpfung.</p>
+      </article>
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">CO₂</span>
+        <p class="fig-benefit-card__label">Transparente Bilanz</p>
+        <p class="fig-benefit-card__desc">Dashboards zeigen Einsparungen in Echtzeit – auditierbar für Kommunen und Partner.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="how-it-works" class="fig-section fig-section--contrast">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>So funktioniert Future is Green</h2>
+      <p>Wir verbinden Mikrohub, Software und letzte Meile zu einem geschlossenen System. Jede Station liefert Daten – jede Tour bringt uns einer klimafreundlichen Innenstadt näher.</p>
+    </div>
+    <div class="fig-process-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-process-step">
+        <span class="fig-process-step__number">1</span>
+        <h3>Warenannahme im Mikrohub</h3>
+        <p>Lieferungen von Großhändlern und lokalen Produzent:innen landen gebündelt im nächstgelegenen Mikrohub. Digitale Erfassung und Lagerung verkürzen Wege und Wartezeiten.</p>
+      </article>
+      <article class="fig-process-step">
+        <span class="fig-process-step__number">2</span>
+        <h3>Intelligente Tourenplanung</h3>
+        <p>Unsere Software optimiert Touren nach Zeitfenstern, Prioritäten und Verkehrslage. So bleiben Strecken kurz, Geräusche gering und Lieferzeiten verlässlich.</p>
+      </article>
+      <article class="fig-process-step">
+        <span class="fig-process-step__number">3</span>
+        <h3>Letzte Meile mit E-Cargobikes</h3>
+        <p>Emissionfreie Zustellung an Läden, Schließfächer oder Haushalte – leise, flexibel und freundlich im Stadtbild.</p>
+      </article>
+      <article class="fig-process-step">
+        <span class="fig-process-step__number">4</span>
+        <h3>Transparenz in Echtzeit</h3>
+        <p>Dashboards zeigen Status, ETA und CO₂-Einsparung live. Händler:innen und Kund:innen behalten jede Sendung im Blick.</p>
+      </article>
+    </div>
+    <div class="uk-text-center uk-margin-large-top" data-uk-scrollspy="cls: uk-animation-fade; delay: 200">
+      <a class="fig-button fig-button--primary" href="#contact">
+        <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Jetzt Pilot starten
+      </a>
+    </div>
+  </div>
+</section>
+
+<section id="offerings" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Angebote für alle Stadt-Akteur:innen</h2>
+      <p>Ob Händler:in, Kommune oder Logistikpartner – Future is Green skaliert mit Ihrem Bedarf.</p>
+    </div>
+    <div class="fig-offerings" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-offering-card">
+        <h3>Für Händler:innen</h3>
+        <ul>
+          <li>Same-Day &amp; Next-Day innerhalb Ihres Bezirks</li>
+          <li>Retourenabwicklung direkt im Kiez</li>
+          <li>Lager- und Kommissionierservice im Mikrohub</li>
+          <li>Integration in Shop- &amp; POS-Systeme (Shopware, Shopify, Woo, ERP)</li>
+        </ul>
+      </article>
+      <article class="fig-offering-card">
+        <h3>Für Kommunen</h3>
+        <ul>
+          <li>Entlastung innerstädtischer Straßen und Anwohner:innen</li>
+          <li>Datenbasierte Verkehrs- und Umweltberichte</li>
+          <li>Skalierbares Hub-Konzept für jeden Kiez</li>
+          <li>Förderung lokaler Wirtschaftskreisläufe</li>
+        </ul>
+      </article>
+      <article class="fig-offering-card">
+        <h3>Für Logistikpartner</h3>
+        <ul>
+          <li>White-Label-Zustellung auf der letzten Meile</li>
+          <li>Peak-Handling für Saisons &amp; Events</li>
+          <li>Nachhaltigkeitsreporting für Ihre Kund:innen</li>
+        </ul>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="cases" class="fig-section fig-section--contrast">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Case-Teaser aus unseren Pilotquartieren</h2>
+      <p>Zwei Bezirke, ein Ziel: Logistik, die urbanen Raum zurückgibt.</p>
+    </div>
+    <div class="fig-case-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-case-card">
+        <h3>Fallstudie 1 – „Kiez A“</h3>
+        <ul>
+          <li>-37% Lieferverkehr im Wohngebiet</li>
+          <li>+28% Pünktlichkeit im Zeitfenster 10–14 Uhr</li>
+          <li>1 Mikrohub, 8 Cargobikes, 120 angebundene Shops</li>
+        </ul>
+        <div class="fig-case-card__cta">
+          <a class="fig-link" href="#contact">
+            <span data-uk-icon="icon: arrow-right"></span>Zur Fallstudie
+          </a>
+        </div>
+      </article>
+      <article class="fig-case-card">
+        <h3>Fallstudie 2 – „Innenstadt B“</h3>
+        <ul>
+          <li>Stabiler Verkehrsfluss in definierten Lieferfenstern</li>
+          <li>Messbare Lärmminderung in Nebenstraßen</li>
+          <li>Reale CO₂-Ersparnis: 7,4&nbsp;t pro Jahr</li>
+        </ul>
+        <div class="fig-case-card__cta">
+          <a class="fig-link" href="#contact">
+            <span data-uk-icon="icon: arrow-right"></span>Zur Fallstudie
+          </a>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="technology" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Technologie, die Logistik greifbar macht</h2>
+      <p>Future is Green verbindet smarte Software mit offenen Schnittstellen. Jede Integration bringt Transparenz und Tempo.</p>
+    </div>
+    <div class="fig-technology-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-technology-card">
+        <h3>Tourenplanung &amp; Hub-Software</h3>
+        <ul class="fig-feature-list">
+          <li><span class="fig-feature-icon">✓</span><span>KI-gestützte Bündelung und Routenplanung</span></li>
+          <li><span class="fig-feature-icon">✓</span><span>Live-Tracking mit ETA-Berechnung und Slot-Management</span></li>
+          <li><span class="fig-feature-icon">✓</span><span>Offene API für ERP, Shops und BI-Tools</span></li>
+          <li><span class="fig-feature-icon">✓</span><span>Webhooks &amp; Datenexport für individuelle Auswertungen</span></li>
+          <li><span class="fig-feature-icon">✓</span><span>KPI-Dashboard: CO₂, Pünktlichkeit, Auslastung, Stopps, Lieferrate</span></li>
+        </ul>
+      </article>
+      <article class="fig-technology-card">
+        <h3>Schnittstellen &amp; Sensorik</h3>
+        <ul class="fig-feature-list">
+          <li><span class="fig-feature-icon">↔</span><span>Shopware, Shopify, WooCommerce out of the box</span></li>
+          <li><span class="fig-feature-icon">↔</span><span>ERP/OMS via REST-API</span></li>
+          <li><span class="fig-feature-icon">↔</span><span>IoT-Sensorik für Temperatur- und Schocküberwachung (optional)</span></li>
+        </ul>
+      </article>
+      <article class="fig-technology-card">
+        <h3>Sicherheit &amp; Compliance</h3>
+        <ul class="fig-feature-list">
+          <li><span class="fig-feature-icon">🔒</span><span>DSGVO-konformes Hosting in Deutschland/EU</span></li>
+          <li><span class="fig-feature-icon">🔒</span><span>Rollen- und Rechtemanagement für Teams &amp; Partner</span></li>
+          <li><span class="fig-feature-icon">🔒</span><span>Verschlüsselte Datenflüsse (TLS, Encryption at rest)</span></li>
+          <li><span class="fig-feature-icon">🔒</span><span>Audit-Logs &amp; Export für Compliance-Anforderungen</span></li>
+        </ul>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="pricing" class="fig-section fig-section--contrast">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Preismodelle, die mitwachsen</h2>
+      <p>Skalierbare Pakete – vom ersten Pilot bis zum Rollout über Stadtgrenzen hinweg.</p>
+    </div>
+    <div class="fig-pricing-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-pricing-card">
+        <h3>Händler:innen</h3>
+        <p>Paketpreise nach Volumen und Bezirk – inklusive Same-Day, Retouren und Lagerflächen.</p>
+        <ul>
+          <li>Flexible Kontingente pro Standort</li>
+          <li>Transparente Monatsreports</li>
+        </ul>
+      </article>
+      <article class="fig-pricing-card">
+        <h3>Kommunen</h3>
+        <p>Pilot- und Rollout-Pakete mit Förderoptionen. Datenreports sichern politische Entscheidungen ab.</p>
+        <ul>
+          <li>Impact-Reporting für Umwelt &amp; Verkehr</li>
+          <li>Beratung zu Fördermitteln &amp; Skalierung</li>
+        </ul>
+      </article>
+      <article class="fig-pricing-card">
+        <h3>Logistikpartner</h3>
+        <p>White-Label-Modelle mit SLA. Wir erweitern Ihre Flotte um leise letzte Meile.</p>
+        <ul>
+          <li>Service-Level-Agreements nach Bedarf</li>
+          <li>Nachhaltigkeitskennzahlen für Ihr Reporting</li>
+        </ul>
+      </article>
+    </div>
+    <div class="uk-text-center uk-margin-large-top" data-uk-scrollspy="cls: uk-animation-fade; delay: 200">
+      <a class="fig-button fig-button--primary" href="#contact">
+        <span class="uk-margin-small-right" data-uk-icon="icon: receiver"></span>Angebot anfragen
+      </a>
+    </div>
+  </div>
+</section>
+
+<section id="about" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-about-grid" data-uk-grid data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > div; delay: 150">
+      <div>
+        <h2>Über uns</h2>
+        <p>Wir sind Mobilitätsplaner:innen, Logistikexpert:innen und Softwareentwickler:innen – vereint durch die Vision lebenswerter Städte. Future is Green vernetzt urbane Logistik mit sozialer Verantwortung und messbarer Wirkung.</p>
+        <h3>Partner &amp; Netzwerk</h3>
+        <div class="fig-partner-grid">
+          <span class="fig-partner-tag">Stadtwerke – Energie &amp; Ladeinfrastruktur</span>
+          <span class="fig-partner-tag">Hochschule&nbsp;XY – Verkehrsdatenauswertung</span>
+          <span class="fig-partner-tag">IHK – lokale Wirtschaftsförderung</span>
+        </div>
+      </div>
+      <div>
+        <h3>Meilensteine</h3>
+        <ul class="fig-timeline">
+          <li><strong>2023:</strong> Konzeptvalidierung &amp; erste Piloten</li>
+          <li><strong>2024:</strong> Software-Beta &amp; Hub-Prototyp</li>
+          <li><strong>2025:</strong> Skalierung auf drei Bezirke plus Partnernetzwerke</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="faq" class="fig-section fig-section--contrast">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>FAQ</h2>
+      <p>Antworten auf die wichtigsten Fragen rund um unsere Pilotprogramme.</p>
+    </div>
+    <ul class="uk-accordion" data-uk-accordion>
+      <li>
+        <a class="uk-accordion-title" href="#">Wie schnell kann ein Pilot starten?</a>
+        <div class="uk-accordion-content">
+          <p>In 6–10 Wochen begleiten wir Standortcheck, Partnerakquise, Setup, Schulungen und Go-Live.</p>
+        </div>
+      </li>
+      <li>
+        <a class="uk-accordion-title" href="#">Wie misst ihr die Wirkung?</a>
+        <div class="uk-accordion-content">
+          <p>Unser Dashboard erfasst CO₂-, Lärm- und Verkehrsdaten. Zusätzlich evaluieren wir mit der lokalen Hochschule.</p>
+        </div>
+      </li>
+      <li>
+        <a class="uk-accordion-title" href="#">Welche Stadtteile sind geeignet?</a>
+        <div class="uk-accordion-content">
+          <p>Hohe Dichte, gemischte Nutzung und bestehende Lieferprobleme sind ideale Voraussetzungen – wir beraten individuell.</p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section id="contact" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Jetzt gemeinsam loslegen</h2>
+      <p>Fragen, Pilotanfrage oder Angebot? Wir melden uns persönlich mit den nächsten Schritten.</p>
+    </div>
+    <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" data-uk-grid data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > div; delay: 150">
+      <div>
+        <form id="contact-form" class="uk-form-stacked uk-width-large uk-margin-auto">
+          <div class="uk-margin">
+            <label class="uk-form-label" for="fig-form-name">Name</label>
+            <input class="uk-input" id="fig-form-name" name="name" type="text" required>
+          </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="fig-form-email">E-Mail</label>
+            <input class="uk-input" id="fig-form-email" name="email" type="email" required>
+          </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="fig-form-msg">Nachricht</label>
+            <textarea class="uk-textarea" id="fig-form-msg" name="message" rows="5" required></textarea>
+          </div>
+          <div class="uk-margin turnstile-field" data-turnstile-container>
+            <div class="turnstile-widget">{{ turnstile_widget }}</div>
+            <p class="uk-text-small turnstile-hint" data-turnstile-hint hidden>Bitte bestätigen Sie, dass Sie kein Roboter sind.</p>
+          </div>
+          <div class="uk-margin">
+            <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
+          </div>
+          <input type="text" name="company" autocomplete="off" tabindex="-1" class="uk-hidden" aria-hidden="true">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+          <button class="fig-button fig-button--primary uk-width-1-1" type="submit">
+            <span class="uk-margin-small-right" data-uk-icon="icon: mail"></span>Nachricht senden
+          </button>
+        </form>
+      </div>
+      <div>
+        <div class="uk-grid uk-child-width-1-1 uk-grid-small">
+          <div>
+            <div class="fig-contact-card">
+              <p class="uk-text-large uk-margin-small-bottom">E-Mail</p>
+              <a class="uk-link-reset js-email-link" data-user="hello" data-domain="futureisgreen.city" href="#">hello [at] futureisgreen.city</a>
+            </div>
+          </div>
+          <div>
+            <div class="fig-contact-card">
+              <p class="uk-text-large uk-margin-small-bottom">Social</p>
+              <ul class="uk-list uk-list-divider uk-margin-remove">
+                <li><a class="fig-link" href="https://www.linkedin.com" target="_blank" rel="noopener"><span data-uk-icon="icon: linkedin"></span>LinkedIn</a></li>
+                <li><a class="fig-link" href="https://mastodon.social" target="_blank" rel="noopener"><span data-uk-icon="icon: world"></span>Mastodon</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.js-email-link').forEach(function (anchor) {
+      var user = anchor.getAttribute('data-user');
+      var domain = anchor.getAttribute('data-domain');
+      if (user && domain) {
+        var email = user + '@' + domain;
+        anchor.href = 'mailto:' + email;
+        anchor.textContent = email;
+      }
+    });
+  });
+</script>
+
+<div id="contact-modal" uk-modal>
+  <div class="uk-modal-dialog uk-modal-body">
+    <p id="contact-modal-message" aria-live="polite"></p>
+    <button class="uk-button uk-button-primary uk-modal-close" type="button">OK</button>
+  </div>
+</div>$$
+)
+ON CONFLICT (slug) DO UPDATE
+SET title = EXCLUDED.title,
+    content = EXCLUDED.content;

--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -1,0 +1,649 @@
+body.qr-landing.future-is-green-theme {
+  --fig-primary: #138f52;
+  --fig-primary-dark: #0c6f3f;
+  --fig-secondary: #ffffff;
+  --fig-background: #f0f9f3;
+  --fig-surface: #ffffff;
+  --fig-text: #123524;
+  --fig-muted: #3f5a4b;
+  --fig-accent: #9cd78f;
+  --fig-border: rgba(19, 143, 82, 0.18);
+  background: var(--fig-background);
+  color: var(--fig-text);
+  font-family: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
+}
+
+body.qr-landing.future-is-green-theme .landing-content {
+  background: transparent;
+}
+
+.future-is-green-theme .qr-topbar,
+.future-is-green-theme .uk-navbar,
+.future-is-green-theme .uk-navbar-container {
+  background: rgba(240, 249, 243, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--fig-border);
+  color: var(--fig-text);
+}
+
+.future-is-green-theme .uk-navbar a {
+  color: var(--fig-text);
+}
+
+.future-is-green-theme .fig-cta .fig-primary-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--fig-secondary);
+  background: var(--fig-primary);
+  box-shadow: 0 16px 36px -24px rgba(19, 143, 82, 0.85);
+  text-decoration: none;
+  transition: transform 0.18s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.future-is-green-theme .fig-cta .fig-primary-link:hover,
+.future-is-green-theme .fig-cta .fig-primary-link:focus {
+  background: var(--fig-primary-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 20px 36px -20px rgba(19, 143, 82, 0.9);
+}
+
+.future-is-green-theme .fig-hero {
+  position: relative;
+  padding-top: 120px;
+  padding-bottom: 96px;
+  overflow: hidden;
+}
+
+.future-is-green-theme .fig-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(19, 143, 82, 0.18), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(19, 143, 82, 0.12), transparent 55%);
+  z-index: 0;
+}
+
+.future-is-green-theme .fig-hero > .uk-container,
+.future-is-green-theme .fig-hero .fig-hero__copy,
+.future-is-green-theme .fig-hero .fig-hero__visual {
+  position: relative;
+  z-index: 1;
+}
+
+.future-is-green-theme .fig-hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  background: rgba(19, 143, 82, 0.12);
+  border-radius: 999px;
+  color: var(--fig-primary-dark);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.future-is-green-theme .fig-hero__title {
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  color: var(--fig-text);
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.future-is-green-theme .fig-hero__subtitle {
+  color: var(--fig-muted);
+  font-size: 1.1rem;
+}
+
+.future-is-green-theme .fig-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 32px 0 28px;
+}
+
+.future-is-green-theme .fig-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 26px;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.18s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.future-is-green-theme .fig-button--primary {
+  background: var(--fig-primary);
+  color: var(--fig-secondary);
+  box-shadow: 0 18px 34px -20px rgba(19, 143, 82, 0.65);
+}
+
+.future-is-green-theme .fig-button--primary:hover,
+.future-is-green-theme .fig-button--primary:focus {
+  background: var(--fig-primary-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 20px 36px -18px rgba(12, 111, 63, 0.7);
+}
+
+.future-is-green-theme .fig-button--ghost {
+  background: transparent;
+  color: var(--fig-primary);
+  border: 1px solid rgba(19, 143, 82, 0.28);
+}
+
+.future-is-green-theme .fig-button--ghost:hover,
+.future-is-green-theme .fig-button--ghost:focus {
+  color: var(--fig-primary-dark);
+  border-color: rgba(19, 143, 82, 0.45);
+  transform: translateY(-1px);
+}
+
+.future-is-green-theme .fig-hero__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.future-is-green-theme .fig-hero__stats li {
+  padding: 14px 18px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 14px;
+  border: 1px solid rgba(19, 143, 82, 0.16);
+  font-weight: 500;
+  color: var(--fig-text);
+  box-shadow: 0 12px 24px -20px rgba(16, 52, 36, 0.35);
+}
+
+.future-is-green-theme .fig-hero__card {
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(19, 143, 82, 0.18);
+  box-shadow: 0 32px 60px -40px rgba(16, 52, 36, 0.5);
+}
+
+.future-is-green-theme .fig-hero__card-title {
+  font-size: 1.6rem;
+  color: var(--fig-text);
+  margin-bottom: 16px;
+}
+
+.future-is-green-theme .fig-hero__card p {
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-hero__card-metric {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 24px 0;
+}
+
+.future-is-green-theme .fig-hero__metric-value {
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: var(--fig-primary);
+}
+
+.future-is-green-theme .fig-hero__metric-label {
+  font-size: 0.95rem;
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-hero__card-note {
+  font-size: 0.95rem;
+}
+
+.future-is-green-theme .fig-trust {
+  margin-top: 48px;
+  padding: 20px 24px;
+  border-radius: 16px;
+  background: rgba(19, 143, 82, 0.08);
+  border: 1px solid rgba(19, 143, 82, 0.18);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 20px;
+}
+
+.future-is-green-theme .fig-trust__label {
+  font-weight: 600;
+  color: var(--fig-text);
+}
+
+.future-is-green-theme .fig-trust__logos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.future-is-green-theme .fig-trust__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: var(--fig-secondary);
+  border: 1px solid rgba(19, 143, 82, 0.16);
+  color: var(--fig-muted);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.future-is-green-theme .fig-section {
+  position: relative;
+  padding: 96px 0;
+  background: transparent;
+}
+
+.future-is-green-theme .fig-section--contrast {
+  background: #ffffff;
+  border-top: 1px solid rgba(19, 143, 82, 0.08);
+  border-bottom: 1px solid rgba(19, 143, 82, 0.08);
+}
+
+.future-is-green-theme .fig-section__intro {
+  max-width: 680px;
+  margin: 0 auto 48px;
+  text-align: center;
+}
+
+.future-is-green-theme .fig-section__intro h2 {
+  margin-bottom: 16px;
+  color: var(--fig-text);
+}
+
+.future-is-green-theme .fig-section__intro p {
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-benefits-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .future-is-green-theme .fig-benefits-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.future-is-green-theme .fig-benefit-card {
+  border-radius: 16px;
+  background: var(--fig-secondary);
+  border: 1px solid rgba(19, 143, 82, 0.12);
+  padding: 28px;
+  box-shadow: 0 18px 44px -32px rgba(16, 52, 36, 0.4);
+  text-align: left;
+}
+
+.future-is-green-theme .fig-benefit-card__value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--fig-primary);
+}
+
+.future-is-green-theme .fig-benefit-card__label {
+  font-weight: 500;
+  color: var(--fig-text);
+  margin-top: 8px;
+}
+
+.future-is-green-theme .fig-benefit-card__desc {
+  color: var(--fig-muted);
+  margin-top: 12px;
+}
+
+.future-is-green-theme .fig-process-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .future-is-green-theme .fig-process-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.future-is-green-theme .fig-process-step {
+  padding: 32px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(19, 143, 82, 0.15);
+  box-shadow: 0 20px 42px -30px rgba(16, 52, 36, 0.45);
+}
+
+.future-is-green-theme .fig-process-step__number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgba(19, 143, 82, 0.12);
+  color: var(--fig-primary);
+  font-weight: 700;
+  font-size: 1.2rem;
+  margin-bottom: 16px;
+}
+
+.future-is-green-theme .fig-process-step h3 {
+  color: var(--fig-text);
+  margin-bottom: 12px;
+}
+
+.future-is-green-theme .fig-process-step p {
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-offerings {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .future-is-green-theme .fig-offerings {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.future-is-green-theme .fig-offering-card {
+  padding: 28px;
+  border-radius: 18px;
+  background: var(--fig-secondary);
+  border: 1px solid rgba(19, 143, 82, 0.12);
+  box-shadow: 0 18px 44px -30px rgba(16, 52, 36, 0.42);
+}
+
+.future-is-green-theme .fig-offering-card h3 {
+  color: var(--fig-text);
+  margin-bottom: 16px;
+}
+
+.future-is-green-theme .fig-offering-card ul {
+  padding-left: 20px;
+  margin: 0;
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-case-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .future-is-green-theme .fig-case-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.future-is-green-theme .fig-case-card {
+  padding: 28px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(19, 143, 82, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 18px 42px -32px rgba(16, 52, 36, 0.45);
+}
+
+.future-is-green-theme .fig-case-card h3 {
+  margin: 0;
+  color: var(--fig-text);
+}
+
+.future-is-green-theme .fig-case-card ul {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-case-card .fig-case-card__cta {
+  margin-top: auto;
+}
+
+.future-is-green-theme .fig-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--fig-primary);
+  text-decoration: none;
+}
+
+.future-is-green-theme .fig-link:hover,
+.future-is-green-theme .fig-link:focus {
+  color: var(--fig-primary-dark);
+  text-decoration: underline;
+}
+
+.future-is-green-theme .fig-technology-grid {
+  display: grid;
+  gap: 32px;
+}
+
+@media (min-width: 960px) {
+  .future-is-green-theme .fig-technology-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.future-is-green-theme .fig-technology-card {
+  padding: 30px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(19, 143, 82, 0.14);
+  box-shadow: 0 20px 44px -32px rgba(16, 52, 36, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.future-is-green-theme .fig-technology-card h3 {
+  margin: 0;
+  color: var(--fig-text);
+}
+
+.future-is-green-theme .fig-technology-card p {
+  margin: 0;
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-feature-list {
+  display: grid;
+  gap: 18px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.future-is-green-theme .fig-feature-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-feature-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: rgba(19, 143, 82, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fig-primary);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.future-is-green-theme .fig-pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 0;
+  margin: 24px 0 0;
+  list-style: none;
+}
+
+.future-is-green-theme .fig-pill-list li {
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(19, 143, 82, 0.1);
+  color: var(--fig-text);
+  font-weight: 500;
+}
+
+.future-is-green-theme .fig-pricing-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .future-is-green-theme .fig-pricing-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.future-is-green-theme .fig-pricing-card {
+  padding: 30px;
+  border-radius: 20px;
+  background: var(--fig-secondary);
+  border: 1px solid rgba(19, 143, 82, 0.16);
+  box-shadow: 0 18px 46px -32px rgba(16, 52, 36, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.future-is-green-theme .fig-pricing-card h3 {
+  margin: 0;
+  color: var(--fig-text);
+}
+
+.future-is-green-theme .fig-pricing-card p {
+  margin: 0;
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-pricing-card ul {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-about-grid {
+  display: grid;
+  gap: 32px;
+}
+
+@media (min-width: 960px) {
+  .future-is-green-theme .fig-about-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.future-is-green-theme .fig-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-left: 2px solid rgba(19, 143, 82, 0.2);
+  padding-left: 20px;
+}
+
+.future-is-green-theme .fig-timeline li {
+  position: relative;
+  margin-bottom: 18px;
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-timeline li::before {
+  content: '';
+  position: absolute;
+  left: -28px;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--fig-primary);
+  box-shadow: 0 0 0 4px rgba(19, 143, 82, 0.18);
+}
+
+.future-is-green-theme .fig-partner-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.future-is-green-theme .fig-partner-tag {
+  padding: 10px 18px;
+  border-radius: 14px;
+  background: rgba(19, 143, 82, 0.12);
+  color: var(--fig-text);
+  font-weight: 500;
+}
+
+.future-is-green-theme #faq .uk-accordion-title {
+  font-weight: 600;
+  color: var(--fig-text);
+}
+
+.future-is-green-theme #faq .uk-accordion-content {
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-contact-card {
+  border-radius: 18px;
+  border: 1px solid rgba(19, 143, 82, 0.14);
+  padding: 28px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 42px -30px rgba(16, 52, 36, 0.42);
+}
+
+.future-is-green-theme .fig-contact-card a {
+  color: var(--fig-primary);
+  font-weight: 600;
+}
+
+.future-is-green-theme .fig-footer {
+  padding: 24px 0;
+  background: rgba(19, 143, 82, 0.1);
+  border-top: 1px solid rgba(19, 143, 82, 0.16);
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-footer a {
+  color: var(--fig-primary);
+  text-decoration: none;
+}
+
+.future-is-green-theme .fig-footer a:hover,
+.future-is-green-theme .fig-footer a:focus {
+  text-decoration: underline;
+}
+
+@media (max-width: 959px) {
+  .future-is-green-theme .fig-hero {
+    padding-top: 88px;
+    padding-bottom: 72px;
+  }
+
+  .future-is-green-theme .fig-hero__stats {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .future-is-green-theme .fig-section {
+    padding: 72px 0;
+  }
+}

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -96,6 +96,11 @@ class HomeController
                     $ctrl = new \App\Controller\Marketing\CalserverController();
                     return $ctrl($request, $response);
                 }
+            } elseif ($home === 'future-is-green') {
+                if ($catalogParam === '') {
+                    $ctrl = new \App\Controller\Marketing\FutureIsGreenController();
+                    return $ctrl($request, $response);
+                }
             }
         }
         if ($role !== 'admin') {

--- a/src/Controller/Marketing/FutureIsGreenController.php
+++ b/src/Controller/Marketing/FutureIsGreenController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Marketing;
+
+use App\Application\Seo\PageSeoConfigService;
+use App\Service\PageService;
+
+class FutureIsGreenController extends MarketingPageController
+{
+    public function __construct(?PageService $pages = null, ?PageSeoConfigService $seo = null) {
+        parent::__construct('future-is-green', $pages, $seo);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -483,6 +483,14 @@ return function (\Slim\App $app, TranslationService $translator) {
         $args['landingSlug'] = 'landing';
         return $controller->show($request, $response, $args);
     });
+    $app->get('/future-is-green', function (Request $request, Response $response) use ($resolveMarketingAccess) {
+        [$request, $allowed] = $resolveMarketingAccess($request);
+        if (!$allowed) {
+            return $response->withStatus(404);
+        }
+        $controller = new \App\Controller\Marketing\FutureIsGreenController();
+        return $controller($request, $response);
+    });
     $app->get('/calserver', function (Request $request, Response $response) use ($resolveMarketingAccess) {
         [$request, $allowed] = $resolveMarketingAccess($request);
         if (!$allowed) {
@@ -519,6 +527,9 @@ return function (\Slim\App $app, TranslationService $translator) {
         }
     );
     $app->post('/landing/contact', ContactController::class)
+        ->add(new RateLimitMiddleware(3, 3600))
+        ->add(new CsrfMiddleware());
+    $app->post('/future-is-green/contact', ContactController::class)
         ->add(new RateLimitMiddleware(3, 3600))
         ->add(new CsrfMiddleware());
     $app->post('/calserver/contact', ContactController::class)

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -1,0 +1,247 @@
+{% extends 'layout.twig' %}
+
+{% set links = [
+    { 'href': '#start', 'label': 'Start', 'icon': 'home' },
+    { 'href': '#benefits', 'label': 'Impact', 'icon': 'bolt' },
+    { 'href': '#how-it-works', 'label': 'So funktioniert’s', 'icon': 'settings' },
+    { 'href': '#offerings', 'label': 'Angebote', 'icon': 'thumbnails' },
+    { 'href': '#cases', 'label': 'Cases', 'icon': 'file-text' },
+    { 'href': '#technology', 'label': 'Technologie', 'icon': 'cloud' },
+    { 'href': '#pricing', 'label': 'Preise', 'icon': 'credit-card' },
+    { 'href': '#about', 'label': 'Über uns', 'icon': 'users' },
+    { 'href': '#faq', 'label': 'FAQ', 'icon': 'question' },
+    { 'href': '#contact', 'label': 'Kontakt', 'icon': 'mail' }
+] %}
+
+{% block title %}{{ metaTitle|default('Future is Green – Urbane Logistik für lebenswerte Städte') }}{% endblock %}
+
+{% block head %}
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="preload" href="{{ basePath }}/css/landing.css" as="style">
+  <link rel="stylesheet" href="{{ basePath }}/css/landing.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/onboarding.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/topbar.landing.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/future-is-green.css">
+  <meta name="page-name" content="Future is Green – Landingpage">
+{% endblock %}
+
+{% block body_theme %}light{% endblock %}
+{% block body_class %}qr-landing future-is-green-theme{% endblock %}
+
+{% block body %}
+  <div class="landing-content">
+    <header class="qr-topbar" id="start">
+      <nav class="uk-navbar-container" data-uk-navbar>
+        <div class="uk-navbar-left">
+          <div class="uk-navbar-item">
+            <button id="offcanvas-toggle"
+                    class="uk-navbar-toggle uk-hidden@m git-btn"
+                    data-uk-navbar-toggle-icon
+                    data-uk-toggle="target: #qr-offcanvas"
+                    aria-controls="qr-offcanvas"
+                    aria-expanded="false"
+                    aria-label="Menü"></button>
+            <a class="uk-logo" href="{{ basePath }}/future-is-green">Future is Green</a>
+          </div>
+        </div>
+        <div class="uk-navbar-right">
+          <ul class="uk-navbar-nav uk-visible@m">
+            {% for link in links %}
+              <li>
+                <a href="{{ link.href }}">
+                  <span class="uk-margin-small-right" data-uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+          <div class="uk-navbar-item fig-cta uk-visible@m">
+            <a class="fig-primary-link" href="#contact">
+              <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Jetzt Pilot starten
+            </a>
+          </div>
+          <div class="uk-navbar-item config-menu uk-inline">
+            <button id="configMenuToggle"
+                    type="button"
+                    class="uk-button uk-button-default git-btn"
+                    aria-label="Konfiguration"
+                    aria-expanded="false">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M19.14 12.94a7.5 7.5 0 0 0 .05-.94 7.5 7.5 0 0 0-.05-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.33a.5.5 0 0 0-.6-.22l-2.39.96a7.6 7.6 0 0 0-1.63-.94l-.36-2.54a.5.5 0 0 0-.5-.43h-3.84a.5.5 0 0 0-.5.43l-.36 2.54c-.57.24-1.12.55-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.7 7.84a.5.5 0 0 0 .12.64l2.03 1.58c-.03.31-.05.63-.05.94s.02.63.05.94L2.82 13.5a.5.5 0 0 0-.12.64l1.92 3.33a.5.5 0 0 0 .6.22l2.39-.96c.51.39 1.06.7 1.63.94l.36 2.54a.5.5 0 0 0 .5.43h3.84a.5.5 0 0 0 .5-.43l.36-2.54c.57-.24 1.12-.55 1.63-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.33a.5.5 0 0 0-.12-.64l-2.03-1.58ZM12 15.5A3.5 3.5 0 1 1 12 8.5a3.5 3.5 0 0 1 0 7Z"
+                      fill="currentColor"/>
+              </svg>
+            </button>
+            <div id="menuDrop"
+                 class="uk-dropdown"
+                 hidden
+                 data-uk-dropdown="mode: click; pos: bottom-right; flip: false; animation: uk-animation-slide-top-small">
+              <ul class="uk-nav uk-dropdown-nav" role="menu">
+                <li>
+                  <button id="themeToggle"
+                          class="uk-button uk-button-default git-btn theme-toggle"
+                          aria-label="Design umschalten"
+                          role="menuitem">
+                    <span id="themeIcon" aria-hidden="true"></span>
+                  </button>
+                </li>
+                <li>
+                  <button id="accessibilityToggle"
+                          class="uk-button uk-button-default git-btn accessibility-toggle"
+                          aria-label="Kontrast umschalten"
+                          role="menuitem">
+                    <span id="accessibilityIcon" aria-hidden="true"></span>
+                  </button>
+                </li>
+                <li>
+                  <div class="uk-inline">
+                    <button id="languageMenuToggle"
+                            type="button"
+                            class="uk-button uk-button-default git-btn"
+                            aria-label="{{ t('language_toggle') }}"
+                            aria-expanded="false"
+                            role="menuitem">
+                      <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm6.93 6h-2.54c-.11-1.47-.43-2.87-.92-4.17 1.84.69 3.29 2.1 4.05 3.84zM12 4c.96 1.18 1.62 2.64 1.88 4H10.12c.26-1.36.92-2.82 1.88-4zM4.26 14c-.17-.64-.26-1.31-.26-2s.09-1.36.26-2h3.09c-.07.66-.11 1.32-.11 2s.04 1.34.11 2H4.26zm.81 2h2.54c.11 1.47.43 2.87.92 4.17-1.84-.69-3.29-2.1-4.05-3.84zm2.54-8H5.07c.76-1.74 2.21-3.15 4.05-3.84-.49 1.3-.81 2.7-.92 4.17zM12 20c-.96-1.18-1.62-2.64-1.88-4h3.76c-.26 1.36-.92 2.82-1.88 4zm2.62-6H9.38c-.08-.66-.12-1.32-.12-2s.04-1.34.12-2h5.24c.08.66.12 1.32.12 2s-.04 1.34-.12 2zm.81 6c.49-1.3.81-2.7.92-4.17h2.54c-.76 1.74-2.21 3.15-4.05 3.84zM16.65 14c.07-.66.11-1.32.11-2s-.04-1.34-.11-2h3.09c.17.64.26 1.31.26 2s-.09 1.36-.26 2h-3.09z"
+                              fill="currentColor"/>
+                      </svg>
+                    </button>
+                    <div id="languageDrop" class="uk-dropdown" hidden data-uk-dropdown="mode: click; pos: left-top; offset: 0">
+                      <ul class="uk-nav uk-dropdown-nav" role="menu">
+                        <li>
+                          <button class="uk-button uk-button-default git-btn lang-option"
+                                  data-lang="de"
+                                  role="menuitem">
+                            <span class="lang-option__icon" aria-hidden="true">
+                              <svg class="lang-option__svg" viewBox="0 0 24 16" role="img" focusable="false">
+                                <rect width="24" height="16" fill="#ffce00" />
+                                <rect width="24" height="10.6667" fill="#dd0000" />
+                                <rect width="24" height="5.3333" fill="#000000" />
+                              </svg>
+                            </span>
+                            <span class="lang-option__label">{{ t('german') }}</span>
+                          </button>
+                        </li>
+                        <li>
+                          <button class="uk-button uk-button-default git-btn lang-option"
+                                  data-lang="en"
+                                  role="menuitem">
+                            <span class="lang-option__icon" aria-hidden="true">
+                              <svg class="lang-option__svg" viewBox="0 0 24 16" role="img" focusable="false">
+                                <rect width="24" height="16" fill="#012169" />
+                                <path fill="#ffffff" d="M0 0h3.2L24 13.6V16h-3.2L0 2.4z" />
+                                <path fill="#ffffff" d="M24 0h-3.2L0 13.6V16h3.2L24 2.4z" />
+                                <path fill="#c8102e" d="M0 0h1.6L24 12.8V16h-1.6L0 3.2z" />
+                                <path fill="#c8102e" d="M24 0h-1.6L0 12.8V16h1.6L24 3.2z" />
+                                <rect x="10" width="4" height="16" fill="#ffffff" />
+                                <rect y="6" width="24" height="4" fill="#ffffff" />
+                                <rect x="10.8" width="2.4" height="16" fill="#c8102e" />
+                                <rect y="6.8" width="24" height="2.4" fill="#c8102e" />
+                              </svg>
+                            </span>
+                            <span class="lang-option__label">{{ t('english') }}</span>
+                          </button>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <div id="qr-offcanvas" data-uk-offcanvas="overlay: true; flip: true">
+      <div class="uk-offcanvas-bar">
+        <button class="uk-offcanvas-close git-btn" type="button" data-uk-close aria-label="Menü schließen"></button>
+        <ul class="uk-nav uk-nav-default">
+          {% for link in links %}
+            <li>
+              <a href="{{ link.href }}">
+                <span class="uk-margin-small-right" data-uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+        <a class="uk-button uk-button-primary git-btn uk-width-1-1 uk-margin-top offcanvas-cta" href="#contact">
+          <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Jetzt Pilot starten
+        </a>
+      </div>
+    </div>
+
+    <section class="fig-hero uk-section uk-section-large">
+      <div class="uk-container">
+        <div class="uk-grid uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
+          <div class="fig-hero__copy" data-uk-scrollspy="cls: uk-animation-slide-left-small">
+            <span class="fig-hero__badge">Gemeinsam gestalten wir die letzte Meile</span>
+            <h1 class="fig-hero__title">Future is Green – die urbane Logistik von morgen: leise, lokal und nachhaltig.</h1>
+            <p class="fig-hero__subtitle">Die Stadt atmet auf: saubere Luft, weniger Lärm, effizientere Wege. Wir verbinden lokale Händler:innen, smarte Hubs und leise E-Cargobikes zu einer Logistikkette, die für Menschen, Umwelt und Wirtschaft funktioniert.</p>
+            <div class="fig-hero__actions">
+              <a class="fig-button fig-button--primary" href="#contact">
+                <span class="uk-margin-small-right" data-uk-icon="icon: cart"></span>Händler:in werden
+              </a>
+              <a class="fig-button fig-button--ghost" href="#contact">
+                <span class="uk-margin-small-right" data-uk-icon="icon: calendar"></span>Pilot anfragen
+              </a>
+            </div>
+            <ul class="fig-hero__stats" role="list">
+              <li role="listitem">0 Emissionen im Quartier</li>
+              <li role="listitem">60% weniger Lieferfahrten</li>
+              <li role="listitem">+24% schnellere Same-Day-Zustellung</li>
+              <li role="listitem">100% lokal &amp; fair</li>
+              <li role="listitem">Transparente CO₂-Bilanz</li>
+            </ul>
+          </div>
+          <div class="fig-hero__visual" data-uk-scrollspy="cls: uk-animation-slide-right-small; delay: 150">
+            <div class="fig-hero__card uk-card uk-card-default uk-card-body">
+              <h2 class="fig-hero__card-title">Wir machen City-Logistik messbar nachhaltig.</h2>
+              <p>Von der Anlieferung im Mikrohub bis zur letzten Meile per Cargo-Bike: Future is Green reduziert Verkehr, Emissionen und Lieferzeiten in dicht besiedelten Quartieren.</p>
+              <div class="fig-hero__card-metric">
+                <span class="fig-hero__metric-value">7,4 t</span>
+                <span class="fig-hero__metric-label">CO₂-Ersparnis pro Jahr in Pilotgebieten</span>
+              </div>
+              <p class="fig-hero__card-note">Live-Dashboards machen Fortschritt sichtbar – für Kommunen, Händler:innen und Bürger:innen.</p>
+            </div>
+          </div>
+        </div>
+        <div class="fig-trust" data-uk-scrollspy="cls: uk-animation-fade; delay: 200">
+          <span class="fig-trust__label">Gefördert &amp; unterstützt von</span>
+          <div class="fig-trust__logos" role="list">
+            <span class="fig-trust__logo" role="listitem">Stadtwerke</span>
+            <span class="fig-trust__logo" role="listitem">IHK</span>
+            <span class="fig-trust__logo" role="listitem">Hochschule&nbsp;XY</span>
+            <span class="fig-trust__logo" role="listitem">EU-Regionalfonds</span>
+            <span class="fig-trust__logo" role="listitem">Urbane Innovation&nbsp;2025</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {{ content|raw }}
+  </div>
+{% endblock %}
+
+{% block footer %}
+  <div class="uk-text-center fig-footer">
+    <a href="{{ basePath }}/impressum">Impressum</a> |
+    <a href="{{ basePath }}/datenschutz">Datenschutz</a> |
+    <a href="{{ basePath }}/lizenz">AGB</a>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ basePath }}/js/app.js" defer></script>
+  <script src="{{ basePath }}/js/landing.js" defer></script>
+  {% if turnstileSiteKey %}
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
+  {% endif %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var contactForm = document.getElementById('contact-form');
+      if (contactForm && !contactForm.hasAttribute('data-contact-endpoint')) {
+        contactForm.setAttribute('data-contact-endpoint', '{{ basePath }}/future-is-green/contact');
+      }
+    });
+  </script>
+{% endblock %}

--- a/tests/Controller/FutureIsGreenControllerTest.php
+++ b/tests/Controller/FutureIsGreenControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class FutureIsGreenControllerTest extends TestCase
+{
+    protected function setUp(): void {
+        parent::setUp();
+        $pdo = $this->getDatabase();
+        try {
+            $pdo->exec("INSERT INTO pages(slug,title,content) VALUES('future-is-green','Future is Green','<p>Future is Green</p>')");
+        } catch (\PDOException $e) {
+            // Ignore duplicates when running multiple tests with shared databases.
+        }
+    }
+
+    public function testFutureIsGreenPage(): void {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/future-is-green');
+        $request = $request->withUri($request->getUri()->withHost('main.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('Future is Green – Landingpage', $body);
+        $this->assertStringContainsString('/future-is-green/contact', $body);
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+
+    public function testFutureIsGreenPageTenant(): void {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/future-is-green');
+        $request = $request->withUri($request->getUri()->withHost('tenant.main.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(404, $response->getStatusCode());
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated Future is Green marketing template with green/white styling and contact endpoint wiring
- seed the Future is Green page content including benefits, process, offers, cases, technology, pricing, about, FAQ and contact sections
- register routing, controller, home-page option and tests to expose the new landing page safely

## Testing
- vendor/bin/phpunit tests/Controller/FutureIsGreenControllerTest.php *(fails: vendor/bin/phpunit missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de81a6bf5c832b857c4e00df97cf20