### PR TITLE
Update calServer module posters to mp4

### DIFF
--- a/migrations/20251120_update_calserver_module_posters.sql
+++ b/migrations/20251120_update_calserver_module_posters.sql
@@ -1,0 +1,32 @@
+-- Update calServer module preview posters to reference MP4 assets
+UPDATE pages
+SET content = REPLACE(
+    REPLACE(
+        REPLACE(
+            REPLACE(content,
+                'poster="{{ basePath }}/uploads/calserver-module-device-management.webp"',
+                'poster="{{ basePath }}/uploads/calserver-module-device-management.mp4"'),
+            'poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"',
+            'poster="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4"'),
+        'poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"',
+        'poster="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4"'),
+    'poster="{{ basePath }}/uploads/calserver-module-self-service.webp"',
+    'poster="{{ basePath }}/uploads/calserver-module-self-service.mp4"'),
+    updated_at = CURRENT_TIMESTAMP
+WHERE slug = 'calserver';
+
+UPDATE pages
+SET content = REPLACE(
+    REPLACE(
+        REPLACE(
+            REPLACE(content,
+                'poster="{{ basePath }}/uploads/calserver-module-device-management.webp"',
+                'poster="{{ basePath }}/uploads/calserver-module-device-management.mp4"'),
+            'poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"',
+            'poster="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4"'),
+        'poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"',
+        'poster="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4"'),
+    'poster="{{ basePath }}/uploads/calserver-module-self-service.webp"',
+    'poster="{{ basePath }}/uploads/calserver-module-self-service.mp4"'),
+    updated_at = CURRENT_TIMESTAMP
+WHERE slug = 'calserver-en';

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -909,7 +909,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                            loop
                            playsinline
                            preload="auto"
-                           poster="{{ basePath }}/uploads/calserver-module-device-management.webp"
+                           poster="{{ basePath }}/uploads/calserver-module-device-management.mp4"
                            aria-label="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
                       <source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -938,7 +938,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                            loop
                            playsinline
                            preload="auto"
-                           poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
+                           poster="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4"
                            aria-label="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
                       <source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -967,7 +967,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                            loop
                            playsinline
                            preload="auto"
-                           poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
+                           poster="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4"
                            aria-label="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
                       <source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.
@@ -996,7 +996,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                            loop
                            playsinline
                            preload="auto"
-                           poster="{{ basePath }}/uploads/calserver-module-self-service.webp"
+                           poster="{{ basePath }}/uploads/calserver-module-self-service.mp4"
                            aria-label="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
                       <source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4">
                       Ihr Browser unterstützt keine HTML5-Videos.


### PR DESCRIPTION
## Summary
- update the seeded calServer module poster URLs to point at the MP4 assets
- add a migration to swap the poster attributes for the German and English pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e34cc9d658832bbedc1bb9cb1aa3e9