### PR TITLE
Update Future is Green footer to match calServer layout

### DIFF
--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -497,10 +497,58 @@
 {% endblock %}
 
 {% block footer %}
-  <div class="uk-text-center fig-footer">
-    <a href="{{ basePath }}/impressum">Impressum</a> |
-    <a href="{{ basePath }}/datenschutz">Datenschutz</a> |
-    <a href="{{ basePath }}/lizenz">AGB</a>
+  <div class="fig-footer">
+    <div class="footer-columns">
+      <div class="footer-section footer-about">
+        <strong>Future is Green</strong>
+        <p>Urbane Logistik für lebenswerte Städte – leise, lokal und nachhaltig.</p>
+      </div>
+      <div class="footer-section footer-contact">
+        <strong>Kontakt</strong>
+        <p>
+          Future is Green Logistic Solutions<br>
+          <a
+            class="js-email-link"
+            data-user="hello"
+            data-domain="futureisgreen.city"
+            href="#"
+          >hello [at] futureisgreen.city</a>
+        </p>
+        <ul>
+          <li>
+            <a href="https://www.linkedin.com" rel="noopener" target="_blank">
+              <span class="uk-margin-small-right" data-uk-icon="icon: linkedin"></span>LinkedIn
+            </a>
+          </li>
+          <li>
+            <a href="https://mastodon.social" rel="noopener" target="_blank">
+              <span class="uk-margin-small-right" data-uk-icon="icon: world"></span>Mastodon
+            </a>
+          </li>
+        </ul>
+      </div>
+      <div class="footer-section footer-navigation">
+        <strong>Bereiche</strong>
+        <ul>
+          <li><a href="#benefits">Wirkung</a></li>
+          <li><a href="#how-it-works">So funktioniert’s</a></li>
+          <li><a href="#offerings">Pakete &amp; Module</a></li>
+          <li><a href="#technology">Technologie &amp; Integrationen</a></li>
+          <li><a href="#cases">Referenzen</a></li>
+          <li><a href="#pricing">Preise &amp; Vergleich</a></li>
+          <li><a href="#faq">FAQ</a></li>
+          <li><a href="#contact">Kontakt</a></li>
+        </ul>
+      </div>
+      <div class="footer-section footer-legal">
+        <strong>Rechtliches</strong>
+        <ul>
+          <li><a href="{{ basePath }}/impressum">{{ t('imprint') }}</a></li>
+          <li><a href="{{ basePath }}/datenschutz">{{ t('privacy') }}</a></li>
+          <li><a href="{{ basePath }}/lizenz">{{ t('license') }}</a></li>
+        </ul>
+      </div>
+    </div>
   </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- replace the Future is Green footer with the multi-column layout used on the calServer page
- include page-specific tagline, contact details, navigation anchors, and legal links in the footer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68decb6013d4832b9c0709ed3b2a160e