### PR TITLE
Fix rag pipeline imports for domain index rebuild

### DIFF
--- a/scripts/rag_pipeline.py
+++ b/scripts/rag_pipeline.py
@@ -2,7 +2,12 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from rag_chatbot import PipelineOptions, run_pipeline
 

--- a/tests/Integration/DomainChatPipelineExecutionTest.php
+++ b/tests/Integration/DomainChatPipelineExecutionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use App\Service\RagChat\DomainDocumentStorage;
+use App\Service\RagChat\DomainIndexManager;
+use Slim\Psr7\UploadedFile;
+use Tests\TestCase;
+
+use function bin2hex;
+use function file_get_contents;
+use function file_put_contents;
+use function is_dir;
+use function is_file;
+use function is_link;
+use function json_decode;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function scandir;
+use function strlen;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class DomainChatPipelineExecutionTest extends TestCase
+{
+    public function testRebuildUsingPythonPipelineProducesIndex(): void
+    {
+        $baseDir = sys_get_temp_dir() . '/rag-domain-' . bin2hex(random_bytes(4));
+        $domainsDir = $baseDir . '/domains';
+
+        mkdir($domainsDir, 0775, true);
+
+        $storage = new DomainDocumentStorage($domainsDir);
+        $tempFile = tempnam(sys_get_temp_dir(), 'upload');
+        $content = "# Domain Facts\n\nExample knowledge base.";
+        file_put_contents($tempFile, $content);
+        $uploaded = new UploadedFile(
+            $tempFile,
+            'facts.md',
+            'text/markdown',
+            strlen($content),
+            UPLOAD_ERR_OK
+        );
+        $storage->storeDocument('python.example', $uploaded);
+
+        if (is_file($tempFile)) {
+            unlink($tempFile);
+        }
+
+        $projectRoot = dirname(__DIR__, 2);
+        $indexManager = new DomainIndexManager($storage, $projectRoot, 'python3');
+
+        try {
+            $result = $indexManager->rebuild('python.example');
+
+            self::assertTrue($result['success']);
+            self::assertFalse($result['cleared']);
+
+            $indexPath = $storage->getIndexPath('python.example');
+            self::assertFileExists($indexPath);
+
+            $raw = file_get_contents($indexPath);
+            self::assertNotFalse($raw);
+            $payload = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+
+            self::assertIsArray($payload);
+            self::assertArrayHasKey('chunks', $payload);
+            self::assertNotSame([], $payload['chunks']);
+        } finally {
+            $this->cleanupDirectory($baseDir);
+        }
+    }
+
+    private function cleanupDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $target = $path . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($target)) {
+                $this->cleanupDirectory($target);
+                continue;
+            }
+
+            if (is_file($target) || is_link($target)) {
+                unlink($target);
+            }
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the rag pipeline script adds the project root to Python's module search path before importing `rag_chatbot`
- add an integration test that rebuilds a domain index via the real Python pipeline to prevent regressions

## Testing
- ./vendor/bin/phpunit tests/Integration/DomainChatPipelineExecutionTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e1bc0989e4832baeba8fcfed3663e6