### PR TITLE
Move calServer assistant CTA to contact section

### DIFF
--- a/migrations/20251107_move_calserver_chat_button.sql
+++ b/migrations/20251107_move_calserver_chat_button.sql
@@ -1,0 +1,34 @@
+-- Move the calServer assistant chat button from the hero into the contact section
+UPDATE pages
+SET content = replace(
+    content,
+$$                </div>
+                <div class="calserver-proof-seals uk-margin-small-top">$$,
+$$                </div>
+                <button class="uk-button uk-button-default uk-width-1-1 uk-margin-small-top calserver-chat-trigger"
+                        type="button"
+                        data-calserver-chat-open
+                        aria-haspopup="dialog"
+                        aria-controls="calserver-chat-modal">
+                  <span class="uk-margin-small-right" data-uk-icon="icon: commenting"></span>Assistent fragen
+                </button>
+                <div class="calserver-proof-seals uk-margin-small-top">$$
+)
+WHERE slug = 'calserver';
+
+UPDATE pages
+SET content = replace(
+    content,
+$$                </div>
+                <div class="calserver-proof-seals uk-margin-small-top">$$,
+$$                </div>
+                <button class="uk-button uk-button-default uk-width-1-1 uk-margin-small-top calserver-chat-trigger"
+                        type="button"
+                        data-calserver-chat-open
+                        aria-haspopup="dialog"
+                        aria-controls="calserver-chat-modal">
+                  <span class="uk-margin-small-right" data-uk-icon="icon: commenting"></span>Ask assistant
+                </button>
+                <div class="calserver-proof-seals uk-margin-small-top">$$
+)
+WHERE slug = 'calserver-en';

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -258,13 +258,6 @@
                  rel="noopener">
                 <span class="uk-margin-small-right" data-uk-icon="icon: calendar"></span>{{ hero.ctaSecondary }}
               </a>
-              <button class="uk-button uk-button-default calserver-chat-trigger"
-                      type="button"
-                      data-calserver-chat-open
-                      aria-haspopup="dialog"
-                      aria-controls="calserver-chat-modal">
-                <span class="uk-margin-small-right" data-uk-icon="icon: commenting"></span>{{ hero.ctaChat }}
-              </button>
             </div>
             <div class="qr-proof uk-margin-top">
               <span>{{ hero.proof }}</span>


### PR DESCRIPTION
## Summary
- remove the calServer assistant chat CTA from the hero action row
- update the marketing content so the assistant chat button appears in the contact section for both languages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1afad8480832b8e571e8edd66f9b0