### PR TITLE
Adjust Future is Green logo scale and hero card corners

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -13,7 +13,7 @@ body.qr-landing.future-is-green-theme {
   --fig-accent: #9cd78f;
   --fig-border: rgba(19, 143, 82, 0.18);
   --fig-logo-size: clamp(56px, 8.4vw, 80px);
-  --fig-logo-expanded-scale: 1.12;
+  --fig-logo-expanded-scale: 1.14;
   --fig-logo-condensed-scale: 1;
   --fig-border-soft: rgba(19, 143, 82, 0.12);
   --fig-border-strong: rgba(19, 143, 82, 0.22);
@@ -200,7 +200,7 @@ body.qr-landing.future-is-green-theme .landing-content {
 @media (max-width: 640px) {
   body.qr-landing.future-is-green-theme {
     --fig-logo-size: clamp(54px, 18vw, 68px);
-    --fig-logo-expanded-scale: 1.1;
+    --fig-logo-expanded-scale: 1.12;
   }
 }
 
@@ -398,7 +398,7 @@ body.qr-landing.future-is-green-theme .landing-content {
 }
 
 .future-is-green-theme .fig-hero__card {
-  border-radius: 20px;
+  border-radius: 0;
   background: var(--fig-surface-strong);
   border: 1px solid var(--fig-border);
   box-shadow: var(--fig-shadow-card);


### PR DESCRIPTION
## Summary
- increase the Future is Green logo's expanded scale variables to enlarge the emblem slightly
- update the hero metric card styling to use square corners for a sharper look

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb0d20918832bbd13f86f37fbd00c