### PR TITLE
Fix phpstan warnings in DomainIndexManager

### DIFF
--- a/src/Service/RagChat/DomainIndexManager.php
+++ b/src/Service/RagChat/DomainIndexManager.php
@@ -74,8 +74,8 @@ final class DomainIndexManager
         $result['cleared'] = false;
 
         if ($result['success'] !== true) {
-            $stderr = isset($result['stderr']) ? trim($result['stderr']) : '';
-            $stdout = isset($result['stdout']) ? trim($result['stdout']) : '';
+            $stderr = trim($result['stderr']);
+            $stdout = trim($result['stdout']);
             $message = $stderr !== '' ? $stderr : $stdout;
             if ($message === '') {
                 $message = 'Domain index rebuild failed.';


### PR DESCRIPTION
## Summary
- remove redundant isset checks on runSyncProcess output in the domain index rebuild logic to satisfy phpstan's array-shape analysis

## Testing
- vendor/bin/phpstan analyse -c phpstan.neon.dist *(fails: vendor/bin/phpstan is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22c2a0740832b9612055581344cdc