### PR TITLE
Ensure footer about copy renders in white

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -1117,6 +1117,11 @@ body.qr-landing.future-is-green-theme .landing-content {
   color: var(--fig-muted);
 }
 
+.future-is-green-theme .fig-footer .footer-about strong,
+.future-is-green-theme .fig-footer .footer-about p {
+  color: #ffffff;
+}
+
 .future-is-green-theme .fig-footer a {
   color: var(--fig-primary);
   text-decoration: none;


### PR DESCRIPTION
## Summary
- override the footer about section colours on the Future is Green landing page to render the headline and description in white for consistent branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded45c1328832baa2f7a75353be024