### PR TITLE
Improve Future is Green technology cards on mobile

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -970,12 +970,12 @@ body.qr-landing.future-is-green-theme .landing-content {
 
 .future-is-green-theme .fig-technology-interactive__display {
   position: relative;
+  transition: min-height 0.3s ease;
 }
 
 @media (max-width: 768px) {
   .future-is-green-theme .fig-technology-interactive__display {
-    min-height: clamp(24rem, 60vh, 32rem);
-    transition: min-height 0.3s ease;
+    min-height: 0;
   }
 }
 

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -661,6 +661,17 @@
         return window.setTimeout(callback, 16);
       };
       var measurementScheduled = false;
+      var desktopMediaQuery = window.matchMedia
+        ? window.matchMedia('(min-width: 960px)')
+        : null;
+
+      function shouldLockDisplayHeight() {
+        if (!desktopMediaQuery) {
+          return true;
+        }
+
+        return desktopMediaQuery.matches;
+      }
       var resizeObserver = typeof ResizeObserver === 'function'
         ? new ResizeObserver(function () {
             scheduleDisplayHeightMeasurement();
@@ -733,6 +744,11 @@
 
         raf(function () {
           measurementScheduled = false;
+
+          if (!shouldLockDisplayHeight()) {
+            display.style.minHeight = '';
+            return;
+          }
 
           var maxHeight = panels.reduce(function (acc, panel) {
             var panelHeight = measurePanelHeight(panel);
@@ -883,6 +899,15 @@
       grid.classList.add('fig-technology-grid--is-enhanced');
       grid.setAttribute('aria-hidden', 'true');
       grid.dataset.figTechnologyEnhanced = 'true';
+
+      if (desktopMediaQuery) {
+        var mqListener = scheduleDisplayHeightMeasurement;
+        if (typeof desktopMediaQuery.addEventListener === 'function') {
+          desktopMediaQuery.addEventListener('change', mqListener);
+        } else if (typeof desktopMediaQuery.addListener === 'function') {
+          desktopMediaQuery.addListener(mqListener);
+        }
+      }
 
       window.addEventListener('resize', scheduleDisplayHeightMeasurement);
     }


### PR DESCRIPTION
## Summary
- relax the mobile min-height styling for the Future is Green technology display and keep smooth transitions
- update the interactive tab logic to only lock panel height on desktop breakpoints and react to media query changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03fbcf068832baf49f343c2d450a1