### PR TITLE
Stack hero stats vertically on small screens

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -878,3 +878,9 @@ body.qr-landing.future-is-green-theme .landing-content {
     padding: 72px 0;
   }
 }
+
+@media (max-width: 639px) {
+  .future-is-green-theme .fig-hero__stats {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- stack the hero statistics list on the Future is Green landing page into a single column on narrow viewports to avoid cramped tiles

## Testing
- no automated tests were run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dead93ec54832bafbb72798890502a