### PR TITLE
Add curl to nginx reloader image

### DIFF
--- a/nginx-reloader/Dockerfile
+++ b/nginx-reloader/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-alpine
 
 # The reloader needs the Docker CLI to send reload commands
-RUN apk add --no-cache docker-cli \
+RUN apk add --no-cache docker-cli curl \
     && pip install flask
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- install curl in the nginx-reloader Docker image to provide a minimal HTTP client for fallback requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfedda2108832bacf7c95417b31a9f