### PR TITLE
Adjust Future is Green topbar logo styling

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -131,7 +131,7 @@ body.qr-landing.future-is-green-theme .landing-content {
   width: var(--fig-logo-size);
   height: var(--fig-logo-size);
   padding: clamp(8px, 1.4vw, 14px);
-  border-radius: 16px;
+  border-radius: 0;
   border: 1px solid rgba(19, 143, 82, 0.08);
   background: var(--fig-secondary);
   box-shadow: 0 18px 36px -28px rgba(19, 143, 82, 0.65);
@@ -182,7 +182,7 @@ body.qr-landing.future-is-green-theme .landing-content {
 .future-is-green-theme .qr-topbar.fig-topbar--condensed .fig-logo__image {
   transform: scale(var(--fig-logo-condensed-scale));
   box-shadow: 0 14px 28px -26px rgba(19, 143, 82, 0.55);
-  border-radius: 14px;
+  border-radius: 0;
 }
 
 .future-is-green-theme .fig-visually-hidden {


### PR DESCRIPTION
## Summary
- set the Future is Green topbar logo image to use square corners in both regular and condensed states

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68debc9601f8832ba306d076aac454a0