### PR TITLE
Add TXT support to RAG loader

### DIFF
--- a/rag_chatbot/loader.py
+++ b/rag_chatbot/loader.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Iterable, Iterator, Sequence
 
 
-SUPPORTED_EXTENSIONS: Sequence[str] = (".md", ".markdown", ".html", ".htm")
+SUPPORTED_EXTENSIONS: Sequence[str] = (".md", ".markdown", ".html", ".htm", ".txt")
 
 
 @dataclass(frozen=True)

--- a/tests/test_rag_loader.py
+++ b/tests/test_rag_loader.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from rag_chatbot.loader import iter_source_files, load_documents
+
+
+def test_iter_source_files_includes_txt(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    text_file = docs_dir / "notizen.txt"
+    text_file.write_text("Ein Textdokument nur für Tests.", encoding="utf-8")
+
+    files = list(iter_source_files([docs_dir]))
+
+    assert text_file in files
+
+    documents = load_documents([docs_dir])
+    assert documents
+    assert documents[0].path == text_file
+    assert "Textdokument" in documents[0].text
+    assert documents[0].source.endswith("notizen.txt")

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from rag_chatbot import PipelineOptions, run_pipeline
 
 
-def create_sample_source(tmp_path: Path) -> Path:
+def create_sample_source(tmp_path: Path, extension: str = ".md") -> Path:
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     sample = """# Titel\n\nDies ist ein Testdokument. Es enthält mehrere Sätze."""
-    path = docs_dir / "sample.md"
+    if not extension.startswith("."):
+        extension = f".{extension}"
+    path = docs_dir / f"sample{extension}"
     path.write_text(sample, encoding="utf-8")
     return docs_dir
 
@@ -81,6 +83,29 @@ def test_pipeline_force_rebuilds(tmp_path: Path) -> None:
     forced = run_pipeline(replace(options, force=True))
     assert forced.corpus is not None
     assert forced.index is not None
+
+
+def test_pipeline_processes_txt_sources(tmp_path: Path) -> None:
+    docs_dir = create_sample_source(tmp_path, ".txt")
+    corpus_path = tmp_path / "data" / "corpus.jsonl"
+    index_path = tmp_path / "data" / "index.json"
+
+    options = PipelineOptions(
+        sources=[docs_dir],
+        corpus_path=corpus_path,
+        index_path=index_path,
+        max_words=50,
+        overlap=10,
+    )
+
+    result = run_pipeline(options)
+
+    assert result.corpus is not None
+    assert result.index is not None
+
+    corpus_entries = corpus_path.read_text(encoding="utf-8").strip().splitlines()
+    assert corpus_entries, "Die Wissensbasis enthält keine Einträge"
+    assert any("sample.txt" in entry for entry in corpus_entries)
 
 
 def test_pipeline_requires_sources(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- allow the RAG document loader to include `.txt` files so it matches the domain upload rules
- extend pipeline coverage with a `.txt` source regression test and add a loader unit test for text files

## Testing
- python -m pytest tests/test_rag_loader.py tests/test_rag_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e16a9710e8832b9b899be598ee9572