### PR TITLE
Fix technology tab height measurement for Future is Green

### DIFF
--- a/public/css/future-is-green.css
+++ b/public/css/future-is-green.css
@@ -980,7 +980,6 @@ body.qr-landing.future-is-green-theme .landing-content {
 }
 
 .future-is-green-theme .fig-technology-panel {
-  height: 100%;
   padding: 32px;
   border-radius: 20px;
   background: var(--fig-surface);

--- a/templates/marketing/future-is-green.twig
+++ b/templates/marketing/future-is-green.twig
@@ -750,13 +750,11 @@
             return;
           }
 
-          var maxHeight = panels.reduce(function (acc, panel) {
-            var panelHeight = measurePanelHeight(panel);
-            return panelHeight > acc ? panelHeight : acc;
-          }, 0);
+          var activePanel = panels[activeIndex];
+          var measuredHeight = measurePanelHeight(activePanel);
 
-          if (maxHeight > 0) {
-            display.style.minHeight = maxHeight + 'px';
+          if (measuredHeight > 0) {
+            display.style.minHeight = measuredHeight + 'px';
           } else {
             display.style.minHeight = '';
           }


### PR DESCRIPTION
## Summary
- measure the Future is Green technology display height based on the active panel instead of the tallest card
- allow technology panels to shrink with their content by removing the forced 100% height rule

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35e23b108832b8ef68ae1275830fe