### PR TITLE
Fix Future is Green technology toggles on mobile

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -806,15 +806,14 @@ body.qr-landing.future-is-green-theme .landing-content {
 
 @media (max-width: 959px) {
   .future-is-green-theme .fig-technology-nav {
-    grid-auto-flow: column;
-    grid-auto-columns: minmax(240px, 1fr);
-    overflow-x: auto;
-    padding-bottom: 8px;
-    scroll-snap-type: x mandatory;
+    grid-auto-flow: row;
+    grid-auto-rows: auto;
+    overflow: visible;
+    padding-bottom: 0;
   }
 
   .future-is-green-theme .fig-technology-nav__item {
-    scroll-snap-align: start;
+    scroll-snap-align: unset;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust the Future is Green technology navigation styles so the toggles stack vertically on mobile

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68debcfe5e1c832ba5eb38ac321d4780