### PR TITLE
Add landing news tab to admin pages

### DIFF
--- a/templates/admin.twig
+++ b/templates/admin.twig
@@ -922,12 +922,14 @@
       <li class="{{ activeRoute == 'pages' ? 'uk-active' }}">
         <div class="uk-container uk-container-large">
           <h2 class="uk-heading-bullet">{{ t('heading_pages') }}</h2>
+          {% set currentPageTab = pageTab|default('seo') %}
           <ul id="pageTabs" class="uk-tab" uk-tab="connect: #pageSwitcher">
-            <li class="uk-active"><a href="#">{{ t('tab_landingpage_seo') }}</a></li>
-            <li><a href="#">{{ t('tab_landingpage_content') }}</a></li>
+            <li class="{{ currentPageTab == 'seo' ? 'uk-active' }}"><a href="#">{{ t('tab_landingpage_seo') }}</a></li>
+            <li class="{{ currentPageTab == 'content' ? 'uk-active' }}"><a href="#">{{ t('tab_landingpage_content') }}</a></li>
+            <li class="{{ currentPageTab == 'landing-news' ? 'uk-active' }}"><a href="#">{{ t('tab_landing_news') }}</a></li>
           </ul>
           <ul id="pageSwitcher" class="uk-switcher uk-margin">
-            <li>
+            <li class="{{ currentPageTab == 'seo' ? 'uk-active' }}">
               {% if seo_pages|default([]) is empty %}
                 <div class="uk-alert uk-alert-warning">{{ t('text_no_marketing_pages') }}</div>
               {% else %}
@@ -1015,7 +1017,7 @@
               </form>
               {% endif %}
             </li>
-            <li>
+            <li class="{{ currentPageTab == 'content' ? 'uk-active' }}">
               {% if pages|default([]) is empty %}
                 <div class="uk-alert uk-alert-warning">{{ t('text_no_marketing_pages') }}</div>
               {% else %}
@@ -1104,6 +1106,17 @@
                   </div>
                 </div>
               {% endif %}
+            </li>
+            <li class="{{ currentPageTab == 'landing-news' ? 'uk-active' }}">
+              <div class="uk-flex uk-flex-between uk-flex-middle uk-margin-small-bottom uk-flex-wrap">
+                <h3 class="uk-heading-bullet uk-margin-remove">{{ t('heading_landing_news') }}</h3>
+                <a class="uk-button uk-button-primary uk-margin-small-top uk-margin-remove-top@s" href="{{ basePath }}/admin/landing-news/create">{{ t('button_add_news') }}</a>
+              </div>
+              {% include 'admin/landing_news/_list.twig' with {
+                entries: landingNewsEntries|default([]),
+                status: landingNewsStatus|default(''),
+                csrfToken: csrf_token
+              } %}
             </li>
           </ul>
         </div>

--- a/templates/admin/_nav.twig
+++ b/templates/admin/_nav.twig
@@ -21,7 +21,6 @@
       { href: basePath ~ '/admin/questions', icon: 'question', text: t('tab_questions') },
       { href: basePath ~ '/admin/media', icon: 'image', text: t('tab_media'), roles: ['admin', 'catalog-editor'] },
       { href: basePath ~ '/admin/pages', icon: 'file-edit', text: t('tab_pages'), admin: true },
-      { href: basePath ~ '/admin/landing-news', icon: 'file-text', text: t('tab_landing_news'), admin: true },
     ]
   },
   {

--- a/templates/admin/landing_news/_list.twig
+++ b/templates/admin/landing_news/_list.twig
@@ -1,0 +1,60 @@
+{% set newsEntries = entries|default([]) %}
+{% set newsStatus = status|default('') %}
+{% set token = csrfToken|default('') %}
+
+{% if newsStatus == 'created' %}
+  <div class="uk-alert-success" uk-alert>{{ t('message_news_created') }}</div>
+{% elseif newsStatus == 'updated' %}
+  <div class="uk-alert-success" uk-alert>{{ t('message_news_updated') }}</div>
+{% elseif newsStatus == 'deleted' %}
+  <div class="uk-alert-success" uk-alert>{{ t('message_news_deleted') }}</div>
+{% endif %}
+
+<div class="uk-overflow-auto uk-margin-top">
+  <table class="uk-table uk-table-divider uk-table-striped">
+    <thead>
+      <tr>
+        <th>{{ t('column_title') }}</th>
+        <th>{{ t('column_page') }}</th>
+        <th>{{ t('column_status') }}</th>
+        <th>{{ t('column_published') }}</th>
+        <th>{{ t('column_actions') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for entry in newsEntries %}
+        <tr>
+          <td>{{ entry.title }}</td>
+          <td>{{ entry.pageTitle }}</td>
+          <td>
+            {% if entry.isPublished %}
+              <span class="uk-label uk-label-success">{{ t('status_published') }}</span>
+            {% else %}
+              <span class="uk-label">{{ t('status_draft') }}</span>
+            {% endif %}
+          </td>
+          <td>
+            {% if entry.publishedAt %}
+              {{ entry.publishedAt|date('d.m.Y H:i') }}
+            {% else %}
+              &mdash;
+            {% endif %}
+          </td>
+          <td>
+            <div class="uk-flex uk-flex-middle" style="gap: 12px;">
+              <a class="uk-button uk-button-text" href="{{ basePath }}/admin/landing-news/{{ entry.id }}">{{ t('action_edit') }}</a>
+              <form method="post" action="{{ basePath }}/admin/landing-news/{{ entry.id }}/delete" onsubmit="return confirm('{{ t('confirm_news_delete') }}');">
+                <input type="hidden" name="_token" value="{{ token }}">
+                <button type="submit" class="uk-button uk-button-text uk-text-danger">{{ t('action_delete') }}</button>
+              </form>
+            </div>
+          </td>
+        </tr>
+      {% else %}
+        <tr>
+          <td colspan="5" class="uk-text-center">{{ t('message_news_empty') }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/templates/admin/landing_news/form.twig
+++ b/templates/admin/landing_news/form.twig
@@ -117,7 +117,7 @@
           </div>
           <div class="uk-width-1-1 uk-margin-top">
             <button type="submit" class="uk-button uk-button-primary">{{ t('button_save') }}</button>
-            <a class="uk-button uk-button-default" href="{{ basePath }}/admin/landing-news">{{ t('button_cancel') }}</a>
+            <a class="uk-button uk-button-default" href="{{ basePath }}/admin/pages?pageTab=landing-news">{{ t('button_cancel') }}</a>
           </div>
           {% if error %}
             <div class="uk-width-1-1">

--- a/templates/admin/landing_news/index.twig
+++ b/templates/admin/landing_news/index.twig
@@ -55,62 +55,11 @@
     </aside>
     <main class="uk-width-expand uk-padding-small@xs uk-padding">
       <div class="uk-container uk-container-expand">
-        {% if status == 'created' %}
-          <div class="uk-alert-success" uk-alert>{{ t('message_news_created') }}</div>
-        {% elseif status == 'updated' %}
-          <div class="uk-alert-success" uk-alert>{{ t('message_news_updated') }}</div>
-        {% elseif status == 'deleted' %}
-          <div class="uk-alert-success" uk-alert>{{ t('message_news_deleted') }}</div>
-        {% endif %}
-
-        <div class="uk-overflow-auto uk-margin-top">
-          <table class="uk-table uk-table-divider uk-table-striped">
-            <thead>
-              <tr>
-                <th>{{ t('column_title') }}</th>
-                <th>{{ t('column_page') }}</th>
-                <th>{{ t('column_status') }}</th>
-                <th>{{ t('column_published') }}</th>
-                <th>{{ t('column_actions') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for entry in entries %}
-                <tr>
-                  <td>{{ entry.title }}</td>
-                  <td>{{ entry.pageTitle }}</td>
-                  <td>
-                    {% if entry.isPublished %}
-                      <span class="uk-label uk-label-success">{{ t('status_published') }}</span>
-                    {% else %}
-                      <span class="uk-label">{{ t('status_draft') }}</span>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% if entry.publishedAt %}
-                      {{ entry.publishedAt|date('d.m.Y H:i') }}
-                    {% else %}
-                      &mdash;
-                    {% endif %}
-                  </td>
-                  <td>
-                    <div class="uk-flex uk-flex-middle" style="gap: 12px;">
-                      <a class="uk-button uk-button-text" href="{{ basePath }}/admin/landing-news/{{ entry.id }}">{{ t('action_edit') }}</a>
-                      <form method="post" action="{{ basePath }}/admin/landing-news/{{ entry.id }}/delete" onsubmit="return confirm('{{ t('confirm_news_delete') }}');">
-                        <input type="hidden" name="_token" value="{{ csrfToken }}">
-                        <button type="submit" class="uk-button uk-button-text uk-text-danger">{{ t('action_delete') }}</button>
-                      </form>
-                    </div>
-                  </td>
-                </tr>
-              {% else %}
-                <tr>
-                  <td colspan="5" class="uk-text-center">{{ t('message_news_empty') }}</td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+        {% include 'admin/landing_news/_list.twig' with {
+          entries: entries,
+          status: status,
+          csrfToken: csrfToken
+        } %}
       </div>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- surface the landing news listing as a third tab inside the admin pages section and reuse the table partial
- load landing news data from the dashboard controller while redirecting the dedicated index route to the pages tab
- align navigation and form actions with the new tab structure

## Testing
- php -l src/Controller/AdminController.php
- php -l src/Controller/Admin/LandingNewsController.php


------
https://chatgpt.com/codex/tasks/task_e_68dff1d84efc832bb30f3d579e76fed8