### PR TITLE
Trigger proxy reload when marketing domains change

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,10 @@ Let's-Encrypt-Zertifikat, sobald der Container gestartet wird. Damit das
 Stamm-Domain-Zertifikat (`MAIN_DOMAIN`) nicht versehentlich fehlt,
 ergänzt `docker-compose.yml` diesen Host seit Version 4.16 automatisch in
 `VIRTUAL_HOST`/`LETSENCRYPT_HOST`. Zusätzliche Domains kannst du wie
-bisher über `MARKETING_DOMAINS` anhängen.
+bisher über `MARKETING_DOMAINS` anhängen. Beim Start normalisiert der
+Container die Liste (Leerzeichen und Zeilenumbrüche werden entfernt) und
+löst einen Reload des Proxys über `NGINX_RELOADER_URL` aus, sodass der
+`acme-companion` direkt Zertifikate für neue Marketing-Domains anfordert.
 
 Weitere nützliche Variablen in `.env` sind:
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,6 +33,34 @@ if [ ! -f /var/www/data/config.json ] && [ -d /var/www/data-default ]; then
     cp -a /var/www/data-default/. /var/www/data/
 fi
 
+# Normalize the Let's Encrypt host list and trigger a proxy reload when it changes.
+normalize_hosts() {
+    printf '%s' "$1" | tr '\n' ',' | sed -e 's/[[:space:]]//g' -e 's/,\{2,\}/,/g' -e 's/^,//' -e 's/,$//'
+}
+
+if [ -n "$LETSENCRYPT_HOST" ]; then
+    normalized_hosts=$(normalize_hosts "$LETSENCRYPT_HOST")
+    cache_file=/var/www/data/.letsencrypt-hosts
+
+    if [ "$normalized_hosts" != "$LETSENCRYPT_HOST" ]; then
+        echo "Warning: LETSENCRYPT_HOST contains whitespace; normalized to '$normalized_hosts'" >&2
+    fi
+
+    if [ -n "$normalized_hosts" ]; then
+        mkdir -p "$(dirname "$cache_file")"
+        if [ ! -f "$cache_file" ] || [ "$(cat "$cache_file" 2>/dev/null)" != "$normalized_hosts" ]; then
+            echo "$normalized_hosts" > "$cache_file"
+            if [ -n "$NGINX_RELOADER_URL" ]; then
+                if curl -fs -X POST -H "X-Token: ${NGINX_RELOAD_TOKEN:-changeme}" "$NGINX_RELOADER_URL" >/dev/null; then
+                    echo "Triggered nginx reload for updated certificate host list"
+                else
+                    echo "Warning: Failed to trigger nginx reload at $NGINX_RELOADER_URL" >&2
+                fi
+            fi
+        fi
+    fi
+fi
+
 if [ -n "$POSTGRES_DSN" ] && [ -f docs/schema.sql ]; then
     host=$(echo "$POSTGRES_DSN" | sed -n 's/.*host=\([^;]*\).*/\1/p')
     port=$(echo "$POSTGRES_DSN" | sed -n 's/.*port=\([^;]*\).*/\1/p')


### PR DESCRIPTION
## Summary
- normalize the LETSENCRYPT host list in the Docker entrypoint and trigger the nginx reload webhook when it changes
- document the automatic reload behaviour for marketing domains in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfb6cf0adc832ba024052df3a183b2