### PR TITLE
Fix phpstan findings in marketing and rag chat services

### DIFF
--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -203,11 +203,9 @@ class MarketingPageController
                 $pattern
             );
 
-            if ($formatter !== false) {
-                $formatted = $formatter->format($date);
-                if ($formatted !== false) {
-                    return $formatted;
-                }
+            $formatted = $formatter->format($date);
+            if ($formatted !== false) {
+                return $formatted;
             }
         }
 

--- a/src/Service/RagChat/DomainDocumentStorage.php
+++ b/src/Service/RagChat/DomainDocumentStorage.php
@@ -38,11 +38,11 @@ final class DomainDocumentStorage
         foreach ($metadata as $id => $entry) {
             $filename = $entry['filename'];
             $path = $uploadsDir . DIRECTORY_SEPARATOR . $filename;
-            $size = is_file($path) ? (int) filesize($path) : (int) ($entry['size'] ?? 0);
-            $uploadedAt = $entry['uploaded_at'] ?? date('c');
+            $size = is_file($path) ? (int) filesize($path) : (int) $entry['size'];
+            $uploadedAt = $entry['uploaded_at'];
             $updatedAt = is_file($path)
                 ? date('c', (int) filemtime($path))
-                : ($entry['updated_at'] ?? $uploadedAt);
+                : $entry['updated_at'];
 
             $documents[] = [
                 'id' => $id,

--- a/src/Service/RagChat/HttpChatResponder.php
+++ b/src/Service/RagChat/HttpChatResponder.php
@@ -124,7 +124,15 @@ final class HttpChatResponder implements ChatResponderInterface
             $id = isset($item['id']) ? (string) $item['id'] : '';
             $text = isset($item['text']) ? (string) $item['text'] : '';
             $score = isset($item['score']) ? (float) $item['score'] : 0.0;
-            $metadata = isset($item['metadata']) && is_array($item['metadata']) ? $item['metadata'] : [];
+            $metadata = [];
+            if (isset($item['metadata'])) {
+                /** @var mixed $rawMetadata */
+                $rawMetadata = $item['metadata'];
+                if (is_array($rawMetadata)) {
+                    /** @var array<string, mixed> $rawMetadata */
+                    $metadata = $rawMetadata;
+                }
+            }
 
             $normalised[] = [
                 'id' => $id,


### PR DESCRIPTION
## Summary
- drop the redundant IntlDateFormatter failure guard in the marketing page controller
- trust normalised metadata when building rag chat document listings
- tighten metadata normalisation in the HTTP chat responder to satisfy static analysis

## Testing
- vendor/bin/phpstan --no-progress --memory-limit=512M *(fails: vendor dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12a35319c832b9677f25fb38db739