### PR TITLE
Improve Future Is Green mega menu layout

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -94,12 +94,79 @@ body.qr-landing.future-is-green-theme .landing-content {
   color: var(--fig-text);
 }
 
+.future-is-green-theme .uk-navbar-dropdown {
+  width: 720px;
+  padding: 16px 0;
+  box-sizing: border-box;
+}
+
+.future-is-green-theme .uk-navbar-dropdown .uk-nav {
+  padding: 8px 0;
+}
+
+.future-is-green-theme .uk-navbar-dropdown-nav > li > a {
+  padding: 10px 18px;
+  line-height: 1.35;
+  font-weight: 500;
+  border-radius: 6px;
+  transition: background-color 0.18s ease;
+}
+
+.future-is-green-theme .uk-navbar-dropdown-nav > li + li {
+  margin-top: 2px;
+}
+
+.future-is-green-theme .uk-navbar-dropdown-nav > li > a:hover,
+.future-is-green-theme .uk-navbar-dropdown-nav > li > a:focus {
+  background: rgba(0, 0, 0, 0.035);
+}
+
+.future-is-green-theme .uk-navbar-dropdown-nav > li > a:focus-visible {
+  outline: 2px solid rgba(19, 143, 82, 0.5);
+  outline-offset: 2px;
+}
+
+.future-is-green-theme .nav-sub {
+  display: block;
+  margin-top: 2px;
+  font-size: 12.5px;
+  line-height: 1.35;
+  opacity: 0.8;
+}
+
 .future-is-green-theme .menu-explain {
+  padding: 18px;
   border-left: 1px solid rgba(0, 0, 0, 0.06);
+  background: #f7f8f9;
+  min-height: 220px;
+}
+
+.future-is-green-theme .menu-explain h5 {
+  margin: 0 0 6px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.future-is-green-theme .menu-explain p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  opacity: 0.92;
 }
 
 .future-is-green-theme .menu-explain .explain-pane.uk-hidden {
   display: none !important;
+}
+
+.future-is-green-theme .uk-navbar-dropdown h5,
+.future-is-green-theme .uk-navbar-dropdown h6 {
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.future-is-green-theme .uk-navbar-dropdown h6 {
+  font-size: 13px;
+  opacity: 0.75;
 }
 
 .future-is-green-theme section[id] {
@@ -197,6 +264,17 @@ body.qr-landing.future-is-green-theme .landing-content {
   border: 0;
 }
 
+@media (max-width: 959px) {
+  .future-is-green-theme .uk-navbar-dropdown {
+    width: 100%;
+  }
+
+  .future-is-green-theme .menu-explain {
+    border-left: 0;
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+  }
+}
+
 @media (max-width: 640px) {
   body.qr-landing.future-is-green-theme {
     --fig-logo-size: clamp(54px, 18vw, 68px);
@@ -208,10 +286,6 @@ body.qr-landing.future-is-green-theme .landing-content {
   .future-is-green-theme .uk-navbar-nav > li > a {
     padding-left: 12px;
     padding-right: 12px;
-  }
-
-  .future-is-green-theme .uk-navbar-dropdown {
-    width: 720px;
   }
 }
 

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -67,27 +67,42 @@
           <ul class="uk-navbar-nav fig-mega-nav">
             <li>
               <a href="#benefits" uk-scroll>Wirkung</a>
-              <div class="uk-navbar-dropdown uk-padding-remove" uk-dropdown="offset: 20; delay-hide: 150">
-                <div class="uk-grid-collapse uk-child-width-1-2@s" uk-grid>
+              <div class="uk-navbar-dropdown uk-padding-remove" uk-dropdown="offset: 20; delay-hide: 150; pos: bottom-left">
+                <div class="uk-grid-divider uk-grid-small uk-child-width-1-2@s" uk-grid>
                   <div>
                     <ul class="uk-nav uk-navbar-dropdown-nav">
-                      <li><a href="#benefits" uk-scroll data-explain="kpi">KPIs im Quartier</a></li>
-                      <li><a href="#benefits" uk-scroll data-explain="cases">Pilotgebiete &amp; Zahlen</a></li>
-                      <li><a href="#benefits" uk-scroll data-explain="audit">CO₂-Bilanz &amp; Audit</a></li>
+                      <li>
+                        <a href="#benefits" uk-scroll data-explain="kpi">
+                          KPIs im Quartier
+                          <span class="nav-sub">0 Emissionen, −60% Fahrten, +24% Tempo</span>
+                        </a>
+                      </li>
+                      <li>
+                        <a href="#benefits" uk-scroll data-explain="cases">
+                          Pilotgebiete &amp; Zahlen
+                          <span class="nav-sub">Filterbar nach Stadt/Branche</span>
+                        </a>
+                      </li>
+                      <li>
+                        <a href="#benefits" uk-scroll data-explain="audit">
+                          CO₂-Bilanz &amp; Audit
+                          <span class="nav-sub">Methodik, Audit-Scopes, Reporting</span>
+                        </a>
+                      </li>
                     </ul>
                   </div>
-                  <div class="menu-explain uk-background-muted uk-padding">
+                  <div class="menu-explain">
                     <div class="explain-pane" data-explain-pane="kpi">
-                      <h5 class="uk-margin-remove">Wirkung verstehen</h5>
-                      <p class="uk-text-small uk-margin-small">0 Emissionen, −60% Fahrten, +24% Zustelltempo: die 6 Punkte zeigen, wie Klimaschutz, Lebensqualität und Liefertempo zusammengehen.</p>
+                      <h5>Wirkung verstehen</h5>
+                      <p>Sechs Kennzahlen zeigen, wie Klimaschutz, Lebensqualität und Tempo zusammengehen.</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="cases">
-                      <h5 class="uk-margin-remove">Reale Ergebnisse</h5>
-                      <p class="uk-text-small uk-margin-small">Pilotgebiete nach Stadt/Branche filterbar – mit verifizierten Kennzahlen.</p>
+                      <h5>Reale Ergebnisse</h5>
+                      <p>Pilotquartiere mit verifizierten Kennzahlen und Lessons Learned.</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="audit">
-                      <h5 class="uk-margin-remove">Transparenz &amp; Audit</h5>
-                      <p class="uk-text-small uk-margin-small">Dashboards, Messmethoden und Audit-Scopes für Kommunen &amp; Partner.</p>
+                      <h5>Transparenz &amp; Audit</h5>
+                      <p>Live-Dashboards, Messmethoden und Audit-Scopes für Kommunen &amp; Partner.</p>
                     </div>
                   </div>
                 </div>
@@ -95,27 +110,42 @@
             </li>
             <li>
               <a href="#how-it-works" uk-scroll>Lösungen</a>
-              <div class="uk-navbar-dropdown uk-padding-remove" uk-dropdown="offset: 20; delay-hide: 150">
-                <div class="uk-grid-collapse uk-child-width-1-2@s" uk-grid>
+              <div class="uk-navbar-dropdown uk-padding-remove" uk-dropdown="offset: 20; delay-hide: 150; pos: bottom-left">
+                <div class="uk-grid-divider uk-grid-small uk-child-width-1-2@s" uk-grid>
                   <div>
                     <ul class="uk-nav uk-navbar-dropdown-nav">
-                      <li><a href="#how-it-works" uk-scroll data-explain="flow">So funktioniert’s</a></li>
-                      <li><a href="#offerings" uk-scroll data-explain="pakete">Pakete &amp; Module</a></li>
-                      <li><a href="#technology" uk-scroll data-explain="tech">Technologie &amp; Integrationen</a></li>
+                      <li>
+                        <a href="#how-it-works" uk-scroll data-explain="flow">
+                          So funktioniert’s
+                          <span class="nav-sub">KI-Routen, gebündelte Stopps, Off-Peak-Lieferungen</span>
+                        </a>
+                      </li>
+                      <li>
+                        <a href="#offerings" uk-scroll data-explain="pakete">
+                          Pakete &amp; Module
+                          <span class="nav-sub">Start, Pro, City – kombinierbar</span>
+                        </a>
+                      </li>
+                      <li>
+                        <a href="#technology" uk-scroll data-explain="tech">
+                          Technologie &amp; Integrationen
+                          <span class="nav-sub">ERP/Shop-Anbindung, Dashboards, CO₂-Bilanz</span>
+                        </a>
+                      </li>
                     </ul>
                   </div>
-                  <div class="menu-explain uk-background-muted uk-padding">
+                  <div class="menu-explain">
                     <div class="explain-pane" data-explain-pane="flow">
-                      <h5 class="uk-margin-remove">Vom Mikrohub zur Haustür</h5>
-                      <p class="uk-text-small uk-margin-small">KI-Routen, gebündelte Stopps, Off-Peak-Lieferungen – effizient &amp; leise.</p>
+                      <h5>Vom Mikrohub zur Haustür</h5>
+                      <p>KI-Routen, gebündelte Stopps und Off-Peak-Lieferungen sorgen für Tempo ohne Lärm.</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="pakete">
-                      <h5 class="uk-margin-remove">Passend skalieren</h5>
-                      <p class="uk-text-small uk-margin-small">Start, Pro, City – kombinierbare Module für Quartiere jeder Größe.</p>
+                      <h5>Passend skalieren</h5>
+                      <p>Start, Pro und City kombinieren Module für Quartiere jeder Größe.</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="tech">
-                      <h5 class="uk-margin-remove">API-first</h5>
-                      <p class="uk-text-small uk-margin-small">ERP/Shop-Anbindung, Live-Dashboards, auditierbare CO₂-Bilanz.</p>
+                      <h5>API-first</h5>
+                      <p>ERP- &amp; Shop-Integrationen, Live-Dashboards und auditierbare CO₂-Bilanzen.</p>
                     </div>
                   </div>
                 </div>
@@ -123,27 +153,42 @@
             </li>
             <li>
               <a href="#cases" uk-scroll>Referenzen</a>
-              <div class="uk-navbar-dropdown uk-padding-remove" uk-dropdown="offset: 20; delay-hide: 150">
-                <div class="uk-grid-collapse uk-child-width-1-2@s" uk-grid>
+              <div class="uk-navbar-dropdown uk-padding-remove" uk-dropdown="offset: 20; delay-hide: 150; pos: bottom-left">
+                <div class="uk-grid-divider uk-grid-small uk-child-width-1-2@s" uk-grid>
                   <div>
                     <ul class="uk-nav uk-navbar-dropdown-nav">
-                      <li><a href="#cases" uk-scroll data-explain="story">Case Stories</a></li>
-                      <li><a href="#cases" uk-scroll data-explain="branchen">Branchenfilter</a></li>
-                      <li><a href="#cases" uk-scroll data-explain="reports">Impact-Reports</a></li>
+                      <li>
+                        <a href="#cases" uk-scroll data-explain="story">
+                          Case Stories
+                          <span class="nav-sub">Kommunen, Händler:innen &amp; Rider im O-Ton</span>
+                        </a>
+                      </li>
+                      <li>
+                        <a href="#cases" uk-scroll data-explain="branchen">
+                          Branchenfilter
+                          <span class="nav-sub">Von Lebensmittel bis Pharma – schnell gefunden</span>
+                        </a>
+                      </li>
+                      <li>
+                        <a href="#cases" uk-scroll data-explain="reports">
+                          Impact-Reports
+                          <span class="nav-sub">Kennzahlen, Lessons Learned, Zertifizierungen</span>
+                        </a>
+                      </li>
                     </ul>
                   </div>
-                  <div class="menu-explain uk-background-muted uk-padding">
+                  <div class="menu-explain">
                     <div class="explain-pane" data-explain-pane="story">
-                      <h5 class="uk-margin-remove">Stimmen aus der Praxis</h5>
-                      <p class="uk-text-small uk-margin-small">Was Kommunen, Händler:innen und Rider über den Umbau berichten.</p>
+                      <h5>Stimmen aus der Praxis</h5>
+                      <p>Was Kommunen, Händler:innen und Rider über den Umbau berichten.</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="branchen">
-                      <h5 class="uk-margin-remove">Filter nach Branchen</h5>
-                      <p class="uk-text-small uk-margin-small">Von Lebensmitteln bis Pharma – passende Referenzen in Sekunden finden.</p>
+                      <h5>Filter nach Branchen</h5>
+                      <p>Von Lebensmitteln bis Pharma – passende Referenzen in Sekunden finden.</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="reports">
-                      <h5 class="uk-margin-remove">Zahlen zum Nachlesen</h5>
-                      <p class="uk-text-small uk-margin-small">PDF-Reports mit Kennzahlen, Lessons Learned und Zertifizierungen.</p>
+                      <h5>Zahlen zum Nachlesen</h5>
+                      <p>PDF-Reports mit Kennzahlen, Lessons Learned und Zertifizierungen.</p>
                     </div>
                   </div>
                 </div>
@@ -151,27 +196,42 @@
             </li>
             <li>
               <a href="#pricing" uk-scroll>Preise &amp; FAQ</a>
-              <div class="uk-navbar-dropdown uk-padding-remove" uk-dropdown="offset: 20; delay-hide: 150">
-                <div class="uk-grid-collapse uk-child-width-1-2@s" uk-grid>
+              <div class="uk-navbar-dropdown uk-padding-remove" uk-dropdown="offset: 20; delay-hide: 150; pos: bottom-left">
+                <div class="uk-grid-divider uk-grid-small uk-child-width-1-2@s" uk-grid>
                   <div>
                     <ul class="uk-nav uk-navbar-dropdown-nav">
-                      <li><a href="#pricing" uk-scroll data-explain="preise">Pakete &amp; Vergleich</a></li>
-                      <li><a href="#faq" uk-scroll data-explain="faq">Häufige Fragen</a></li>
-                      <li><a href="#pricing" uk-scroll data-explain="service">Service-Level</a></li>
+                      <li>
+                        <a href="#pricing" uk-scroll data-explain="preise">
+                          Pakete &amp; Vergleich
+                          <span class="nav-sub">Start, Pro, City im direkten Überblick</span>
+                        </a>
+                      </li>
+                      <li>
+                        <a href="#faq" uk-scroll data-explain="faq">
+                          Häufige Fragen
+                          <span class="nav-sub">Finanzierung, Aufbauzeit, Zustellfenster</span>
+                        </a>
+                      </li>
+                      <li>
+                        <a href="#pricing" uk-scroll data-explain="service">
+                          Service-Level
+                          <span class="nav-sub">SLA, Schulung, Monitoring auf einen Blick</span>
+                        </a>
+                      </li>
                     </ul>
                   </div>
-                  <div class="menu-explain uk-background-muted uk-padding">
+                  <div class="menu-explain">
                     <div class="explain-pane" data-explain-pane="preise">
-                      <h5 class="uk-margin-remove">Transparente Pakete</h5>
-                      <p class="uk-text-small uk-margin-small">Vergleiche Start, Pro und City – monatlich kündbar, Förderfähig.</p>
+                      <h5>Transparente Pakete</h5>
+                      <p>Vergleiche Start, Pro und City – monatlich kündbar und förderfähig.</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="faq">
-                      <h5 class="uk-margin-remove">Antworten in Sekunden</h5>
-                      <p class="uk-text-small uk-margin-small">Finanzierung, Aufbauzeit, Zustellfenster – alles kompakt erklärt.</p>
+                      <h5>Antworten in Sekunden</h5>
+                      <p>Finanzierung, Aufbauzeit und Zustellfenster sind kompakt erklärt.</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="service">
-                      <h5 class="uk-margin-remove">Service &amp; Support</h5>
-                      <p class="uk-text-small uk-margin-small">SLA, Schulungen, Monitoring – abgestimmt auf Stadt &amp; Partner.</p>
+                      <h5>Service &amp; Support</h5>
+                      <p>SLA, Schulungen und Monitoring – abgestimmt auf Stadt &amp; Partner.</p>
                     </div>
                   </div>
                 </div>
@@ -458,12 +518,27 @@
   {% endif %}
   <script>
     (function () {
-      function onChange(e) {
+      var hoverIntentTimer;
+
+      function scheduleSwap(e) {
         var link = e.target.closest('a[data-explain]');
         if (!link) {
           return;
         }
 
+        clearTimeout(hoverIntentTimer);
+
+        if (e.type === 'focusin') {
+          swapPane(link);
+          return;
+        }
+
+        hoverIntentTimer = setTimeout(function () {
+          swapPane(link);
+        }, 90);
+      }
+
+      function swapPane(link) {
         var dropdown = link.closest('.uk-navbar-dropdown');
         if (!dropdown) {
           return;
@@ -477,8 +552,8 @@
         });
       }
 
-      document.addEventListener('mouseover', onChange, true);
-      document.addEventListener('focusin', onChange, true);
+      document.addEventListener('mouseover', scheduleSwap, true);
+      document.addEventListener('focusin', scheduleSwap, true);
     })();
 
     document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Summary
- restyle the Future is Green mega menu with clearer hierarchy and spacing
- update the dropdown markup to use a two-column grid with link subtitles and refined explain panes
- smooth out the hover interaction with a short intent delay while keeping keyboard focus responsive

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68deb346383c832bb81bcb4bd7746090