### PR TITLE
Fix footer social icon contrast in dark mode

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -1136,6 +1136,28 @@ body.qr-landing.future-is-green-theme .landing-content {
   text-decoration: none;
 }
 
+.future-is-green-theme .fig-footer .footer-contact a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.future-is-green-theme .fig-footer .footer-contact a .uk-icon,
+.future-is-green-theme .fig-footer .footer-contact a [data-uk-icon] {
+  color: inherit;
+  display: inline-flex;
+}
+
+.future-is-green-theme .fig-footer .footer-contact a .uk-icon svg,
+.future-is-green-theme .fig-footer .footer-contact a [data-uk-icon] svg {
+  stroke: currentColor;
+  fill: currentColor;
+}
+
+.future-is-green-theme[data-theme='dark']:not(.high-contrast) .fig-footer a {
+  color: var(--fig-secondary);
+}
+
 .future-is-green-theme .fig-footer a:hover,
 .future-is-green-theme .fig-footer a:focus {
   text-decoration: underline;


### PR DESCRIPTION
## Summary
- ensure the Future is Green footer social icons inherit the link color so they stay legible
- adjust footer link styling in dark mode to use the light secondary tone for higher contrast

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ded7fdadb4832bac7f3997ef98c775