### PR TITLE
Connect rag chat CLI to chat service

### DIFF
--- a/tests/test_rag_chat.py
+++ b/tests/test_rag_chat.py
@@ -42,14 +42,18 @@ def test_chat_session_builds_prompt_with_context() -> None:
     index = FakeIndex(results)
     captured: list = []
 
+    expected_response = "QuizRace ist eine Quiz-Plattform."
+
     def responder(prompt):
         captured.append(prompt)
-        return "QuizRace ist eine Quiz-Plattform."  # noqa: D401
+        return expected_response  # noqa: D401
 
     session = ChatSession(index, responder=responder, top_k=2)
     turn = session.send("Was ist QuizRace?")
 
-    assert turn.response == "QuizRace ist eine Quiz-Plattform."
+    assert turn.response == expected_response
+    assert "Basierend auf der Wissensbasis" not in turn.response
+    assert "\n1." not in turn.response
     assert captured[0].context == tuple(results)
     messages = captured[0].messages
     assert messages[0].role == "system"


### PR DESCRIPTION
## Summary
- replace the CLI responder with a chat-service client that sends prompts to the configured endpoint and surfaces errors
- adjust the interactive session to use the new responder and drop the context list formatting
- extend the chat session test to assert the raw responder output is used without bullet lists

## Testing
- pytest tests/test_rag_chat.py

------
https://chatgpt.com/codex/tasks/task_e_68e05e6b4078832b82cc961e656c4eeb