### PR TITLE
Set calServer default theme to light

### DIFF
--- a/templates/marketing/calserver.twig
+++ b/templates/marketing/calserver.twig
@@ -467,9 +467,9 @@
 
         if (storedTheme === null) {
           if (hasStorageHelpers) {
-            setStored(darkKey, 'true');
+            setStored(darkKey, 'false');
           } else if (typeof localStorage !== 'undefined') {
-            localStorage.setItem(darkKey, 'true');
+            localStorage.setItem(darkKey, 'false');
           }
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- ensure the calServer marketing page stores light mode as the initial preference when no theme is saved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26f728eec832b9eb532fe8bc3d7eb