### PR TITLE
Update maintenance status CTA to point to news feed

### DIFF
--- a/templates/marketing/calserver-maintenance.twig
+++ b/templates/marketing/calserver-maintenance.twig
@@ -171,7 +171,7 @@
               <p class="calserver-maintenance-hero__subtitle">{{ t('calserver_maintenance_hero_subtitle') }}</p>
               <div class="calserver-maintenance-hero__actions" role="group" aria-label="{{ t('calserver_maintenance_actions_label') }}">
                 <a class="uk-button uk-button-primary git-btn"
-                   href="{{ basePath }}/status">
+                   href="{{ basePath }}/news">
                   <span class="uk-margin-small-right" data-uk-icon="icon: rss"></span>{{ t('calserver_maintenance_cta_primary') }}
                 </a>
                 <a class="uk-button uk-button-default git-btn"


### PR DESCRIPTION
## Summary
- point the maintenance page status button to the news feed URL instead of the old status endpoint

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68dfff4a9498832bb2faaa1ff0f319a6