### PR TITLE
Add Future is Green wordmark to marketing topbar

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -139,11 +139,42 @@ body.qr-landing.future-is-green-theme .landing-content {
   transition: transform 0.28s ease, box-shadow 0.28s ease, border-radius 0.28s ease;
 }
 
+.future-is-green-theme .fig-logo__wordmark {
+  display: inline-flex;
+  align-items: center;
+  margin-left: clamp(12px, 2.4vw, 28px);
+}
+
+.future-is-green-theme .fig-logo__wordmark-svg {
+  display: block;
+  width: clamp(180px, 24vw, 288px);
+  height: auto;
+  color: var(--fig-text);
+}
+
+.future-is-green-theme .fig-logo__wordmark-svg .fig-wordmark__connector {
+  opacity: 0.6;
+}
+
+.future-is-green-theme .fig-logo__wordmark-svg .fig-wordmark__subtitle {
+  opacity: 0.58;
+}
+
 .future-is-green-theme .fig-logo__img {
   display: block;
   width: 100%;
   height: 100%;
   object-fit: contain;
+}
+
+.future-is-green-theme .qr-topbar.fig-topbar--condensed .fig-logo__wordmark-svg {
+  width: clamp(168px, 20vw, 260px);
+}
+
+@media (max-width: 960px) {
+  .future-is-green-theme .fig-logo__wordmark {
+    display: none;
+  }
 }
 
 .future-is-green-theme .qr-topbar.fig-topbar--condensed .fig-logo__image {

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -38,6 +38,28 @@
                      loading="eager"
                      decoding="async">
               </span>
+              <span class="fig-logo__wordmark" aria-hidden="true">
+                <svg class="fig-logo__wordmark-svg" viewBox="0 0 320 92" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <text x="0"
+                        y="38"
+                        font-family="Poppins, 'Helvetica Neue', Arial, sans-serif"
+                        font-size="34"
+                        font-weight="700"
+                        letter-spacing="0.02em">
+                    <tspan class="fig-wordmark__strong" fill="currentColor">FUTURE</tspan>
+                    <tspan class="fig-wordmark__connector" fill="currentColor" font-weight="500"> is </tspan>
+                    <tspan class="fig-wordmark__strong" fill="currentColor">GREEN</tspan>
+                  </text>
+                  <text x="0"
+                        y="78"
+                        class="fig-wordmark__subtitle"
+                        font-family="Poppins, 'Helvetica Neue', Arial, sans-serif"
+                        font-size="18"
+                        letter-spacing="0.32em"
+                        font-weight="500"
+                        fill="currentColor">LOGISTIC SOLUTIONS</text>
+                </svg>
+              </span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- embed an inline SVG wordmark mirroring the "FUTURE is GREEN" lettering next to the existing top navigation logo
- add responsive styling so the wordmark aligns with the logo, adapts to theme colors, and hides on compact viewports

## Testing
- Manual check: http://localhost:8080/future-is-green

------
https://chatgpt.com/codex/tasks/task_e_68deaa80d608832bb58b2c0b084f6a79