### PR TITLE
Fix phpstan static analysis warnings

### DIFF
--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -132,7 +132,7 @@ class MarketingPageController
         if ($landingNews !== []) {
             $data['landingNews'] = $landingNews;
             $data['landingNewsBasePath'] = $landingNewsBasePath;
-            $data['landingNewsIndexUrl'] = $landingNewsBasePath !== null ? $basePath . $landingNewsBasePath : null;
+            $data['landingNewsIndexUrl'] = $basePath . $landingNewsBasePath;
         }
 
         if (in_array($templateSlug, ['calserver', 'landing'], true)) {

--- a/src/Service/LandingMediaReferenceService.php
+++ b/src/Service/LandingMediaReferenceService.php
@@ -210,10 +210,6 @@ class LandingMediaReferenceService
         $references = [];
 
         foreach ($entries as $entry) {
-            if (!$entry instanceof LandingNews) {
-                continue;
-            }
-
             $references = array_merge(
                 $references,
                 $this->collectMarkupReferences(


### PR DESCRIPTION
## Summary
- remove the redundant null comparison when building the landing news index URL
- drop the always-true instanceof guard when iterating landing news entries

## Testing
- vendor/bin/phpstan analyse --no-progress --memory-limit=512M *(fails: vendor/bin/phpstan not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb2d42ff0832ba1d1c674f5fd8fda