### PR TITLE
Fix hero button sizing on calserver maintenance page

### DIFF
--- a/public/css/calserver-maintenance.css
+++ b/public/css/calserver-maintenance.css
@@ -77,6 +77,21 @@ body.qr-landing.calserver-maintenance-theme {
   gap: 1rem;
 }
 
+.calserver-maintenance-hero__actions .uk-button.git-btn {
+  width: auto;
+  height: auto;
+  min-width: 0;
+  min-height: 0;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
 .calserver-maintenance-hero__actions .uk-button-primary {
   background: linear-gradient(135deg, #2563eb, #38bdf8);
   border: none;


### PR DESCRIPTION
## Summary
- override the git button defaults inside the maintenance hero to allow full-width CTA sizing
- adjust padding, radius and alignment so both hero buttons render at the expected standard dimensions

## Testing
- Manual visual check of http://127.0.0.1:8000/calserver-maintenance

------
https://chatgpt.com/codex/tasks/task_e_68dff0f2d534832b8ca7d37fe1b27e98