### PR TITLE
Show landing news list on calserver maintenance page

### DIFF
--- a/public/css/calserver-maintenance.css
+++ b/public/css/calserver-maintenance.css
@@ -374,6 +374,58 @@ body.qr-landing.calserver-maintenance-theme {
   border-bottom: 1px solid rgba(148, 163, 184, 0.2);
 }
 
+.calserver-maintenance-updates__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.calserver-maintenance-updates__item {
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.35);
+}
+
+.calserver-maintenance-updates__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.calserver-maintenance-updates__date {
+  color: #93c5fd;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.calserver-maintenance-updates__link,
+.calserver-maintenance-updates__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.calserver-maintenance-updates__link {
+  text-decoration: none;
+}
+
+.calserver-maintenance-updates__link:hover,
+.calserver-maintenance-updates__link:focus {
+  color: #bfdbfe;
+  text-decoration: underline;
+}
+
+.calserver-maintenance-updates__excerpt {
+  margin-top: 0.75rem;
+  color: #cbd5f5;
+  line-height: 1.6;
+}
+
 .calserver-maintenance-updates .uk-button-text {
   color: #60a5fa;
 }
@@ -416,6 +468,14 @@ body.qr-landing.calserver-maintenance-theme {
 
   .calserver-maintenance-section__header {
     margin-bottom: 2.5rem;
+  }
+
+  .calserver-maintenance-updates__item {
+    padding: 1.25rem;
+  }
+
+  .calserver-maintenance-updates__header {
+    gap: 0.25rem;
   }
 }
 

--- a/templates/marketing/calserver-maintenance.twig
+++ b/templates/marketing/calserver-maintenance.twig
@@ -209,16 +209,28 @@
               <a class="uk-button uk-button-text" href="{{ landingNewsIndexUrl }}">{{ t('calserver_maintenance_updates_link') }}</a>
             {% endif %}
           </div>
-          <div class="uk-grid-large" data-uk-grid>
+          <ul class="calserver-maintenance-updates__list">
             {% for item in landingNews %}
-              <div class="uk-width-1-1 uk-width-1-3@m">
-                {% include 'marketing/_news_teaser.twig' with {
-                  news: item,
-                  newsBasePath: landingNewsBasePath
-                } %}
-              </div>
+              {% if item.isPublished %}
+                {% set detailPath = landingNewsBasePath is defined and landingNewsBasePath ? basePath ~ landingNewsBasePath ~ '/' ~ item.slug : null %}
+                <li class="calserver-maintenance-updates__item">
+                  <div class="calserver-maintenance-updates__header">
+                    {% if item.publishedAt %}
+                      <span class="calserver-maintenance-updates__date">{{ item.publishedAt|date('d.m.Y') }}</span>
+                    {% endif %}
+                    {% if detailPath %}
+                      <a class="calserver-maintenance-updates__link" href="{{ detailPath }}">{{ item.title }}</a>
+                    {% else %}
+                      <span class="calserver-maintenance-updates__title">{{ item.title }}</span>
+                    {% endif %}
+                  </div>
+                  {% if item.excerpt %}
+                    <div class="calserver-maintenance-updates__excerpt">{{ item.excerpt|raw }}</div>
+                  {% endif %}
+                </li>
+              {% endif %}
             {% endfor %}
-          </div>
+          </ul>
         </div>
       </section>
     {% endif %}


### PR DESCRIPTION
## Summary
- render the calserver maintenance update section as a list of published landing news entries with titles, dates, and excerpts
- add dedicated styling for the update list to match the calserver maintenance theme and improve readability

## Testing
- Manual verification of /calserver-maintenance

------
https://chatgpt.com/codex/tasks/task_e_68dff86f2710832ba1d2665f559ae308