### PR TITLE
Add configuration toggles to admin offcanvas

### DIFF
--- a/public/css/topbar.css
+++ b/public/css/topbar.css
@@ -109,6 +109,28 @@ body:not(.dark-mode) .topbar .uk-navbar-nav>li>a{
   color:var(--topbar-text);
 }
 
+#qr-offcanvas .offcanvas-switches{
+  margin-top:24px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  padding-left:0;
+}
+
+#qr-offcanvas .offcanvas-switches>li{
+  list-style:none;
+}
+
+#qr-offcanvas .offcanvas-switches .git-btn{
+  width:100%;
+  justify-content:flex-start;
+  gap:12px;
+}
+
+#qr-offcanvas .offcanvas-switches .git-btn span{
+  display:inline-flex;
+}
+
 @media (max-width: 640px) {
   .topbar .uk-navbar-right {
     position: absolute;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -3651,7 +3651,7 @@ document.addEventListener('DOMContentLoaded', function () {
   let cardIndex = 0;
 
   // --------- Hilfe-Seitenleiste ---------
-  const helpBtn = document.getElementById('helpBtn');
+  const helpButtons = document.querySelectorAll('.help-toggle');
   const helpSidebar = document.getElementById('helpSidebar');
   const helpContent = document.getElementById('helpContent');
   const qrDesignModal = document.getElementById('qrDesignModal');
@@ -4076,15 +4076,19 @@ document.addEventListener('DOMContentLoaded', function () {
     return active ? active.getAttribute('data-help') || '' : '';
   }
 
-  helpBtn?.addEventListener('click', () => {
-    if (!helpSidebar || !helpContent) return;
-    let text = activeHelpText();
-    if (!text && window.location.pathname.endsWith('/admin/event/settings')) {
-      text = window.transEventSettingsHelp || '';
-    }
-    helpContent.innerHTML = text;
-    if (window.UIkit && UIkit.offcanvas) UIkit.offcanvas(helpSidebar).show();
-  });
+  if (helpButtons.length) {
+    helpButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        if (!helpSidebar || !helpContent) return;
+        let text = activeHelpText();
+        if (!text && window.location.pathname.endsWith('/admin/event/settings')) {
+          text = window.transEventSettingsHelp || '';
+        }
+        helpContent.innerHTML = text;
+        if (window.UIkit && UIkit.offcanvas) UIkit.offcanvas(helpSidebar).show();
+      });
+    });
+  }
 
   adminMenuToggle?.addEventListener('click', e => {
     e.preventDefault();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -12,9 +12,9 @@ document.addEventListener('DOMContentLoaded', function () {
   const offcanvasHasItems = offcanvas && offcanvas.querySelector('li');
   const darkStylesheet = document.querySelector('link[href$="dark.css"]');
   const uikitStylesheet = document.querySelector('link[href*="uikit"]');
-  const themeIcon = document.getElementById('themeIcon');
-  const accessibilityIcon = document.getElementById('accessibilityIcon');
-  const helpBtn = document.getElementById('helpBtn');
+  const themeIcons = document.querySelectorAll('.theme-icon');
+  const accessibilityIcons = document.querySelectorAll('.accessibility-icon');
+  const helpButtons = document.querySelectorAll('.help-toggle');
   const teamNameBtn = document.getElementById('teamNameBtn');
 
   if (offcanvasToggle && !offcanvasHasItems) {
@@ -100,16 +100,20 @@ document.addEventListener('DOMContentLoaded', function () {
         <path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor" opacity="0.4"/>
       </svg>`;
 
-  if (themeIcon) {
-    themeIcon.innerHTML = dark ? sunSVG : moonSVG;
+  if (themeIcons.length) {
+    themeIcons.forEach((icon) => {
+      icon.innerHTML = dark ? sunSVG : moonSVG;
+    });
   }
 
   let accessible = getStored(STORAGE_KEYS.BARRIER_FREE) === 'true';
   if (accessible) {
     document.body.classList.add('high-contrast');
   }
-  if (accessibilityIcon) {
-    accessibilityIcon.innerHTML = accessible ? accessibilityOnSVG : accessibilityOffSVG;
+  if (accessibilityIcons.length) {
+    accessibilityIcons.forEach((icon) => {
+      icon.innerHTML = accessible ? accessibilityOnSVG : accessibilityOffSVG;
+    });
   }
 
   function updateThemePressed () {
@@ -163,8 +167,10 @@ document.addEventListener('DOMContentLoaded', function () {
         darkStylesheet.toggleAttribute('disabled', !dark);
       }
       setStored(STORAGE_KEYS.DARK_MODE, dark ? 'true' : 'false');
-      if (themeIcon) {
-        themeIcon.innerHTML = dark ? sunSVG : moonSVG;
+      if (themeIcons.length) {
+        themeIcons.forEach((icon) => {
+          icon.innerHTML = dark ? sunSVG : moonSVG;
+        });
       }
       updateThemePressed();
       try { UIkit.dropdown('#menuDrop').hide(); } catch (e) {}
@@ -176,18 +182,22 @@ document.addEventListener('DOMContentLoaded', function () {
       event.preventDefault();
       accessible = document.body.classList.toggle('high-contrast');
       setStored(STORAGE_KEYS.BARRIER_FREE, accessible ? 'true' : 'false');
-      if (accessibilityIcon) {
-        accessibilityIcon.innerHTML = accessible ? accessibilityOnSVG : accessibilityOffSVG;
+      if (accessibilityIcons.length) {
+        accessibilityIcons.forEach((icon) => {
+          icon.innerHTML = accessible ? accessibilityOnSVG : accessibilityOffSVG;
+        });
       }
       updateAccessibilityPressed();
       try { UIkit.dropdown('#menuDrop').hide(); } catch (e) {}
     }
   });
 
-  if (helpBtn) {
-    helpBtn.addEventListener('click', function () {
-      try { UIkit.dropdown('#menuDrop').hide(); } catch (e) {}
-      UIkit.offcanvas('#helpDrawer').show();
+  if (helpButtons.length) {
+    helpButtons.forEach((button) => {
+      button.addEventListener('click', function () {
+        try { UIkit.dropdown('#menuDrop').hide(); } catch (e) {}
+        UIkit.offcanvas('#helpDrawer').show();
+      });
     });
   }
 

--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -1616,6 +1616,29 @@
       <button class="uk-offcanvas-close" type="button" uk-close aria-label="{{ t('menu') }}"></button>
       <h3 class="uk-margin-small">QuizRace</h3>
       {% include 'admin/_nav.twig' %}
+      <ul class="uk-nav uk-nav-default offcanvas-switches" role="menu">
+        <li>
+          <button class="uk-button uk-button-default git-btn theme-toggle" aria-label="{{ t('design_toggle') }}" role="menuitem">
+            <span class="theme-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="currentColor"></path></svg>
+            </span>
+          </button>
+        </li>
+        <li>
+          <button class="uk-button uk-button-default git-btn accessibility-toggle" aria-label="{{ t('contrast_toggle') }}" role="menuitem">
+            <span class="accessibility-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor" /></svg>
+            </span>
+          </button>
+        </li>
+        <li>
+          <button class="uk-button uk-button-default git-btn help-toggle" aria-label="{{ t('help') }}" role="menuitem">
+            <span aria-hidden="true">
+              <svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2Zm0 16a1.25 1.25 0 1 1 0 2.5A1.25 1.25 0 0 1 12 18Zm1.1-3.9v.65h-2.1V14c0-1.35.9-2.01 1.84-2.56.84-.5 1.66-.99 1.66-1.94 0-.86-.7-1.5-1.75-1.5-1.06 0-1.77.63-1.9 1.6H8.7C8.86 7.63 10.13 6 12.75 6c2.32 0 3.9 1.33 3.9 3.23 0 1.87-1.46 2.7-2.37 3.22-.87.5-1.18.76-1.18 1.65Z" fill="currentColor"/></svg>
+            </span>
+          </button>
+        </li>
+      </ul>
     </div>
   </div>
 {% endblock %}

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -73,7 +73,7 @@
                           class="uk-button uk-button-default git-btn theme-toggle"
                           aria-label="Design umschalten"
                           role="menuitem">
-                    <span id="themeIcon" aria-hidden="true"></span>
+                    <span id="themeIcon" class="theme-icon" aria-hidden="true"></span>
                   </button>
                 </li>
                 <li>
@@ -81,7 +81,7 @@
                           class="uk-button uk-button-default git-btn accessibility-toggle"
                           aria-label="Kontrast umschalten"
                           role="menuitem">
-                    <span id="accessibilityIcon" aria-hidden="true"></span>
+                    <span id="accessibilityIcon" class="accessibility-icon" aria-hidden="true"></span>
                   </button>
                 </li>
                 <li>

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -81,7 +81,7 @@
                           class="uk-button uk-button-default git-btn theme-toggle"
                           aria-label="Design umschalten"
                           role="menuitem">
-                    <span id="themeIcon" aria-hidden="true"></span>
+                    <span id="themeIcon" class="theme-icon" aria-hidden="true"></span>
                   </button>
                 </li>
                 <li>
@@ -89,7 +89,7 @@
                           class="uk-button uk-button-default git-btn accessibility-toggle"
                           aria-label="Kontrast umschalten"
                           role="menuitem">
-                    <span id="accessibilityIcon" aria-hidden="true"></span>
+                    <span id="accessibilityIcon" class="accessibility-icon" aria-hidden="true"></span>
                   </button>
                 </li>
                 <li>

--- a/templates/marketing/landing.twig
+++ b/templates/marketing/landing.twig
@@ -60,12 +60,12 @@
               <ul class="uk-nav uk-dropdown-nav" role="menu">
                 <li>
                   <button id="themeToggle" class="uk-button uk-button-default git-btn theme-toggle" aria-label="Design umschalten" role="menuitem">
-                    <span id="themeIcon" aria-hidden="true"></span>
+                    <span id="themeIcon" class="theme-icon" aria-hidden="true"></span>
                   </button>
                 </li>
                 <li>
                   <button id="accessibilityToggle" class="uk-button uk-button-default git-btn accessibility-toggle" aria-label="Kontrast umschalten" role="menuitem">
-                    <span id="accessibilityIcon" aria-hidden="true"></span>
+                    <span id="accessibilityIcon" class="accessibility-icon" aria-hidden="true"></span>
                   </button>
                 </li>
                 <li>

--- a/templates/topbar.twig
+++ b/templates/topbar.twig
@@ -36,20 +36,20 @@
             <ul class="uk-nav uk-dropdown-nav" role="menu">
               <li>
                 <button id="themeToggle" class="uk-button uk-button-default git-btn theme-toggle" aria-label="{{ t('design_toggle') }}" role="menuitem">
-                  <span id="themeIcon" aria-hidden="true">
+                  <span id="themeIcon" class="theme-icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="currentColor"></path></svg>
                   </span>
                 </button>
               </li>
               <li>
                 <button id="accessibilityToggle" class="uk-button uk-button-default git-btn accessibility-toggle" aria-label="{{ t('contrast_toggle') }}" role="menuitem">
-                  <span id="accessibilityIcon" aria-hidden="true">
+                  <span id="accessibilityIcon" class="accessibility-icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 2a10 10 0 0 0 0 20z" fill="currentColor" /></svg>
                   </span>
                 </button>
               </li>
               <li>
-                <button id="helpBtn" class="uk-button uk-button-default git-btn" aria-label="{{ t('help') }}" role="menuitem">
+                <button id="helpBtn" class="uk-button uk-button-default git-btn help-toggle" aria-label="{{ t('help') }}" role="menuitem">
                   <span aria-hidden="true">
                     <svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2Zm0 16a1.25 1.25 0 1 1 0 2.5A1.25 1.25 0 0 1 12 18Zm1.1-3.9v.65h-2.1V14c0-1.35.9-2.01 1.84-2.56.84-.5 1.66-.99 1.66-1.94 0-.86-.7-1.5-1.75-1.5-1.06 0-1.77.63-1.9 1.6H8.7C8.86 7.63 10.13 6 12.75 6c2.32 0 3.9 1.33 3.9 3.23 0 1.87-1.46 2.7-2.37 3.22-.87.5-1.18.76-1.18 1.65Z" fill="currentColor"/></svg>
                   </span>


### PR DESCRIPTION
## Summary
- add theme, accessibility, and help controls to the admin offcanvas navigation
- share toggle button markup and icon styling across top bar, marketing, and admin templates
- update JavaScript and CSS so multiple toggle instances stay in sync and render cleanly in the offcanvas

## Testing
- not run (manual admin login not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de99d7f55c832b9b344e059083208e