### PR TITLE
Add automated pipeline workflow for RAG chatbot

### DIFF
--- a/docs/rag-chatbot/implementation-journal.md
+++ b/docs/rag-chatbot/implementation-journal.md
@@ -92,3 +92,17 @@ Ziele der fünften Phase:
 2. `ChatTranscript` um Ladefunktionen (`from_dict`, `load`) erweitert, damit gespeicherte JSON-Dateien direkt wieder eingelesen werden können. `TranscriptContext` und `TranscriptTurn` besitzen nun passende `from_dict`-Hilfsfunktionen.
 3. CLI-Skript `scripts/rag_report.py` ergänzt. Es lädt ein Transcript, erzeugt den Bericht und gibt ihn als Text oder JSON aus. Parameter wie `--top` steuern die Anzahl der angezeigten Quellen.
 4. Neue Tests (`tests/test_rag_report.py`) prüfen Report-Erstellung, Formatierung und den Roundtrip zwischen Speichern und Laden eines Transkripts.
+
+## Phase 6: Automatisierter Pipeline-Workflow
+
+Ziele der sechsten Phase:
+
+- Wissensbasis und semantischen Index in einem wiederholbaren Schritt aktualisieren.
+- Änderungen an den Dokumentationsquellen automatisch erkennen und nur notwendige Schritte neu ausführen.
+- Den Workflow über ein CLI-Werkzeug ansteuerbar machen und durch Tests absichern.
+
+### Umsetzungsschritte
+
+1. Neues Modul `rag_chatbot/pipeline.py` entwickelt. Es bündelt Konfiguration (`PipelineOptions`), Ergebnisobjekte (`PipelineResult`) und die Funktion `run_pipeline()`, die auf Basis von Zeitstempeln entscheidet, ob Wissensbasis oder Index neu erzeugt werden müssen.
+2. Skript `scripts/rag_pipeline.py` hinzugefügt. Es kombiniert Corpus- und Indexaufbau in einer Kommandozeilenoberfläche, erlaubt optionale Parameter (Chunk-Größe, Vokabularbegrenzung, `--force`) und informiert, ob Schritte übersprungen wurden.
+3. Ergänzende Tests (`tests/test_rag_pipeline.py`) prüfen Neuaufbau, Überspringen unveränderter Artefakte, das Erzwingen von Rebuilds sowie Fehlerbehandlung bei fehlenden Quellen.

--- a/rag_chatbot/__init__.py
+++ b/rag_chatbot/__init__.py
@@ -4,6 +4,7 @@ from .chat import ChatMessage, ChatPrompt, ChatResponder, ChatSession, ChatTurn
 from .corpus_builder import BuildOptions, BuildResult, build_corpus
 from .index_builder import IndexOptions, IndexResult, build_index
 from .loader import Document
+from .pipeline import PipelineOptions, PipelineResult, run_pipeline
 from .report import (
     SourceReport,
     TranscriptReport,
@@ -37,9 +38,12 @@ __all__ = [
     "TranscriptContext",
     "TranscriptStats",
     "TranscriptTurn",
+    "PipelineOptions",
+    "PipelineResult",
     "build_report",
     "format_report",
     "load_report",
     "load_transcript",
     "report_from_json",
+    "run_pipeline",
 ]

--- a/rag_chatbot/pipeline.py
+++ b/rag_chatbot/pipeline.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Automatisierter Workflow zum Erzeugen von Wissensbasis und Index."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from .corpus_builder import BuildOptions, BuildResult, build_corpus
+from .index_builder import IndexOptions, IndexResult, build_index
+from .loader import iter_source_files
+
+
+@dataclass(frozen=True)
+class PipelineOptions:
+    """Einstellungen für den End-to-End-Aufbau der Wissensbasis."""
+
+    sources: Sequence[Path]
+    corpus_path: Path
+    index_path: Path
+    max_words: int = 180
+    overlap: int = 40
+    max_features: int | None = None
+    min_term_length: int = 2
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """Ergebnis des Pipeline-Durchlaufs."""
+
+    corpus: BuildResult | None
+    index: IndexResult | None
+    skipped: tuple[str, ...]
+
+
+def run_pipeline(options: PipelineOptions) -> PipelineResult:
+    """Führt den kompletten Aufbau inklusive Index aus."""
+
+    source_files = _collect_source_files(options.sources)
+    skipped: list[str] = []
+
+    corpus_result: BuildResult | None
+    if options.force or _needs_rebuild(options.corpus_path, source_files):
+        corpus_options = BuildOptions(
+            sources=options.sources,
+            output_path=options.corpus_path,
+            max_words=options.max_words,
+            overlap=options.overlap,
+        )
+        corpus_result = build_corpus(corpus_options)
+    else:
+        corpus_result = None
+        skipped.append("corpus")
+
+    index_dependencies: list[Path] = [options.corpus_path]
+    index_result: IndexResult | None
+    if options.force or corpus_result is not None or _needs_rebuild(options.index_path, index_dependencies):
+        index_options = IndexOptions(
+            corpus_path=options.corpus_path,
+            output_path=options.index_path,
+            max_features=options.max_features,
+            min_term_length=options.min_term_length,
+        )
+        index_result = build_index(index_options)
+    else:
+        index_result = None
+        skipped.append("index")
+
+    return PipelineResult(corpus=corpus_result, index=index_result, skipped=tuple(skipped))
+
+
+def _collect_source_files(sources: Sequence[Path]) -> tuple[Path, ...]:
+    if not sources:
+        raise ValueError("Es wurden keine Quellen übergeben.")
+    files: list[Path] = [Path(path) for path in iter_source_files(sources)]
+    if not files:
+        raise ValueError("In den angegebenen Quellen wurden keine unterstützten Dateien gefunden.")
+    return tuple(files)
+
+
+def _needs_rebuild(target: Path, dependencies: Sequence[Path]) -> bool:
+    if not target.exists():
+        return True
+    try:
+        target_mtime = target.stat().st_mtime
+    except FileNotFoundError:  # pragma: no cover - Race condition
+        return True
+    for dependency in dependencies:
+        try:
+            dep_mtime = dependency.stat().st_mtime
+        except FileNotFoundError:
+            continue
+        if dep_mtime > target_mtime:
+            return True
+    return False
+
+
+__all__ = ["PipelineOptions", "PipelineResult", "run_pipeline"]
+

--- a/scripts/rag_pipeline.py
+++ b/scripts/rag_pipeline.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from rag_chatbot import PipelineOptions, run_pipeline
+
+DEFAULT_SOURCES = [
+    Path("README.md"),
+    Path("docs"),
+    Path("content"),
+]
+DEFAULT_CORPUS = Path("data/rag-chatbot/corpus.jsonl")
+DEFAULT_INDEX = Path("data/rag-chatbot/index.json")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Führt Wissensbasis- und Indexaufbau in einem Schritt aus.",
+    )
+    parser.add_argument(
+        "sources",
+        nargs="*",
+        type=Path,
+        default=DEFAULT_SOURCES,
+        help="Dateien oder Ordner mit Dokumentationsinhalten",
+    )
+    parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=DEFAULT_CORPUS,
+        help="Zieldatei für die Wissensbasis (JSONL)",
+    )
+    parser.add_argument(
+        "--index",
+        type=Path,
+        default=DEFAULT_INDEX,
+        help="Zieldatei für den semantischen Index (JSON)",
+    )
+    parser.add_argument(
+        "--max-words",
+        type=int,
+        default=180,
+        help="Maximale Wortanzahl pro Chunk",
+    )
+    parser.add_argument(
+        "--overlap",
+        type=int,
+        default=40,
+        help="Überlappung der Chunks in Wörtern",
+    )
+    parser.add_argument(
+        "--max-features",
+        type=int,
+        default=None,
+        help="Optionales Limit für das TF-IDF-Vokabular",
+    )
+    parser.add_argument(
+        "--min-term-length",
+        type=int,
+        default=2,
+        help="Minimale Länge eines Terms für das Vokabular",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Erzwingt den Neuaufbau unabhängig von Zeitstempeln",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    options = PipelineOptions(
+        sources=args.sources,
+        corpus_path=args.corpus,
+        index_path=args.index,
+        max_words=args.max_words,
+        overlap=args.overlap,
+        max_features=args.max_features,
+        min_term_length=args.min_term_length,
+        force=args.force,
+    )
+
+    result = run_pipeline(options)
+
+    if result.corpus:
+        corpus = result.corpus
+        print(
+            "Wissensbasis aktualisiert:",
+            f"Dokumente: {corpus.documents}",
+            f"Chunks: {corpus.chunks}",
+            f"Ø Wörter pro Chunk: {corpus.average_words}",
+            f"Datei: {corpus.output_path}",
+            sep="\n",
+        )
+    else:
+        print("Wissensbasis ist bereits aktuell.")
+
+    if result.index:
+        index = result.index
+        print(
+            "Index aktualisiert:",
+            f"Chunks: {index.chunks}",
+            f"Vokabulargröße: {index.vocabulary_size}",
+            f"Datei: {index.output_path}",
+            sep="\n",
+        )
+    else:
+        print("Index ist bereits aktuell.")
+
+
+if __name__ == "__main__":  # pragma: no cover - Skripteintrittspunkt
+    main()
+

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -1,0 +1,99 @@
+import os
+from dataclasses import replace
+from pathlib import Path
+
+from rag_chatbot import PipelineOptions, run_pipeline
+
+
+def create_sample_source(tmp_path: Path) -> Path:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    sample = """# Titel\n\nDies ist ein Testdokument. Es enthält mehrere Sätze."""
+    path = docs_dir / "sample.md"
+    path.write_text(sample, encoding="utf-8")
+    return docs_dir
+
+
+def test_pipeline_builds_and_skips_when_up_to_date(tmp_path: Path) -> None:
+    docs_dir = create_sample_source(tmp_path)
+    corpus_path = tmp_path / "data" / "corpus.jsonl"
+    index_path = tmp_path / "data" / "index.json"
+
+    options = PipelineOptions(
+        sources=[docs_dir],
+        corpus_path=corpus_path,
+        index_path=index_path,
+        max_words=50,
+        overlap=10,
+    )
+
+    first = run_pipeline(options)
+    assert first.corpus is not None
+    assert first.index is not None
+    assert first.skipped == ()
+
+    second = run_pipeline(options)
+    assert second.corpus is None
+    assert second.index is None
+    assert "corpus" in second.skipped
+    assert "index" in second.skipped
+
+
+def test_pipeline_rebuilds_when_source_changes(tmp_path: Path) -> None:
+    docs_dir = create_sample_source(tmp_path)
+    corpus_path = tmp_path / "data" / "corpus.jsonl"
+    index_path = tmp_path / "data" / "index.json"
+
+    options = PipelineOptions(
+        sources=[docs_dir],
+        corpus_path=corpus_path,
+        index_path=index_path,
+        max_words=50,
+        overlap=10,
+    )
+
+    run_pipeline(options)
+
+    source_file = next(docs_dir.glob("*.md"))
+    stat = source_file.stat()
+    os.utime(source_file, (stat.st_atime, stat.st_mtime + 5))
+
+    rebuilt = run_pipeline(options)
+    assert rebuilt.corpus is not None
+    assert rebuilt.index is not None
+
+
+def test_pipeline_force_rebuilds(tmp_path: Path) -> None:
+    docs_dir = create_sample_source(tmp_path)
+    corpus_path = tmp_path / "data" / "corpus.jsonl"
+    index_path = tmp_path / "data" / "index.json"
+
+    options = PipelineOptions(
+        sources=[docs_dir],
+        corpus_path=corpus_path,
+        index_path=index_path,
+        max_words=50,
+        overlap=10,
+    )
+
+    run_pipeline(options)
+
+    forced = run_pipeline(replace(options, force=True))
+    assert forced.corpus is not None
+    assert forced.index is not None
+
+
+def test_pipeline_requires_sources(tmp_path: Path) -> None:
+    corpus_path = tmp_path / "data" / "corpus.jsonl"
+    index_path = tmp_path / "data" / "index.json"
+    options = PipelineOptions(
+        sources=[],
+        corpus_path=corpus_path,
+        index_path=index_path,
+    )
+    try:
+        run_pipeline(options)
+    except ValueError as exc:
+        assert "Quellen" in str(exc)
+    else:  # pragma: no cover - sollte nicht erreicht werden
+        raise AssertionError("Pipeline hat fehlende Quellen nicht erkannt")


### PR DESCRIPTION
## Summary
- add a pipeline module that orchestrates corpus and index generation with freshness checks
- provide a rag_pipeline CLI to run the end-to-end workflow and update the implementation journal with Phase 6
- cover the new behaviour with dedicated tests for rebuilds, skips, and forced runs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfb8a6a334832bb2ee6649807b78f4