### PR TITLE
Fix domain-specific RAG fallback for subdomain hosts

### DIFF
--- a/tests/Service/RagChat/RagChatServiceTest.php
+++ b/tests/Service/RagChat/RagChatServiceTest.php
@@ -189,6 +189,28 @@ final class RagChatServiceTest extends TestCase
         }
     }
 
+    public function testAnswerFallsBackToSubdomainAliasWhenHostIncludesParentDomain(): void
+    {
+        $path = $this->createIndexFile();
+        $responder = new class('Natürlich!') implements ChatResponderInterface {
+            public function respond(array $messages, array $context): string
+            {
+                return 'Natürlich!';
+            }
+        };
+
+        $service = new RagChatService($path, $this->domainBase, $responder);
+
+        $this->createDomainIndex('calserver');
+
+        $response = $service->answer('calserver inventar', 'de', 'calserver.quizrace.de');
+
+        $context = $response->getContext();
+        self::assertNotSame([], $context);
+        self::assertSame('Domain Knowledge (Abschnitt 1)', $context[0]->getLabel());
+        self::assertSame('calserver', $context[0]->getMetadata()['domain']);
+    }
+
     private function createIndexFile(): string
     {
         $payload = [


### PR DESCRIPTION
## Summary
- ensure RagChatService looks for alternate domain index candidates so subdomain hosts can reuse base indexes
- add regression coverage for calserver-style domain aliasing

## Testing
- vendor/bin/phpunit tests/Service/RagChat/RagChatServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e18bf8154c832bbdb91a970b3d6aeb