### PR TITLE
Allow hyphenation for Future is Green stat label

### DIFF
--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -371,7 +371,7 @@
               </span>
               <span class="fig-hero__stat-label">
                 <strong>15 km</strong>
-                <span>durchschnittliche Tour pro Rider</span>
+                <span>durch&shy;schnittliche Tour pro Rider</span>
               </span>
             </li>
             <li class="fig-hero__stat" role="listitem">


### PR DESCRIPTION
## Summary
- add a soft hyphen to the "durchschnittliche Tour pro Rider" label so the text can wrap inside the Future is Green stats card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deae26286c832ba6d94a1616cb7edb