### PR TITLE
Add dynamic landing news routes for marketing pages

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -484,6 +484,22 @@ return function (\Slim\App $app, TranslationService $translator) {
         $args['landingSlug'] = 'landing';
         return $controller->show($request, $response, $args);
     });
+    $app->get('/{landingSlug:[a-z0-9-]+}/news', function (Request $request, Response $response, array $args) use ($resolveMarketingAccess) {
+        [$request, $allowed] = $resolveMarketingAccess($request);
+        if (!$allowed) {
+            return $response->withStatus(404);
+        }
+        $controller = new MarketingLandingNewsController();
+        return $controller->index($request, $response, $args);
+    });
+    $app->get('/{landingSlug:[a-z0-9-]+}/news/{newsSlug:[a-z0-9-]+}', function (Request $request, Response $response, array $args) use ($resolveMarketingAccess) {
+        [$request, $allowed] = $resolveMarketingAccess($request);
+        if (!$allowed) {
+            return $response->withStatus(404);
+        }
+        $controller = new MarketingLandingNewsController();
+        return $controller->show($request, $response, $args);
+    });
     $app->get('/future-is-green', function (Request $request, Response $response) use ($resolveMarketingAccess) {
         [$request, $allowed] = $resolveMarketingAccess($request);
         if (!$allowed) {

--- a/tests/Controller/LandingNewsControllerTest.php
+++ b/tests/Controller/LandingNewsControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class LandingNewsControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $pdo = $this->getDatabase();
+        $pdo->prepare('DELETE FROM landing_news WHERE slug = ?')->execute(['grand-opening']);
+        $pdo->prepare('DELETE FROM pages WHERE slug = ?')->execute(['festival']);
+
+        $stmt = $pdo->prepare('INSERT INTO pages (slug, title, content) VALUES (?, ?, ?)');
+        $stmt->execute(['festival', 'Festival', '<p>Festival</p>']);
+
+        $idStmt = $pdo->prepare('SELECT id FROM pages WHERE slug = ? LIMIT 1');
+        $idStmt->execute(['festival']);
+        $pageId = (int) $idStmt->fetchColumn();
+        if ($pageId <= 0) {
+            $this->fail('Failed to create landing page for news test.');
+        }
+
+        $newsStmt = $pdo->prepare(
+            'INSERT INTO landing_news (page_id, slug, title, excerpt, content, published_at, is_published) '
+            . 'VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?)' 
+        );
+        $newsStmt->execute([
+            $pageId,
+            'grand-opening',
+            'Grand Opening',
+            '<p>Summary</p>',
+            '<p>Full content</p>',
+            1,
+        ]);
+    }
+
+    public function testCustomLandingNewsArticleIsReachable(): void
+    {
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/festival/news/grand-opening');
+        $response = $app->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('Grand Opening', $body);
+        $this->assertStringContainsString('Festival', $body);
+    }
+}


### PR DESCRIPTION
## Summary
- add generic marketing landing news routes that forward the slug to the controller
- rely on the shared resolvePage logic to load the matching landing page for each slug
- add a functional test that covers accessing a news article for a non-default landing page

## Testing
- vendor/bin/phpunit --filter LandingNewsControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68dffc8b0aa4832bafb568a31b9dbebb