### PR TITLE
Add conversational interface and CLI for RAG chatbot

### DIFF
--- a/docs/rag-chatbot/implementation-journal.md
+++ b/docs/rag-chatbot/implementation-journal.md
@@ -46,7 +46,20 @@ Ziele der zweiten Phase:
    `--min-term-length`) zu erzeugen.
 4. Neue Tests (`tests/test_rag_index.py`) prüfen Indexaufbau, Fehlerfälle und Retrieval-Relevanz.
 
-### Nächste Schritte (Ausblick)
+## Phase 3: Chat-Interface mit Kontextverwaltung
 
-- **Phase 3**: Anbindung eines Chat-Frontends inkl. Konversations- und Kontextverwaltung.
+Ziele der dritten Phase:
+
+- Eine Konversationsschicht ergänzen, die vorherige Nutzer- und Assistentenantworten verwaltet.
+- Kontext aus dem semantischen Index automatisch zum Prompt hinzufügen.
+- Ein CLI-Frontend bereitstellen, das die wichtigsten Parameter (Top-K, Mindestscore, Verlaufslänge) konfigurierbar macht.
+
+### Umsetzungsschritte
+
+1. Neues Modul `rag_chatbot/chat.py` mit `ChatSession`, `ChatPrompt` und `ChatTurn` implementiert. Die Klasse fasst Kontextpassagen
+   zusammen, verwaltet die Historie in einem begrenzten Fenster und liefert strukturierte Prompts für LLM-Aufrufe.
+2. CLI-Tool `scripts/rag_chat.py` ergänzt. Es lädt den Index, startet eine interaktive Konsole und generiert Antworten auf Basis
+   der gefundenen Kontext-Chunks. Parameter wie `--top-k`, `--min-score` und `--history-limit` steuern Verhalten und Trefferqualität.
+3. Automatisierter Test `tests/test_rag_chat.py` sichert das neue Verhalten ab (Prompt-Aufbau, Kontextintegration,
+   Historienbegrenzung und Fehlerfälle).
 

--- a/rag_chatbot/__init__.py
+++ b/rag_chatbot/__init__.py
@@ -1,11 +1,17 @@
 """Hilfsfunktionen zur Vorbereitung der Wissensbasis für den RAG-Chatbot."""
 
-from .corpus_builder import build_corpus, BuildOptions, BuildResult
-from .index_builder import build_index, IndexOptions, IndexResult
+from .chat import ChatMessage, ChatPrompt, ChatResponder, ChatSession, ChatTurn
+from .corpus_builder import BuildOptions, BuildResult, build_corpus
+from .index_builder import IndexOptions, IndexResult, build_index
 from .loader import Document
 from .retrieval import SearchResult, SemanticIndex
 
 __all__ = [
+    "ChatMessage",
+    "ChatPrompt",
+    "ChatResponder",
+    "ChatSession",
+    "ChatTurn",
     "build_corpus",
     "BuildOptions",
     "BuildResult",

--- a/rag_chatbot/chat.py
+++ b/rag_chatbot/chat.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+"""Chat-spezifische Komponenten für den RAG-Chatbot."""
+
+from dataclasses import dataclass
+from typing import Protocol, Sequence
+
+from .retrieval import SearchResult, SemanticIndex
+
+
+ChatRole = str
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    """Eine Chat-Nachricht mit Rolle und Inhalt."""
+
+    role: ChatRole
+    content: str
+
+
+@dataclass(frozen=True)
+class ChatPrompt:
+    """Eingabestruktur für LLM-Aufrufe."""
+
+    messages: tuple[ChatMessage, ...]
+    context: tuple[SearchResult, ...]
+
+
+@dataclass(frozen=True)
+class ChatTurn:
+    """Ergebnis eines Chat-Durchlaufs."""
+
+    response: str
+    prompt: ChatPrompt
+
+
+class ChatResponder(Protocol):
+    """Protokoll für Antwortgeneratoren."""
+
+    def __call__(self, prompt: ChatPrompt) -> str:  # pragma: no cover - Signatur
+        ...
+
+
+DEFAULT_SYSTEM_PROMPT = (
+    "Du bist ein hilfreicher Assistent für die QuizRace-Dokumentation. "
+    "Beantworte Fragen ausschließlich anhand der bereitgestellten Kontexte."
+)
+
+DEFAULT_CONTEXT_HEADER = "Kontext aus der Wissensbasis:\n"
+
+
+class ChatSession:
+    """Verwaltet eine Konversation und baut Eingaben für ein Sprachmodell."""
+
+    def __init__(
+        self,
+        index: SemanticIndex,
+        responder: ChatResponder,
+        *,
+        system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+        history_limit: int = 6,
+        top_k: int = 4,
+        min_score: float = 0.05,
+    ) -> None:
+        if history_limit < 0:
+            raise ValueError("history_limit darf nicht negativ sein.")
+        if top_k <= 0:
+            raise ValueError("top_k muss größer als 0 sein.")
+
+        self._index = index
+        self._responder = responder
+        self._system_prompt = system_prompt.strip()
+        self._history_limit = history_limit
+        self._top_k = top_k
+        self._min_score = min_score
+        self._history: list[ChatMessage] = []
+
+    @property
+    def history(self) -> tuple[ChatMessage, ...]:
+        """Gibt die bisherige Konversation ohne System-Prompt zurück."""
+
+        return tuple(self._history)
+
+    def send(self, user_message: str) -> ChatTurn:
+        user_message = user_message.strip()
+        if not user_message:
+            raise ValueError("Die Nutzer-Nachricht darf nicht leer sein.")
+
+        context = self._index.search(user_message, top_k=self._top_k, min_score=self._min_score)
+        context_message = self._build_context_message(context)
+
+        messages: list[ChatMessage] = [ChatMessage("system", self._system_prompt)]
+        if self._history:
+            messages.extend(self._history)
+        if context_message:
+            messages.append(context_message)
+        messages.append(ChatMessage("user", user_message))
+
+        prompt = ChatPrompt(messages=tuple(messages), context=tuple(context))
+        response = self._responder(prompt).strip()
+
+        self._history.extend((ChatMessage("user", user_message), ChatMessage("assistant", response)))
+        self._truncate_history()
+
+        return ChatTurn(response=response, prompt=prompt)
+
+    def _truncate_history(self) -> None:
+        if self._history_limit == 0:
+            self._history.clear()
+            return
+        max_messages = self._history_limit * 2
+        excess = len(self._history) - max_messages
+        if excess > 0:
+            del self._history[:excess]
+
+    def _build_context_message(self, context: Sequence[SearchResult]) -> ChatMessage | None:
+        if not context:
+            return None
+        lines = [DEFAULT_CONTEXT_HEADER]
+        for index, item in enumerate(context, start=1):
+            summary = _summarise_text(item.text)
+            source = _format_source(item)
+            lines.append(f"[{index}] {source}\n{summary}")
+        content = "\n\n".join(lines)
+        return ChatMessage("system", content)
+
+
+def _summarise_text(text: str, limit: int = 420) -> str:
+    condensed = " ".join(text.split())
+    if len(condensed) <= limit:
+        return condensed
+    return condensed[: limit - 1] + "…"
+
+
+def _format_source(result: SearchResult) -> str:
+    metadata = result.metadata
+    title = metadata.get("title")
+    chunk_index = metadata.get("chunk_index")
+    if title:
+        if chunk_index is not None:
+            return f"{title} (Abschnitt {chunk_index})"
+        return str(title)
+    source = metadata.get("source")
+    if source:
+        return str(source)
+    return result.chunk_id
+
+
+__all__ = [
+    "ChatMessage",
+    "ChatPrompt",
+    "ChatResponder",
+    "ChatSession",
+    "ChatTurn",
+    "DEFAULT_SYSTEM_PROMPT",
+]

--- a/scripts/rag_chat.py
+++ b/scripts/rag_chat.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from rag_chatbot import ChatMessage, ChatPrompt, ChatSession, ChatTurn, SemanticIndex
+
+
+class ContextResponder:
+    """Einfache Heuristik, die die gefundenen Chunks zusammenfasst."""
+
+    def __call__(self, prompt: ChatPrompt) -> str:
+        question = _extract_user_message(prompt.messages)
+        if not prompt.context:
+            return (
+                "Ich konnte keine passenden Informationen in der Dokumentation finden. "
+                "Bitte stelle deine Frage anders oder schränke das Thema ein."
+            )
+
+        lines = [
+            "Basierend auf der Wissensbasis habe ich folgende Hinweise gefunden:",
+        ]
+        for index, item in enumerate(prompt.context, start=1):
+            source = _format_source(item.metadata)
+            snippet = _summarise(item.text)
+            lines.append(f"{index}. {source}: {snippet}")
+
+        if question:
+            lines.append("")
+            lines.append(f"Frage: {question}")
+        return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Interaktive Konsole für den RAG-Chatbot")
+    parser.add_argument(
+        "--index",
+        type=Path,
+        default=Path("data/rag-chatbot/index.json"),
+        help="Pfad zum zuvor erzeugten semantischen Index",
+    )
+    parser.add_argument("--top-k", type=int, default=4, help="Anzahl der Kontext-Chunks pro Frage")
+    parser.add_argument(
+        "--min-score",
+        type=float,
+        default=0.05,
+        help="Minimale Ähnlichkeit, damit ein Chunk berücksichtigt wird",
+    )
+    parser.add_argument(
+        "--history-limit",
+        type=int,
+        default=6,
+        help="Anzahl der vorangegangenen Benutzer/Assistenten-Paare, die behalten werden",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    index = SemanticIndex(args.index)
+    session = ChatSession(
+        index,
+        responder=ContextResponder(),
+        history_limit=args.history_limit,
+        top_k=args.top_k,
+        min_score=args.min_score,
+    )
+
+    print("QuizRace RAG-Chatbot – Tippe 'quit' oder 'exit' zum Beenden.")
+    while True:
+        try:
+            user_input = input("Du: ")
+        except (KeyboardInterrupt, EOFError):
+            print()
+            break
+        if user_input.strip().lower() in {"quit", "exit"}:
+            break
+        if not user_input.strip():
+            continue
+
+        turn = session.send(user_input)
+        print(_format_turn(turn))
+
+
+def _format_turn(turn: ChatTurn) -> str:
+    context_lines = []
+    for index, item in enumerate(turn.prompt.context, start=1):
+        source = _format_source(item.metadata)
+        context_lines.append(f"[{index}] {source} (Score: {item.score:.2f})")
+    formatted = []
+    if context_lines:
+        formatted.append("Kontext")
+        formatted.extend(context_lines)
+    formatted.append("")
+    formatted.append(f"Bot: {turn.response}")
+    return "\n".join(formatted)
+
+
+def _extract_user_message(messages: Iterable[ChatMessage]) -> str:
+    for message in reversed(tuple(messages)):
+        role = getattr(message, "role", None)
+        if role == "user":
+            return getattr(message, "content", "")
+    return ""
+
+
+def _format_source(metadata: dict[str, object]) -> str:
+    title = metadata.get("title")
+    if title:
+        return str(title)
+    source = metadata.get("source")
+    if source:
+        return str(source)
+    return metadata.get("id", "Unbekannte Quelle")
+
+
+def _summarise(text: str, limit: int = 320) -> str:
+    condensed = " ".join(text.split())
+    if len(condensed) <= limit:
+        return condensed
+    return condensed[: limit - 1] + "…"
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rag_chat.py
+++ b/tests/test_rag_chat.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import pytest
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag_chatbot.chat import ChatSession
+from rag_chatbot.retrieval import SearchResult
+
+
+@dataclass
+class FakeIndex:
+    results: List[SearchResult]
+
+    def search(self, query: str, *, top_k: int, min_score: float):
+        return self.results[:top_k]
+
+
+def test_chat_session_builds_prompt_with_context() -> None:
+    results = [
+        SearchResult(
+            chunk_id="doc:0001",
+            score=0.8,
+            text="QuizRace ist eine Webanwendung für Quizrunden.",
+            metadata={"title": "README", "chunk_index": 0},
+        ),
+        SearchResult(
+            chunk_id="doc:0002",
+            score=0.7,
+            text="Sie nutzt Slim Framework und UIkit.",
+            metadata={"title": "README", "chunk_index": 1},
+        ),
+    ]
+    index = FakeIndex(results)
+    captured: list = []
+
+    def responder(prompt):
+        captured.append(prompt)
+        return "QuizRace ist eine Quiz-Plattform."  # noqa: D401
+
+    session = ChatSession(index, responder=responder, top_k=2)
+    turn = session.send("Was ist QuizRace?")
+
+    assert turn.response == "QuizRace ist eine Quiz-Plattform."
+    assert captured[0].context == tuple(results)
+    messages = captured[0].messages
+    assert messages[0].role == "system"
+    assert messages[-1].content == "Was ist QuizRace?"
+    assert messages[-2].role == "system"
+    assert "Kontext aus der Wissensbasis" in messages[-2].content
+    assert "README" in messages[-2].content
+
+
+def test_chat_session_truncates_history() -> None:
+    index = FakeIndex([])
+    prompts: list = []
+    responses = iter(["Antwort 1", "Antwort 2"])
+
+    def responder(prompt):
+        prompts.append(prompt)
+        return next(responses)
+
+    session = ChatSession(index, responder=responder, history_limit=1, top_k=1)
+
+    session.send("Erste Frage")
+    session.send("Zweite Frage")
+
+    second_messages = prompts[1].messages
+    assert second_messages[0].role == "system"
+    assert second_messages[1].content == "Erste Frage"
+    assert second_messages[2].content == "Antwort 1"
+    assert second_messages[3].content == "Zweite Frage"
+
+
+def test_chat_session_rejects_empty_input() -> None:
+    index = FakeIndex([])
+
+    def responder(prompt):
+        return ""
+
+    session = ChatSession(index, responder=responder)
+
+    with pytest.raises(ValueError):
+        session.send("   ")


### PR DESCRIPTION
## Summary
- document Phase 3 goals in the implementation journal
- add a chat session module that constructs prompts with retrieved context and manages conversation history
- provide an interactive CLI and tests to exercise the new chat workflow

## Testing
- pytest tests/test_rag_chat.py

------
https://chatgpt.com/codex/tasks/task_e_68dfae823ab8832b8d4d83af981c29c0