### PR TITLE
Reduce Hosting in Germany badge size

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -812,7 +812,7 @@ body.qr-landing:not([data-theme="dark"]) .contact-card span{
 
 .calserver-proof-seals__badge{
   display:block;
-  height:72px;
+  height:54px;
   width:auto;
 }
 


### PR DESCRIPTION
## Summary
- shrink the calServer "Hosting in Germany" badge by 25% via CSS to present a smaller logo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee5ef1644832ba760f58ca5dd35ed