### PR TITLE
Make maintenance window dynamic on calHelp landing page

### DIFF
--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -382,6 +382,7 @@ return [
     'calserver_maintenance_status_value' => 'Geplante Wartung',
     'calserver_maintenance_status_window' => 'Wartungszeitraum',
     'calserver_maintenance_status_window_value' => '12.–14. Juni (ganztägig)',
+    'calserver_maintenance_status_window_suffix' => '(ganztägig)',
     'calserver_maintenance_status_hint' => 'Wir haben vollständige Backups erstellt und überwachen alle Systeme. Deine Inhalte bleiben sicher erhalten.',
     'calserver_maintenance_cta_primary' => 'Status-Updates abonnieren',
     'calserver_maintenance_cta_secondary' => 'Support kontaktieren',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -384,6 +384,7 @@ return [
     'calserver_maintenance_status_value' => 'Scheduled maintenance',
     'calserver_maintenance_status_window' => 'Maintenance period',
     'calserver_maintenance_status_window_value' => '12–14 June (all day)',
+    'calserver_maintenance_status_window_suffix' => '(all day)',
     'calserver_maintenance_status_hint' => 'Full backups are completed and systems are monitored throughout the window. Your content remains safe.',
     'calserver_maintenance_cta_primary' => 'Subscribe to status updates',
     'calserver_maintenance_cta_secondary' => 'Contact support',

--- a/templates/marketing/calserver-maintenance.twig
+++ b/templates/marketing/calserver-maintenance.twig
@@ -190,7 +190,12 @@
                 </div>
                 <div class="calserver-maintenance-status__item">
                   <dt>{{ t('calserver_maintenance_status_window') }}</dt>
-                  <dd>{{ t('calserver_maintenance_status_window_value') }}</dd>
+                  {% if maintenanceWindowLabel is defined and maintenanceWindowLabel %}
+                    {% set suffix = t('calserver_maintenance_status_window_suffix') %}
+                    <dd>{{ maintenanceWindowLabel }}{% if suffix %} {{ suffix }}{% endif %}</dd>
+                  {% else %}
+                    <dd>{{ t('calserver_maintenance_status_window_value') }}</dd>
+                  {% endif %}
                 </div>
               </dl>
               <p class="calserver-maintenance-status__hint">{{ t('calserver_maintenance_status_hint') }}</p>


### PR DESCRIPTION
## Summary
- compute the calHelp maintenance window dynamically based on the current date and locale
- render the localized maintenance window range in the template while keeping a static fallback
- add explicit translation entries for the maintenance window suffix in German and English

## Testing
- php -l src/Controller/Marketing/MarketingPageController.php

------
https://chatgpt.com/codex/tasks/task_e_68e04aeb82f0832b9270c2d8f9c0b1e2