### PR TITLE
Add configurable domain normalization prefixes

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -12,6 +12,9 @@ MAIN_DOMAIN=quizrace.app      # Hauptdomain des Quiz-Containers
 # Komma- oder zeilengetrennte Liste zusätzlicher Marketing-Domains für Landing Pages
 # (für TLS-Zertifikate bitte kommagetrennt eintragen)
 MARKETING_DOMAINS=
+# Zusätzliche Subdomain-Präfixe, die bei der Normalisierung entfernt werden (komma- oder zeilengetrennt)
+# Standard: "www admin assistant"
+DOMAIN_STRIPPED_PREFIXES=
 APP_IMAGE=sommerfest-quiz:latest # Docker-Image für Tenant-Container
 # Tag des lokal gebauten Slim-Images (docker build -t <tag> .),
 # das vom Onboarding-Skript verwendet wird

--- a/src/Application/Middleware/DomainMiddleware.php
+++ b/src/Application/Middleware/DomainMiddleware.php
@@ -6,6 +6,7 @@ namespace App\Application\Middleware;
 
 use App\Infrastructure\Database;
 use App\Service\DomainStartPageService;
+use App\Support\DomainNameHelper;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface;
@@ -135,10 +136,6 @@ class DomainMiddleware implements MiddlewareInterface
     }
 
     private function normalizeHost(string $host, bool $stripAdmin = true): string {
-        $host = strtolower($host);
-
-        $pattern = $stripAdmin ? '/^(www|admin)\./' : '/^www\./';
-
-        return (string) preg_replace($pattern, '', $host);
+        return DomainNameHelper::normalize($host, $stripAdmin);
     }
 }

--- a/src/Application/Middleware/SessionMiddleware.php
+++ b/src/Application/Middleware/SessionMiddleware.php
@@ -6,6 +6,7 @@ namespace App\Application\Middleware;
 
 use App\Service\SessionService;
 use App\Infrastructure\Database;
+use App\Support\DomainNameHelper;
 use PDO;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -27,11 +28,9 @@ class SessionMiddleware implements Middleware
         }
 
         if (session_status() === PHP_SESSION_NONE && !headers_sent()) {
-            $host = strtolower($request->getUri()->getHost());
-            $host = (string) preg_replace('/^(www|admin)\./', '', $host);
+            $host = DomainNameHelper::normalize($request->getUri()->getHost());
 
-            $domain = strtolower((string) getenv('MAIN_DOMAIN'));
-            $domain = (string) preg_replace('/^(www|admin)\./', '', $domain);
+            $domain = DomainNameHelper::normalize((string) getenv('MAIN_DOMAIN'));
 
             if ($domain === '' || !$this->hostMatchesDomain($host, $domain)) {
                 $domain = $host;

--- a/src/Application/Seo/PageSeoConfigService.php
+++ b/src/Application/Seo/PageSeoConfigService.php
@@ -12,6 +12,7 @@ use App\Domain\PageSeoConfig;
 use App\Infrastructure\Cache\PageSeoCache;
 use App\Infrastructure\Database;
 use App\Infrastructure\Event\EventDispatcher;
+use App\Support\DomainNameHelper;
 use PDO;
 
 /**
@@ -223,12 +224,7 @@ class PageSeoConfigService
             return null;
         }
 
-        $normalized = strtolower(trim($domain));
-        if ($normalized === '') {
-            return null;
-        }
-
-        $normalized = (string) preg_replace('/^(www|admin)\./', '', $normalized);
+        $normalized = DomainNameHelper::normalize($domain);
 
         return $normalized === '' ? null : $normalized;
     }

--- a/src/Support/DomainNameHelper.php
+++ b/src/Support/DomainNameHelper.php
@@ -9,6 +9,7 @@ namespace App\Support;
  */
 final class DomainNameHelper
 {
+
     private function __construct()
     {
     }
@@ -27,12 +28,45 @@ final class DomainNameHelper
             }
         }
 
-        $pattern = $stripAdmin ? '/^(www|admin)\./' : '/^www\./';
-        $normalized = (string) preg_replace($pattern, '', $domain);
+        $prefixes = $stripAdmin
+            ? self::getStrippablePrefixes()
+            : ['www'];
+
+        if ($prefixes !== []) {
+            $pattern = sprintf('/^(%s)\./', implode('|', array_map(
+                static fn (string $prefix): string => preg_quote($prefix, '/'),
+                $prefixes
+            )));
+            $normalized = (string) preg_replace($pattern, '', $domain);
+        } else {
+            $normalized = $domain;
+        }
+
         $normalized = preg_replace('/[^a-z0-9\-.]/', '', $normalized) ?? '';
         $normalized = trim($normalized, '.');
 
         return $normalized;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function getStrippablePrefixes(): array
+    {
+        $env = getenv('DOMAIN_STRIPPED_PREFIXES');
+        if ($env !== false) {
+            $raw = preg_split('/[\s,]+/', strtolower((string) $env)) ?: [];
+        } else {
+            $raw = [];
+        }
+
+        $raw = array_filter(array_map(static fn (string $prefix): string => trim($prefix), $raw));
+
+        if ($raw === []) {
+            $raw = ['www', 'admin', 'assistant'];
+        }
+
+        return array_values(array_unique(array_merge(['www'], $raw)));
     }
 }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -49,6 +49,7 @@ use App\Service\SessionService;
 use App\Service\StripeService;
 use App\Service\VersionService;
 use App\Infrastructure\Database;
+use App\Support\DomainNameHelper;
 use App\Controller\Admin\ProfileController;
 use App\Application\Middleware\LanguageMiddleware;
 use App\Application\Middleware\CsrfMiddleware;
@@ -183,10 +184,10 @@ return function (\Slim\App $app, TranslationService $translator) {
             } else {
                 $marketingList = array_filter(preg_split('/[\s,]+/', strtolower($marketingDomains)) ?: []);
                 $marketingList = array_map(
-                    static fn (string $domain): string => (string) preg_replace('/^www\./', '', $domain),
+                    static fn (string $domain): string => DomainNameHelper::normalize($domain, stripAdmin: false),
                     $marketingList
                 );
-                $normalizedHost = (string) preg_replace('/^www\./', '', $host);
+                $normalizedHost = DomainNameHelper::normalize($host, stripAdmin: false);
                 if (in_array($normalizedHost, $marketingList, true)) {
                     $computed = 'marketing';
                 }

--- a/tests/Service/DomainStartPageServiceTest.php
+++ b/tests/Service/DomainStartPageServiceTest.php
@@ -67,6 +67,8 @@ class DomainStartPageServiceTest extends TestCase
         yield 'with scheme' => ['https://calserver.de', 'calserver.de', true];
         yield 'with uppercase and path' => ['HTTP://WWW.CALSERVER.DE/foo', 'calserver.de', true];
         yield 'admin subdomain stripped' => ['admin.calserver.de', 'calserver.de', true];
+        yield 'assistant subdomain stripped' => ['assistant.calserver.de', 'calserver.de', true];
         yield 'marketing subdomain kept when admin stripping disabled' => ['admin.calserver.de', 'admin.calserver.de', false];
+        yield 'assistant subdomain kept when admin stripping disabled' => ['assistant.calserver.de', 'assistant.calserver.de', false];
     }
 }

--- a/tests/Support/DomainNameHelperTest.php
+++ b/tests/Support/DomainNameHelperTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use App\Support\DomainNameHelper;
+use PHPUnit\Framework\TestCase;
+
+class DomainNameHelperTest extends TestCase
+{
+    /**
+     * @dataProvider provideDomains
+     *
+     * @param non-empty-string $expected
+     */
+    public function testNormalizeStripsKnownPrefixes(string $input, string $expected): void {
+        self::assertSame($expected, DomainNameHelper::normalize($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideDomains(): iterable {
+        yield 'base domain' => ['example.com', 'example.com'];
+        yield 'www prefix' => ['www.example.com', 'example.com'];
+        yield 'admin prefix' => ['admin.example.com', 'example.com'];
+        yield 'assistant prefix' => ['assistant.example.com', 'example.com'];
+        yield 'mixed case with scheme' => ['HTTPS://ASSISTANT.Example.COM/path', 'example.com'];
+    }
+
+    /**
+     * @dataProvider provideLegacyDomains
+     */
+    public function testNormalizeKeepsPrefixesWhenAdminStrippingDisabled(string $input, string $expected): void {
+        self::assertSame($expected, DomainNameHelper::normalize($input, stripAdmin: false));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideLegacyDomains(): iterable {
+        yield 'www removed' => ['www.example.com', 'example.com'];
+        yield 'admin kept' => ['admin.example.com', 'admin.example.com'];
+        yield 'assistant kept' => ['assistant.example.com', 'assistant.example.com'];
+    }
+}


### PR DESCRIPTION
## Summary
- extend `DomainNameHelper` so additional subdomain prefixes (like `assistant`) can be configured and stripped during normalisation
- update middleware and routing code to rely on the shared helper and document the new environment toggle
- add unit coverage for the helper and extend existing start-page tests for the new alias handling

## Testing
- `./vendor/bin/phpunit tests/Support/DomainNameHelperTest.php`
- `./vendor/bin/phpunit tests/Service/DomainStartPageServiceTest.php`
- `POSTGRES_DSN=sqlite::memory: POSTGRES_USER= POSTGRES_PASSWORD= ./vendor/bin/phpunit tests/DomainMiddlewareTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68e18244e9ac832ba0e037f1f2074653