### PR TITLE
Deduplicate localized marketing start page options

### DIFF
--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -7,6 +7,7 @@ namespace App\Controller\Marketing;
 use App\Application\Seo\PageSeoConfigService;
 use App\Service\LandingNewsService;
 use App\Service\MailService;
+use App\Service\MarketingSlugResolver;
 use App\Service\PageService;
 use App\Service\ProvenExpertRatingService;
 use App\Service\TurnstileConfig;
@@ -279,24 +280,6 @@ class MarketingPageController
     }
 
     private function resolveLocalizedSlug(string $baseSlug, string $locale): string {
-        $locale = strtolower(trim($locale));
-        if ($locale === '' || $locale === 'de') {
-            return $baseSlug;
-        }
-
-        $map = [
-            'calserver' => [
-                'en' => 'calserver-en',
-            ],
-            'calserver-maintenance' => [
-                'en' => 'calserver-maintenance-en',
-            ],
-        ];
-
-        if (isset($map[$baseSlug][$locale])) {
-            return $map[$baseSlug][$locale];
-        }
-
-        return $baseSlug;
+        return MarketingSlugResolver::resolveLocalizedSlug($baseSlug, $locale);
     }
 }

--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -43,8 +43,13 @@ class DomainStartPageService
                 continue;
             }
 
+            $baseSlug = MarketingSlugResolver::resolveBaseSlug($slug);
             $title = trim($page->getTitle());
-            $options[$slug] = $title !== '' ? $title : $this->buildLabelFromSlug($slug);
+            $label = $title !== '' ? $title : $this->buildLabelFromSlug($baseSlug);
+
+            if (!isset($options[$baseSlug]) || $slug === $baseSlug) {
+                $options[$baseSlug] = $label;
+            }
         }
 
         return $options;

--- a/src/Service/MarketingSlugResolver.php
+++ b/src/Service/MarketingSlugResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+final class MarketingSlugResolver
+{
+    /**
+     * Map of base marketing page slugs to their localized counterparts.
+     *
+     * @var array<string,array<string,string>>
+     */
+    public const LOCALIZED_SLUG_MAP = [
+        'calserver' => [
+            'en' => 'calserver-en',
+        ],
+        'calserver-maintenance' => [
+            'en' => 'calserver-maintenance-en',
+        ],
+    ];
+
+    private function __construct()
+    {
+    }
+
+    public static function resolveLocalizedSlug(string $baseSlug, string $locale): string
+    {
+        $locale = strtolower(trim($locale));
+        if ($locale === '' || $locale === 'de') {
+            return $baseSlug;
+        }
+
+        if (isset(self::LOCALIZED_SLUG_MAP[$baseSlug][$locale])) {
+            return self::LOCALIZED_SLUG_MAP[$baseSlug][$locale];
+        }
+
+        return $baseSlug;
+    }
+
+    public static function resolveBaseSlug(string $slug): string
+    {
+        $normalized = strtolower(trim($slug));
+        if ($normalized === '') {
+            return $normalized;
+        }
+
+        foreach (self::LOCALIZED_SLUG_MAP as $baseSlug => $localizedSlugs) {
+            if (in_array($normalized, $localizedSlugs, true)) {
+                return $baseSlug;
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/tests/Service/DomainStartPageServiceTest.php
+++ b/tests/Service/DomainStartPageServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\DomainStartPageService;
+use App\Service\PageService;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class DomainStartPageServiceTest extends TestCase
+{
+    public function testMarketingAliasSlugsAreExcludedFromOptions(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            'CREATE TABLE pages ('
+            . 'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+            . 'slug TEXT NOT NULL, '
+            . 'title TEXT NOT NULL, '
+            . 'content TEXT NOT NULL)'
+        );
+
+        $pdo->exec("INSERT INTO pages (slug, title, content) VALUES ('calserver-en', 'A English Calserver', '...')");
+        $pdo->exec("INSERT INTO pages (slug, title, content) VALUES ('calserver', 'Calserver', '...')");
+        $pdo->exec("INSERT INTO pages (slug, title, content) VALUES ('calserver-maintenance-en', 'A Maintenance EN', '...')");
+        $pdo->exec("INSERT INTO pages (slug, title, content) VALUES ('calserver-maintenance', 'Maintenance', '...')");
+        $pdo->exec("INSERT INTO pages (slug, title, content) VALUES ('special', 'Special Offer', '...')");
+
+        $service = new DomainStartPageService($pdo);
+        $pageService = new PageService($pdo);
+
+        $options = $service->getStartPageOptions($pageService);
+
+        $this->assertArrayHasKey('help', $options);
+        $this->assertArrayHasKey('events', $options);
+        $this->assertArrayHasKey('calserver', $options);
+        $this->assertArrayHasKey('calserver-maintenance', $options);
+        $this->assertArrayHasKey('special', $options);
+        $this->assertArrayNotHasKey('calserver-en', $options);
+        $this->assertArrayNotHasKey('calserver-maintenance-en', $options);
+
+        $this->assertSame('Calserver', $options['calserver']);
+        $this->assertSame('Maintenance', $options['calserver-maintenance']);
+        $this->assertSame('Special Offer', $options['special']);
+        $this->assertCount(5, $options);
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared marketing slug resolver to keep localized mappings in sync
- normalize start page options to ignore localized alias slugs
- cover the behaviour with a domain start page service test

## Testing
- ./vendor/bin/phpunit tests/Service/DomainStartPageServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dfb8c08228832b9ee3e34fa74fa859