### PR TITLE
Reduce Future is Green wordmark width

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -215,7 +215,7 @@ body.qr-landing.future-is-green-theme .landing-content {
 
 .future-is-green-theme .fig-logo__wordmark-svg {
   display: block;
-  width: clamp(168px, 22vw, 268px);
+  width: clamp(109.2px, 14.3vw, 174.2px);
   height: auto;
   color: var(--fig-text);
 }


### PR DESCRIPTION
## Summary
- reduce the Future is Green wordmark SVG width clamp by 35% to shrink the logo

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec1fedf70832bbc71b7a283898c62