### PR TITLE
Add inline Future is Green logo markup and responsive styling

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -30,6 +30,115 @@ body.qr-landing.future-is-green-theme .landing-content {
   color: var(--fig-text);
 }
 
+.future-is-green-theme .fig-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  padding: 6px 0;
+  color: var(--fig-text);
+  text-decoration: none;
+  line-height: 1;
+  max-width: clamp(180px, 26vw, 340px);
+}
+
+.future-is-green-theme .fig-logo__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(38px, 5vw, 54px);
+  height: clamp(38px, 5vw, 54px);
+  flex-shrink: 0;
+}
+
+.future-is-green-theme .fig-logo__svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.future-is-green-theme .fig-logo__text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  line-height: 1.05;
+  min-width: 0;
+}
+
+.future-is-green-theme .fig-logo__title {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 0.4em;
+  font-size: clamp(0.7rem, 0.5rem + 0.8vw, 1.05rem);
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.future-is-green-theme .fig-logo__title-primary {
+  color: var(--fig-text);
+}
+
+.future-is-green-theme .fig-logo__title-connector {
+  color: var(--fig-muted);
+  font-weight: 500;
+  letter-spacing: 0.22em;
+}
+
+.future-is-green-theme .fig-logo__title-accent {
+  color: var(--fig-primary);
+  font-weight: 700;
+  letter-spacing: 0.24em;
+}
+
+.future-is-green-theme .fig-logo__subtitle {
+  font-size: clamp(0.55rem, 0.38rem + 0.6vw, 0.8rem);
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .future-is-green-theme .fig-logo {
+    gap: 10px;
+  }
+
+  .future-is-green-theme .fig-logo__title {
+    font-size: clamp(0.68rem, 0.54rem + 0.9vw, 0.9rem);
+    letter-spacing: 0.14em;
+  }
+
+  .future-is-green-theme .fig-logo__title-connector,
+  .future-is-green-theme .fig-logo__title-accent {
+    letter-spacing: 0.18em;
+  }
+
+  .future-is-green-theme .fig-logo__subtitle {
+    letter-spacing: 0.22em;
+  }
+}
+
+@media (min-width: 960px) {
+  .future-is-green-theme .uk-navbar-nav > li > a {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
 .future-is-green-theme .fig-cta .fig-primary-link {
   display: inline-flex;
   align-items: center;

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -42,7 +42,29 @@
                     aria-controls="qr-offcanvas"
                     aria-expanded="false"
                     aria-label="Menü"></button>
-            <a class="uk-logo" href="{{ basePath }}/future-is-green">Future is Green</a>
+            <a class="uk-logo fig-logo" href="{{ basePath }}/future-is-green">
+              <span class="fig-visually-hidden">Future is Green – Logistic Solutions</span>
+              <span class="fig-logo__icon" aria-hidden="true">
+                <svg class="fig-logo__svg"
+                     viewBox="0 0 64 64"
+                     focusable="false"
+                     aria-hidden="true"
+                     xmlns="http://www.w3.org/2000/svg">
+                  <path d="M32 6 6 26h6v22a6 6 0 0 0 6 6h28a6 6 0 0 0 6-6V26h6L32 6z" fill="#0c6f3f"/>
+                  <path d="M32 12.6 14 26.8v20.2a4 4 0 0 0 4 4h28a4 4 0 0 0 4-4V26.8L32 12.6z" fill="#138f52"/>
+                  <path d="M32 23.8c-6.2 0-11.2 5-11.2 11.3 0 7.8 11.2 17.3 11.2 17.3s11.2-9.5 11.2-17.3c0-6.3-5-11.3-11.2-11.3Zm0 15.4a4.1 4.1 0 1 1 0-8.2 4.1 4.1 0 0 1 0 8.2Z" fill="#9cd78f"/>
+                  <path d="M32 29.6a5.6 5.6 0 0 0-5.6 5.6v16.8h11.2V35.2A5.6 5.6 0 0 0 32 29.6Z" fill="#f0f9f3" opacity="0.9"/>
+                </svg>
+              </span>
+              <span class="fig-logo__text" aria-hidden="true">
+                <span class="fig-logo__title">
+                  <span class="fig-logo__title-primary">FUTURE</span>
+                  <span class="fig-logo__title-connector">is</span>
+                  <span class="fig-logo__title-accent">GREEN</span>
+                </span>
+                <span class="fig-logo__subtitle">LOGISTIC SOLUTIONS</span>
+              </span>
+            </a>
           </div>
         </div>
         <div class="uk-navbar-right">


### PR DESCRIPTION
## Summary
- replace the Future is Green navbar logo text with an inline SVG mark and structured text for accessibility
- add styling for the new logo icon and typography so the mark and wording align responsively across breakpoints
- tweak navbar link padding on wide screens to keep the navigation balanced with the broader logo lockup

## Testing
- php -S 0.0.0.0:8080 -t public public/router.php

------
https://chatgpt.com/codex/tasks/task_e_68de99ed9720832b926b792cd8e45089