### PR TITLE
Add Python runtime to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 
 RUN apk add --no-cache \
     libpng libjpeg-turbo freetype libwebp postgresql-client imagemagick \
+    python3 py3-pip \
     && apk add --no-cache --virtual .build-deps \
        libpng-dev libjpeg-turbo-dev freetype-dev libwebp-dev postgresql-dev imagemagick-dev $PHPIZE_DEPS \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \


### PR DESCRIPTION
## Summary
- install python3 and py3-pip in the base image so the runtime matches DomainIndexManager requirements

## Testing
- not run (infrastructure-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e23c7b3b98832bb4646ec2d6d8682b