### PR TITLE
Move Future is Green hero stats below hero content

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -108,6 +108,10 @@ body.qr-landing.future-is-green-theme .landing-content {
   margin: 32px 0 28px;
 }
 
+.future-is-green-theme .fig-hero__stats-bar {
+  margin-top: 48px;
+}
+
 .future-is-green-theme .fig-button {
   display: inline-flex;
   align-items: center;

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -185,73 +185,6 @@
                 <span class="uk-margin-small-right" data-uk-icon="icon: calendar"></span>Pilot anfragen
               </a>
             </div>
-            <ul class="fig-hero__stats" role="list">
-              <li class="fig-hero__stat" role="listitem">
-                <span class="fig-hero__stat-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false">
-                    <path d="M19 5c-5-1-10 2-11 6-1 3 1.2 6 4.2 7 3.3 1 6.8-1 6.8-1 1-2 1-6 0-12Z"></path>
-                    <path d="M5 19c1.4-3.1 5.4-6.2 9-7.5"></path>
-                  </svg>
-                </span>
-                <span class="fig-hero__stat-label">
-                  <strong>0</strong>
-                  <span>Emissionen im Quartier</span>
-                </span>
-              </li>
-              <li class="fig-hero__stat" role="listitem">
-                <span class="fig-hero__stat-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false">
-                    <path d="M3.5 8.5h8v7h-7a1 1 0 0 1-1-1v-6Z"></path>
-                    <path d="M11.5 10.5h4.2l3 3v2h-7.2"></path>
-                    <circle cx="7.5" cy="18" r="1.8"></circle>
-                    <circle cx="17" cy="18" r="1.8"></circle>
-                  </svg>
-                </span>
-                <span class="fig-hero__stat-label">
-                  <strong>60%</strong>
-                  <span>weniger Lieferfahrten</span>
-                </span>
-              </li>
-              <li class="fig-hero__stat" role="listitem">
-                <span class="fig-hero__stat-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false">
-                    <path d="M5 16.5 14.5 7"></path>
-                    <path d="M9 7h5V12"></path>
-                    <path d="M4 20h10"></path>
-                  </svg>
-                </span>
-                <span class="fig-hero__stat-label">
-                  <strong>+24%</strong>
-                  <span>schnellere Same-Day-Zustellung</span>
-                </span>
-              </li>
-              <li class="fig-hero__stat" role="listitem">
-                <span class="fig-hero__stat-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false">
-                    <circle cx="12" cy="12" r="6.5"></circle>
-                    <path d="M9.8 11.2c-.6-.6-.6-1.6 0-2.2s1.6-.6 2.2 0c.6-.6 1.6-.6 2.2 0s.6 1.6 0 2.2L12 15l-2.2-3.8Z"></path>
-                  </svg>
-                </span>
-                <span class="fig-hero__stat-label">
-                  <strong>100%</strong>
-                  <span>lokal &amp; fair</span>
-                </span>
-              </li>
-              <li class="fig-hero__stat" role="listitem">
-                <span class="fig-hero__stat-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false">
-                    <circle cx="12" cy="12" r="7.5"></circle>
-                    <path d="M12 12V6"></path>
-                    <path d="M12 12 17 15"></path>
-                    <path d="M6 12h6"></path>
-                  </svg>
-                </span>
-                <span class="fig-hero__stat-label">
-                  <strong>Transparente</strong>
-                  <span>CO₂-Bilanz</span>
-                </span>
-              </li>
-            </ul>
           </div>
           <div class="fig-hero__visual" data-uk-scrollspy="cls: uk-animation-slide-right-small; delay: 150">
             <div class="fig-hero__card uk-card uk-card-default uk-card-body">
@@ -264,6 +197,75 @@
               <p class="fig-hero__card-note">Live-Dashboards machen Fortschritt sichtbar – für Kommunen, Händler:innen und Bürger:innen.</p>
             </div>
           </div>
+        </div>
+        <div class="fig-hero__stats-bar" data-uk-scrollspy="cls: uk-animation-fade; delay: 200">
+          <ul class="fig-hero__stats" role="list">
+            <li class="fig-hero__stat" role="listitem">
+              <span class="fig-hero__stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <path d="M19 5c-5-1-10 2-11 6-1 3 1.2 6 4.2 7 3.3 1 6.8-1 6.8-1 1-2 1-6 0-12Z"></path>
+                  <path d="M5 19c1.4-3.1 5.4-6.2 9-7.5"></path>
+                </svg>
+              </span>
+              <span class="fig-hero__stat-label">
+                <strong>0</strong>
+                <span>Emissionen im Quartier</span>
+              </span>
+            </li>
+            <li class="fig-hero__stat" role="listitem">
+              <span class="fig-hero__stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <path d="M3.5 8.5h8v7h-7a1 1 0 0 1-1-1v-6Z"></path>
+                  <path d="M11.5 10.5h4.2l3 3v2h-7.2"></path>
+                  <circle cx="7.5" cy="18" r="1.8"></circle>
+                  <circle cx="17" cy="18" r="1.8"></circle>
+                </svg>
+              </span>
+              <span class="fig-hero__stat-label">
+                <strong>60%</strong>
+                <span>weniger Lieferfahrten</span>
+              </span>
+            </li>
+            <li class="fig-hero__stat" role="listitem">
+              <span class="fig-hero__stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <path d="M5 16.5 14.5 7"></path>
+                  <path d="M9 7h5V12"></path>
+                  <path d="M4 20h10"></path>
+                </svg>
+              </span>
+              <span class="fig-hero__stat-label">
+                <strong>+24%</strong>
+                <span>schnellere Same-Day-Zustellung</span>
+              </span>
+            </li>
+            <li class="fig-hero__stat" role="listitem">
+              <span class="fig-hero__stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <circle cx="12" cy="12" r="6.5"></circle>
+                  <path d="M9.8 11.2c-.6-.6-.6-1.6 0-2.2s1.6-.6 2.2 0c.6-.6 1.6-.6 2.2 0s.6 1.6 0 2.2L12 15l-2.2-3.8Z"></path>
+                </svg>
+              </span>
+              <span class="fig-hero__stat-label">
+                <strong>100%</strong>
+                <span>lokal &amp; fair</span>
+              </span>
+            </li>
+            <li class="fig-hero__stat" role="listitem">
+              <span class="fig-hero__stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <circle cx="12" cy="12" r="7.5"></circle>
+                  <path d="M12 12V6"></path>
+                  <path d="M12 12 17 15"></path>
+                  <path d="M6 12h6"></path>
+                </svg>
+              </span>
+              <span class="fig-hero__stat-label">
+                <strong>Transparente</strong>
+                <span>CO₂-Bilanz</span>
+              </span>
+            </li>
+          </ul>
         </div>
         <div class="fig-trust" data-uk-scrollspy="cls: uk-animation-fade; delay: 200">
           <span class="fig-trust__label">Gefördert &amp; unterstützt von</span>


### PR DESCRIPTION
## Summary
- relocate the Future is Green hero stats list below the hero grid so it spans the full layout width
- add dedicated styling for the relocated stats bar to preserve spacing beneath the hero content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de984b9644832b98839bdf49704a62