### PR TITLE
Adjust mega menu descriptions on Future is Green landing page

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -126,14 +126,6 @@ body.qr-landing.future-is-green-theme .landing-content {
   outline-offset: 2px;
 }
 
-.future-is-green-theme .nav-sub {
-  display: block;
-  margin-top: 2px;
-  font-size: 12.5px;
-  line-height: 1.35;
-  opacity: 0.8;
-}
-
 .future-is-green-theme .menu-explain {
   padding: 18px;
   border-left: 1px solid rgba(0, 0, 0, 0.06);
@@ -152,6 +144,13 @@ body.qr-landing.future-is-green-theme .landing-content {
   font-size: 13px;
   line-height: 1.5;
   opacity: 0.92;
+}
+
+.future-is-green-theme .menu-explain p.menu-explain__subline {
+  margin-top: 8px;
+  font-size: 12.5px;
+  line-height: 1.4;
+  opacity: 0.78;
 }
 
 .future-is-green-theme .menu-explain .explain-pane.uk-hidden {

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -74,19 +74,16 @@
                       <li>
                         <a href="#benefits" uk-scroll data-explain="kpi">
                           KPIs im Quartier
-                          <span class="nav-sub">0 Emissionen, −60% Fahrten, +24% Tempo</span>
                         </a>
                       </li>
                       <li>
                         <a href="#benefits" uk-scroll data-explain="cases">
                           Pilotgebiete &amp; Zahlen
-                          <span class="nav-sub">Filterbar nach Stadt/Branche</span>
                         </a>
                       </li>
                       <li>
                         <a href="#benefits" uk-scroll data-explain="audit">
                           CO₂-Bilanz &amp; Audit
-                          <span class="nav-sub">Methodik, Audit-Scopes, Reporting</span>
                         </a>
                       </li>
                     </ul>
@@ -95,14 +92,17 @@
                     <div class="explain-pane" data-explain-pane="kpi">
                       <h5>Wirkung verstehen</h5>
                       <p>Sechs Kennzahlen zeigen, wie Klimaschutz, Lebensqualität und Tempo zusammengehen.</p>
+                      <p class="menu-explain__subline">0 Emissionen, −60% Fahrten, +24% Tempo</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="cases">
                       <h5>Reale Ergebnisse</h5>
                       <p>Pilotquartiere mit verifizierten Kennzahlen und Lessons Learned.</p>
+                      <p class="menu-explain__subline">Filterbar nach Stadt/Branche</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="audit">
                       <h5>Transparenz &amp; Audit</h5>
                       <p>Live-Dashboards, Messmethoden und Audit-Scopes für Kommunen &amp; Partner.</p>
+                      <p class="menu-explain__subline">Methodik, Audit-Scopes, Reporting</p>
                     </div>
                   </div>
                 </div>
@@ -117,19 +117,16 @@
                       <li>
                         <a href="#how-it-works" uk-scroll data-explain="flow">
                           So funktioniert’s
-                          <span class="nav-sub">KI-Routen, gebündelte Stopps, Off-Peak-Lieferungen</span>
                         </a>
                       </li>
                       <li>
                         <a href="#offerings" uk-scroll data-explain="pakete">
                           Pakete &amp; Module
-                          <span class="nav-sub">Start, Pro, City – kombinierbar</span>
                         </a>
                       </li>
                       <li>
                         <a href="#technology" uk-scroll data-explain="tech">
                           Technologie &amp; Integrationen
-                          <span class="nav-sub">ERP/Shop-Anbindung, Dashboards, CO₂-Bilanz</span>
                         </a>
                       </li>
                     </ul>
@@ -138,14 +135,17 @@
                     <div class="explain-pane" data-explain-pane="flow">
                       <h5>Vom Mikrohub zur Haustür</h5>
                       <p>KI-Routen, gebündelte Stopps und Off-Peak-Lieferungen sorgen für Tempo ohne Lärm.</p>
+                      <p class="menu-explain__subline">KI-Routen, gebündelte Stopps, Off-Peak-Lieferungen</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="pakete">
                       <h5>Passend skalieren</h5>
                       <p>Start, Pro und City kombinieren Module für Quartiere jeder Größe.</p>
+                      <p class="menu-explain__subline">Start, Pro, City – kombinierbar</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="tech">
                       <h5>API-first</h5>
                       <p>ERP- &amp; Shop-Integrationen, Live-Dashboards und auditierbare CO₂-Bilanzen.</p>
+                      <p class="menu-explain__subline">ERP/Shop-Anbindung, Dashboards, CO₂-Bilanz</p>
                     </div>
                   </div>
                 </div>
@@ -160,19 +160,16 @@
                       <li>
                         <a href="#cases" uk-scroll data-explain="story">
                           Case Stories
-                          <span class="nav-sub">Kommunen, Händler:innen &amp; Rider im O-Ton</span>
                         </a>
                       </li>
                       <li>
                         <a href="#cases" uk-scroll data-explain="branchen">
                           Branchenfilter
-                          <span class="nav-sub">Von Lebensmittel bis Pharma – schnell gefunden</span>
                         </a>
                       </li>
                       <li>
                         <a href="#cases" uk-scroll data-explain="reports">
                           Impact-Reports
-                          <span class="nav-sub">Kennzahlen, Lessons Learned, Zertifizierungen</span>
                         </a>
                       </li>
                     </ul>
@@ -181,14 +178,17 @@
                     <div class="explain-pane" data-explain-pane="story">
                       <h5>Stimmen aus der Praxis</h5>
                       <p>Was Kommunen, Händler:innen und Rider über den Umbau berichten.</p>
+                      <p class="menu-explain__subline">Kommunen, Händler:innen &amp; Rider im O-Ton</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="branchen">
                       <h5>Filter nach Branchen</h5>
                       <p>Von Lebensmitteln bis Pharma – passende Referenzen in Sekunden finden.</p>
+                      <p class="menu-explain__subline">Von Lebensmittel bis Pharma – schnell gefunden</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="reports">
                       <h5>Zahlen zum Nachlesen</h5>
                       <p>PDF-Reports mit Kennzahlen, Lessons Learned und Zertifizierungen.</p>
+                      <p class="menu-explain__subline">Kennzahlen, Lessons Learned, Zertifizierungen</p>
                     </div>
                   </div>
                 </div>
@@ -203,19 +203,16 @@
                       <li>
                         <a href="#pricing" uk-scroll data-explain="preise">
                           Pakete &amp; Vergleich
-                          <span class="nav-sub">Start, Pro, City im direkten Überblick</span>
                         </a>
                       </li>
                       <li>
                         <a href="#faq" uk-scroll data-explain="faq">
                           Häufige Fragen
-                          <span class="nav-sub">Finanzierung, Aufbauzeit, Zustellfenster</span>
                         </a>
                       </li>
                       <li>
                         <a href="#pricing" uk-scroll data-explain="service">
                           Service-Level
-                          <span class="nav-sub">SLA, Schulung, Monitoring auf einen Blick</span>
                         </a>
                       </li>
                     </ul>
@@ -224,14 +221,17 @@
                     <div class="explain-pane" data-explain-pane="preise">
                       <h5>Transparente Pakete</h5>
                       <p>Vergleiche Start, Pro und City – monatlich kündbar und förderfähig.</p>
+                      <p class="menu-explain__subline">Start, Pro, City im direkten Überblick</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="faq">
                       <h5>Antworten in Sekunden</h5>
                       <p>Finanzierung, Aufbauzeit und Zustellfenster sind kompakt erklärt.</p>
+                      <p class="menu-explain__subline">Finanzierung, Aufbauzeit, Zustellfenster</p>
                     </div>
                     <div class="explain-pane uk-hidden" data-explain-pane="service">
                       <h5>Service &amp; Support</h5>
                       <p>SLA, Schulungen und Monitoring – abgestimmt auf Stadt &amp; Partner.</p>
+                      <p class="menu-explain__subline">SLA, Schulung, Monitoring auf einen Blick</p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- move the Future is Green mega menu sublines into the explanation column instead of the navigation links
- style the new explanation subline text to match the dropdown design

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68debdabe3b0832b98dad56cf08e32cc