### PR TITLE
Adjust maintenance landing topbar and hero buttons

### DIFF
--- a/public/css/calserver-maintenance.css
+++ b/public/css/calserver-maintenance.css
@@ -77,17 +77,40 @@ body.qr-landing.calserver-maintenance-theme {
   gap: 1rem;
 }
 
+.calserver-maintenance-hero__actions .uk-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 0.85rem 1.9rem;
+  min-height: 3.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.35;
+  transition: transform 0.18s ease, box-shadow 0.2s ease,
+    background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.calserver-maintenance-hero__actions .uk-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.45);
+}
+
 .calserver-maintenance-hero__actions .uk-button-primary {
   background: linear-gradient(135deg, #2563eb, #38bdf8);
   border: none;
   color: #0b1220;
   font-weight: 600;
+  box-shadow: 0 22px 38px rgba(37, 99, 235, 0.32);
 }
 
 .calserver-maintenance-hero__actions .uk-button-primary:hover,
 .calserver-maintenance-hero__actions .uk-button-primary:focus {
   background: linear-gradient(135deg, #1d4ed8, #0ea5e9);
   color: #f8fafc;
+  transform: translateY(-1px);
+  box-shadow: 0 24px 44px rgba(14, 165, 233, 0.35);
 }
 
 .calserver-maintenance-hero__actions .uk-button-default {
@@ -100,6 +123,7 @@ body.qr-landing.calserver-maintenance-theme {
 .calserver-maintenance-hero__actions .uk-button-default:focus {
   border-color: rgba(148, 163, 184, 0.7);
   color: #f8fafc;
+  transform: translateY(-1px);
 }
 
 .calserver-maintenance-status-card {

--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -381,7 +381,7 @@ body.qr-landing .site-footer {
   backdrop-filter: blur(8px);
   color:var(--qr-text);
   min-height:64px;
-  height:64px;
+  padding:12px 0;
   border-bottom: 1px solid var(--qr-card-border);
   position: sticky;
   top: 0;
@@ -390,7 +390,7 @@ body.qr-landing .site-footer {
 @media (max-width: 959px) {
   .qr-landing .qr-topbar{
     min-height:56px;
-    height:56px;
+    padding:8px 0;
   }
 }
 body.dark-mode .qr-landing .qr-topbar{


### PR DESCRIPTION
## Summary
- allow the landing topbar to grow with its contents by replacing the fixed height with responsive padding
- restyle the maintenance hero buttons with consistent spacing, pill shapes, and stronger focus/hover states

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dfe6639ea0832b9dceec5f088f1d17