### PR TITLE
Add icon-enhanced stats list to Future is Green hero

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -159,9 +159,53 @@ body.qr-landing.future-is-green-theme .landing-content {
   background: rgba(255, 255, 255, 0.9);
   border-radius: 14px;
   border: 1px solid rgba(19, 143, 82, 0.16);
-  font-weight: 500;
   color: var(--fig-text);
   box-shadow: 0 12px 24px -20px rgba(16, 52, 36, 0.35);
+}
+
+.future-is-green-theme .fig-hero__stat {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.future-is-green-theme .fig-hero__stat-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(19, 143, 82, 0.12);
+  color: var(--fig-primary);
+  flex-shrink: 0;
+}
+
+.future-is-green-theme .fig-hero__stat-icon svg {
+  width: 24px;
+  height: 24px;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+.future-is-green-theme .fig-hero__stat-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.future-is-green-theme .fig-hero__stat-label strong {
+  font-size: 1.1rem;
+  color: var(--fig-primary-dark);
+}
+
+.future-is-green-theme .fig-hero__stat-label span {
+  color: var(--fig-muted);
 }
 
 .future-is-green-theme .fig-hero__card {

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -186,11 +186,71 @@
               </a>
             </div>
             <ul class="fig-hero__stats" role="list">
-              <li role="listitem">0 Emissionen im Quartier</li>
-              <li role="listitem">60% weniger Lieferfahrten</li>
-              <li role="listitem">+24% schnellere Same-Day-Zustellung</li>
-              <li role="listitem">100% lokal &amp; fair</li>
-              <li role="listitem">Transparente CO₂-Bilanz</li>
+              <li class="fig-hero__stat" role="listitem">
+                <span class="fig-hero__stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false">
+                    <path d="M19 5c-5-1-10 2-11 6-1 3 1.2 6 4.2 7 3.3 1 6.8-1 6.8-1 1-2 1-6 0-12Z"></path>
+                    <path d="M5 19c1.4-3.1 5.4-6.2 9-7.5"></path>
+                  </svg>
+                </span>
+                <span class="fig-hero__stat-label">
+                  <strong>0</strong>
+                  <span>Emissionen im Quartier</span>
+                </span>
+              </li>
+              <li class="fig-hero__stat" role="listitem">
+                <span class="fig-hero__stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false">
+                    <path d="M3.5 8.5h8v7h-7a1 1 0 0 1-1-1v-6Z"></path>
+                    <path d="M11.5 10.5h4.2l3 3v2h-7.2"></path>
+                    <circle cx="7.5" cy="18" r="1.8"></circle>
+                    <circle cx="17" cy="18" r="1.8"></circle>
+                  </svg>
+                </span>
+                <span class="fig-hero__stat-label">
+                  <strong>60%</strong>
+                  <span>weniger Lieferfahrten</span>
+                </span>
+              </li>
+              <li class="fig-hero__stat" role="listitem">
+                <span class="fig-hero__stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false">
+                    <path d="M5 16.5 14.5 7"></path>
+                    <path d="M9 7h5V12"></path>
+                    <path d="M4 20h10"></path>
+                  </svg>
+                </span>
+                <span class="fig-hero__stat-label">
+                  <strong>+24%</strong>
+                  <span>schnellere Same-Day-Zustellung</span>
+                </span>
+              </li>
+              <li class="fig-hero__stat" role="listitem">
+                <span class="fig-hero__stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false">
+                    <circle cx="12" cy="12" r="6.5"></circle>
+                    <path d="M9.8 11.2c-.6-.6-.6-1.6 0-2.2s1.6-.6 2.2 0c.6-.6 1.6-.6 2.2 0s.6 1.6 0 2.2L12 15l-2.2-3.8Z"></path>
+                  </svg>
+                </span>
+                <span class="fig-hero__stat-label">
+                  <strong>100%</strong>
+                  <span>lokal &amp; fair</span>
+                </span>
+              </li>
+              <li class="fig-hero__stat" role="listitem">
+                <span class="fig-hero__stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false">
+                    <circle cx="12" cy="12" r="7.5"></circle>
+                    <path d="M12 12V6"></path>
+                    <path d="M12 12 17 15"></path>
+                    <path d="M6 12h6"></path>
+                  </svg>
+                </span>
+                <span class="fig-hero__stat-label">
+                  <strong>Transparente</strong>
+                  <span>CO₂-Bilanz</span>
+                </span>
+              </li>
             </ul>
           </div>
           <div class="fig-hero__visual" data-uk-scrollspy="cls: uk-animation-slide-right-small; delay: 150">


### PR DESCRIPTION
## Summary
- replace the hero stats list on the Future is Green landing page with an icon-enhanced layout
- add styling hooks in the Future is Green CSS bundle for the new stat icon and label presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de92d06768832ba2791593e6151f1d