### PR TITLE
Reduce Future is Green logo size

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -12,7 +12,7 @@ body.qr-landing.future-is-green-theme {
   --fig-muted: #3f5a4b;
   --fig-accent: #9cd78f;
   --fig-border: rgba(19, 143, 82, 0.18);
-  --fig-logo-size: clamp(56px, 8.4vw, 80px);
+  --fig-logo-size: clamp(39.2px, 5.88vw, 56px);
   --fig-logo-expanded-scale: 1.35;
   --fig-logo-condensed-scale: 1;
   --fig-border-soft: rgba(19, 143, 82, 0.12);
@@ -196,7 +196,7 @@ body.qr-landing.future-is-green-theme .landing-content {
   box-sizing: border-box;
   width: var(--fig-logo-size);
   height: var(--fig-logo-size);
-  padding: clamp(8px, 1.4vw, 14px);
+  padding: clamp(5.6px, 0.98vw, 9.8px);
   border-radius: 0;
   border: 1px solid rgba(19, 143, 82, 0.08);
   background: var(--fig-secondary);
@@ -210,12 +210,12 @@ body.qr-landing.future-is-green-theme .landing-content {
 .future-is-green-theme .fig-logo__wordmark {
   display: inline-flex;
   align-items: center;
-  margin-left: clamp(12px, 2.4vw, 28px);
+  margin-left: clamp(8.4px, 1.68vw, 19.6px);
 }
 
 .future-is-green-theme .fig-logo__wordmark-svg {
   display: block;
-  width: clamp(168px, 22vw, 268px);
+  width: clamp(117.6px, 15.4vw, 187.6px);
   height: auto;
   color: var(--fig-text);
 }
@@ -272,7 +272,7 @@ body.qr-landing.future-is-green-theme .landing-content {
 
 @media (max-width: 640px) {
   body.qr-landing.future-is-green-theme {
-    --fig-logo-size: clamp(54px, 18vw, 68px);
+    --fig-logo-size: clamp(37.8px, 12.6vw, 47.6px);
     --fig-logo-expanded-scale: 1.35;
   }
 }


### PR DESCRIPTION
## Summary
- reduce the Future is Green header logo and wordmark dimensions by roughly 30% through CSS variable adjustments

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dec01f5ac0832b8c77ef8aed6e7f38