### PR TITLE
Fix PHPStan findings for mail provider services

### DIFF
--- a/src/Service/MailProvider/BrevoProvider.php
+++ b/src/Service/MailProvider/BrevoProvider.php
@@ -57,7 +57,8 @@ class BrevoProvider implements MailProviderInterface
             }
         }
 
-        if ($email->getFrom()->count() === 0 && $this->fromAddress !== '') {
+        $fromAddresses = $email->getFrom();
+        if ($fromAddresses === [] && $this->fromAddress !== '') {
             $email->from($this->fromAddress);
         }
 
@@ -148,16 +149,7 @@ class BrevoProvider implements MailProviderInterface
             $fromName = (string) ($profile['imprint_name'] ?? '');
         }
 
-        $result = $fromName !== '' ? sprintf('%s <%s>', $fromName, $fromEmail) : $fromEmail;
-
-        if ($result === '') {
-            if (!in_array('SMTP_FROM', $this->missingConfig, true)) {
-                $this->missingConfig[] = 'SMTP_FROM';
-            }
-            $this->configured = false;
-        }
-
-        return $result;
+        return $fromName !== '' ? sprintf('%s <%s>', $fromName, $fromEmail) : $fromEmail;
     }
 
     private function createDefaultMailer(): MailerInterface

--- a/src/Service/MailProvider/MailProviderManager.php
+++ b/src/Service/MailProvider/MailProviderManager.php
@@ -82,9 +82,6 @@ class MailProviderManager
 
         $factory = $this->factories[$name];
         $provider = $factory();
-        if (!$provider instanceof MailProviderInterface) {
-            throw new RuntimeException('Invalid mail provider configuration.');
-        }
 
         $this->activeProvider = $provider;
 


### PR DESCRIPTION
## Summary
- avoid calling count() on the Address array returned by `Email::getFrom()` and streamline from-address resolution in `BrevoProvider`
- remove the redundant `instanceof` guard in `MailProviderManager`

## Testing
- vendor/bin/phpstan --no-progress --memory-limit=512M *(fails: vendor/bin/phpstan missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e35f334654832baea95478ae9e5e8c