### PR TITLE
Prevent hero metric unit break on Future is Green page

### DIFF
--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -388,7 +388,7 @@
               <h2 class="fig-hero__card-title">Wir machen City-Logistik messbar nachhaltig.</h2>
               <p>Von der Anlieferung im Mikrohub bis zur letzten Meile per Cargo-Bike: Future is Green reduziert Verkehr, Emissionen und Lieferzeiten in dicht besiedelten Quartieren.</p>
               <div class="fig-hero__card-metric">
-                <span class="fig-hero__metric-value">7,4 t</span>
+                <span class="fig-hero__metric-value">7,4&nbsp;t</span>
                 <span class="fig-hero__metric-label">CO₂-Ersparnis pro Jahr in Pilotgebieten</span>
               </div>
               <p class="fig-hero__card-note">Live-Dashboards machen Fortschritt sichtbar – für Kommunen, Händler:innen und Bürger:innen.</p>


### PR DESCRIPTION
## Summary
- ensure the "7,4 t" hero metric keeps its value and unit on one line by using a non-breaking space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0207fef4832b81f8f69b1b7eabec