### PR TITLE
Improve renew_ssl.sh environment handling for nginx reload

### DIFF
--- a/scripts/renew_ssl.sh
+++ b/scripts/renew_ssl.sh
@@ -3,14 +3,53 @@
 set -e
 
 SCRIPT_DIR="$(dirname "$0")"
+ENV_FILE="${ENV_FILE:-$SCRIPT_DIR/../.env}"
+
+# Preserve manually exported values before loading .env defaults
+ORIG_RELOAD_TOKEN="${NGINX_RELOAD_TOKEN-}"
+ORIG_RELOADER_URL="${NGINX_RELOADER_URL-}"
+ORIG_NGINX_CONTAINER="${NGINX_CONTAINER-}"
+
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+fi
+
+# Restore explicitly exported values so we do not override the caller's environment
+if [ -n "$ORIG_RELOAD_TOKEN" ]; then
+  NGINX_RELOAD_TOKEN="$ORIG_RELOAD_TOKEN"
+fi
+
+if [ -n "$ORIG_RELOADER_URL" ]; then
+  NGINX_RELOADER_URL="$ORIG_RELOADER_URL"
+fi
+
+if [ -n "$ORIG_NGINX_CONTAINER" ]; then
+  NGINX_CONTAINER="$ORIG_NGINX_CONTAINER"
+fi
 
 if [ "$#" -lt 1 ]; then
   echo "Usage: $0 <tenant-slug>|--main" >&2
   exit 1
 fi
 
-RELOADER_URL="${NGINX_RELOADER_URL:-http://nginx-reloader:8080/reload}"
-RELOAD_TOKEN="${NGINX_RELOAD_TOKEN:-changeme}"
+if [ "${NGINX_RELOADER_URL+x}" = "x" ]; then
+  RELOADER_URL="$NGINX_RELOADER_URL"
+else
+  RELOADER_URL="http://nginx-reloader:8080/reload"
+fi
+
+if [ "${NGINX_RELOAD_TOKEN+x}" = "x" ]; then
+  RELOAD_TOKEN="$NGINX_RELOAD_TOKEN"
+else
+  RELOAD_TOKEN="changeme"
+fi
+
+if [ "${NGINX_CONTAINER+x}" = "x" ]; then
+  RELOAD_TARGET="$NGINX_CONTAINER"
+else
+  RELOAD_TARGET="nginx"
+fi
 
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   DOCKER_COMPOSE="docker compose"
@@ -37,9 +76,36 @@ else
   fi
 fi
 
-if ! curl -fs -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" >/dev/null; then
-  echo "Failed to trigger nginx reload" >&2
-  exit 1
+RELOAD_SUCCESS=0
+
+if [ -n "$RELOADER_URL" ]; then
+  HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "X-Token: $RELOAD_TOKEN" "$RELOADER_URL" || true)
+  if [ "$HTTP_STATUS" = "200" ]; then
+    RELOAD_SUCCESS=1
+  elif [ -n "$HTTP_STATUS" ]; then
+    echo "nginx reload webhook responded with HTTP $HTTP_STATUS, falling back to local docker exec" >&2
+  else
+    echo "nginx reload webhook unreachable, falling back to local docker exec" >&2
+  fi
+else
+  echo "nginx reload webhook disabled, falling back to local docker exec" >&2
+fi
+
+if [ "$RELOAD_SUCCESS" -eq 0 ]; then
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Failed to trigger nginx reload: docker CLI not available for local fallback" >&2
+    exit 1
+  fi
+
+  if ! docker ps --format '{{.Names}}' | grep -Fxq "$RELOAD_TARGET"; then
+    echo "Failed to trigger nginx reload: container '$RELOAD_TARGET' not found" >&2
+    exit 1
+  fi
+
+  if ! docker exec "$RELOAD_TARGET" nginx -s reload >/dev/null 2>&1; then
+    echo "Failed to trigger nginx reload via docker exec" >&2
+    exit 1
+  fi
 fi
 
 if [ -z "$DOCKER_COMPOSE" ]; then


### PR DESCRIPTION
## Summary
- load the renew_ssl.sh environment defaults from the deployment .env file while keeping manually exported overrides
- add a docker exec fallback when the nginx reload webhook cannot be reached and provide clearer diagnostics

## Testing
- ./scripts/renew_ssl.sh


------
https://chatgpt.com/codex/tasks/task_e_68dfbf6fc180832b900676fc85884276