### PR TITLE
Default calServer landing page to light mode

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -23,8 +23,8 @@
   <meta name="page-name" content="calServer – Marketingseite">
 {% endblock %}
 
-{% block body_theme %}dark{% endblock %}
-{% block body_class %}qr-landing dark-mode calserver-theme{% endblock %}
+{% block body_theme %}light{% endblock %}
+{% block body_class %}qr-landing calserver-theme{% endblock %}
 
 {% block body %}
   <div class="landing-content">


### PR DESCRIPTION
## Summary
- make the calServer marketing page render in light mode by default
- remove the unnecessary dark-mode class from the landing page body classes so theme toggles work from a light baseline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dedf5f8b34832b883a2d3bf0302b19