### PR TITLE
Fix RAG chatbot form listeners initialization

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -4664,13 +4664,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Page editors are handled in trumbowyg-pages.js
 
-  loadBackups();
-  const path = window.location.pathname.replace(basePath + '/admin', '');
-  const currentRoute = path.replace(/^\/|\/$/g, '') || 'dashboard';
-  if (currentRoute === 'tenants') {
-    syncTenants();
-  }
-});
   ragChatFields.token?.addEventListener('input', () => {
     if (!ragChatFields.tokenClear) return;
     if (ragChatFields.token.value.trim() !== '') {
@@ -4718,3 +4711,11 @@ document.addEventListener('DOMContentLoaded', function () {
         notify(transRagChatSaveError, 'danger');
       });
   });
+
+  loadBackups();
+  const path = window.location.pathname.replace(basePath + '/admin', '');
+  const currentRoute = path.replace(/^\/|\/$/g, '') || 'dashboard';
+  if (currentRoute === 'tenants') {
+    syncTenants();
+  }
+});


### PR DESCRIPTION
## Summary
- ensure the RAG chatbot token listeners are registered inside the DOMContentLoaded callback so field references are defined

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e179760830832b8ec735b035d0c636