### PR TITLE
Add follow-up migration for Future is Green benefits copy

### DIFF
--- a/migrations/20251101_update_future_is_green_benefits.sql
+++ b/migrations/20251101_update_future_is_green_benefits.sql
@@ -1,0 +1,363 @@
+UPDATE pages
+SET content = $$<section id="benefits" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Wirkung im Quartier</h2>
+      <p>Unsere Pilotgebiete zeigen: Klimaschutz, Lebensqualität und Liefertempo schließen sich nicht aus. Future is Green reduziert Verkehr und macht Same-Day-Lieferungen nachhaltiger – für Menschen, Umwelt und lokale Wirtschaft.</p>
+    </div>
+    <div class="fig-benefits-grid" role="list" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 120">
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">0</span>
+        <p class="fig-benefit-card__label">Emissionen im Quartier</p>
+        <p class="fig-benefit-card__desc">Vollelektrische Flotten auf Ökostrom senken lokale Emissionen auf null – spürbar bessere Luft für alle.</p>
+      </article>
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">–60%</span>
+        <p class="fig-benefit-card__label">weniger Lieferfahrten</p>
+        <p class="fig-benefit-card__desc">Mikrohubs bündeln Warenströme: weniger Staus, weniger Leerfahrten, weniger Stress vor der Haustür.</p>
+      </article>
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">+24%</span>
+        <p class="fig-benefit-card__label">schnellere Same-Day-Zustellung</p>
+        <p class="fig-benefit-card__desc">KI-Tourenplanung priorisiert Zeitfenster und Routen – zuverlässig pünktlich, auch in der Rushhour.</p>
+      </article>
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">100%</span>
+        <p class="fig-benefit-card__label">lokal &amp; fair</p>
+        <p class="fig-benefit-card__desc">Faire Jobs, kurze Wege, starke Partnerschaften: Wertschöpfung bleibt in der Stadt – bei Händler:innen und Ridern.</p>
+      </article>
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">CO₂</span>
+        <p class="fig-benefit-card__label">transparente Bilanz</p>
+        <p class="fig-benefit-card__desc">Live-Dashboards zeigen Einsparungen in Echtzeit – auditierbar für Kommunen, Partner und Fördergeber.</p>
+      </article>
+      <article class="fig-benefit-card" role="listitem">
+        <span class="fig-benefit-card__value">–35%</span>
+        <p class="fig-benefit-card__label">weniger Lärm &amp; Parkdruck</p>
+        <p class="fig-benefit-card__desc">Leise E-Fahrzeuge, gebündelte Stopps und Off-Peak-Lieferungen beruhigen Straßen und schaffen Platz für Menschen.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="how-it-works" class="fig-section fig-section--contrast">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>So funktioniert Future is Green</h2>
+      <p>Wir verbinden Mikrohub, Software und letzte Meile zu einem geschlossenen System. Jede Station liefert Daten – jede Tour bringt uns einer klimafreundlichen Innenstadt näher.</p>
+    </div>
+    <div class="fig-process-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-process-step">
+        <span class="fig-process-step__number">1</span>
+        <h3>Warenannahme im Mikrohub</h3>
+        <p>Lieferungen von Großhändlern und lokalen Produzent:innen landen gebündelt im nächstgelegenen Mikrohub. Digitale Erfassung und Lagerung verkürzen Wege und Wartezeiten.</p>
+      </article>
+      <article class="fig-process-step">
+        <span class="fig-process-step__number">2</span>
+        <h3>Intelligente Tourenplanung</h3>
+        <p>Unsere Software optimiert Touren nach Zeitfenstern, Prioritäten und Verkehrslage. So bleiben Strecken kurz, Geräusche gering und Lieferzeiten verlässlich.</p>
+      </article>
+      <article class="fig-process-step">
+        <span class="fig-process-step__number">3</span>
+        <h3>Letzte Meile mit E-Cargobikes</h3>
+        <p>Emissionfreie Zustellung an Läden, Schließfächer oder Haushalte – leise, flexibel und freundlich im Stadtbild.</p>
+      </article>
+      <article class="fig-process-step">
+        <span class="fig-process-step__number">4</span>
+        <h3>Transparenz in Echtzeit</h3>
+        <p>Dashboards zeigen Status, ETA und CO₂-Einsparung live. Händler:innen und Kund:innen behalten jede Sendung im Blick.</p>
+      </article>
+    </div>
+    <div class="uk-text-center uk-margin-large-top" data-uk-scrollspy="cls: uk-animation-fade; delay: 200">
+      <a class="fig-button fig-button--primary" href="#contact">
+        <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Jetzt Pilot starten
+      </a>
+    </div>
+  </div>
+</section>
+
+<section id="offerings" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Angebote für alle Stadt-Akteur:innen</h2>
+      <p>Ob Händler:in, Kommune oder Logistikpartner – Future is Green skaliert mit Ihrem Bedarf.</p>
+    </div>
+    <div class="fig-offerings" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-offering-card">
+        <h3>Für Händler:innen</h3>
+        <ul>
+          <li>Same-Day &amp; Next-Day innerhalb Ihres Bezirks</li>
+          <li>Retourenabwicklung direkt im Kiez</li>
+          <li>Lager- und Kommissionierservice im Mikrohub</li>
+          <li>Integration in Shop- &amp; POS-Systeme (Shopware, Shopify, Woo, ERP)</li>
+        </ul>
+      </article>
+      <article class="fig-offering-card">
+        <h3>Für Kommunen</h3>
+        <ul>
+          <li>Entlastung innerstädtischer Straßen und Anwohner:innen</li>
+          <li>Datenbasierte Verkehrs- und Umweltberichte</li>
+          <li>Skalierbares Hub-Konzept für jeden Kiez</li>
+          <li>Förderung lokaler Wirtschaftskreisläufe</li>
+        </ul>
+      </article>
+      <article class="fig-offering-card">
+        <h3>Für Logistikpartner</h3>
+        <ul>
+          <li>White-Label-Zustellung auf der letzten Meile</li>
+          <li>Peak-Handling für Saisons &amp; Events</li>
+          <li>Nachhaltigkeitsreporting für Ihre Kund:innen</li>
+        </ul>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="cases" class="fig-section fig-section--contrast">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Case-Teaser aus unseren Pilotquartieren</h2>
+      <p>Zwei Bezirke, ein Ziel: Logistik, die urbanen Raum zurückgibt.</p>
+    </div>
+    <div class="fig-case-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-case-card">
+        <h3>Fallstudie 1 – „Kiez A“</h3>
+        <ul>
+          <li>-37% Lieferverkehr im Wohngebiet</li>
+          <li>+28% Pünktlichkeit im Zeitfenster 10–14 Uhr</li>
+          <li>1 Mikrohub, 8 Cargobikes, 120 angebundene Shops</li>
+        </ul>
+        <div class="fig-case-card__cta">
+          <a class="fig-link" href="#contact">
+            <span data-uk-icon="icon: arrow-right"></span>Zur Fallstudie
+          </a>
+        </div>
+      </article>
+      <article class="fig-case-card">
+        <h3>Fallstudie 2 – „Innenstadt B“</h3>
+        <ul>
+          <li>Stabiler Verkehrsfluss in definierten Lieferfenstern</li>
+          <li>Messbare Lärmminderung in Nebenstraßen</li>
+          <li>Reale CO₂-Ersparnis: 7,4&nbsp;t pro Jahr</li>
+        </ul>
+        <div class="fig-case-card__cta">
+          <a class="fig-link" href="#contact">
+            <span data-uk-icon="icon: arrow-right"></span>Zur Fallstudie
+          </a>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="technology" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Technologie, die Logistik greifbar macht</h2>
+      <p>Future is Green verbindet smarte Software mit offenen Schnittstellen. Jede Integration bringt Transparenz und Tempo.</p>
+    </div>
+    <div class="fig-technology-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-technology-card">
+        <h3>Tourenplanung &amp; Hub-Software</h3>
+        <ul class="fig-feature-list">
+          <li><span class="fig-feature-icon">✓</span><span>KI-gestützte Bündelung und Routenplanung</span></li>
+          <li><span class="fig-feature-icon">✓</span><span>Live-Tracking mit ETA-Berechnung und Slot-Management</span></li>
+          <li><span class="fig-feature-icon">✓</span><span>Offene API für ERP, Shops und BI-Tools</span></li>
+          <li><span class="fig-feature-icon">✓</span><span>Webhooks &amp; Datenexport für individuelle Auswertungen</span></li>
+          <li><span class="fig-feature-icon">✓</span><span>KPI-Dashboard: CO₂, Pünktlichkeit, Auslastung, Stopps, Lieferrate</span></li>
+        </ul>
+      </article>
+      <article class="fig-technology-card">
+        <h3>Schnittstellen &amp; Sensorik</h3>
+        <ul class="fig-feature-list">
+          <li><span class="fig-feature-icon">↔</span><span>Shopware, Shopify, WooCommerce out of the box</span></li>
+          <li><span class="fig-feature-icon">↔</span><span>ERP/OMS via REST-API</span></li>
+          <li><span class="fig-feature-icon">↔</span><span>IoT-Sensorik für Temperatur- und Schocküberwachung (optional)</span></li>
+        </ul>
+      </article>
+      <article class="fig-technology-card">
+        <h3>Sicherheit &amp; Compliance</h3>
+        <ul class="fig-feature-list">
+          <li><span class="fig-feature-icon">🔒</span><span>DSGVO-konformes Hosting in Deutschland/EU</span></li>
+          <li><span class="fig-feature-icon">🔒</span><span>Rollen- und Rechtemanagement für Teams &amp; Partner</span></li>
+          <li><span class="fig-feature-icon">🔒</span><span>Verschlüsselte Datenflüsse (TLS, Encryption at rest)</span></li>
+          <li><span class="fig-feature-icon">🔒</span><span>Audit-Logs &amp; Export für Compliance-Anforderungen</span></li>
+        </ul>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="pricing" class="fig-section fig-section--contrast">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Preismodelle, die mitwachsen</h2>
+      <p>Skalierbare Pakete – vom ersten Pilot bis zum Rollout über Stadtgrenzen hinweg.</p>
+    </div>
+    <div class="fig-pricing-grid" data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > article; delay: 150">
+      <article class="fig-pricing-card">
+        <h3>Händler:innen</h3>
+        <p>Paketpreise nach Volumen und Bezirk – inklusive Same-Day, Retouren und Lagerflächen.</p>
+        <ul>
+          <li>Flexible Kontingente pro Standort</li>
+          <li>Transparente Monatsreports</li>
+        </ul>
+      </article>
+      <article class="fig-pricing-card">
+        <h3>Kommunen</h3>
+        <p>Pilot- und Rollout-Pakete mit Förderoptionen. Datenreports sichern politische Entscheidungen ab.</p>
+        <ul>
+          <li>Impact-Reporting für Umwelt &amp; Verkehr</li>
+          <li>Beratung zu Fördermitteln &amp; Skalierung</li>
+        </ul>
+      </article>
+      <article class="fig-pricing-card">
+        <h3>Logistikpartner</h3>
+        <p>White-Label-Modelle mit SLA. Wir erweitern Ihre Flotte um leise letzte Meile.</p>
+        <ul>
+          <li>Service-Level-Agreements nach Bedarf</li>
+          <li>Nachhaltigkeitskennzahlen für Ihr Reporting</li>
+        </ul>
+      </article>
+    </div>
+    <div class="uk-text-center uk-margin-large-top" data-uk-scrollspy="cls: uk-animation-fade; delay: 200">
+      <a class="fig-button fig-button--primary" href="#contact">
+        <span class="uk-margin-small-right" data-uk-icon="icon: receiver"></span>Angebot anfragen
+      </a>
+    </div>
+  </div>
+</section>
+
+<section id="about" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-about-grid" data-uk-grid data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > div; delay: 150">
+      <div>
+        <h2>Über uns</h2>
+        <p>Wir sind Mobilitätsplaner:innen, Logistikexpert:innen und Softwareentwickler:innen – vereint durch die Vision lebenswerter Städte. Future is Green vernetzt urbane Logistik mit sozialer Verantwortung und messbarer Wirkung.</p>
+        <h3>Partner &amp; Netzwerk</h3>
+        <div class="fig-partner-grid">
+          <span class="fig-partner-tag">Stadtwerke – Energie &amp; Ladeinfrastruktur</span>
+          <span class="fig-partner-tag">Hochschule&nbsp;XY – Verkehrsdatenauswertung</span>
+          <span class="fig-partner-tag">IHK – lokale Wirtschaftsförderung</span>
+        </div>
+      </div>
+      <div>
+        <h3>Meilensteine</h3>
+        <ul class="fig-timeline">
+          <li><strong>2023:</strong> Konzeptvalidierung &amp; erste Piloten</li>
+          <li><strong>2024:</strong> Software-Beta &amp; Hub-Prototyp</li>
+          <li><strong>2025:</strong> Skalierung auf drei Bezirke plus Partnernetzwerke</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="faq" class="fig-section fig-section--contrast">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>FAQ</h2>
+      <p>Antworten auf die wichtigsten Fragen rund um unsere Pilotprogramme.</p>
+    </div>
+    <ul class="uk-accordion" data-uk-accordion>
+      <li>
+        <a class="uk-accordion-title" href="#">Wie schnell kann ein Pilot starten?</a>
+        <div class="uk-accordion-content">
+          <p>In 6–10 Wochen begleiten wir Standortcheck, Partnerakquise, Setup, Schulungen und Go-Live.</p>
+        </div>
+      </li>
+      <li>
+        <a class="uk-accordion-title" href="#">Wie misst ihr die Wirkung?</a>
+        <div class="uk-accordion-content">
+          <p>Unser Dashboard erfasst CO₂-, Lärm- und Verkehrsdaten. Zusätzlich evaluieren wir mit der lokalen Hochschule.</p>
+        </div>
+      </li>
+      <li>
+        <a class="uk-accordion-title" href="#">Welche Stadtteile sind geeignet?</a>
+        <div class="uk-accordion-content">
+          <p>Hohe Dichte, gemischte Nutzung und bestehende Lieferprobleme sind ideale Voraussetzungen – wir beraten individuell.</p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</section>
+
+<section id="contact" class="fig-section">
+  <div class="uk-container">
+    <div class="fig-section__intro" data-uk-scrollspy="cls: uk-animation-slide-top-small">
+      <h2>Jetzt gemeinsam loslegen</h2>
+      <p>Fragen, Pilotanfrage oder Angebot? Wir melden uns persönlich mit den nächsten Schritten.</p>
+    </div>
+    <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" data-uk-grid data-uk-scrollspy="cls: uk-animation-slide-bottom-small; target: > div; delay: 150">
+      <div>
+        <form id="contact-form" class="uk-form-stacked uk-width-large uk-margin-auto">
+          <div class="uk-margin">
+            <label class="uk-form-label" for="fig-form-name">Name</label>
+            <input class="uk-input" id="fig-form-name" name="name" type="text" required>
+          </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="fig-form-email">E-Mail</label>
+            <input class="uk-input" id="fig-form-email" name="email" type="email" required>
+          </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="fig-form-msg">Nachricht</label>
+            <textarea class="uk-textarea" id="fig-form-msg" name="message" rows="5" required></textarea>
+          </div>
+          <div class="uk-margin turnstile-field" data-turnstile-container>
+            <div class="turnstile-widget">{{ turnstile_widget }}</div>
+            <p class="uk-text-small turnstile-hint" data-turnstile-hint hidden>Bitte bestätigen Sie, dass Sie kein Roboter sind.</p>
+          </div>
+          <div class="uk-margin">
+            <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
+          </div>
+          <input type="text" name="company" autocomplete="off" tabindex="-1" class="uk-hidden" aria-hidden="true">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+          <button class="fig-button fig-button--primary uk-width-1-1" type="submit">
+            <span class="uk-margin-small-right" data-uk-icon="icon: mail"></span>Nachricht senden
+          </button>
+        </form>
+      </div>
+      <div>
+        <div class="uk-grid uk-child-width-1-1 uk-grid-small">
+          <div>
+            <div class="fig-contact-card">
+              <p class="uk-text-large uk-margin-small-bottom">E-Mail</p>
+              <a class="uk-link-reset js-email-link" data-user="hello" data-domain="futureisgreen.city" href="#">hello [at] futureisgreen.city</a>
+            </div>
+          </div>
+          <div>
+            <div class="fig-contact-card">
+              <p class="uk-text-large uk-margin-small-bottom">Social</p>
+              <ul class="uk-list uk-list-divider uk-margin-remove">
+                <li><a class="fig-link" href="https://www.linkedin.com" target="_blank" rel="noopener"><span data-uk-icon="icon: linkedin"></span>LinkedIn</a></li>
+                <li><a class="fig-link" href="https://mastodon.social" target="_blank" rel="noopener"><span data-uk-icon="icon: world"></span>Mastodon</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.js-email-link').forEach(function (anchor) {
+      var user = anchor.getAttribute('data-user');
+      var domain = anchor.getAttribute('data-domain');
+      if (user && domain) {
+        var email = user + '@' + domain;
+        anchor.href = 'mailto:' + email;
+        anchor.textContent = email;
+      }
+    });
+  });
+</script>
+
+<div id="contact-modal" uk-modal>
+  <div class="uk-modal-dialog uk-modal-body">
+    <p id="contact-modal-message" aria-live="polite"></p>
+    <button class="uk-button uk-button-primary uk-modal-close" type="button">OK</button>
+  </div>
+</div>$$
+WHERE slug = 'future-is-green';


### PR DESCRIPTION
## Summary
- restore the original Future is Green page migration
- add a follow-up migration that updates the benefits copy to the latest six impact statements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea37bbd50832bbac1c46c2773d5e0