### PR TITLE
Ensure renew_ssl.sh starts nginx reloader before executing reload

### DIFF
--- a/scripts/renew_ssl.sh
+++ b/scripts/renew_ssl.sh
@@ -46,6 +46,12 @@ if ! curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null; th
       COMPOSE_CMD="$COMPOSE_CMD -p \"$SLUG\""
     fi
 
+    # Ensure the reload helper is running before we attempt to exec into it.
+    if ! sh -c "$COMPOSE_CMD up -d --no-deps \"$RELOADER_SERVICE\"" >/dev/null 2>&1; then
+      echo "Failed to start $RELOADER_SERVICE" >&2
+      exit 1
+    fi
+
     if ! sh -c "$COMPOSE_CMD exec -T \"$RELOADER_SERVICE\" curl -fs -X POST -H \"X-Token: $RELOAD_TOKEN\" http://127.0.0.1:8080/reload" >/dev/null 2>&1; then
       echo "Failed to trigger nginx reload" >&2
       exit 1


### PR DESCRIPTION
## Summary
- start the nginx-reloader service before invoking the curl fallback in renew_ssl.sh
- fail fast when the reloader container cannot be started

## Testing
- not run (infrastructure-dependent script)


------
https://chatgpt.com/codex/tasks/task_e_68dfe16e0e24832b9adf12c64bd898d0