### PR TITLE
Fix .env parsing failures with parentheses

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -3,18 +3,7 @@
 $settings = [];
 
 // Load environment variables from .env if available
-$envFile = __DIR__ . '/../.env';
-if (is_readable($envFile)) {
-    $vars = parse_ini_file($envFile, false, INI_SCANNER_RAW);
-    if (is_array($vars)) {
-        foreach ($vars as $key => $value) {
-            if (getenv($key) === false) {
-                putenv($key . '=' . $value);
-                $_ENV[$key] = $value;
-            }
-        }
-    }
-}
+\App\Support\EnvLoader::loadAndSet(__DIR__ . '/../.env');
 
 $settings += [
     'displayErrorDetails' => false,

--- a/public/index.php
+++ b/public/index.php
@@ -10,18 +10,7 @@ if (!is_readable($autoloader)) {
 require $autoloader;
 
 // Load environment variables from .env if available
-$envFile = __DIR__ . '/../.env';
-if (is_readable($envFile)) {
-    $vars = parse_ini_file($envFile, false, INI_SCANNER_RAW);
-    if (is_array($vars)) {
-        foreach ($vars as $key => $value) {
-            if (getenv($key) === false) {
-                putenv($key . '=' . $value);
-                $_ENV[$key] = $value;
-            }
-        }
-    }
-}
+\App\Support\EnvLoader::loadAndSet(__DIR__ . '/../.env');
 
 use Slim\Views\Twig;
 use Slim\Views\TwigMiddleware;

--- a/scripts/check_stripe_config.php
+++ b/scripts/check_stripe_config.php
@@ -7,18 +7,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use App\Service\StripeService;
 
 // Load environment variables from .env if available
-$envFile = __DIR__ . '/../.env';
-if (is_readable($envFile)) {
-    $vars = parse_ini_file($envFile, false, INI_SCANNER_RAW);
-    if (is_array($vars)) {
-        foreach ($vars as $key => $value) {
-            if (getenv($key) === false) {
-                putenv($key . '=' . $value);
-                $_ENV[$key] = $value;
-            }
-        }
-    }
-}
+\App\Support\EnvLoader::loadAndSet(__DIR__ . '/../.env');
 
 $config = StripeService::isConfigured();
 if ($config['ok']) {

--- a/scripts/run_migrations.php
+++ b/scripts/run_migrations.php
@@ -5,18 +5,7 @@ declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
 // Load environment variables from .env if available
-$envFile = __DIR__ . '/../.env';
-if (is_readable($envFile)) {
-    $vars = parse_ini_file($envFile, false, INI_SCANNER_RAW);
-    if (is_array($vars)) {
-        foreach ($vars as $key => $value) {
-            if (getenv($key) === false) {
-                putenv($key . '=' . $value);
-                $_ENV[$key] = $value;
-            }
-        }
-    }
-}
+\App\Support\EnvLoader::loadAndSet(__DIR__ . '/../.env');
 
 try {
     $errors = \App\Infrastructure\Migrations\MigrationScriptRunner::run(__DIR__ . '/../migrations');

--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Infrastructure\Database;
 use App\Service\AuditLogger;
 use App\Service\TenantService;
+use App\Support\EnvLoader;
 use RuntimeException;
 use Throwable;
 use Symfony\Component\Mailer\Mailer;
@@ -30,11 +31,7 @@ class MailService
     private static function loadEnvConfig(): array {
         $root = dirname(__DIR__, 2);
         $envFile = $root . '/.env';
-        $env = [];
-
-        if (is_readable($envFile)) {
-            $env = parse_ini_file($envFile, false, INI_SCANNER_RAW) ?: [];
-        }
+        $env = EnvLoader::load($envFile);
 
         return [
             'mailer_dsn' => (string) ($env['MAILER_DSN'] ?? getenv('MAILER_DSN') ?: ''),

--- a/src/Support/EnvLoader.php
+++ b/src/Support/EnvLoader.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Lightweight .env reader that tolerates characters parse_ini_file() rejects.
+ */
+final class EnvLoader
+{
+    /**
+     * Load variables from an .env-style file without mutating the environment.
+     *
+     * @return array<string, string>
+     */
+    public static function load(string $path): array
+    {
+        if (!is_readable($path)) {
+            return [];
+        }
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES);
+        if ($lines === false) {
+            return [];
+        }
+
+        $variables = [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || str_starts_with($line, '#') || str_starts_with($line, ';')) {
+                continue;
+            }
+
+            if (!str_contains($line, '=')) {
+                continue;
+            }
+
+            [$name, $rawValue] = explode('=', $line, 2);
+            $name = trim($name);
+
+            if ($name === '') {
+                continue;
+            }
+
+            $variables[$name] = self::normaliseValue($rawValue);
+        }
+
+        return $variables;
+    }
+
+    /**
+     * Load variables and populate $_ENV/putenv without overriding existing values.
+     *
+     * @return array<string, string>
+     */
+    public static function loadAndSet(string $path): array
+    {
+        $variables = self::load($path);
+
+        foreach ($variables as $name => $value) {
+            if (getenv($name) !== false) {
+                continue;
+            }
+
+            putenv($name . '=' . $value);
+            $_ENV[$name] = $value;
+        }
+
+        return $variables;
+    }
+
+    private static function normaliseValue(string $value): string
+    {
+        $value = ltrim($value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        $quoteChar = $value[0];
+        if ($quoteChar === '\'' || $quoteChar === '"') {
+            $value = substr($value, 1);
+            $endPos = strrpos($value, $quoteChar);
+            if ($endPos !== false) {
+                $value = substr($value, 0, $endPos);
+            }
+
+            return str_replace('\\' . $quoteChar, $quoteChar, $value);
+        }
+
+        $buffer = '';
+        $length = strlen($value);
+        $escape = false;
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $value[$i];
+
+            if ($escape) {
+                $buffer .= $char;
+                $escape = false;
+                continue;
+            }
+
+            if ($char === '\\') {
+                $escape = true;
+                continue;
+            }
+
+            if ($char === '#' || $char === ';') {
+                break;
+            }
+
+            $buffer .= $char;
+        }
+
+        if ($escape) {
+            $buffer .= '\\';
+        }
+
+        return rtrim($buffer);
+    }
+}


### PR DESCRIPTION
## Summary
- add a tolerant App\Support\EnvLoader for reading .env files
- reuse the shared loader across the HTTP entrypoint, CLI scripts, and the mail service

## Testing
- php -l src/Support/EnvLoader.php

------
https://chatgpt.com/codex/tasks/task_e_68e12bf53bcc832bbd928387b78577ea