### PR TITLE
Ensure Future is Green landing loads in light mode by default

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -60,7 +60,14 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   const storedTheme = getStored(STORAGE_KEYS.DARK_MODE);
-  let dark = storedTheme !== 'false';
+  let dark;
+
+  if (storedTheme === null || storedTheme === undefined) {
+    dark = document.body.dataset.theme === 'dark' || document.body.classList.contains('dark-mode');
+  } else {
+    const normalizedTheme = String(storedTheme).toLowerCase();
+    dark = normalizedTheme === 'true' || normalizedTheme === '1';
+  }
 
   if (darkStylesheet) {
     darkStylesheet.toggleAttribute('disabled', !dark);


### PR DESCRIPTION
## Summary
- respect the body template's preferred theme when deciding the initial dark-mode setting
- allow the Future is Green landing page to default to the light experience without overriding stored preferences

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec1575a3c832ba0f2e466cfc737da