### PR TITLE
Fix mobile topbar spacing on calserver maintenance page

### DIFF
--- a/public/css/calserver-maintenance.css
+++ b/public/css/calserver-maintenance.css
@@ -17,6 +17,14 @@ body.qr-landing.calserver-maintenance-theme {
   background: transparent;
 }
 
+@media (max-width: 959px) {
+  .calserver-maintenance-theme .qr-topbar {
+    height: auto;
+    min-height: 72px;
+    padding-block: 16px;
+  }
+}
+
 .calserver-maintenance-theme .uk-navbar-nav > li > a {
   color: #cbd5f5;
   font-weight: 500;


### PR DESCRIPTION
## Summary
- add a mobile-specific override for the calserver maintenance topbar so the sticky header clears the hamburger toggle

## Testing
- not run (css-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dff04f6af8832bb8c062ecacbe536b