### PR TITLE
Canonicalize marketing domains for RAG storage

### DIFF
--- a/src/Controller/Admin/DomainChatKnowledgeController.php
+++ b/src/Controller/Admin/DomainChatKnowledgeController.php
@@ -129,7 +129,7 @@ final class DomainChatKnowledgeController
             }
         }
 
-        $normalized = DomainNameHelper::normalize($domain);
+        $normalized = DomainNameHelper::canonicalizeSlug($domain);
         if ($normalized === '') {
             throw new InvalidArgumentException('Invalid domain parameter.');
         }

--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -103,8 +103,13 @@ class DomainStartPageService
         }
 
         $marketingHost = $this->normalizeDomain($host, stripAdmin: false);
-        if ($marketingHost !== '' && $marketingHost !== $normalizedHost) {
+        if ($marketingHost !== '' && !in_array($marketingHost, $candidates, true)) {
             $candidates[] = $marketingHost;
+        }
+
+        $canonicalHost = DomainNameHelper::canonicalizeSlug($host);
+        if ($canonicalHost !== '' && !in_array($canonicalHost, $candidates, true)) {
+            $candidates[] = $canonicalHost;
         }
 
         foreach ($candidates as $candidate) {
@@ -366,22 +371,24 @@ class DomainStartPageService
                 continue;
             }
             $normalized = $this->normalizeDomain($domain);
-            if ($normalized === '') {
+            $canonical = DomainNameHelper::canonicalizeSlug($domain);
+            if ($normalized === '' || $canonical === '') {
                 continue;
             }
-            if (!isset($domains[$normalized])) {
-                $domains[$normalized] = [
+            if (!isset($domains[$canonical])) {
+                $domains[$canonical] = [
                     'domain' => $normalized,
-                    'normalized' => $normalized,
+                    'normalized' => $canonical,
                     'type' => 'marketing',
                 ];
             }
         }
 
-        $current = $this->normalizeDomain($currentHost);
+        $currentDisplay = $this->normalizeDomain($currentHost, stripAdmin: false);
+        $current = DomainNameHelper::canonicalizeSlug($currentHost);
         if ($current !== '' && !isset($domains[$current])) {
             $domains[$current] = [
-                'domain' => $current,
+                'domain' => $currentDisplay !== '' ? $currentDisplay : $current,
                 'normalized' => $current,
                 'type' => 'custom',
             ];

--- a/src/Service/RagChat/DomainIndexManager.php
+++ b/src/Service/RagChat/DomainIndexManager.php
@@ -32,7 +32,7 @@ final class DomainIndexManager
      */
     public function rebuild(string $domain): array
     {
-        $normalized = DomainNameHelper::normalize($domain);
+        $normalized = DomainNameHelper::canonicalizeSlug($domain);
         if ($normalized === '') {
             throw new RuntimeException('Invalid domain supplied.');
         }

--- a/tests/Integration/DomainChatKnowledgeWorkflowTest.php
+++ b/tests/Integration/DomainChatKnowledgeWorkflowTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use App\Controller\Admin\DomainChatKnowledgeController;
+use App\Controller\Marketing\CalserverChatController;
+use App\Service\RagChat\DomainDocumentStorage;
+use App\Service\RagChat\DomainIndexManager;
+use App\Service\RagChat\RagChatService;
+use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Psr7\UploadedFile;
+use Tests\TestCase;
+
+use function bin2hex;
+use function file_put_contents;
+use function json_decode;
+use function json_encode;
+use function mkdir;
+use function random_bytes;
+use function scandir;
+use function sys_get_temp_dir;
+use function tempnam;
+use function file_exists;
+use function is_dir;
+use function is_file;
+use function is_link;
+use function unlink;
+use function rmdir;
+
+final class DomainChatKnowledgeWorkflowTest extends TestCase
+{
+    public function testLegacyMarketingDomainUploadIsAccessibleViaSlug(): void
+    {
+        $baseDir = sys_get_temp_dir() . '/rag-domain-' . bin2hex(random_bytes(4));
+        $domainsDir = $baseDir . '/domains';
+        $projectRoot = $baseDir . '/project';
+        $scriptsDir = $projectRoot . '/scripts';
+        $globalIndexPath = $baseDir . '/global-index.json';
+
+        mkdir($domainsDir, 0775, true);
+        mkdir($scriptsDir, 0775, true);
+
+        $pipelineScript = <<<'PHP_SCRIPT'
+<?php
+declare(strict_types=1);
+
+$uploadsDir = $argv[1] ?? '';
+$corpusPath = null;
+$indexPath = null;
+for ($i = 2; $i < $argc; $i++) {
+    if ($argv[$i] === '--corpus' && isset($argv[$i + 1])) {
+        $corpusPath = $argv[++$i];
+        continue;
+    }
+    if ($argv[$i] === '--index' && isset($argv[$i + 1])) {
+        $indexPath = $argv[++$i];
+        continue;
+    }
+}
+
+$content = 'Calserver uptime details';
+if ($uploadsDir !== '' && is_dir($uploadsDir)) {
+    $items = scandir($uploadsDir);
+    if ($items !== false) {
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $uploadsDir . DIRECTORY_SEPARATOR . $item;
+            if (is_file($path)) {
+                $fileContent = file_get_contents($path);
+                if ($fileContent !== false) {
+                    $content = trim($fileContent);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+if ($corpusPath !== null) {
+    file_put_contents($corpusPath, json_encode(['id' => 'chunk-1', 'text' => $content]) . PHP_EOL);
+}
+
+if ($indexPath !== null) {
+    $payload = [
+        'vocabulary' => ['uptime'],
+        'idf' => [1.0],
+        'chunks' => [[
+            'id' => 'chunk-1',
+            'text' => $content,
+            'metadata' => ['source' => 'doc'],
+            'vector' => [[0, 1.0]],
+            'norm' => 1.0,
+        ]],
+    ];
+    file_put_contents($indexPath, json_encode($payload));
+}
+PHP_SCRIPT;
+        file_put_contents($scriptsDir . '/rag_pipeline.py', $pipelineScript);
+
+        file_put_contents($globalIndexPath, json_encode([
+            'vocabulary' => [],
+            'idf' => [],
+            'chunks' => [],
+        ]));
+
+        $previousMarketing = getenv('MARKETING_DOMAINS');
+        putenv('MARKETING_DOMAINS=calserver.com');
+        $_ENV['MARKETING_DOMAINS'] = 'calserver.com';
+
+        try {
+            $storage = new DomainDocumentStorage($domainsDir);
+            $indexManager = new DomainIndexManager($storage, $projectRoot, 'php');
+            $controller = new DomainChatKnowledgeController($storage, $indexManager);
+
+            $responseFactory = new ResponseFactory();
+
+            $uploadRequest = $this->createRequest(
+                'POST',
+                '/admin/domain-chat/documents?domain=calserver.com',
+                ['Content-Type' => 'multipart/form-data']
+            );
+            $tempFile = tempnam(sys_get_temp_dir(), 'upload');
+            file_put_contents($tempFile, 'Calserver uptime details');
+            $uploaded = new UploadedFile(
+                $tempFile,
+                'guide.md',
+                'text/markdown',
+                strlen('Calserver uptime details'),
+                UPLOAD_ERR_OK
+            );
+            $uploadRequest = $uploadRequest->withUploadedFiles(['document' => $uploaded]);
+
+            $uploadResponse = $controller->upload($uploadRequest, $responseFactory->createResponse());
+            $payload = json_decode((string) $uploadResponse->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+            self::assertSame(201, $uploadResponse->getStatusCode());
+            self::assertArrayHasKey('document', $payload);
+
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+
+            $rebuildRequest = $this->createRequest(
+                'POST',
+                '/admin/domain-chat/rebuild?domain=calserver.com',
+                ['Accept' => 'application/json']
+            );
+            $rebuildResponse = $controller->rebuild($rebuildRequest, $responseFactory->createResponse());
+            $rebuildPayload = json_decode((string) $rebuildResponse->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+            self::assertSame(200, $rebuildResponse->getStatusCode());
+            self::assertTrue($rebuildPayload['success']);
+
+            $ragService = new RagChatService($globalIndexPath, $domainsDir, null, static fn (): array => []);
+            $chatController = new CalserverChatController('calserver', $ragService);
+
+            $chatRequest = $this->createRequest(
+                'POST',
+                '/calserver/chat',
+                [
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'application/json',
+                ]
+            );
+            $chatRequest->getBody()->write(json_encode(['question' => 'Wie ist die uptime?']));
+            $chatRequest->getBody()->rewind();
+
+            $chatResponse = $chatController($chatRequest, $responseFactory->createResponse());
+            $chatPayload = json_decode((string) $chatResponse->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+            self::assertSame(200, $chatResponse->getStatusCode());
+            self::assertSame('Wie ist die uptime?', $chatPayload['question']);
+            self::assertNotSame([], $chatPayload['context']);
+            self::assertSame('calserver', $chatPayload['context'][0]['metadata']['domain']);
+            self::assertSame('doc', $chatPayload['context'][0]['metadata']['source']);
+        } finally {
+            if ($previousMarketing === false) {
+                putenv('MARKETING_DOMAINS');
+                unset($_ENV['MARKETING_DOMAINS']);
+            } else {
+                putenv('MARKETING_DOMAINS=' . $previousMarketing);
+                $_ENV['MARKETING_DOMAINS'] = $previousMarketing;
+            }
+
+            $this->cleanupDirectory($baseDir);
+        }
+    }
+
+    private function cleanupDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $target = $path . '/' . $item;
+            if (is_dir($target)) {
+                $this->cleanupDirectory($target);
+                continue;
+            }
+
+            if (is_file($target) || is_link($target)) {
+                unlink($target);
+            }
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Summary
- canonicalize marketing domains via DomainNameHelper so start page configuration and admin flows expose slug-based identifiers while retaining display labels
- migrate legacy <domain>.com RAG document directories to slug-based storage and update the index manager and admin controller to consume the shared canonicalization
- add unit and integration tests covering marketing slug normalization and a full upload/rebuild/chat workflow for calserver.com

## Testing
- vendor/bin/phpunit tests/Service/RagChat/DomainDocumentStorageTest.php tests/Service/DomainStartPageServiceTest.php tests/Integration/DomainChatKnowledgeWorkflowTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e1add09b98832b8a50150aecc02ea4