### PR TITLE
Remove extra topbar padding above options button

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -245,7 +245,6 @@ body.uk-padding {
   right: 0;
   min-height: 56px;
   padding: 0 0.5rem;
-  padding-top: env(safe-area-inset-top);
   box-sizing: border-box;
   z-index: 1000;
   display: flex;


### PR DESCRIPTION
## Summary
- remove the safe-area padding from the sticky topbar so the options button sits flush at the top

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dff3ac5184832b97befaac6c75038a