### PR TITLE
Remove trust label pill styling on Future is Green

### DIFF
--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -476,7 +476,7 @@
         ] %}
         <div class="fig-trust" data-uk-scrollspy="cls: uk-animation-fade; delay: 200">
           <div class="fig-trust__headline">
-            <span class="fig-trust__label">Gefördert &amp; unterstützt von</span>
+            <span>Gefördert &amp; unterstützt von</span>
             <div class="fig-trust__ticker" aria-hidden="true">
               <div class="fig-trust__ticker-track">
                 {% for logo in trustLogos %}


### PR DESCRIPTION
## Summary
- remove the pill styling wrapper around the "Gefördert & unterstützt von" label on the Future is Green landing page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68debfe79f84832b8d2a0e5f848aad3c