### PR TITLE
Adjust mobile topbar spacing on Future is Green landing page

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -130,6 +130,10 @@ body.qr-landing.future-is-green-theme .landing-content {
   color: var(--fig-text);
 }
 
+.future-is-green-theme .qr-topbar .uk-navbar-toggle {
+  margin-right: 1mm;
+}
+
 .future-is-green-theme .uk-navbar a {
   color: var(--fig-text);
 }


### PR DESCRIPTION
## Summary
- add a small margin between the mobile hamburger toggle and the logo on the Future is Green landing page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df0368ac24832ba957dea2555aaa93