### PR TITLE
Remove border from calserver logo image

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -143,9 +143,9 @@ body.qr-landing.calserver-theme[data-theme="high-contrast"] {
     width: var(--cs-logo-size);
     height: var(--cs-logo-size);
     border-radius: 18px;
-    border: 1px solid var(--cs-logo-border);
-    background: var(--cs-logo-bg);
-    box-shadow: var(--cs-logo-shadow);
+    border: none;
+    background: none;
+    box-shadow: none;
     overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- remove the decorative frame around the calserver landing page logo so the image is shown without a border

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3037af9ac832b9567f1b85adffe0c