### PR TITLE
Implement Phase 4 logging and evaluation for RAG chatbot

### DIFF
--- a/docs/rag-chatbot/implementation-journal.md
+++ b/docs/rag-chatbot/implementation-journal.md
@@ -1,7 +1,7 @@
 # RAG Chatbot – Implementation Journal
 
 Dieses Journal begleitet den Aufbau eines Retrieval-Augmented-Generation-Chatbots für die QuizRace-Dokumentation.
-Die Arbeit ist in drei Phasen gegliedert. Dieser Commit deckt **Phase 1** und **Phase 2** ab.
+Die Arbeit ist in vier Phasen gegliedert. Dieses Journal beschreibt die Umsetzung von **Phase 1** bis **Phase 4**.
 
 ## Phase 1: Wissensbasis vorbereiten
 
@@ -63,3 +63,17 @@ Ziele der dritten Phase:
 3. Automatisierter Test `tests/test_rag_chat.py` sichert das neue Verhalten ab (Prompt-Aufbau, Kontextintegration,
    Historienbegrenzung und Fehlerfälle).
 
+## Phase 4: Auswertung und Gesprächsprotokolle
+
+Ziele der vierten Phase:
+
+- Chatverläufe strukturiert erfassen, um Antwortqualität und Quellenabdeckung zu bewerten.
+- Eine Auswertung bereitstellen, die Statistiken über Kontexte und genutzte Quellen liefert.
+- Einen reproduzierbaren Batch-Workflow schaffen, der mehrere Fragen gegen den Index laufen lässt und die Ergebnisse speichert.
+
+### Umsetzungsschritte
+
+1. Neues Modul `rag_chatbot/transcript.py` implementiert. Es enthält `ChatTranscript` zur Aufzeichnung von Chat-Runden, inklusive Hilfsklassen für Kontextdaten und Statistikberechnung.
+2. `ChatSession` akzeptiert optional ein `ChatTranscript` und protokolliert automatisch jede Anfrage mitsamt Prompt, Antwort und Kontexttreffern.
+3. CLI-Skript `scripts/rag_eval.py` ergänzt, um Fragenstapel aus einer Textdatei gegen den semantischen Index auszuführen und das erzeugte Transcript als JSON zu speichern.
+4. Neue Tests (`tests/test_rag_transcript.py`) prüfen die Aufzeichnung, Statistikberechnung und den JSON-Export der Gesprächsprotokolle.

--- a/rag_chatbot/__init__.py
+++ b/rag_chatbot/__init__.py
@@ -5,6 +5,7 @@ from .corpus_builder import BuildOptions, BuildResult, build_corpus
 from .index_builder import IndexOptions, IndexResult, build_index
 from .loader import Document
 from .retrieval import SearchResult, SemanticIndex
+from .transcript import ChatTranscript, TranscriptContext, TranscriptStats, TranscriptTurn
 
 __all__ = [
     "ChatMessage",
@@ -21,4 +22,8 @@ __all__ = [
     "IndexResult",
     "SemanticIndex",
     "SearchResult",
+    "ChatTranscript",
+    "TranscriptContext",
+    "TranscriptStats",
+    "TranscriptTurn",
 ]

--- a/rag_chatbot/transcript.py
+++ b/rag_chatbot/transcript.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+"""Werkzeuge zum Aufzeichnen und Auswerten von Chatverläufen."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from .chat import ChatMessage, ChatTurn
+from .retrieval import SearchResult
+
+
+@dataclass(frozen=True)
+class TranscriptContext:
+    """Metadaten zu einem einzelnen Kontexttreffer."""
+
+    chunk_id: str
+    score: float
+    text: str
+    metadata: dict[str, object]
+
+    @classmethod
+    def from_search_result(cls, result: SearchResult) -> "TranscriptContext":
+        return cls(
+            chunk_id=result.chunk_id,
+            score=result.score,
+            text=result.text,
+            metadata=dict(result.metadata),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "chunk_id": self.chunk_id,
+            "score": self.score,
+            "text": self.text,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass(frozen=True)
+class TranscriptTurn:
+    """Ein protokollierter Frage-Antwort-Durchlauf."""
+
+    question: str
+    response: str
+    context: tuple[TranscriptContext, ...]
+    prompt_messages: tuple[ChatMessage, ...]
+
+    @classmethod
+    def from_prompt(cls, question: str, turn: ChatTurn) -> "TranscriptTurn":
+        context = tuple(TranscriptContext.from_search_result(item) for item in turn.prompt.context)
+        # Kopie der Prompt-Nachrichten, damit spätere Modifikationen nicht das Protokoll verändern.
+        prompt_messages = tuple(
+            ChatMessage(role=message.role, content=message.content)
+            for message in turn.prompt.messages
+        )
+        return cls(
+            question=question,
+            response=turn.response,
+            context=context,
+            prompt_messages=prompt_messages,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "question": self.question,
+            "response": self.response,
+            "context": [item.to_dict() for item in self.context],
+            "prompt": [
+                {
+                    "role": message.role,
+                    "content": message.content,
+                }
+                for message in self.prompt_messages
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class TranscriptStats:
+    """Aggregierte Kennzahlen über ein Gesprächsprotokoll."""
+
+    turns: int
+    context_items: int
+    average_score: float
+    unique_sources: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "turns": self.turns,
+            "context_items": self.context_items,
+            "average_score": self.average_score,
+            "unique_sources": self.unique_sources,
+        }
+
+
+class ChatTranscript:
+    """Sammelt Chat-Durchläufe und speichert sie bei Bedarf als JSON."""
+
+    def __init__(self) -> None:
+        self._turns: list[TranscriptTurn] = []
+
+    @property
+    def turns(self) -> tuple[TranscriptTurn, ...]:
+        return tuple(self._turns)
+
+    def record(self, question: str, turn: ChatTurn) -> None:
+        self._turns.append(TranscriptTurn.from_prompt(question, turn))
+
+    def extend(self, items: Iterable[TranscriptTurn]) -> None:
+        for item in items:
+            self._turns.append(item)
+
+    def clear(self) -> None:
+        self._turns.clear()
+
+    def stats(self) -> TranscriptStats:
+        if not self._turns:
+            return TranscriptStats(turns=0, context_items=0, average_score=0.0, unique_sources=0)
+
+        scores: list[float] = []
+        sources: set[str] = set()
+        for turn in self._turns:
+            for item in turn.context:
+                scores.append(item.score)
+                metadata = item.metadata
+                source = str(
+                    metadata.get("source")
+                    or metadata.get("title")
+                    or item.chunk_id
+                )
+                sources.add(source)
+
+        average = sum(scores) / len(scores) if scores else 0.0
+        return TranscriptStats(
+            turns=len(self._turns),
+            context_items=len(scores),
+            average_score=round(average, 6),
+            unique_sources=len(sources),
+        )
+
+    def to_dict(self, *, include_stats: bool = True) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "turns": [turn.to_dict() for turn in self._turns],
+        }
+        if include_stats:
+            payload["stats"] = self.stats().to_dict()
+        return payload
+
+    def save(self, path: Path, *, include_stats: bool = True) -> None:
+        payload = self.to_dict(include_stats=include_stats)
+        text = json.dumps(payload, ensure_ascii=False, indent=2)
+        path.write_text(text + "\n", encoding="utf-8")
+
+
+__all__ = [
+    "ChatTranscript",
+    "TranscriptContext",
+    "TranscriptStats",
+    "TranscriptTurn",
+]

--- a/scripts/rag_eval.py
+++ b/scripts/rag_eval.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Batch-Auswertung für den RAG-Chatbot."""
+
+import argparse
+import sys
+from pathlib import Path
+from rag_chatbot.chat import ChatPrompt, ChatSession
+from rag_chatbot.retrieval import SemanticIndex
+from rag_chatbot.transcript import ChatTranscript
+
+DEFAULT_INDEX_PATH = Path("data/rag-chatbot/index.json")
+DEFAULT_OUTPUT_PATH = Path("data/rag-chatbot/transcript.json")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Führt mehrere Fragen gegen den RAG-Index aus.")
+    parser.add_argument(
+        "questions",
+        type=Path,
+        help="Textdatei mit Fragen (eine pro Zeile, Leerzeilen werden ignoriert).",
+    )
+    parser.add_argument("--index", type=Path, default=DEFAULT_INDEX_PATH, help="Pfad zum Index (JSON)")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="JSON-Datei für das Gesprächsprotokoll",
+    )
+    parser.add_argument("--top-k", type=int, default=4, help="Maximale Anzahl an Kontexttreffern")
+    parser.add_argument("--min-score", type=float, default=0.05, help="Mindestscore für Treffer")
+    parser.add_argument("--history-limit", type=int, default=6, help="Maximale Gesprächslänge in Runden")
+    return parser.parse_args()
+
+
+def load_questions(path: Path) -> list[str]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    questions: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        questions.append(line)
+    if not questions:
+        raise ValueError("Die Fragenliste ist leer.")
+    return questions
+
+
+def default_responder(prompt: ChatPrompt) -> str:
+    context = prompt.context
+    if not context:
+        return "Ich konnte keine passenden Informationen in der Wissensbasis finden."
+    lines = ["Antwort basierend auf den gefundenen Dokumenten:"]
+    for index, item in enumerate(context, start=1):
+        source = item.metadata.get("title") or item.metadata.get("source") or item.chunk_id
+        snippet = " ".join(item.text.split())
+        lines.append(f"{index}. {snippet} (Quelle: {source})")
+    return "\n".join(lines)
+
+
+def ensure_directory(path: Path) -> None:
+    if path.parent and not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        index = SemanticIndex(args.index)
+    except FileNotFoundError:
+        print(f"Index-Datei {args.index} wurde nicht gefunden.", file=sys.stderr)
+        return 1
+
+    try:
+        questions = load_questions(args.questions)
+    except Exception as exc:  # pragma: no cover - Fehlerausgabe ist trivial
+        print(f"Fehler beim Laden der Fragen: {exc}", file=sys.stderr)
+        return 1
+
+    transcript = ChatTranscript()
+    session = ChatSession(
+        index,
+        responder=default_responder,
+        history_limit=args.history_limit,
+        top_k=args.top_k,
+        min_score=args.min_score,
+        transcript=transcript,
+    )
+
+    for question in questions:
+        turn = session.send(question)
+        print(f"Frage: {question}")
+        print(f"Antwort:\n{turn.response}\n")
+
+    if args.output:
+        ensure_directory(args.output)
+        transcript.save(args.output)
+        stats = transcript.stats()
+        print(
+            f"Gesprächsprotokoll gespeichert in {args.output}"
+            f" (Runden: {stats.turns}, eindeutige Quellen: {stats.unique_sources})."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - Skript-Einstiegspunkt
+    sys.exit(main())

--- a/tests/test_rag_transcript.py
+++ b/tests/test_rag_transcript.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag_chatbot.chat import ChatSession
+from rag_chatbot.retrieval import SearchResult
+from rag_chatbot.transcript import ChatTranscript
+
+
+@dataclass
+class FakeIndex:
+    results: list[SearchResult]
+
+    def search(self, query: str, *, top_k: int, min_score: float):
+        return self.results[:top_k]
+
+
+def test_transcript_records_turn_and_stats() -> None:
+    results = [
+        SearchResult(
+            chunk_id="doc:1",
+            score=0.8,
+            text="QuizRace ist eine Plattform für Quiz-Events.",
+            metadata={"title": "README", "chunk_index": 0},
+        ),
+        SearchResult(
+            chunk_id="doc:2",
+            score=0.6,
+            text="Die Anwendung verwendet Slim Framework.",
+            metadata={"title": "README", "chunk_index": 1},
+        ),
+    ]
+    transcript = ChatTranscript()
+
+    session = ChatSession(
+        FakeIndex(results),
+        responder=lambda prompt: "Antwort aus der Wissensbasis.",
+        top_k=2,
+        transcript=transcript,
+    )
+
+    session.send("Was ist QuizRace?")
+
+    assert len(transcript.turns) == 1
+    turn = transcript.turns[0]
+    assert turn.question == "Was ist QuizRace?"
+    assert turn.response.startswith("Antwort aus der Wissensbasis")
+    assert len(turn.context) == 2
+    assert turn.context[0].metadata["title"] == "README"
+
+    stats = transcript.stats()
+    assert stats.turns == 1
+    assert stats.context_items == 2
+    assert stats.unique_sources == 1
+    assert stats.average_score == 0.7
+
+
+def test_transcript_save_creates_json(tmp_path: Path) -> None:
+    results = [
+        SearchResult(
+            chunk_id="doc:42",
+            score=0.9,
+            text="QuizRace unterstützt Team-Wettbewerbe.",
+            metadata={"source": "docs/features.md"},
+        ),
+    ]
+    transcript = ChatTranscript()
+    session = ChatSession(
+        FakeIndex(results),
+        responder=lambda prompt: "Antwort mit Kontext.",
+        top_k=1,
+        transcript=transcript,
+    )
+
+    session.send("Welche Wettbewerbe unterstützt QuizRace?")
+
+    output = tmp_path / "transcript.json"
+    transcript.save(output)
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert "turns" in payload
+    assert len(payload["turns"]) == 1
+    assert payload["turns"][0]["question"].startswith("Welche Wettbewerbe")
+    assert payload["stats"]["turns"] == 1
+    assert payload["stats"]["unique_sources"] == 1


### PR DESCRIPTION
## Summary
- add transcript utilities that capture chat turns with context metadata and statistics
- extend ChatSession to optionally record transcripts and expose a batch evaluation CLI
- document Phase 4 in the implementation journal and add tests for transcript recording

## Testing
- pytest tests/test_rag_transcript.py tests/test_rag_chat.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb3174874832bbc7a62180937122c