### PR TITLE
Include CSRF token in marketing page payload

### DIFF
--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -131,6 +131,7 @@ class MarketingPageController
             'hreflang' => $config?->getHreflang(),
             'turnstileSiteKey' => $this->turnstileConfig->isEnabled() ? $this->turnstileConfig->getSiteKey() : null,
             'turnstileEnabled' => $this->turnstileConfig->isEnabled(),
+            'csrf_token' => $csrf,
         ];
 
         if ($landingNews !== []) {

--- a/tests/Controller/CalserverControllerTest.php
+++ b/tests/Controller/CalserverControllerTest.php
@@ -29,6 +29,7 @@ class CalserverControllerTest extends TestCase
         $body = (string) $response->getBody();
         $this->assertStringContainsString('calServer – Marketingseite', $body);
         $this->assertStringContainsString('data-calserver-cookie-banner', $body);
+        $this->assertStringNotContainsString("csrfToken: ''", $body);
         if ($old === false) {
             putenv('MAIN_DOMAIN');
         } else {


### PR DESCRIPTION
## Summary
- expose the session CSRF token when rendering marketing pages so Twig templates receive it
- extend the calServer controller test to ensure the rendered page includes a non-empty CSRF token value

## Testing
- ./vendor/bin/phpunit tests/Controller/CalserverControllerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e058b81ce0832b9559b2c64731f9b7