### PR TITLE
Normalize domain start pages consistently with RAG domain handling

### DIFF
--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Support\DomainNameHelper;
 use InvalidArgumentException;
 use PDO;
 use PDOException;
@@ -400,15 +401,7 @@ class DomainStartPageService
      * Normalize a hostname by trimming and removing known prefixes.
      */
     public function normalizeDomain(string $domain, bool $stripAdmin = true): string {
-        $domain = strtolower(trim($domain));
-        if ($domain === '') {
-            return '';
-        }
-
-        $pattern = $stripAdmin ? '/^(www|admin)\./' : '/^www\./';
-        $normalized = (string) preg_replace($pattern, '', $domain);
-
-        return $normalized;
+        return DomainNameHelper::normalize($domain, $stripAdmin);
     }
 
     private function normalizeEmail(?string $email): ?string {

--- a/src/Support/DomainNameHelper.php
+++ b/src/Support/DomainNameHelper.php
@@ -20,6 +20,13 @@ final class DomainNameHelper
             return '';
         }
 
+        if (str_contains($domain, '://')) {
+            $host = parse_url($domain, PHP_URL_HOST);
+            if (is_string($host) && $host !== '') {
+                $domain = $host;
+            }
+        }
+
         $pattern = $stripAdmin ? '/^(www|admin)\./' : '/^www\./';
         $normalized = (string) preg_replace($pattern, '', $domain);
         $normalized = preg_replace('/[^a-z0-9\-.]/', '', $normalized) ?? '';

--- a/tests/Service/DomainStartPageServiceTest.php
+++ b/tests/Service/DomainStartPageServiceTest.php
@@ -47,4 +47,26 @@ class DomainStartPageServiceTest extends TestCase
         $this->assertSame('Special Offer', $options['special']);
         $this->assertCount(5, $options);
     }
+
+    /**
+     * @dataProvider provideDomains
+     */
+    public function testNormalizeDomainSanitizesInput(string $input, string $expected, bool $stripAdmin): void
+    {
+        $service = new DomainStartPageService(new PDO('sqlite::memory:'));
+
+        self::assertSame($expected, $service->normalizeDomain($input, $stripAdmin));
+    }
+
+    /**
+     * @return iterable<string,array{string,string,bool}>
+     */
+    public static function provideDomains(): iterable
+    {
+        yield 'plain domain' => ['calserver.de', 'calserver.de', true];
+        yield 'with scheme' => ['https://calserver.de', 'calserver.de', true];
+        yield 'with uppercase and path' => ['HTTP://WWW.CALSERVER.DE/foo', 'calserver.de', true];
+        yield 'admin subdomain stripped' => ['admin.calserver.de', 'calserver.de', true];
+        yield 'marketing subdomain kept when admin stripping disabled' => ['admin.calserver.de', 'admin.calserver.de', false];
+    }
 }

--- a/tests/Service/RagChat/DomainDocumentStorageTest.php
+++ b/tests/Service/RagChat/DomainDocumentStorageTest.php
@@ -61,6 +61,23 @@ final class DomainDocumentStorageTest extends TestCase
         $storage->storeDocument('example.com', $file);
     }
 
+    public function testProtocolPrefixedDomainsNormaliseToSameValue(): void
+    {
+        $storage = new DomainDocumentStorage($this->basePath);
+
+        $indexPath = $storage->getIndexPath('https://www.CalServer.de/path');
+        $expectedIndexPath = $this->basePath . DIRECTORY_SEPARATOR . 'calserver.de' . DIRECTORY_SEPARATOR . 'index.json';
+
+        self::assertSame($expectedIndexPath, $indexPath);
+        self::assertDirectoryExists(dirname($indexPath));
+
+        $document = $storage->storeDocument('https://calserver.de', $this->createUpload('Guide.md', '## Hello'));
+        $documents = $storage->listDocuments('calserver.de');
+
+        self::assertCount(1, $documents);
+        self::assertSame($document['id'], $documents[0]['id']);
+    }
+
     private function createUpload(string $name, string $content): UploadedFile
     {
         $tempFile = tempnam(sys_get_temp_dir(), 'upload');


### PR DESCRIPTION
## Summary
- reuse DomainNameHelper inside DomainStartPageService to align normalization with chat domain handling
- strip URL schemes before sanitizing host names to avoid persisting protocol prefixes
- cover protocol-prefixed inputs with new tests for the start page service and domain document storage

## Testing
- vendor/bin/phpunit tests/Service/DomainStartPageServiceTest.php
- vendor/bin/phpunit tests/Service/RagChat/DomainDocumentStorageTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e171dddf1c832b83f5c621bd436df6