### PR TITLE
Adjust maintenance topbar height

### DIFF
--- a/public/css/calserver-maintenance.css
+++ b/public/css/calserver-maintenance.css
@@ -17,6 +17,12 @@ body.qr-landing.calserver-maintenance-theme {
   background: transparent;
 }
 
+.calserver-maintenance-theme .qr-topbar {
+  height: auto;
+  min-height: calc(48px + 16px);
+  padding: 8px 0;
+}
+
 @media (max-width: 959px) {
   .calserver-maintenance-theme .qr-topbar {
     height: auto;


### PR DESCRIPTION
## Summary
- let the calHelp maintenance topbar grow with its contents so the sticky region covers the full menu button height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dffe315224832ba183a3fba8328265