### PR TITLE
Fix mobile menu header contrast on Future is Green

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -134,6 +134,10 @@ body.qr-landing.future-is-green-theme .landing-content {
   color: var(--fig-text);
 }
 
+.future-is-green-theme:not([data-theme='dark']) #qr-offcanvas .uk-nav-header {
+  color: #000000;
+}
+
 .future-is-green-theme .uk-navbar-dropdown {
   width: 720px;
   padding: 16px 0;


### PR DESCRIPTION
## Summary
- ensure the Future is Green offcanvas menu headers use black text in light mode for better legibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68defdb17640832baf485703ed6a3fa8