### PR TITLE
Set Future is Green footer emphasis text to white

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -1117,8 +1117,13 @@ body.qr-landing.future-is-green-theme .landing-content {
   color: var(--fig-muted);
 }
 
-.future-is-green-theme .fig-footer .footer-about strong,
-.future-is-green-theme .fig-footer .footer-about p {
+
+.future-is-green-theme .fig-footer strong {
+  color: #ffffff;
+}
+
+.future-is-green-theme .fig-footer .footer-about p,
+.future-is-green-theme .fig-footer .footer-contact p {
   color: #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- ensure all strong elements in the Future is Green footer render in white
- color the Future is Green contact sentence white to match the emphasis

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ded6de3430832b9a3381811ec7760f