### PR TITLE
Fix footer background on calHelp maintenance page

### DIFF
--- a/public/css/calserver-maintenance.css
+++ b/public/css/calserver-maintenance.css
@@ -471,7 +471,7 @@ body.qr-landing.calserver-maintenance-theme {
 }
 
 .calserver-maintenance-theme .footer-columns {
-  background: rgba(10, 18, 33, 0.9);
+  background: transparent;
   border-top: 1px solid rgba(148, 163, 184, 0.2);
 }
 


### PR DESCRIPTION
## Summary
- make the calHelp maintenance footer columns transparent to remove the blue background tint

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dffec011d0832ba4e50eb47bd1503f