### PR TITLE
Fix phpstan issues in semantic index

### DIFF
--- a/src/Service/RagChat/SemanticIndex.php
+++ b/src/Service/RagChat/SemanticIndex.php
@@ -116,7 +116,7 @@ final class SemanticIndex
     }
 
     /**
-     * @param array<int, array{id:mixed,text:mixed,metadata?:mixed,vector?:mixed,norm?:mixed}> $items
+     * @param array<int, mixed> $items
      *
      * @return array<int, array{id:string,text:string,metadata:array<string,mixed>,vector:array<int,float>,norm:float}>
      */
@@ -171,14 +171,19 @@ final class SemanticIndex
             return [];
         }
 
-        $text = mb_strtolower($text, 'UTF-8');
-        if ($text === '') {
+        $lowercase = mb_strtolower($text, 'UTF-8');
+        if ($lowercase === '') {
             return [];
         }
 
         $matches = [];
-        preg_match_all(self::TOKEN_PATTERN, $text, $matches);
-        $tokens = $matches[0] ?? [];
+        $matchCount = preg_match_all(self::TOKEN_PATTERN, $lowercase, $matches);
+        if ($matchCount === false || $matchCount === 0) {
+            return [];
+        }
+
+        /** @var list<string> $tokens */
+        $tokens = $matches[0];
         if ($tokens === []) {
             return [];
         }
@@ -197,9 +202,6 @@ final class SemanticIndex
         }
 
         $total = array_sum($counts);
-        if ($total <= 0) {
-            return [];
-        }
 
         $vector = [];
         foreach ($counts as $index => $count) {


### PR DESCRIPTION
## Summary
- relax the semantic index payload type hint so non-array items are skipped safely
- adjust tokenisation logic to work with a lowercase copy and handle empty match counts explicitly
- remove redundant guard on the TF total after counting tokens

## Testing
- vendor/bin/phpstan analyse -c phpstan.neon.dist *(fails: vendor/bin/phpstan missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe2a9c588832b93daa4b412642939