### PR TITLE
Add animated sponsor ticker to Future is Green trust section

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -436,24 +436,107 @@ body.qr-landing.future-is-green-theme .landing-content {
 
 .future-is-green-theme .fig-trust {
   margin-top: 48px;
-  padding: 20px 24px;
+  padding: 24px;
   border-radius: 16px;
   background: var(--fig-surface-muted);
   border: 1px solid var(--fig-border);
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 24px;
+  align-items: stretch;
+  position: relative;
+  overflow: hidden;
+}
+
+.future-is-green-theme .fig-trust__headline {
+  position: relative;
+  display: flex;
+  justify-content: center;
   align-items: center;
-  gap: 20px;
+  padding: 12px 0;
 }
 
 .future-is-green-theme .fig-trust__label {
+  position: relative;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 24px;
+  border-radius: 999px;
+  background: var(--fig-surface-muted);
   font-weight: 600;
   color: var(--fig-text);
+  box-shadow: 0 12px 32px rgba(9, 45, 26, 0.12);
+}
+
+.future-is-green-theme .fig-trust__ticker {
+  position: absolute;
+  inset: 0;
+  margin: 0 8px;
+  border-radius: 999px;
+  background: var(--fig-surface);
+  border: 1px solid var(--fig-border-soft);
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.future-is-green-theme .fig-trust__ticker::before,
+.future-is-green-theme .fig-trust__ticker::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  width: 48px;
+  height: 100%;
+  z-index: 2;
+}
+
+.future-is-green-theme .fig-trust__ticker::before {
+  left: 0;
+  background: linear-gradient(90deg, var(--fig-surface) 0%, transparent 100%);
+}
+
+.future-is-green-theme .fig-trust__ticker::after {
+  right: 0;
+  background: linear-gradient(270deg, var(--fig-surface) 0%, transparent 100%);
+}
+
+.future-is-green-theme .fig-trust__ticker-track {
+  display: flex;
+  gap: 12px;
+  padding: 12px 24px;
+  width: max-content;
+  animation: fig-trust-marquee 26s linear infinite;
+}
+
+.future-is-green-theme .fig-trust__pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 18px;
+  border-radius: 999px;
+  background: var(--fig-surface-soft);
+  border: 1px solid var(--fig-border-soft);
+  color: var(--fig-muted);
+  font-weight: 600;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+@keyframes fig-trust-marquee {
+  0% {
+    transform: translateX(0);
+  }
+
+  100% {
+    transform: translateX(-50%);
+  }
 }
 
 .future-is-green-theme .fig-trust__logos {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 12px;
 }
 

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -403,14 +403,35 @@
             </li>
           </ul>
         </div>
+        {% set trustLogos = [
+          'Stadtwerke',
+          'IHK',
+          'Hochschule&nbsp;XY',
+          'EU-Regionalfonds',
+          'Urbane Innovation&nbsp;2025',
+          'Logistiknetzwerk&nbsp;Nord',
+          'Bundesumweltamt',
+          'Förderinitiative&nbsp;Smart&nbsp;City',
+          'Mobilitätsrat&nbsp;Zukunft'
+        ] %}
         <div class="fig-trust" data-uk-scrollspy="cls: uk-animation-fade; delay: 200">
-          <span class="fig-trust__label">Gefördert &amp; unterstützt von</span>
+          <div class="fig-trust__headline">
+            <div class="fig-trust__ticker" aria-hidden="true">
+              <div class="fig-trust__ticker-track">
+                {% for logo in trustLogos %}
+                  <span class="fig-trust__pill">{{ logo|raw }}</span>
+                {% endfor %}
+                {% for logo in trustLogos %}
+                  <span class="fig-trust__pill">{{ logo|raw }}</span>
+                {% endfor %}
+              </div>
+            </div>
+            <span class="fig-trust__label">Gefördert &amp; unterstützt von</span>
+          </div>
           <div class="fig-trust__logos" role="list">
-            <span class="fig-trust__logo" role="listitem">Stadtwerke</span>
-            <span class="fig-trust__logo" role="listitem">IHK</span>
-            <span class="fig-trust__logo" role="listitem">Hochschule&nbsp;XY</span>
-            <span class="fig-trust__logo" role="listitem">EU-Regionalfonds</span>
-            <span class="fig-trust__logo" role="listitem">Urbane Innovation&nbsp;2025</span>
+            {% for logo in trustLogos %}
+              <span class="fig-trust__logo" role="listitem">{{ logo|raw }}</span>
+            {% endfor %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add an animated ticker behind the "Gefördert & unterstützt von" label using the trust pill list
- refactor the Future is Green trust section to share a single logo list with four additional supporters
- style the new marquee animation and update the layout for the trust badges

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68deafbbaf94832ba052fcd8ce102193