### PR TITLE
Implementiere Phase 2 für den RAG-Chatbot

### DIFF
--- a/docs/rag-chatbot/implementation-journal.md
+++ b/docs/rag-chatbot/implementation-journal.md
@@ -1,7 +1,7 @@
 # RAG Chatbot – Implementation Journal
 
 Dieses Journal begleitet den Aufbau eines Retrieval-Augmented-Generation-Chatbots für die QuizRace-Dokumentation.
-Die Arbeit ist in drei Phasen gegliedert. Dieser Commit deckt **Phase 1** ab.
+Die Arbeit ist in drei Phasen gegliedert. Dieser Commit deckt **Phase 1** und **Phase 2** ab.
 
 ## Phase 1: Wissensbasis vorbereiten
 
@@ -24,8 +24,29 @@ Diese Schritte bilden die Grundlage für Phasen 2 und 3 (Embedding/Retrieval sow
    - Nach erfolgreichem Lauf entstehen eine JSONL-Datei (`data/rag-chatbot/corpus.jsonl`) und eine Zusammenfassung der wichtigsten Kennzahlen (Anzahl Dokumente/Chunks, durchschnittliche Wortzahl).
 3. Automatisierte Tests (`tests/test_rag_chunker.py`) stellen sicher, dass Chunking und Export deterministisch funktionieren.
 
+## Phase 2: Semantischen Index aufbauen
+
+Ziele der zweiten Phase:
+
+- Die erstellte Wissensbasis automatisiert in einen numerischen Vektorraum überführen.
+- Einen semantischen Index generieren, der für jede Textpassage TF-IDF-Vektoren und Normen speichert.
+- Eine Retrieval-API bereitstellen, die für Anfragen ähnliche Chunks per Kosinus-Ähnlichkeit findet.
+- Den Workflow als CLI-Skript reproduzierbar machen und mit Tests absichern.
+
+### Umsetzungsschritte
+
+1. Neues Modul `rag_chatbot/index_builder.py` eingeführt:
+   - Tokenisiert alle Chunks aus der JSONL-Wissensbasis, filtert kurze Terme und baut ein Vokabular.
+   - Berechnet TF-IDF-Gewichte samt Normen und speichert Index, Vokabular und Metadaten als JSON.
+   - Liefert Statistiken zur Indexgröße über `IndexResult`.
+2. Retrieval-Layer `rag_chatbot/retrieval.py` implementiert:
+   - `SemanticIndex` lädt den JSON-Index, rekonstruiert Sparse-Vektoren und beantwortet Suchanfragen.
+   - `search()` liefert sortierte `SearchResult`-Objekte inklusive Score, Text und Metadaten.
+3. CLI-Tool `scripts/build_rag_index.py` ergänzt, um den Index mit optionalen Parametern (`--max-features`,
+   `--min-term-length`) zu erzeugen.
+4. Neue Tests (`tests/test_rag_index.py`) prüfen Indexaufbau, Fehlerfälle und Retrieval-Relevanz.
+
 ### Nächste Schritte (Ausblick)
 
-- **Phase 2**: Vektorisierung der Chunks, Aufbau eines semantischen Index und Retrieval-API.
 - **Phase 3**: Anbindung eines Chat-Frontends inkl. Konversations- und Kontextverwaltung.
 

--- a/rag_chatbot/__init__.py
+++ b/rag_chatbot/__init__.py
@@ -1,11 +1,18 @@
 """Hilfsfunktionen zur Vorbereitung der Wissensbasis für den RAG-Chatbot."""
 
 from .corpus_builder import build_corpus, BuildOptions, BuildResult
+from .index_builder import build_index, IndexOptions, IndexResult
 from .loader import Document
+from .retrieval import SearchResult, SemanticIndex
 
 __all__ = [
     "build_corpus",
     "BuildOptions",
     "BuildResult",
     "Document",
+    "build_index",
+    "IndexOptions",
+    "IndexResult",
+    "SemanticIndex",
+    "SearchResult",
 ]

--- a/rag_chatbot/index_builder.py
+++ b/rag_chatbot/index_builder.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+TOKEN_RE = re.compile(r"\b\w+\b", re.UNICODE)
+
+
+@dataclass(frozen=True)
+class IndexOptions:
+    corpus_path: Path
+    output_path: Path
+    max_features: int | None = None
+    min_term_length: int = 2
+
+
+@dataclass(frozen=True)
+class IndexResult:
+    chunks: int
+    vocabulary_size: int
+    output_path: Path
+
+
+def build_index(options: IndexOptions) -> IndexResult:
+    chunks = list(_load_corpus(options.corpus_path))
+    if not chunks:
+        raise ValueError("Das Korpus ist leer – bitte zuerst die Wissensbasis erzeugen.")
+
+    tokenised_texts = [_tokenise(chunk["text"]) for chunk in chunks]
+    vocabulary = _build_vocabulary(
+        tokenised_texts,
+        max_features=options.max_features,
+        min_term_length=options.min_term_length,
+    )
+    if not vocabulary:
+        raise ValueError("Es konnten keine Terme für den Index extrahiert werden.")
+
+    idf = _compute_idf(tokenised_texts, vocabulary)
+    indexed_chunks = _vectorise_chunks(chunks, tokenised_texts, vocabulary, idf)
+
+    payload = {
+        "vocabulary": vocabulary,
+        "idf": idf,
+        "chunks": indexed_chunks,
+    }
+
+    options.output_path.parent.mkdir(parents=True, exist_ok=True)
+    options.output_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    return IndexResult(
+        chunks=len(indexed_chunks),
+        vocabulary_size=len(vocabulary),
+        output_path=options.output_path,
+    )
+
+
+def _load_corpus(path: Path) -> Iterable[dict[str, object]]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def _tokenise(text: str) -> list[str]:
+    tokens = [token.lower() for token in TOKEN_RE.findall(text)]
+    return tokens
+
+
+def _build_vocabulary(
+    tokenised_texts: Sequence[Sequence[str]],
+    *,
+    max_features: int | None,
+    min_term_length: int,
+) -> list[str]:
+    term_counts: Counter[str] = Counter()
+    for tokens in tokenised_texts:
+        filtered = [token for token in tokens if len(token) >= min_term_length]
+        term_counts.update(filtered)
+
+    if not term_counts:
+        return []
+
+    sorted_terms = sorted(
+        term_counts.items(),
+        key=lambda item: (-item[1], item[0]),
+    )
+    if max_features is not None:
+        sorted_terms = sorted_terms[: max_features]
+    return [term for term, _ in sorted_terms]
+
+
+def _compute_idf(tokenised_texts: Sequence[Sequence[str]], vocabulary: Sequence[str]) -> list[float]:
+    doc_freq: Counter[str] = Counter()
+    for tokens in tokenised_texts:
+        unique_tokens = {token for token in tokens if token in vocabulary}
+        doc_freq.update(unique_tokens)
+
+    total_docs = len(tokenised_texts)
+    idf = []
+    for term in vocabulary:
+        df = doc_freq.get(term, 0)
+        weight = math.log((1 + total_docs) / (1 + df)) + 1.0
+        idf.append(round(weight, 6))
+    return idf
+
+
+def _vectorise_chunks(
+    chunks: Sequence[dict[str, object]],
+    tokenised_texts: Sequence[Sequence[str]],
+    vocabulary: Sequence[str],
+    idf: Sequence[float],
+) -> list[dict[str, object]]:
+    vocab_index = {term: index for index, term in enumerate(vocabulary)}
+    indexed_chunks: list[dict[str, object]] = []
+
+    for chunk, tokens in zip(chunks, tokenised_texts, strict=True):
+        counts = Counter(token for token in tokens if token in vocab_index)
+        total = sum(counts.values())
+        vector: list[list[float]] = []
+        norm_sq = 0.0
+        if total > 0:
+            for term, count in counts.items():
+                index = vocab_index[term]
+                tf = count / total
+                weight = tf * idf[index]
+                norm_sq += weight * weight
+                vector.append([index, round(weight, 6)])
+        vector.sort(key=lambda item: item[0])
+
+        indexed_chunks.append(
+            {
+                "id": chunk["id"],
+                "text": chunk["text"],
+                "metadata": {
+                    key: chunk[key]
+                    for key in ("source", "title", "chunk_index", "word_count")
+                    if key in chunk
+                },
+                "vector": vector,
+                "norm": round(math.sqrt(norm_sq), 6),
+            }
+        )
+
+    return indexed_chunks
+

--- a/rag_chatbot/retrieval.py
+++ b/rag_chatbot/retrieval.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from .index_builder import TOKEN_RE
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    chunk_id: str
+    score: float
+    text: str
+    metadata: dict[str, Any]
+
+
+class SemanticIndex:
+    """Lädt einen semantischen Index und ermöglicht Ähnlichkeitssuchen."""
+
+    def __init__(self, path: Path):
+        if not path.exists():
+            raise FileNotFoundError(path)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        self._vocabulary: list[str] = list(payload.get("vocabulary", []))
+        self._idf: list[float] = list(payload.get("idf", []))
+        self._term_to_index = {term: index for index, term in enumerate(self._vocabulary)}
+        self._chunks = [
+            _IndexedChunk.from_payload(item)
+            for item in payload.get("chunks", [])
+        ]
+
+    @property
+    def vocabulary(self) -> tuple[str, ...]:
+        return tuple(self._vocabulary)
+
+    def search(self, query: str, *, top_k: int = 5, min_score: float = 0.0) -> list[SearchResult]:
+        query_vector = self._vectorise(query)
+        if not query_vector:
+            return []
+
+        query_norm = math.sqrt(sum(weight * weight for weight in query_vector.values()))
+        if query_norm == 0.0:
+            return []
+
+        results: list[SearchResult] = []
+        for chunk in self._chunks:
+            if chunk.norm == 0.0:
+                continue
+            score = chunk.dot(query_vector)
+            if score <= 0.0:
+                continue
+            similarity = score / (chunk.norm * query_norm)
+            if similarity >= min_score:
+                results.append(
+                    SearchResult(
+                        chunk_id=chunk.chunk_id,
+                        score=round(similarity, 6),
+                        text=chunk.text,
+                        metadata=dict(chunk.metadata),
+                    )
+                )
+
+        results.sort(key=lambda item: item.score, reverse=True)
+        return results[:top_k]
+
+    def _vectorise(self, text: str) -> dict[int, float]:
+        tokens = [token.lower() for token in TOKEN_RE.findall(text)]
+        counts: dict[int, int] = {}
+        for token in tokens:
+            index = self._term_to_index.get(token)
+            if index is None:
+                continue
+            counts[index] = counts.get(index, 0) + 1
+        total = sum(counts.values())
+        if total == 0:
+            return {}
+        vector: dict[int, float] = {}
+        for index, count in counts.items():
+            tf = count / total
+            weight = tf * self._idf[index]
+            vector[index] = weight
+        return vector
+
+
+@dataclass(frozen=True)
+class _IndexedChunk:
+    chunk_id: str
+    text: str
+    metadata: dict[str, Any]
+    vector: dict[int, float]
+    norm: float
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "_IndexedChunk":
+        vector_pairs: Iterable[Iterable[float]] = payload.get("vector", [])
+        vector: dict[int, float] = {}
+        for pair in vector_pairs:
+            if not isinstance(pair, list) or len(pair) != 2:
+                continue
+            index, weight = int(pair[0]), float(pair[1])
+            vector[index] = weight
+
+        return cls(
+            chunk_id=str(payload.get("id", "")),
+            text=str(payload.get("text", "")),
+            metadata=dict(payload.get("metadata", {})),
+            vector=vector,
+            norm=float(payload.get("norm", 0.0)),
+        )
+
+    def dot(self, other: dict[int, float]) -> float:
+        score = 0.0
+        for index, weight in other.items():
+            if index in self.vector:
+                score += self.vector[index] * weight
+        return score
+

--- a/scripts/build_rag_index.py
+++ b/scripts/build_rag_index.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from rag_chatbot import IndexOptions, build_index
+
+DEFAULT_CORPUS = Path("data/rag-chatbot/corpus.jsonl")
+DEFAULT_OUTPUT = Path("data/rag-chatbot/index.json")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Erzeugt den semantischen Index für den RAG-Chatbot.",
+    )
+    parser.add_argument(
+        "corpus",
+        type=Path,
+        nargs="?",
+        default=DEFAULT_CORPUS,
+        help="Pfad zur JSONL-Wissensbasis",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Zieldatei für den Index",
+    )
+    parser.add_argument(
+        "--max-features",
+        type=int,
+        default=None,
+        help="Begrenzt die Anzahl der Terme im Vokabular",
+    )
+    parser.add_argument(
+        "--min-term-length",
+        type=int,
+        default=2,
+        help="Minimale Länge eines Terms, damit er in den Index aufgenommen wird",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_arguments()
+    options = IndexOptions(
+        corpus_path=args.corpus,
+        output_path=args.output,
+        max_features=args.max_features,
+        min_term_length=args.min_term_length,
+    )
+    result = build_index(options)
+    print(
+        "Index erzeugt:",
+        f"{result.chunks} Chunk(s) verarbeitet",
+        f"{result.vocabulary_size} Terme im Vokabular",
+        f"Datei: {result.output_path}",
+        sep="\n",
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_rag_index.py
+++ b/tests/test_rag_index.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag_chatbot import IndexOptions, build_index
+from rag_chatbot.retrieval import SemanticIndex
+
+
+def _write_corpus(path: Path, entries: list[dict[str, object]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for entry in entries:
+            json.dump(entry, handle, ensure_ascii=False)
+            handle.write("\n")
+
+
+def test_build_index_creates_file(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus.jsonl"
+    entries = [
+        {
+            "id": "doc:0000",
+            "source": "doc.md",
+            "title": "Python Einstieg",
+            "chunk_index": 0,
+            "word_count": 4,
+            "text": "Python macht Spaß beim Programmieren.",
+        },
+        {
+            "id": "doc:0001",
+            "source": "doc.md",
+            "title": "PHP Einstieg",
+            "chunk_index": 1,
+            "word_count": 4,
+            "text": "PHP eignet sich für Webanwendungen.",
+        },
+    ]
+    _write_corpus(corpus, entries)
+
+    output = tmp_path / "index.json"
+    options = IndexOptions(corpus_path=corpus, output_path=output, min_term_length=3)
+    result = build_index(options)
+
+    assert output.exists()
+    assert result.chunks == 2
+    assert result.vocabulary_size > 0
+
+
+def test_build_index_requires_non_empty_corpus(tmp_path: Path) -> None:
+    corpus = tmp_path / "empty.jsonl"
+    corpus.write_text("", encoding="utf-8")
+    output = tmp_path / "index.json"
+
+    options = IndexOptions(corpus_path=corpus, output_path=output)
+    try:
+        build_index(options)
+    except ValueError as exc:  # pragma: no cover - branch expected in test
+        assert "leer" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Fehler wurde nicht ausgelöst")
+
+
+def test_semantic_index_returns_best_match(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus.jsonl"
+    entries = [
+        {
+            "id": "doc:0000",
+            "source": "doc.md",
+            "title": "Python Einstieg",
+            "chunk_index": 0,
+            "word_count": 6,
+            "text": "Python ist eine beliebte Programmiersprache für Datenanalyse.",
+        },
+        {
+            "id": "doc:0001",
+            "source": "doc.md",
+            "title": "PHP Einstieg",
+            "chunk_index": 1,
+            "word_count": 6,
+            "text": "PHP ist weit verbreitet im Web und in Content-Management-Systemen.",
+        },
+    ]
+    _write_corpus(corpus, entries)
+
+    output = tmp_path / "index.json"
+    options = IndexOptions(corpus_path=corpus, output_path=output)
+    build_index(options)
+
+    index = SemanticIndex(output)
+    results = index.search("Wie kann ich mit Python Daten analysieren?", top_k=1)
+
+    assert results, "Es wurde kein Treffer gefunden"
+    assert results[0].chunk_id == "doc:0000"
+    assert "Python" in results[0].text
+


### PR DESCRIPTION
## Summary
- ergänze einen TF-IDF-basierten Index-Builder inklusive Optionen und Persistenz
- implementiere eine Retrieval-API mit Kosinus-Suche auf dem erzeugten Index
- erweitere Dokumentation, CLI-Workflow und Tests zur Abdeckung von Phase 2

## Testing
- pytest tests/test_rag_chunker.py tests/test_rag_index.py

------
https://chatgpt.com/codex/tasks/task_e_68dfad1d67c0832b8073b53ad68dfd8e