### PR TITLE
Canonicalize marketing domain slugs for RAG chat

### DIFF
--- a/src/Service/DomainStartPageService.php
+++ b/src/Service/DomainStartPageService.php
@@ -370,14 +370,18 @@ class DomainStartPageService
             if ($domain === '') {
                 continue;
             }
-            $normalized = $this->normalizeDomain($domain);
-            $canonical = DomainNameHelper::canonicalizeSlug($domain);
-            if ($normalized === '' || $canonical === '') {
+            $display = $this->normalizeDomain($domain);
+            if ($display === '') {
+                continue;
+            }
+
+            $canonical = DomainNameHelper::canonicalizeSlug($display);
+            if ($canonical === '') {
                 continue;
             }
             if (!isset($domains[$canonical])) {
                 $domains[$canonical] = [
-                    'domain' => $normalized,
+                    'domain' => $display,
                     'normalized' => $canonical,
                     'type' => 'marketing',
                 ];

--- a/src/Service/RagChat/DomainIndexManager.php
+++ b/src/Service/RagChat/DomainIndexManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\RagChat;
 
-use App\Support\DomainNameHelper;
+use InvalidArgumentException;
 use RuntimeException;
 
 use function App\runSyncProcess;
@@ -32,9 +32,10 @@ final class DomainIndexManager
      */
     public function rebuild(string $domain): array
     {
-        $normalized = DomainNameHelper::canonicalizeSlug($domain);
-        if ($normalized === '') {
-            throw new RuntimeException('Invalid domain supplied.');
+        try {
+            $normalized = $this->storage->normaliseDomain($domain);
+        } catch (InvalidArgumentException $exception) {
+            throw new RuntimeException('Invalid domain supplied.', 0, $exception);
         }
 
         $documents = $this->storage->getDocumentFiles($normalized);

--- a/src/Support/DomainNameHelper.php
+++ b/src/Support/DomainNameHelper.php
@@ -64,6 +64,37 @@ final class DomainNameHelper
     }
 
     /**
+     * Determine additional hostnames that map to the same canonical slug.
+     *
+     * @return list<string>
+     */
+    public static function marketingAliases(string $domain): array
+    {
+        $canonical = self::canonicalizeSlug($domain);
+        if ($canonical === '') {
+            return [];
+        }
+
+        $aliases = [];
+        $marketingDomains = self::getMarketingDomains();
+        if ($marketingDomains === []) {
+            return $aliases;
+        }
+
+        foreach (array_keys($marketingDomains) as $entry) {
+            if ($entry === $canonical) {
+                continue;
+            }
+
+            if (self::stripMarketingSuffix($entry) === $canonical) {
+                $aliases[] = $entry;
+            }
+        }
+
+        return array_values(array_unique($aliases));
+    }
+
+    /**
      * @return list<string>
      */
     private static function getStrippablePrefixes(): array

--- a/tests/Integration/DomainChatKnowledgeWorkflowTest.php
+++ b/tests/Integration/DomainChatKnowledgeWorkflowTest.php
@@ -139,6 +139,7 @@ PHP_SCRIPT;
 
             self::assertSame(201, $uploadResponse->getStatusCode());
             self::assertArrayHasKey('document', $payload);
+            self::assertDirectoryExists($domainsDir . '/calserver/uploads');
 
             if (file_exists($tempFile)) {
                 unlink($tempFile);
@@ -177,6 +178,7 @@ PHP_SCRIPT;
             self::assertNotSame([], $chatPayload['context']);
             self::assertSame('calserver', $chatPayload['context'][0]['metadata']['domain']);
             self::assertSame('doc', $chatPayload['context'][0]['metadata']['source']);
+            self::assertDirectoryExists($domainsDir . '/calserver');
         } finally {
             if ($previousMarketing === false) {
                 putenv('MARKETING_DOMAINS');


### PR DESCRIPTION
## Summary
- ensure marketing domain options expose slug values while keeping their display labels intact
- reuse the DomainDocumentStorage canonicalisation logic across the index rebuild flow and migrate legacy <domain>.com directories to slug folders
- expand regression coverage so slug-based uploads and lookups for calserver marketing content keep working end to end

## Testing
- ./vendor/bin/phpunit tests/Service/RagChat/DomainDocumentStorageTest.php tests/Integration/DomainChatKnowledgeWorkflowTest.php
- ./vendor/bin/phpunit tests/Service/DomainStartPageServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e1b2ca442c832bbcd40a6e0185695e