### PR TITLE
Implement newsletter subscription flow with Brevo integration

### DIFF
--- a/migrations/20250401_newsletter_subscriptions.sql
+++ b/migrations/20250401_newsletter_subscriptions.sql
@@ -1,0 +1,16 @@
+-- Track marketing newsletter subscriptions and consent metadata.
+CREATE TABLE IF NOT EXISTS newsletter_subscriptions (
+    email TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    consent_requested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    consent_confirmed_at TIMESTAMP NULL,
+    unsubscribe_at TIMESTAMP NULL,
+    consent_metadata TEXT NULL,
+    attributes TEXT NULL,
+    unsubscribe_metadata TEXT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_newsletter_subscriptions_email
+    ON newsletter_subscriptions(email);
+CREATE INDEX IF NOT EXISTS idx_newsletter_subscriptions_status
+    ON newsletter_subscriptions(status);

--- a/src/Controller/Marketing/NewsletterController.php
+++ b/src/Controller/Marketing/NewsletterController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Marketing;
+
+use App\Infrastructure\Database;
+use App\Service\EmailConfirmationService;
+use App\Service\MailProvider\MailProviderManager;
+use App\Service\NewsletterSubscriptionService;
+use App\Service\SettingsService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use RuntimeException;
+use Slim\Views\Twig;
+
+use function is_array;
+use function json_decode;
+use function trim;
+
+class NewsletterController
+{
+    public function confirm(Request $request, Response $response): Response
+    {
+        $token = trim((string) ($request->getQueryParams()['token'] ?? ''));
+        if ($token === '') {
+            return $this->renderStatus($request, $response, false, 'confirm');
+        }
+
+        $pdo = Database::connectFromEnv();
+        $confirmationService = new EmailConfirmationService($pdo);
+
+        $manager = $request->getAttribute('mailProviderManager');
+        if (!$manager instanceof MailProviderManager) {
+            $manager = new MailProviderManager(new SettingsService($pdo));
+        }
+
+        $service = new NewsletterSubscriptionService($pdo, $confirmationService, $manager);
+
+        $success = false;
+        try {
+            $success = $service->confirmSubscription($token);
+        } catch (RuntimeException $exception) {
+            error_log('Newsletter confirmation failed: ' . $exception->getMessage());
+            $success = false;
+        }
+
+        return $this->renderStatus($request, $response, $success, 'confirm');
+    }
+
+    public function unsubscribe(Request $request, Response $response): Response
+    {
+        $data = $request->getParsedBody();
+        if (!is_array($data)) {
+            $body = $request->getBody();
+            if ($body->isSeekable()) {
+                $body->rewind();
+            }
+            $data = json_decode((string) $body, true);
+        }
+
+        if (!is_array($data)) {
+            return $response->withStatus(400);
+        }
+
+        $email = trim((string) ($data['email'] ?? ''));
+        if ($email === '') {
+            return $response->withStatus(400);
+        }
+
+        $pdo = Database::connectFromEnv();
+        $confirmationService = new EmailConfirmationService($pdo);
+
+        $manager = $request->getAttribute('mailProviderManager');
+        if (!$manager instanceof MailProviderManager) {
+            $manager = new MailProviderManager(new SettingsService($pdo));
+        }
+
+        $service = new NewsletterSubscriptionService($pdo, $confirmationService, $manager);
+
+        $serverParams = $request->getServerParams();
+        $metadata = [
+            'ip' => isset($serverParams['REMOTE_ADDR']) ? (string) $serverParams['REMOTE_ADDR'] : null,
+            'user_agent' => isset($serverParams['HTTP_USER_AGENT']) ? (string) $serverParams['HTTP_USER_AGENT'] : null,
+            'source' => 'marketing-unsubscribe',
+        ];
+
+        try {
+            $success = $service->unsubscribe($email, $metadata);
+        } catch (RuntimeException $exception) {
+            error_log('Newsletter unsubscribe failed: ' . $exception->getMessage());
+
+            return $response->withStatus(500);
+        }
+
+        return $success ? $response->withStatus(204) : $response->withStatus(400);
+    }
+
+    private function renderStatus(Request $request, Response $response, bool $success, string $mode): Response
+    {
+        $twig = Twig::fromRequest($request);
+
+        return $twig->render($response, 'marketing/newsletter_status.twig', [
+            'success' => $success,
+            'mode' => $mode,
+        ]);
+    }
+}

--- a/src/Service/NewsletterSubscriptionService.php
+++ b/src/Service/NewsletterSubscriptionService.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Service\MailProvider\MailProviderManager;
+use DateTimeImmutable;
+use PDO;
+use PDOException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Throwable;
+
+class NewsletterSubscriptionService
+{
+    private PDO $pdo;
+
+    private EmailConfirmationService $confirmationService;
+
+    private MailProviderManager $providerManager;
+
+    private ?MailService $mailService;
+
+    private LoggerInterface $logger;
+
+    public function __construct(
+        PDO $pdo,
+        EmailConfirmationService $confirmationService,
+        MailProviderManager $providerManager,
+        ?MailService $mailService = null,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->pdo = $pdo;
+        $this->confirmationService = $confirmationService;
+        $this->providerManager = $providerManager;
+        $this->mailService = $mailService;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Initiate a double opt-in flow for the given email address.
+     *
+     * @param array<string,mixed> $metadata   Additional context (ip, user_agent, source)
+     * @param array<string,mixed> $attributes Attributes forwarded to the mail provider upon confirmation
+     */
+    public function requestSubscription(
+        string $email,
+        string $confirmationEndpoint,
+        array $metadata = [],
+        array $attributes = []
+    ): void {
+        $email = $this->normalizeEmail($email);
+        if ($email === null) {
+            throw new RuntimeException('Invalid email address for newsletter subscription.');
+        }
+
+        if ($this->mailService === null) {
+            throw new RuntimeException('Mail service is not available for newsletter confirmations.');
+        }
+
+        $token = $this->confirmationService->createToken($email);
+        $this->storePendingSubscription($email, $metadata, $attributes);
+        $confirmationUrl = $this->buildConfirmationUrl($confirmationEndpoint, $token);
+        $this->mailService->sendDoubleOptIn($email, $confirmationUrl);
+    }
+
+    /**
+     * Confirm a pending subscription via token.
+     */
+    public function confirmSubscription(string $token): bool
+    {
+        $token = trim($token);
+        if ($token === '') {
+            return false;
+        }
+
+        $email = $this->confirmationService->confirmToken($token);
+        if ($email === null) {
+            return false;
+        }
+
+        $subscription = $this->findSubscription($email);
+        if ($subscription === null) {
+            $this->ensureSubscriptionRow($email);
+            $subscription = ['attributes' => null];
+        }
+
+        $this->markSubscribed($email);
+        $attributes = $this->decodeScalarMap($subscription['attributes'] ?? null);
+
+        if ($this->providerManager->isConfigured()) {
+            try {
+                $this->providerManager->subscribe($email, $attributes);
+            } catch (Throwable $exception) {
+                $this->logger->error('Brevo subscription failed', [
+                    'email' => $email,
+                    'exception' => $exception,
+                ]);
+                throw new RuntimeException('Failed to subscribe contact to newsletter.', 0, $exception);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Cancel an existing subscription.
+     *
+     * @param array<string,mixed> $metadata Additional context (ip, user_agent, source)
+     */
+    public function unsubscribe(string $email, array $metadata = []): bool
+    {
+        $email = $this->normalizeEmail($email);
+        if ($email === null) {
+            return false;
+        }
+
+        $subscription = $this->findSubscription($email);
+        $this->markUnsubscribed($email, $metadata, $subscription !== null);
+
+        if ($this->providerManager->isConfigured()) {
+            try {
+                $this->providerManager->unsubscribe($email);
+            } catch (Throwable $exception) {
+                $this->logger->error('Brevo unsubscribe failed', [
+                    'email' => $email,
+                    'exception' => $exception,
+                ]);
+                throw new RuntimeException('Failed to unsubscribe contact from newsletter.', 0, $exception);
+            }
+        }
+
+        return true;
+    }
+
+    private function normalizeEmail(string $email): ?string
+    {
+        $email = trim($email);
+        if ($email === '' || filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            return null;
+        }
+
+        return strtolower($email);
+    }
+
+    private function buildConfirmationUrl(string $endpoint, string $token): string
+    {
+        $endpoint = trim($endpoint);
+        if ($endpoint === '') {
+            throw new RuntimeException('Confirmation endpoint is required.');
+        }
+
+        $separator = str_contains($endpoint, '?') ? '&' : '?';
+
+        return $endpoint . $separator . 'token=' . urlencode($token);
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     * @param array<string,mixed> $attributes
+     */
+    private function storePendingSubscription(string $email, array $metadata, array $attributes): void
+    {
+        $now = $this->now();
+        $metadataJson = $this->encodeScalarMap($metadata);
+        $attributesJson = $this->encodeScalarMap($attributes);
+
+        $sql = <<<'SQL'
+INSERT INTO newsletter_subscriptions (email, status, consent_requested_at, consent_metadata, attributes)
+VALUES (:email, 'pending', :requested_at, :metadata, :attributes)
+ON CONFLICT(email) DO UPDATE SET
+    status = excluded.status,
+    consent_requested_at = excluded.consent_requested_at,
+    consent_metadata = excluded.consent_metadata,
+    attributes = excluded.attributes,
+    consent_confirmed_at = NULL,
+    unsubscribe_at = NULL,
+    unsubscribe_metadata = NULL
+SQL;
+
+        $this->executeStatement($sql, [
+            'email' => $email,
+            'requested_at' => $now,
+            'metadata' => $metadataJson,
+            'attributes' => $attributesJson,
+        ]);
+    }
+
+    private function ensureSubscriptionRow(string $email): void
+    {
+        $sql = <<<'SQL'
+INSERT INTO newsletter_subscriptions (email, status, consent_requested_at)
+VALUES (:email, 'pending', :requested_at)
+ON CONFLICT(email) DO NOTHING
+SQL;
+
+        $this->executeStatement($sql, [
+            'email' => $email,
+            'requested_at' => $this->now(),
+        ]);
+    }
+
+    private function markSubscribed(string $email): void
+    {
+        $sql = <<<'SQL'
+UPDATE newsletter_subscriptions
+   SET status = 'subscribed',
+       consent_confirmed_at = :confirmed_at
+ WHERE email = :email
+SQL;
+
+        $this->executeStatement($sql, [
+            'email' => $email,
+            'confirmed_at' => $this->now(),
+        ]);
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function markUnsubscribed(string $email, array $metadata, bool $exists): void
+    {
+        $now = $this->now();
+        $metadataJson = $this->encodeScalarMap($metadata);
+
+        if ($exists) {
+            $sql = <<<'SQL'
+UPDATE newsletter_subscriptions
+   SET status = 'unsubscribed',
+       unsubscribe_at = :unsubscribed_at,
+       unsubscribe_metadata = :metadata
+ WHERE email = :email
+SQL;
+
+            $this->executeStatement($sql, [
+                'email' => $email,
+                'unsubscribed_at' => $now,
+                'metadata' => $metadataJson,
+            ]);
+
+            return;
+        }
+
+        $sql = <<<'SQL'
+INSERT INTO newsletter_subscriptions (email, status, consent_requested_at, unsubscribe_at, unsubscribe_metadata)
+VALUES (:email, 'unsubscribed', :requested_at, :unsubscribed_at, :metadata)
+ON CONFLICT(email) DO UPDATE SET
+    status = excluded.status,
+    unsubscribe_at = excluded.unsubscribe_at,
+    unsubscribe_metadata = excluded.unsubscribe_metadata
+SQL;
+
+        $this->executeStatement($sql, [
+            'email' => $email,
+            'requested_at' => $now,
+            'unsubscribed_at' => $now,
+            'metadata' => $metadataJson,
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function findSubscription(string $email): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT email, status, consent_metadata, attributes FROM newsletter_subscriptions WHERE email = :email'
+        );
+        $stmt->execute(['email' => $email]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    private function executeStatement(string $sql, array $params): void
+    {
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute($params);
+        } catch (PDOException $exception) {
+            $this->logger->error('Newsletter subscription persistence failed', [
+                'sql' => $sql,
+                'params' => $params,
+                'exception' => $exception,
+            ]);
+            throw new RuntimeException('Failed to persist newsletter subscription state.', 0, $exception);
+        }
+    }
+
+    private function encodeScalarMap(array $data): ?string
+    {
+        $normalized = $this->normalizeScalarMap($data);
+        if ($normalized === []) {
+            return null;
+        }
+
+        try {
+            return json_encode($normalized, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            $this->logger->error('Failed to encode newsletter metadata', [
+                'data' => $data,
+                'exception' => $exception,
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * @return array<string,scalar>
+     */
+    private function decodeScalarMap(?string $json): array
+    {
+        if ($json === null || trim($json) === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            $this->logger->error('Failed to decode newsletter metadata', [
+                'json' => $json,
+                'exception' => $exception,
+            ]);
+
+            return [];
+        }
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return $this->normalizeScalarMap($decoded);
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     * @return array<string,scalar>
+     */
+    private function normalizeScalarMap(array $data): array
+    {
+        $normalized = [];
+        foreach ($data as $key => $value) {
+            if (!is_string($key)) {
+                continue;
+            }
+
+            if (is_scalar($value)) {
+                $normalized[$key] = $value;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function now(): string
+    {
+        return (new DateTimeImmutable())->format('Y-m-d H:i:s');
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -87,6 +87,7 @@ use App\Controller\Marketing\MarketingPageController;
 use App\Controller\Marketing\ContactController;
 use App\Controller\Marketing\LandingNewsController as MarketingLandingNewsController;
 use App\Controller\Marketing\MarketingChatController;
+use App\Controller\Marketing\NewsletterController;
 use App\Controller\RegisterController;
 use App\Controller\OnboardingController;
 use App\Controller\OnboardingEmailController;
@@ -157,6 +158,7 @@ require_once __DIR__ . '/Controller/Marketing/LandingController.php';
 require_once __DIR__ . '/Controller/Marketing/CalserverController.php';
 require_once __DIR__ . '/Controller/Marketing/MarketingChatController.php';
 require_once __DIR__ . '/Controller/Marketing/ContactController.php';
+require_once __DIR__ . '/Controller/Marketing/NewsletterController.php';
 require_once __DIR__ . '/Controller/Marketing/LandingNewsController.php';
 require_once __DIR__ . '/Controller/RegisterController.php';
 require_once __DIR__ . '/Controller/OnboardingController.php';
@@ -589,6 +591,18 @@ return function (\Slim\App $app, TranslationService $translator) {
         ->add(new CsrfMiddleware());
     $app->post('/calserver/contact', ContactController::class)
         ->add(new RateLimitMiddleware(3, 3600))
+        ->add(new CsrfMiddleware());
+    $app->get('/newsletter/confirm', function (Request $request, Response $response): Response {
+        $controller = new NewsletterController();
+
+        return $controller->confirm($request, $response);
+    });
+    $app->post('/newsletter/unsubscribe', function (Request $request, Response $response): Response {
+        $controller = new NewsletterController();
+
+        return $controller->unsubscribe($request, $response);
+    })
+        ->add(new RateLimitMiddleware(5, 3600))
         ->add(new CsrfMiddleware());
     $createChatHandler = static function (?string $slug = null) {
         return static function (Request $request, Response $response) use ($slug): Response {

--- a/templates/marketing/newsletter_status.twig
+++ b/templates/marketing/newsletter_status.twig
@@ -1,0 +1,34 @@
+{% extends 'layout.twig' %}
+
+{% block title %}
+  {% if success %}
+    Newsletter bestätigt
+  {% else %}
+    Newsletter-Bestätigung fehlgeschlagen
+  {% endif %}
+{% endblock %}
+
+{% block body %}
+  <div class="uk-section uk-section-default">
+    <div class="uk-container uk-container-small">
+      {% if mode == 'confirm' %}
+        {% if success %}
+          <h1 class="uk-heading-medium">Vielen Dank!</h1>
+          <p class="uk-text-lead">Deine Anmeldung zum QuizRace Newsletter wurde bestätigt.</p>
+          <p>Du erhältst künftig gelegentlich Neuigkeiten und Event-Tipps direkt in dein Postfach. Du kannst dich jederzeit wieder abmelden.</p>
+        {% else %}
+          <h1 class="uk-heading-medium">Bestätigung nicht möglich</h1>
+          <p class="uk-text-lead">Der Bestätigungslink ist ungültig oder wurde bereits verwendet.</p>
+          <p>Bitte fordere bei Bedarf eine neue Bestätigung an oder kontaktiere uns über das Formular auf der Startseite.</p>
+        {% endif %}
+      {% else %}
+        {% if success %}
+          <h1 class="uk-heading-medium">Status aktualisiert</h1>
+        {% else %}
+          <h1 class="uk-heading-medium">Aktion nicht möglich</h1>
+        {% endif %}
+      {% endif %}
+      <p><a class="uk-button uk-button-default" href="{{ basePath }}/landing">Zurück zur Startseite</a></p>
+    </div>
+  </div>
+{% endblock %}

--- a/tests/Service/NewsletterSubscriptionServiceTest.php
+++ b/tests/Service/NewsletterSubscriptionServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Service;
+
+use App\Service\EmailConfirmationService;
+use App\Service\MailProvider\MailProviderManager;
+use App\Service\MailService;
+use App\Service\NewsletterSubscriptionService;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class NewsletterSubscriptionServiceTest extends TestCase
+{
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec(
+            <<<'SQL'
+CREATE TABLE email_confirmations (
+    email TEXT NOT NULL,
+    token TEXT NOT NULL,
+    confirmed INTEGER NOT NULL DEFAULT 0,
+    expires_at TEXT NOT NULL
+);
+CREATE UNIQUE INDEX idx_email_confirmations_token ON email_confirmations(token);
+CREATE UNIQUE INDEX idx_email_confirmations_email ON email_confirmations(email);
+CREATE TABLE newsletter_subscriptions (
+    email TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    consent_requested_at TEXT NOT NULL,
+    consent_confirmed_at TEXT NULL,
+    unsubscribe_at TEXT NULL,
+    consent_metadata TEXT NULL,
+    attributes TEXT NULL,
+    unsubscribe_metadata TEXT NULL
+);
+CREATE UNIQUE INDEX idx_newsletter_subscriptions_email ON newsletter_subscriptions(email);
+SQL
+        );
+    }
+
+    public function testConfirmationSubscribesContact(): void
+    {
+        $mailer = new class extends MailService {
+            public array $sent = [];
+
+            public function __construct()
+            {
+            }
+
+            public function sendDoubleOptIn(string $to, string $link): void
+            {
+                $this->sent[] = [$to, $link];
+            }
+        };
+
+        $manager = $this->createMock(MailProviderManager::class);
+        $manager->method('isConfigured')->willReturn(true);
+        $manager->expects($this->once())
+            ->method('subscribe')
+            ->with('user@example.com', ['FIRSTNAME' => 'Alice']);
+        $manager->expects($this->never())->method('unsubscribe');
+
+        $service = new NewsletterSubscriptionService(
+            $this->pdo,
+            new EmailConfirmationService($this->pdo),
+            $manager,
+            $mailer
+        );
+
+        $service->requestSubscription(
+            'user@example.com',
+            'https://example.com/newsletter/confirm',
+            ['ip' => '127.0.0.1'],
+            ['FIRSTNAME' => 'Alice']
+        );
+
+        $this->assertCount(1, $mailer->sent);
+        $this->assertSame('user@example.com', $mailer->sent[0][0]);
+
+        $query = parse_url($mailer->sent[0][1], PHP_URL_QUERY) ?: '';
+        parse_str($query, $params);
+        $this->assertArrayHasKey('token', $params);
+        $token = (string) $params['token'];
+
+        $this->assertTrue($service->confirmSubscription($token));
+
+        $stmt = $this->pdo->prepare('SELECT status, consent_confirmed_at FROM newsletter_subscriptions WHERE email = :email');
+        $stmt->execute(['email' => 'user@example.com']);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->assertNotFalse($row);
+        $this->assertSame('subscribed', $row['status']);
+        $this->assertNotNull($row['consent_confirmed_at']);
+    }
+
+    public function testUnsubscribePropagatesToProvider(): void
+    {
+        $now = date('Y-m-d H:i:s');
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO newsletter_subscriptions (email, status, consent_requested_at, consent_confirmed_at) VALUES (:email, :status, :requested, :confirmed)'
+        );
+        $stmt->execute([
+            'email' => 'user@example.com',
+            'status' => 'subscribed',
+            'requested' => $now,
+            'confirmed' => $now,
+        ]);
+
+        $manager = $this->createMock(MailProviderManager::class);
+        $manager->method('isConfigured')->willReturn(true);
+        $manager->expects($this->once())
+            ->method('unsubscribe')
+            ->with('user@example.com');
+        $manager->expects($this->never())->method('subscribe');
+
+        $service = new NewsletterSubscriptionService(
+            $this->pdo,
+            new EmailConfirmationService($this->pdo),
+            $manager
+        );
+
+        $result = $service->unsubscribe('user@example.com', ['ip' => '127.0.0.1']);
+        $this->assertTrue($result);
+
+        $stmt = $this->pdo->prepare('SELECT status, unsubscribe_at, unsubscribe_metadata FROM newsletter_subscriptions WHERE email = :email');
+        $stmt->execute(['email' => 'user@example.com']);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->assertNotFalse($row);
+        $this->assertSame('unsubscribed', $row['status']);
+        $this->assertNotNull($row['unsubscribe_at']);
+        $meta = json_decode((string) $row['unsubscribe_metadata'], true);
+        $this->assertIsArray($meta);
+        $this->assertSame('127.0.0.1', $meta['ip']);
+    }
+}


### PR DESCRIPTION
## Summary
- add Brevo client support for newsletter subscribe, unsubscribe, and status reporting
- introduce NewsletterSubscriptionService with consent persistence, newsletter controller endpoints, and Twig confirmation page
- update marketing contact flow to trigger opt-in/out handling and cover the workflow with new PHPUnit tests

## Testing
- vendor/bin/phpunit tests/Service/NewsletterSubscriptionServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e3d57062c0832baff0d1554f38b69b