### PR TITLE
Simplify marketing assistant source display

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -820,42 +820,57 @@ body.qr-landing.calserver-theme .calserver-highlight__intro p {
     margin-top: 12px;
 }
 
-.marketing-chat__context-title {
-    margin: 0 0 8px;
+.marketing-chat__context-toggle {
+    margin: 0;
     font-size: 0.95rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: color-mix(in oklab, var(--qr-muted, #5c6580) 92%, rgba(92, 101, 128, 0.6));
+    cursor: pointer;
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+}
+
+.marketing-chat__context-toggle::-webkit-details-marker {
+    display: none;
+}
+
+.marketing-chat__context-toggle::before {
+    content: '\25B8';
+    display: inline-block;
+    margin-right: 6px;
+    transition: transform 0.2s ease;
+}
+
+.marketing-chat__context[open] .marketing-chat__context-toggle::before {
+    transform: rotate(90deg);
 }
 
 .marketing-chat__context-list {
-    margin: 0;
+    margin: 8px 0 0;
     padding-left: 20px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 8px;
+}
+
+.marketing-chat__context-item {
+    font-size: 0.95rem;
+}
+
+.marketing-chat__context-link {
+    color: var(--calserver-primary, #1f63e6);
+    text-decoration: none;
+}
+
+.marketing-chat__context-link:hover,
+.marketing-chat__context-link:focus {
+    text-decoration: underline;
 }
 
 .marketing-chat__context-label {
-    display: inline-block;
-    margin-bottom: 4px;
-}
-
-.marketing-chat__context-score {
-    margin-left: 8px;
-    font-size: 0.85rem;
-    color: color-mix(in oklab, var(--qr-muted, #5c6580) 88%, rgba(92, 101, 128, 0.5));
-}
-
-.marketing-chat__context-snippet {
-    margin: 0;
-    line-height: 1.45;
-}
-
-.marketing-chat__empty {
-    margin: 12px 0 0;
-    font-style: italic;
-    color: color-mix(in oklab, var(--qr-muted, #5c6580) 85%, rgba(92, 101, 128, 0.55));
+    color: color-mix(in oklab, var(--qr-muted, #5c6580) 92%, rgba(92, 101, 128, 0.6));
 }
 
 .marketing-chat__status {

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -390,6 +390,7 @@ return [
     'marketing_chat_error_validation' => 'Bitte gib eine Frage ein.',
     'marketing_chat_error_rate_limited' => 'Zu viele Anfragen. Bitte warte einen Moment.',
     'marketing_chat_sources' => 'Quellen',
+    'marketing_chat_sources_toggle' => 'Quellen anzeigen',
     'marketing_chat_score' => 'Relevanz',
     'marketing_chat_empty' => 'Keine passenden Hinweise gefunden.',
     'marketing_chat_close' => 'Schließen',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -392,6 +392,7 @@ return [
     'marketing_chat_error_validation' => 'Please enter a question.',
     'marketing_chat_error_rate_limited' => 'Too many requests. Please wait a moment.',
     'marketing_chat_sources' => 'Sources',
+    'marketing_chat_sources_toggle' => 'Show sources',
     'marketing_chat_score' => 'Relevance',
     'marketing_chat_empty' => 'No matching hints found.',
     'marketing_chat_close' => 'Close',

--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -507,6 +507,7 @@
         errorValidation: '{{ t('marketing_chat_error_validation')|e('js') }}',
         errorRateLimited: '{{ t('marketing_chat_error_rate_limited')|e('js') }}',
         sources: '{{ t('marketing_chat_sources')|e('js') }}',
+        sourcesToggle: '{{ t('marketing_chat_sources_toggle')|e('js') }}',
         score: '{{ t('marketing_chat_score')|e('js') }}',
         empty: '{{ t('marketing_chat_empty')|e('js') }}',
         question: '{{ t('marketing_chat_question_label')|e('js') }}'


### PR DESCRIPTION
## Summary
- show marketing assistant answers without inline source details and move references into a collapsible section
- style the collapsible source list as simple links and update localisation strings for the new toggle label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e256d45a00832b8b6117eba2e3e124