### PR TITLE
Load storage helpers before landing scripts on Future is Green page

### DIFF
--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -293,6 +293,7 @@
 {% endblock %}
 
 {% block scripts %}
+  <script src="{{ basePath }}/js/storage.js"></script>
   <script src="{{ basePath }}/js/app.js" defer></script>
   <script src="{{ basePath }}/js/landing.js" defer></script>
   {% if turnstileSiteKey %}


### PR DESCRIPTION
## Summary
- ensure `storage.js` is loaded ahead of the landing bundle so storage helpers are defined when `app.js` executes

## Testing
- Manual verification blocked locally (Future is Green route times out without the required Stripe configuration)


------
https://chatgpt.com/codex/tasks/task_e_68de9a0cf304832ba14f62163e9dabc4