### PR TITLE
Ensure RAG chat falls back to global search only without domain hits

### DIFF
--- a/src/Service/RagChat/RagChatService.php
+++ b/src/Service/RagChat/RagChatService.php
@@ -129,11 +129,13 @@ final class RagChatService
             }
         }
 
-        foreach ($globalIndex->search($question, 4, 0.05) as $result) {
-            if (isset($seenChunks[$result->getChunkId()])) {
-                continue;
+        if ($contextResults === []) {
+            foreach ($globalIndex->search($question, 4, 0.05) as $result) {
+                if (isset($seenChunks[$result->getChunkId()])) {
+                    continue;
+                }
+                $contextResults[] = ['result' => $result, 'domain' => null];
             }
-            $contextResults[] = ['result' => $result, 'domain' => null];
         }
 
         $contextResults = array_slice($contextResults, 0, 6);

--- a/tests/Service/RagChat/RagChatServiceTest.php
+++ b/tests/Service/RagChat/RagChatServiceTest.php
@@ -179,9 +179,14 @@ final class RagChatServiceTest extends TestCase
 
         $response = $service->answer('calserver inventar', 'de', 'example.com');
 
-        self::assertNotSame([], $response->getContext());
-        self::assertSame('Domain Knowledge (Abschnitt 1)', $response->getContext()[0]->getLabel());
-        self::assertSame('example.com', $response->getContext()[0]->getMetadata()['domain']);
+        $context = $response->getContext();
+        self::assertNotSame([], $context);
+        self::assertSame('Domain Knowledge (Abschnitt 1)', $context[0]->getLabel());
+        foreach ($context as $item) {
+            $metadata = $item->getMetadata();
+            self::assertArrayHasKey('domain', $metadata);
+            self::assertSame('example.com', $metadata['domain']);
+        }
     }
 
     private function createIndexFile(): string


### PR DESCRIPTION
## Summary
- guard the global RAG search so it only runs when no domain-specific matches were found
- extend the RagChatService test to assert that domain responses never include global contexts

## Testing
- vendor/bin/phpunit tests/Service/RagChat/RagChatServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e17e50d460832b9a1f5d191a07dfdc