### PR TITLE
Relax PHPDoc for rag chat context arrays

### DIFF
--- a/src/Service/RagChat/ChatResponderInterface.php
+++ b/src/Service/RagChat/ChatResponderInterface.php
@@ -11,7 +11,7 @@ interface ChatResponderInterface
 {
     /**
      * @param list<array{role:string,content:string}> $messages
-     * @param list<array<string,mixed>> $context
+     * @param list<array<string,mixed>|mixed> $context
      */
     public function respond(array $messages, array $context): string;
 }

--- a/src/Service/RagChat/HttpChatResponder.php
+++ b/src/Service/RagChat/HttpChatResponder.php
@@ -53,7 +53,7 @@ class HttpChatResponder implements ChatResponderInterface
 
     /**
      * @param list<array{role:string,content:string}> $messages
-     * @param list<array<string,mixed>> $context
+     * @param list<array<string,mixed>|mixed> $context
      */
     public function respond(array $messages, array $context): string
     {
@@ -107,7 +107,7 @@ class HttpChatResponder implements ChatResponderInterface
     }
 
     /**
-     * @param list<array<string,mixed>> $context
+     * @param list<array<string,mixed>|mixed> $context
      * @return list<array{id:string,text:string,score:float,metadata:array<string,mixed>}>
      */
     protected function normaliseContext(array $context): array
@@ -194,7 +194,7 @@ class HttpChatResponder implements ChatResponderInterface
 
     /**
      * @param list<array{role:string,content:string}> $messages
-     * @param list<array<string,mixed>> $context
+     * @param list<array<string,mixed>|mixed> $context
      * @return array<string,mixed>
      */
     protected function buildRequestPayload(array $messages, array $context): array


### PR DESCRIPTION
## Summary
- allow rag chat context to include non-array entries in the PHPDoc
- keep the context normalisation guard meaningful for malformed payloads

## Testing
- not run (phpstan binary not available in the workspace image)


------
https://chatgpt.com/codex/tasks/task_e_68e16be002cc832bbd529573d01b2afb