### PR TITLE
Fix Future is Green menu contrast in light mode

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -35,6 +35,14 @@ body.qr-landing.future-is-green-theme {
   --fig-shadow-cta: 0 16px 36px -24px rgba(19, 143, 82, 0.85);
   --fig-shadow-cta-hover: 0 20px 36px -20px rgba(19, 143, 82, 0.9);
   --fig-anchor-offset: calc(var(--fig-logo-size) * var(--fig-logo-expanded-scale) + 16px);
+  --qr-bg: var(--fig-background);
+  --qr-bg-soft: color-mix(in oklab, var(--fig-background) 84%, var(--fig-surface) 16%);
+  --qr-card: var(--fig-surface);
+  --qr-card-border: var(--fig-border);
+  --qr-fg: var(--fig-text);
+  --qr-text: var(--fig-text);
+  --qr-muted: var(--fig-muted);
+  --qr-ring: color-mix(in oklab, var(--fig-primary) 45%, transparent);
   background: var(--fig-background);
   color: var(--fig-text);
   font-family: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
@@ -74,6 +82,38 @@ body.qr-landing.future-is-green-theme[data-theme='dark']:not(.high-contrast) {
   --fig-shadow-button-hover: 0 20px 36px -18px rgba(4, 18, 12, 0.74);
   --fig-shadow-cta: 0 16px 36px -24px rgba(76, 201, 134, 0.58);
   --fig-shadow-cta-hover: 0 20px 36px -20px rgba(76, 201, 134, 0.62);
+  --qr-bg: var(--fig-background);
+  --qr-bg-soft: color-mix(in oklab, var(--fig-background) 70%, var(--fig-surface) 30%);
+  --qr-card: var(--fig-surface);
+  --qr-card-border: var(--fig-border);
+  --qr-fg: var(--fig-text);
+  --qr-text: var(--fig-text);
+  --qr-muted: var(--fig-muted);
+  --qr-ring: color-mix(in oklab, var(--fig-primary) 55%, transparent);
+  color-scheme: dark;
+}
+
+body.qr-landing.future-is-green-theme.high-contrast {
+  --qr-bg: #ffffff;
+  --qr-bg-soft: #ffffff;
+  --qr-card: #ffffff;
+  --qr-card-border: #000000;
+  --qr-fg: #000000;
+  --qr-text: #000000;
+  --qr-muted: #000000;
+  --qr-ring: rgba(0, 0, 0, 0.6);
+  color-scheme: light;
+}
+
+body.qr-landing.future-is-green-theme[data-theme='dark'].high-contrast {
+  --qr-bg: #000000;
+  --qr-bg-soft: #000000;
+  --qr-card: #000000;
+  --qr-card-border: #ffffff;
+  --qr-fg: #ffffff;
+  --qr-text: #ffffff;
+  --qr-muted: #ffffff;
+  --qr-ring: rgba(255, 255, 255, 0.72);
   color-scheme: dark;
 }
 


### PR DESCRIPTION
## Summary
- align the Future is Green landing page variables with shared topbar/offcanvas tokens so menu text remains legible in light mode
- provide explicit high-contrast overrides to keep accessibility colours intact across light and dark themes

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68defa31424c832bbf0d42231b17ee2a