### PR TITLE
Add interactive technology module layout on Future is Green page

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -671,6 +671,10 @@ body.qr-landing.future-is-green-theme .landing-content {
   }
 }
 
+.future-is-green-theme .fig-technology-grid.fig-technology-grid--is-enhanced {
+  display: none;
+}
+
 .future-is-green-theme .fig-technology-card {
   padding: 30px;
   border-radius: 18px;
@@ -690,6 +694,129 @@ body.qr-landing.future-is-green-theme .landing-content {
 .future-is-green-theme .fig-technology-card p {
   margin: 0;
   color: var(--fig-muted);
+}
+
+.future-is-green-theme .fig-technology-interactive {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .future-is-green-theme .fig-technology-interactive {
+    grid-template-columns: minmax(0, 340px) minmax(0, 1fr);
+    gap: 32px;
+    align-items: stretch;
+  }
+}
+
+.future-is-green-theme .fig-technology-interactive__nav {
+  position: relative;
+}
+
+.future-is-green-theme .fig-technology-nav {
+  display: grid;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media (max-width: 959px) {
+  .future-is-green-theme .fig-technology-nav {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(240px, 1fr);
+    overflow-x: auto;
+    padding-bottom: 8px;
+    scroll-snap-type: x mandatory;
+  }
+
+  .future-is-green-theme .fig-technology-nav__item {
+    scroll-snap-align: start;
+  }
+}
+
+.future-is-green-theme .fig-technology-nav__item {
+  display: block;
+}
+
+.future-is-green-theme .fig-technology-nav__button {
+  width: 100%;
+  text-align: left;
+  background: var(--fig-surface);
+  border: 1px solid var(--fig-border);
+  border-radius: 18px;
+  padding: 18px 20px;
+  font: inherit;
+  color: var(--fig-text);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  cursor: pointer;
+  box-shadow: var(--fig-shadow-soft);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+.future-is-green-theme .fig-technology-nav__button:focus,
+.future-is-green-theme .fig-technology-nav__button:hover {
+  outline: none;
+  border-color: var(--fig-primary);
+  box-shadow: var(--fig-shadow-medium);
+  transform: translateY(-2px);
+}
+
+.future-is-green-theme .fig-technology-nav__button.is-active {
+  background: var(--fig-surface-soft);
+  border-color: var(--fig-primary);
+  box-shadow: var(--fig-shadow-strong);
+}
+
+.future-is-green-theme .fig-technology-nav__title {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.future-is-green-theme .fig-technology-nav__desc {
+  color: var(--fig-muted);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.future-is-green-theme .fig-technology-interactive__display {
+  position: relative;
+}
+
+.future-is-green-theme .fig-technology-panel {
+  height: 100%;
+  padding: 32px;
+  border-radius: 20px;
+  background: var(--fig-surface);
+  border: 1px solid var(--fig-border);
+  box-shadow: var(--fig-shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  animation: fig-technology-fade 0.32s ease;
+}
+
+.future-is-green-theme .fig-technology-panel:not(.is-active) {
+  display: none;
+}
+
+.future-is-green-theme .fig-technology-panel .fig-feature-list {
+  gap: 16px;
+}
+
+@keyframes fig-technology-fade {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .future-is-green-theme .fig-feature-list {

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -460,6 +460,170 @@
       document.addEventListener('focusin', onChange, true);
     })();
 
+    function enhanceTechnologySection() {
+      var grid = document.querySelector('#technology .fig-technology-grid');
+      if (!grid || grid.classList.contains('fig-technology-grid--is-enhanced')) {
+        return;
+      }
+
+      if (grid.dataset.figTechnologyEnhanced === 'true') {
+        return;
+      }
+
+      var cards = Array.prototype.slice.call(grid.querySelectorAll('.fig-technology-card'));
+      if (cards.length === 0) {
+        return;
+      }
+
+      var interactive = document.createElement('div');
+      interactive.className = 'fig-technology-interactive';
+
+      var scrollspyConfig = grid.getAttribute('data-uk-scrollspy');
+      if (scrollspyConfig) {
+        interactive.setAttribute('data-uk-scrollspy', scrollspyConfig);
+      }
+
+      var navWrapper = document.createElement('div');
+      navWrapper.className = 'fig-technology-interactive__nav';
+
+      var navList = document.createElement('ul');
+      navList.className = 'fig-technology-nav';
+      navList.setAttribute('role', 'tablist');
+      navList.setAttribute('aria-orientation', 'vertical');
+      navWrapper.appendChild(navList);
+
+      var display = document.createElement('div');
+      display.className = 'fig-technology-interactive__display';
+
+      interactive.appendChild(navWrapper);
+      interactive.appendChild(display);
+
+      var buttons = [];
+      var panels = [];
+      var activeIndex = 0;
+
+      cards.forEach(function (card, index) {
+        var panel = card.cloneNode(true);
+        var panelId = 'fig-technology-panel-' + index;
+        var tabId = 'fig-technology-tab-' + index;
+
+        panel.id = panelId;
+        panel.classList.add('fig-technology-panel');
+        panel.setAttribute('role', 'tabpanel');
+        panel.setAttribute('aria-labelledby', tabId);
+        if (index !== 0) {
+          panel.setAttribute('hidden', 'true');
+        } else {
+          panel.classList.add('is-active');
+        }
+
+        display.appendChild(panel);
+        panels.push(panel);
+
+        var heading = panel.querySelector('h3');
+        var headingText = heading ? heading.textContent.trim() : 'Technologie ' + (index + 1);
+
+        var summaryText = '';
+        var summarySource = card.querySelector('.fig-feature-list li span:last-child');
+        if (summarySource) {
+          summaryText = summarySource.textContent.trim();
+        }
+
+        var item = document.createElement('li');
+        item.className = 'fig-technology-nav__item';
+        item.setAttribute('role', 'presentation');
+
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'fig-technology-nav__button';
+        button.id = tabId;
+        button.setAttribute('role', 'tab');
+        button.setAttribute('aria-controls', panelId);
+        button.setAttribute('aria-selected', index === 0 ? 'true' : 'false');
+        button.setAttribute('tabindex', index === 0 ? '0' : '-1');
+
+        var titleSpan = document.createElement('span');
+        titleSpan.className = 'fig-technology-nav__title';
+        titleSpan.textContent = headingText;
+        button.appendChild(titleSpan);
+
+        if (summaryText !== '') {
+          var descSpan = document.createElement('span');
+          descSpan.className = 'fig-technology-nav__desc';
+          descSpan.textContent = summaryText;
+          button.appendChild(descSpan);
+        }
+
+        if (index === 0) {
+          button.classList.add('is-active');
+        }
+
+        item.appendChild(button);
+        navList.appendChild(item);
+        buttons.push(button);
+
+        button.addEventListener('click', function () {
+          activate(index, false);
+        });
+
+        button.addEventListener('keydown', function (event) {
+          var key = event.key || event.which;
+          var targetIndex = null;
+
+          if (key === 'ArrowDown' || key === 'ArrowRight' || key === 40 || key === 39) {
+            targetIndex = (index + 1) % buttons.length;
+          } else if (key === 'ArrowUp' || key === 'ArrowLeft' || key === 38 || key === 37) {
+            targetIndex = (index - 1 + buttons.length) % buttons.length;
+          } else if (key === 'Home' || key === 36) {
+            targetIndex = 0;
+          } else if (key === 'End' || key === 35) {
+            targetIndex = buttons.length - 1;
+          }
+
+          if (targetIndex !== null) {
+            event.preventDefault();
+            activate(targetIndex, true);
+          }
+        });
+      });
+
+      function activate(newIndex, focusTab) {
+        if (newIndex < 0 || newIndex >= panels.length) {
+          return;
+        }
+
+        activeIndex = newIndex;
+
+        buttons.forEach(function (btn, idx) {
+          var isActive = idx === newIndex;
+          btn.classList.toggle('is-active', isActive);
+          btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+          btn.setAttribute('tabindex', isActive ? '0' : '-1');
+          if (isActive && focusTab) {
+            btn.focus();
+          }
+        });
+
+        panels.forEach(function (panel, idx) {
+          var shouldShow = idx === newIndex;
+          if (shouldShow) {
+            panel.removeAttribute('hidden');
+            panel.classList.add('is-active');
+          } else {
+            panel.setAttribute('hidden', 'true');
+            panel.classList.remove('is-active');
+          }
+        });
+      }
+
+      activate(activeIndex, false);
+
+      grid.insertAdjacentElement('afterend', interactive);
+      grid.classList.add('fig-technology-grid--is-enhanced');
+      grid.setAttribute('aria-hidden', 'true');
+      grid.dataset.figTechnologyEnhanced = 'true';
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
       var contactForm = document.getElementById('contact-form');
       if (contactForm && !contactForm.hasAttribute('data-contact-endpoint')) {
@@ -488,6 +652,8 @@
         toggleTopbarState();
         window.addEventListener('scroll', toggleTopbarState, { passive: true });
       }
+
+      enhanceTechnologySection();
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add progressive enhancement to rebuild the "Technologie, die Logistik greifbar macht" section into an interactive layout with selectable cards
- style the new navigation buttons and detail card to mirror the calServer module experience, including responsive behaviour
- hide the legacy grid once enhanced so the original markup remains as a no-JS fallback

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb17d8068832b9d4d4ddfdf19d3c7