### PR TITLE
Prevent global fallback for domain chat without matches

### DIFF
--- a/src/Service/RagChat/RagChatService.php
+++ b/src/Service/RagChat/RagChatService.php
@@ -151,6 +151,12 @@ final class RagChatService
         }
 
         if ($contextResults === []) {
+            if ($normalizedDomain !== '') {
+                $messages = self::MESSAGE_TEMPLATES[$locale] ?? self::MESSAGE_TEMPLATES[self::DEFAULT_LOCALE];
+
+                return new RagChatResponse($question, $messages['no_results'], []);
+            }
+
             foreach ($globalIndex->search($question, 4, 0.05) as $result) {
                 if (isset($seenChunks[$result->getChunkId()])) {
                     continue;


### PR DESCRIPTION
## Summary
- stop the rag chat service from falling back to the global index when a domain is specified but has no matches
- return the standard no-results message in that situation so unrelated global answers are not shown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1846aec04832ba6364a9cf3b55587