### PR TITLE
Link calServer CTA buttons to contact form

### DIFF
--- a/migrations/20251102_update_calserver_cta_links.sql
+++ b/migrations/20251102_update_calserver_cta_links.sql
@@ -1,0 +1,4 @@
+-- Link calServer CTA buttons to the contact form
+UPDATE pages
+SET content = replace(content, 'href="#offer"', 'href="#contact-form"')
+WHERE slug IN ('calserver', 'calserver-en');

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -1471,7 +1471,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 <p class="uk-margin-remove">Erweiterungen (z. B. Speicher, SSO) zubuchbar</p>
               </div>
               <div class="uk-margin-top">
-                <a class="uk-button uk-button-primary uk-width-1-1" href="#offer">Anfrage senden</a>
+                <a class="uk-button uk-button-primary uk-width-1-1" href="#contact-form">Anfrage senden</a>
                 <button class="uk-button uk-button-text uk-width-1-1 uk-margin-small-top" type="button" data-uk-toggle="target: #modal-standard-hosting">Leistungsdetails</button>
               </div>
             </div>
@@ -1493,7 +1493,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 <p class="uk-margin-remove">Upgrade/Downgrade zwischen Plänen möglich</p>
               </div>
               <div class="uk-margin-top">
-                <a class="uk-button uk-button-primary uk-width-1-1" href="#offer">Anfrage senden</a>
+                <a class="uk-button uk-button-primary uk-width-1-1" href="#contact-form">Anfrage senden</a>
                 <button class="uk-button uk-button-text uk-width-1-1 uk-margin-small-top" type="button" data-uk-toggle="target: #modal-performance-hosting">Leistungsdetails</button>
               </div>
             </div>
@@ -1517,7 +1517,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 <p class="uk-margin-remove">Rollout &amp; Betrieb nach gemeinsamem Migrationsplan</p>
               </div>
               <div class="uk-margin-top">
-                <a class="uk-button uk-button-primary uk-width-1-1" href="#offer">Anfrage senden</a>
+                <a class="uk-button uk-button-primary uk-width-1-1" href="#contact-form">Anfrage senden</a>
                 <button class="uk-button uk-button-text uk-width-1-1 uk-margin-small-top" type="button" data-uk-toggle="target: #modal-enterprise-hosting">Leistungsdetails</button>
               </div>
             </div>
@@ -1649,7 +1649,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                 </ul>
               </div>
               <div class="calserver-highlight-card__actions">
-                <a id="trial" class="uk-button uk-button-default" href="#offer">Jetzt testen</a>
+                <a id="trial" class="uk-button uk-button-default" href="#contact-form">Jetzt testen</a>
                 <span class="muted">Zugang &amp; Demo-Umgebung inklusive</span>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- update the calServer marketing page so CTA buttons scroll to the contact form
- keep the SQLite seed data in sync with the new CTA anchor

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e27c0aa2a4832bac31a0283a4f9f3c