### PR TITLE
Add reporting phase to RAG chatbot pipeline

### DIFF
--- a/docs/rag-chatbot/implementation-journal.md
+++ b/docs/rag-chatbot/implementation-journal.md
@@ -1,7 +1,7 @@
 # RAG Chatbot – Implementation Journal
 
 Dieses Journal begleitet den Aufbau eines Retrieval-Augmented-Generation-Chatbots für die QuizRace-Dokumentation.
-Die Arbeit ist in vier Phasen gegliedert. Dieses Journal beschreibt die Umsetzung von **Phase 1** bis **Phase 4**.
+Die Arbeit ist in fünf Phasen gegliedert. Dieses Journal beschreibt die Umsetzung von **Phase 1** bis **Phase 5**.
 
 ## Phase 1: Wissensbasis vorbereiten
 
@@ -77,3 +77,18 @@ Ziele der vierten Phase:
 2. `ChatSession` akzeptiert optional ein `ChatTranscript` und protokolliert automatisch jede Anfrage mitsamt Prompt, Antwort und Kontexttreffern.
 3. CLI-Skript `scripts/rag_eval.py` ergänzt, um Fragenstapel aus einer Textdatei gegen den semantischen Index auszuführen und das erzeugte Transcript als JSON zu speichern.
 4. Neue Tests (`tests/test_rag_transcript.py`) prüfen die Aufzeichnung, Statistikberechnung und den JSON-Export der Gesprächsprotokolle.
+
+## Phase 5: Berichte und Qualitätsmetriken
+
+Ziele der fünften Phase:
+
+- Gesprächsprotokolle automatisiert auswerten und die wichtigsten Kennzahlen hervorheben.
+- Quellenabdeckung sichtbar machen, um blinde Flecken in der Wissensbasis aufzudecken.
+- Einen leicht nutzbaren CLI-Workflow schaffen, der vorhandene Transkripte zusammenfasst.
+
+### Umsetzungsschritte
+
+1. Neues Modul `rag_chatbot/report.py` implementiert. Es erzeugt strukturierte Berichte mit Trefferanzahl, Durchschnitts- und Maximal-Scores pro Quelle und stellt eine menschenlesbare Ausgabe bereit.
+2. `ChatTranscript` um Ladefunktionen (`from_dict`, `load`) erweitert, damit gespeicherte JSON-Dateien direkt wieder eingelesen werden können. `TranscriptContext` und `TranscriptTurn` besitzen nun passende `from_dict`-Hilfsfunktionen.
+3. CLI-Skript `scripts/rag_report.py` ergänzt. Es lädt ein Transcript, erzeugt den Bericht und gibt ihn als Text oder JSON aus. Parameter wie `--top` steuern die Anzahl der angezeigten Quellen.
+4. Neue Tests (`tests/test_rag_report.py`) prüfen Report-Erstellung, Formatierung und den Roundtrip zwischen Speichern und Laden eines Transkripts.

--- a/rag_chatbot/__init__.py
+++ b/rag_chatbot/__init__.py
@@ -4,6 +4,15 @@ from .chat import ChatMessage, ChatPrompt, ChatResponder, ChatSession, ChatTurn
 from .corpus_builder import BuildOptions, BuildResult, build_corpus
 from .index_builder import IndexOptions, IndexResult, build_index
 from .loader import Document
+from .report import (
+    SourceReport,
+    TranscriptReport,
+    build_report,
+    format_report,
+    load_report,
+    load_transcript,
+    report_from_json,
+)
 from .retrieval import SearchResult, SemanticIndex
 from .transcript import ChatTranscript, TranscriptContext, TranscriptStats, TranscriptTurn
 
@@ -22,8 +31,15 @@ __all__ = [
     "IndexResult",
     "SemanticIndex",
     "SearchResult",
+    "SourceReport",
+    "TranscriptReport",
     "ChatTranscript",
     "TranscriptContext",
     "TranscriptStats",
     "TranscriptTurn",
+    "build_report",
+    "format_report",
+    "load_report",
+    "load_transcript",
+    "report_from_json",
 ]

--- a/rag_chatbot/report.py
+++ b/rag_chatbot/report.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+"""Auswertung von Gesprächsprotokollen für den RAG-Chatbot."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean
+import json
+
+from .transcript import ChatTranscript, TranscriptStats
+
+
+@dataclass(frozen=True)
+class SourceReport:
+    """Kennzahlen für eine Quelle innerhalb eines Transkripts."""
+
+    source: str
+    hits: int
+    average_score: float
+    max_score: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "source": self.source,
+            "hits": self.hits,
+            "average_score": self.average_score,
+            "max_score": self.max_score,
+        }
+
+
+@dataclass(frozen=True)
+class TranscriptReport:
+    """Aggregierte Auswertung eines Gesprächsprotokolls."""
+
+    stats: TranscriptStats
+    sources: tuple[SourceReport, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "stats": self.stats.to_dict(),
+            "sources": [source.to_dict() for source in self.sources],
+        }
+
+
+def build_report(transcript: ChatTranscript) -> TranscriptReport:
+    """Erstellt einen Bericht mit Kennzahlen zu einem Transcript."""
+
+    stats = transcript.stats()
+    if stats.turns == 0:
+        return TranscriptReport(stats=stats, sources=tuple())
+
+    buckets: dict[str, list[float]] = {}
+    for turn in transcript.turns:
+        for idx, context in enumerate(turn.context):
+            source = str(context.metadata.get("source") or context.metadata.get("title") or context.chunk_id)
+            buckets.setdefault(source, []).append(context.score)
+
+    sources = tuple(
+        SourceReport(
+            source=source,
+            hits=len(scores),
+            average_score=round(mean(scores), 6),
+            max_score=round(max(scores), 6),
+        )
+        for source, scores in sorted(
+            buckets.items(),
+            key=lambda item: (len(item[1]), mean(item[1])),
+            reverse=True,
+        )
+    )
+
+    return TranscriptReport(stats=stats, sources=sources)
+
+
+def format_report(report: TranscriptReport, *, top_k: int = 5) -> str:
+    """Formatiert den Bericht menschenlesbar."""
+
+    stats = report.stats
+    lines = [
+        "Auswertung des Gesprächsprotokolls:",
+        f"- Runden: {stats.turns}",
+        f"- Kontexttreffer: {stats.context_items}",
+        f"- Durchschnittlicher Score: {stats.average_score}",
+        f"- Einzigartige Quellen: {stats.unique_sources}",
+    ]
+
+    if report.sources:
+        lines.append("")
+        lines.append("Top-Quellen:")
+        for position, source in enumerate(report.sources[:top_k], start=1):
+            lines.append(
+                f"{position}. {source.source} – "
+                f"Treffer: {source.hits}, ⌀ Score: {source.average_score}, Max: {source.max_score}"
+            )
+    else:
+        lines.append("")
+        lines.append("Keine Kontexte im Protokoll vorhanden.")
+
+    return "\n".join(lines)
+
+
+def load_transcript(path: Path) -> ChatTranscript:
+    """Lädt ein gespeichertes Transcript von der Festplatte."""
+
+    return ChatTranscript.load(path)
+
+
+def load_report(path: Path) -> TranscriptReport:
+    """Lädt ein Transcript und gibt dessen Bericht zurück."""
+
+    transcript = load_transcript(path)
+    return build_report(transcript)
+
+
+def report_from_json(text: str) -> TranscriptReport:
+    """Erstellt einen Bericht aus JSON-Text."""
+
+    data = json.loads(text)
+    if not isinstance(data, dict):  # pragma: no cover - defensive programming
+        raise ValueError("Das JSON-Dokument muss ein Objekt enthalten.")
+    transcript = ChatTranscript.from_dict(data)
+    return build_report(transcript)
+
+
+__all__ = [
+    "SourceReport",
+    "TranscriptReport",
+    "build_report",
+    "format_report",
+    "load_transcript",
+    "load_report",
+    "report_from_json",
+]

--- a/scripts/rag_report.py
+++ b/scripts/rag_report.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Erzeugt eine Auswertung für gespeicherte RAG-Transkripte."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from rag_chatbot.report import build_report, format_report, load_transcript
+
+DEFAULT_TRANSCRIPT_PATH = Path("data/rag-chatbot/transcript.json")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Erstellt eine Zusammenfassung für ein RAG-Transcript.")
+    parser.add_argument(
+        "transcript",
+        nargs="?",
+        default=DEFAULT_TRANSCRIPT_PATH,
+        type=Path,
+        help="Pfad zur Transcript-JSON-Datei",
+    )
+    parser.add_argument("--top", type=int, default=5, help="Anzahl der aufzulistenden Top-Quellen")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Bericht als JSON ausgeben",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        transcript = load_transcript(Path(args.transcript))
+    except FileNotFoundError:
+        print(f"Transcript-Datei {args.transcript} wurde nicht gefunden.", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"Fehler beim Laden des Transcripts: {exc}", file=sys.stderr)
+        return 1
+
+    report = build_report(transcript)
+
+    if args.json:
+        payload = report.to_dict()
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(format_report(report, top_k=args.top))
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - Skript Einstiegspunkt
+    sys.exit(main())

--- a/tests/test_rag_report.py
+++ b/tests/test_rag_report.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rag_chatbot.chat import ChatMessage
+from rag_chatbot.report import build_report, format_report, load_report, load_transcript, report_from_json
+from rag_chatbot.transcript import ChatTranscript, TranscriptContext, TranscriptTurn
+
+
+def sample_transcript() -> ChatTranscript:
+    transcript = ChatTranscript()
+    turn_one = TranscriptTurn(
+        question="Was ist QuizRace?",
+        response="Eine Event-Anwendung.",
+        context=(
+            TranscriptContext(
+                chunk_id="chunk-1",
+                score=0.42,
+                text="QuizRace ist eine Web-Anwendung für Veranstaltungen.",
+                metadata={"source": "docs/about.md"},
+            ),
+            TranscriptContext(
+                chunk_id="chunk-2",
+                score=0.37,
+                text="Die Anwendung basiert auf Slim.",
+                metadata={"title": "README"},
+            ),
+        ),
+        prompt_messages=(
+            ChatMessage("system", "system"),
+            ChatMessage("user", "Was ist QuizRace?"),
+            ChatMessage("assistant", "Eine Event-Anwendung."),
+        ),
+    )
+    turn_two = TranscriptTurn(
+        question="Welche Daten speichert QuizRace?",
+        response="Es werden keine personenbezogenen Daten gespeichert.",
+        context=(
+            TranscriptContext(
+                chunk_id="chunk-3",
+                score=0.81,
+                text="Keine personenbezogenen Daten werden erhoben.",
+                metadata={"source": "docs/datenschutz.md"},
+            ),
+        ),
+        prompt_messages=(
+            ChatMessage("system", "system"),
+            ChatMessage("user", "Welche Daten speichert QuizRace?"),
+            ChatMessage("assistant", "Es werden keine personenbezogenen Daten gespeichert."),
+        ),
+    )
+    transcript.extend([turn_one, turn_two])
+    return transcript
+
+
+def test_build_report_summarises_transcript() -> None:
+    transcript = sample_transcript()
+    report = build_report(transcript)
+
+    assert report.stats.turns == 2
+    assert report.stats.context_items == 3
+    assert report.stats.unique_sources == 3
+
+    top_sources = {source.source: source for source in report.sources}
+    assert "docs/about.md" in top_sources
+    assert top_sources["docs/about.md"].hits == 1
+    assert top_sources["docs/about.md"].average_score == 0.42
+
+
+def test_format_report_produces_human_readable_text() -> None:
+    transcript = sample_transcript()
+    report = build_report(transcript)
+
+    output = format_report(report, top_k=2)
+    assert "Auswertung des Gesprächsprotokolls" in output
+    assert "Top-Quellen" in output
+    assert "docs/datenschutz.md" in output
+
+
+def test_transcript_roundtrip(tmp_path: Path) -> None:
+    transcript = sample_transcript()
+    path = tmp_path / "transcript.json"
+    transcript.save(path)
+
+    loaded = load_transcript(path)
+    assert loaded.turns == transcript.turns
+
+    report = load_report(path)
+    assert report.stats.turns == 2
+
+
+def test_report_from_json_accepts_dumped_transcript() -> None:
+    transcript = sample_transcript()
+    payload = transcript.to_dict()
+    text = json.dumps(payload)
+
+    report = report_from_json(text)
+    assert report.stats.turns == 2


### PR DESCRIPTION
## Summary
- document Phase 5 of the RAG chatbot journal and describe the new reporting workflow
- add transcript loading helpers and a reporting module that aggregates per-source stats
- expose a rag_report CLI and tests that cover report generation and formatting

## Testing
- pytest tests/test_rag_report.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb63ddcf4832bb9d648d95d8acb59