### PR TITLE
Support proxied OpenAI chat endpoints

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -79,6 +79,9 @@ PASSWORD_RESET_SECRET=changeme
 
 # RAG-Chatbot (Marketing-Seite)
 #RAG_CHAT_SERVICE_URL=https://chat.example.com/v1/chat
+# When using a proxy domain for OpenAI-compatible APIs, set this to "true" to force the
+# OpenAI responder and parameter mapping.
+#RAG_CHAT_SERVICE_FORCE_OPENAI=false
 #RAG_CHAT_SERVICE_TOKEN=changeme
 #RAG_CHAT_SERVICE_MODEL=gpt-4o-mini
 #RAG_CHAT_SERVICE_TEMPERATURE=0.2


### PR DESCRIPTION
## Summary
- extend the OpenAI endpoint detection to handle proxy URLs and an explicit override flag
- add unit coverage to ensure RagChatService selects the OpenAI responder for proxied endpoints
- document the new RAG_CHAT_SERVICE_FORCE_OPENAI toggle in the sample environment file

## Testing
- vendor/bin/phpunit tests/Service/RagChat/OpenAiChatResponderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e141c86094832b8cb7af404af4a181