### PR TITLE
Remove safe area padding from maintenance topbar

### DIFF
--- a/public/css/calserver-maintenance.css
+++ b/public/css/calserver-maintenance.css
@@ -21,7 +21,8 @@ body.qr-landing.calserver-maintenance-theme {
   .calserver-maintenance-theme .qr-topbar {
     height: auto;
     min-height: 72px;
-    padding-block: 16px;
+    padding-top: 0;
+    padding-bottom: 16px;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the mobile top padding from the maintenance landing page's sticky topbar so controls sit flush with the viewport edge

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dff797396c832bb3feccccf16580ab