### PR TITLE
Remove redundant empty string check in semantic index vectorisation

### DIFF
--- a/src/Service/RagChat/SemanticIndex.php
+++ b/src/Service/RagChat/SemanticIndex.php
@@ -172,9 +172,6 @@ final class SemanticIndex
         }
 
         $lowercase = mb_strtolower($text, 'UTF-8');
-        if ($lowercase === '') {
-            return [];
-        }
 
         $matches = [];
         $matchCount = preg_match_all(self::TOKEN_PATTERN, $lowercase, $matches);


### PR DESCRIPTION
## Summary
- remove the redundant empty-string guard after lowercasing trimmed text to satisfy phpstan

## Testing
- vendor/bin/phpstan --no-progress --memory-limit=512M *(fails: vendor/bin/phpstan missing in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe3cdade4832bbec25fe61f59f6fe