### PR TITLE
Align Future is Green contact button styling

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -372,6 +372,10 @@ body.qr-landing.future-is-green-theme .landing-content {
   gap: 10px;
   padding: 14px 26px;
   border-radius: 999px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
   font-weight: 600;
   text-decoration: none;
   transition: transform 0.18s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;


### PR DESCRIPTION
## Summary
- remove default browser chrome from `.fig-button` on the Future is Green theme
- ensure the contact form submit button matches the visual style of other calls to action

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ded5a04f04832ba416cb303f9835c3