### PR TITLE
Improve marketing assistant modal contrast in dark mode

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -764,36 +764,70 @@ body.qr-landing.calserver-theme .calserver-highlight__intro p {
     display: flex;
     flex-direction: column;
     gap: 16px;
+    --marketing-chat-surface: color-mix(
+        in oklab,
+        var(--qr-card, #f5f7fb) 96%,
+        rgba(255, 255, 255, 0.94)
+    );
+    --marketing-chat-surface-alt: color-mix(
+        in oklab,
+        var(--qr-card, #f5f7fb) 92%,
+        rgba(255, 255, 255, 0.82)
+    );
+    --marketing-chat-emphasis: color-mix(
+        in oklab,
+        var(--calserver-primary, #1f63e6) 18%,
+        rgba(255, 255, 255, 0.94)
+    );
+    --marketing-chat-strong: color-mix(
+        in oklab,
+        var(--qr-text, #1c2131) 90%,
+        rgba(28, 33, 49, 0.1)
+    );
+    --marketing-chat-muted: color-mix(
+        in oklab,
+        var(--qr-muted, #5c6580) 92%,
+        rgba(92, 101, 128, 0.6)
+    );
+    --marketing-chat-border: color-mix(
+        in oklab,
+        var(--qr-card-border, #d8deeb) 85%,
+        transparent
+    );
+    background: var(--marketing-chat-surface);
+    color: var(--marketing-chat-strong);
+    border: 1px solid var(--marketing-chat-border);
     border-radius: 12px;
     box-shadow: 0 28px 64px -40px rgba(9, 20, 40, 0.55), 0 12px 32px -20px rgba(14, 30, 60, 0.35);
 }
 
 .marketing-chat__intro {
     margin: 0;
-    color: color-mix(in oklab, var(--qr-text, #1c2131) 82%, rgba(28, 33, 49, 0.52));
+    color: var(--marketing-chat-muted);
 }
 
 .marketing-chat__messages {
     max-height: 320px;
     overflow-y: auto;
     padding: 12px 16px;
-    background: color-mix(in oklab, var(--qr-card, #f5f7fb) 92%, rgba(255, 255, 255, 0.82));
-    border: 1px solid color-mix(in oklab, var(--qr-border, #d8deeb) 90%, transparent);
+    background: var(--marketing-chat-surface-alt);
+    border: 1px solid color-mix(in oklab, var(--marketing-chat-border) 92%, transparent);
     border-radius: 10px;
 }
 
 .marketing-chat__system {
     margin-bottom: 12px;
     padding: 12px 14px;
-    background: color-mix(in oklab, var(--calserver-primary, #1f63e6) 14%, rgba(255, 255, 255, 0.92));
+    background: var(--marketing-chat-emphasis);
     border-radius: 8px;
     font-weight: 600;
+    color: var(--marketing-chat-strong);
 }
 
 .marketing-chat__turn {
     padding-bottom: 16px;
     margin-bottom: 16px;
-    border-bottom: 1px solid color-mix(in oklab, var(--qr-border, #d8deeb) 86%, transparent);
+    border-bottom: 1px solid color-mix(in oklab, var(--marketing-chat-border) 78%, transparent);
 }
 
 .marketing-chat__turn:last-child {
@@ -825,7 +859,7 @@ body.qr-landing.calserver-theme .calserver-highlight__intro p {
     font-size: 0.95rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: color-mix(in oklab, var(--qr-muted, #5c6580) 92%, rgba(92, 101, 128, 0.6));
+    color: var(--marketing-chat-muted);
     cursor: pointer;
     list-style: none;
     display: inline-flex;
@@ -870,14 +904,14 @@ body.qr-landing.calserver-theme .calserver-highlight__intro p {
 }
 
 .marketing-chat__context-label {
-    color: color-mix(in oklab, var(--qr-muted, #5c6580) 92%, rgba(92, 101, 128, 0.6));
+    color: var(--marketing-chat-muted);
 }
 
 .marketing-chat__status {
     min-height: 1.25em;
     margin: 0;
     font-weight: 600;
-    color: color-mix(in oklab, var(--qr-muted, #5c6580) 92%, rgba(92, 101, 128, 0.5));
+    color: var(--marketing-chat-muted);
 }
 
 .marketing-chat__status--error {
@@ -898,6 +932,40 @@ body.qr-landing.calserver-theme .calserver-highlight__intro p {
 
 .marketing-chat__form--loading textarea {
     opacity: 0.75;
+}
+
+body.qr-landing.calserver-theme.dark-mode:not(.high-contrast) .marketing-chat__dialog,
+body.qr-landing.calserver-theme[data-theme="dark"]:not(.high-contrast) .marketing-chat__dialog {
+    --marketing-chat-surface: color-mix(
+        in oklab,
+        var(--qr-card, #101a2d) 85%,
+        rgba(8, 14, 28, 0.92)
+    );
+    --marketing-chat-surface-alt: color-mix(
+        in oklab,
+        rgba(9, 16, 30, 0.94) 82%,
+        color-mix(in oklab, var(--calserver-primary, #1f63e6) 22%, transparent) 18%
+    );
+    --marketing-chat-emphasis: color-mix(
+        in oklab,
+        var(--calserver-primary, #1f63e6) 42%,
+        rgba(7, 13, 26, 0.88)
+    );
+    --marketing-chat-strong: color-mix(
+        in oklab,
+        #ffffff 94%,
+        rgba(255, 255, 255, 0.72) 6%
+    );
+    --marketing-chat-muted: color-mix(
+        in oklab,
+        rgba(198, 208, 232, 0.92) 88%,
+        rgba(255, 255, 255, 0.7) 12%
+    );
+    --marketing-chat-border: color-mix(
+        in oklab,
+        rgba(31, 99, 230, 0.45) 50%,
+        rgba(255, 255, 255, 0.18) 50%
+    );
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- define theme-aware surface variables for the marketing assistant modal and reuse them across its elements
- adjust message, status, and context colors to use the shared variables for consistent contrast
- override the modal variables in dark mode so copy and system messages remain legible

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e26f53da7c832bb78481fbfdb6e40c