### PR TITLE
Adjust offcanvas navigation colors

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -55,9 +55,15 @@ body:not(.dark-mode) .topbar .uk-navbar-nav>li>a{
   color: var(--qr-fg);
   border: 1px solid var(--drop-border, var(--qr-border));
 }
+.uk-offcanvas-bar .uk-nav-header,
+.uk-offcanvas-bar .uk-nav.uk-nav-divider{
+  color: var(--qr-fg);
+  border-color: var(--qr-border);
+}
 .uk-offcanvas-bar .uk-nav-default>li>a,
 .uk-offcanvas-bar .uk-nav-default .uk-nav-sub a {
   color: var(--qr-fg);
+  border-color: var(--qr-border);
 }
 .git-btn{
   width:40px;height:40px;padding:0;


### PR DESCRIPTION
## Summary
- ensure offcanvas navigation headers and dividers use theme foreground and border variables
- align default offcanvas links with theme border colors for consistent contrast

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de99cb6cec832b8f5ca1c4ad269f52