### PR TITLE
Fix landing news creation form action

### DIFF
--- a/templates/admin/landing_news/form.twig
+++ b/templates/admin/landing_news/form.twig
@@ -3,12 +3,13 @@
 {% set isEdit = entry is not null %}
 {% set formValues = override|default({}) %}
 {% set pageId = formValues.page_id|default(isEdit ? entry.pageId : '') %}
-{% set slug = formValues.slug|default(isEdit ? entry.slug : '') %}
 {% set titleValue = formValues.title|default(isEdit ? entry.title : '') %}
 {% set excerptValue = formValues.excerpt|default(isEdit ? entry.excerpt : '') %}
 {% set contentValue = formValues.content|default(isEdit ? entry.content : '') %}
 {% set published = formValues.is_published is defined ? formValues.is_published : (isEdit ? entry.isPublished : false) %}
 {% set publishedAt = formValues.published_at|default(isEdit and entry.publishedAt ? entry.publishedAt|date('Y-m-d\\TH:i') : '') %}
+{% set slug = formValues.slug|default(isEdit ? entry.slug : '') %}
+{% set formAction = isEdit ? basePath ~ '/admin/landing-news/' ~ entry.id : basePath ~ '/admin/landing-news' %}
 
 {% block title %}{{ isEdit ? t('heading_news_edit') : t('heading_news_create') }}{% endblock %}
 
@@ -68,7 +69,7 @@
     </aside>
     <main class="uk-width-expand uk-padding-small@xs uk-padding">
       <div class="uk-container uk-container-expand">
-        <form method="post" class="uk-form-stacked uk-grid-small" uk-grid>
+        <form method="post" action="{{ formAction }}" class="uk-form-stacked uk-grid-small" uk-grid>
           <input type="hidden" name="_token" value="{{ csrfToken }}">
           <div class="uk-width-1-1 uk-width-1-2@m">
             <label class="uk-form-label" for="landingPage">{{ t('label_news_page') }}</label>


### PR DESCRIPTION
## Summary
- point the landing news admin form at the POST endpoint used to create entries
- keep edit submissions unaffected while allowing the create view to submit successfully

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68def2ecb290832bb5c68b2fda45236e