### PR TITLE
Add calHelp marketing page

### DIFF
--- a/content/marketing/calhelp.html
+++ b/content/marketing/calhelp.html
@@ -1,0 +1,329 @@
+<section id="benefits" class="uk-section uk-section-muted calhelp-section" aria-labelledby="benefits-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="benefits-title" class="uk-heading-medium">Warum jetzt handeln?</h2>
+      <p class="uk-text-lead">Drei starke Gründe, calHelp jetzt zu starten – strukturiert, auditfest, stabil.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-migration-title">
+        <h3 id="benefit-migration-title" class="uk-card-title">Nahtlos umsteigen</h3>
+        <p>Historien aus Altsystemen verlustarm übernehmen, bestehende Tools weiter nutzen. Ohne Doppelerfassung, ohne Datenbruch.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-audit-title">
+        <h3 id="benefit-audit-title" class="uk-card-title">Auditfest arbeiten</h3>
+        <p>DAkkS-konforme Reports, nachvollziehbare Konformitätslogik und klare Freigaben – Prüfungen bestehen statt diskutieren.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-operations-title">
+        <h3 id="benefit-operations-title" class="uk-card-title">Einfach betreiben</h3>
+        <p>In Deutschland gehostet oder On-Prem – mit SSO, Rollen und API. Stabil im Alltag, skalierbar im Wachstum.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="process" class="uk-section calhelp-section" aria-labelledby="process-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="process-title" class="uk-heading-medium">Von Altdaten zu stabilen Abläufen in 5 Schritten</h2>
+      <p class="uk-text-lead">Jede Phase ist klar dokumentiert – inklusive Abnahmen, KPIs und Verantwortlichkeiten.</p>
+    </div>
+    <ol class="calhelp-process" aria-label="Migrationsprozess in fünf Schritten">
+      <li>
+        <h3>Readiness-Check</h3>
+        <p>Systeminventar, Datenumfang, Besonderheiten (z. B. Anhänge, benutzerdefinierte Felder).</p>
+      </li>
+      <li>
+        <h3>Mapping &amp; Regeln</h3>
+        <p>Felder, SI-Präfixe, Status/Workflows, Rollen. Transparent dokumentiert.</p>
+      </li>
+      <li>
+        <h3>Pilot &amp; Validierung</h3>
+        <p>Teilmenge (Golden Samples), Checksummen, Abweichungsbericht. Freigabe als Gate.</p>
+      </li>
+      <li>
+        <h3>Delta-Sync &amp; Cutover</h3>
+        <p>Downtime-arm, sauber geplantes Übergabefenster, klarer Abnahmelauf.</p>
+      </li>
+      <li>
+        <h3>Go-Live &amp; Monitoring</h3>
+        <p>KPIs, Protokolle, Hypercare-Phase. Stabil in den Betrieb überführt.</p>
+      </li>
+    </ol>
+    <p class="calhelp-note">Abnahmekriterien sind vorab definiert (z. B. ≥ 99,5 % korrekte Migration, 0 kritische Abweichungen, Report-Abnahme mit Musterdaten).</p>
+  </div>
+</section>
+
+<section id="usecases" class="uk-section uk-section-muted calhelp-section" aria-labelledby="usecases-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="usecases-title" class="uk-heading-medium">Anwendungsfälle – greifbare Szenarien</h2>
+      <p class="uk-text-lead">calHelp macht Abläufe nachvollziehbar: wer, was, wann.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-lab-title">
+        <h3 id="usecase-lab-title" class="uk-card-title">Use Case A – Kalibrierlabor</h3>
+        <p class="uk-text-emphasis">„Wir müssen Zertifikate schneller und nachvollziehbar erzeugen.“</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Zentrale Stammdaten</li>
+          <li>Automatisierte Prüfaufträge</li>
+          <li>DAkkS-Bausteine</li>
+          <li>Zweisprachige Reports</li>
+        </ul>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-service-title">
+        <h3 id="usecase-service-title" class="uk-card-title">Use Case B – Instandhaltung/Service</h3>
+        <p class="uk-text-emphasis">„Wir wollen Wartungen planen, Nachweise sichern und Rückfragen reduzieren.“</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Erinnerungen</li>
+          <li>Checklisten</li>
+          <li>Statuslogs</li>
+          <li>Revisionssichere Dokumente</li>
+        </ul>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-public-title">
+        <h3 id="usecase-public-title" class="uk-card-title">Use Case C – Öffentliche Verwaltung/Versorger:innen</h3>
+        <p class="uk-text-emphasis">„Wir brauchen konsistente Prozesse, belastbare Nachweise und DSGVO-Konformität.“</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Rollen/Rechte</li>
+          <li>Protokollierung</li>
+          <li>SSO</li>
+          <li>Strukturierte Freigaben</li>
+        </ul>
+      </article>
+    </div>
+    <div class="calhelp-microcopy">
+      <p>Alles Wichtige an einem Ort – ohne Doppelerfassung. Migration in klaren Schritten – mit Testlauf und Abnahme.</p>
+    </div>
+  </div>
+</section>
+
+<section id="proof" class="uk-section calhelp-section" aria-labelledby="proof-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="proof-title" class="uk-heading-medium">Beweis &amp; Sicherheit</h2>
+      <p class="uk-text-lead">Referenzen, Datenschutz und Qualitätsnachweise auf einen Blick.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-ref-title">
+        <h3 id="proof-ref-title" class="uk-card-title">Referenzen</h3>
+        <p>Produktiv eingesetzte Migrationen von MET/TRACK, fortlaufende MET/TEAM-Anbindung.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-security-title">
+        <h3 id="proof-security-title" class="uk-card-title">Sicherheit &amp; DSGVO</h3>
+        <p>Hosting in DE (oder On-Prem), rollenbasierte Zugriffe, Protokollierung, nachvollziehbare Lösch-/Aufbewahrungsregeln.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-quality-title">
+        <h3 id="proof-quality-title" class="uk-card-title">Qualitätscheck</h3>
+        <p>Musterzertifikate, visuelle Report-Diffs, dokumentierte Feld-Mappings.</p>
+      </article>
+    </div>
+    <p class="calhelp-kpi">15+ Jahre Projekterfahrung · 1.600+ umgesetzte Kund:innen-Wünsche · 99,9 % Betriebszeit (aktuell)</p>
+  </div>
+</section>
+
+<section id="services" class="uk-section uk-section-muted calhelp-section" aria-labelledby="services-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="services-title" class="uk-heading-medium">Produktisierte Services – verständlich &amp; kaufbar</h2>
+      <p class="uk-text-lead">Vom ersten Check bis zum stabilen Betrieb – modular buchbar.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-s-title">
+        <h3 id="service-s-title" class="uk-card-title">Paket S – Migration-Check (Fixpreis)</h3>
+        <p>Analyse, Feld-Mapping-Skizze, Risikoabschätzung, Zeitplan. Ergebnis: Entscheidungsgrundlage &amp; Angebot.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-m-title">
+        <h3 id="service-m-title" class="uk-card-title">Paket M – Pilot &amp; Cutover-Plan</h3>
+        <p>Teilmenge migrieren, Validierung, Abweichungsbericht, Go-/No-Go-Empfehlung. Ergebnis: belastbarer Cutover-Plan.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-l-title">
+        <h3 id="service-l-title" class="uk-card-title">Paket L – Vollmigration &amp; Hypercare</h3>
+        <p>Vollübernahme, Delta-Sync, Go-Live-Begleitung (30 Tage), Monitoring mit KPIs. Ergebnis: stabiler Betrieb.</p>
+      </article>
+    </div>
+    <aside class="calhelp-addons" aria-label="Add-ons">
+      <h3>Add-ons</h3>
+      <ul class="uk-list uk-list-bullet">
+        <li>DAkkS-Report-Bundle (zweisprachig)</li>
+        <li>SSO-Starter (EntraID/Google)</li>
+        <li>API-Starter (Integrationsrezepte)</li>
+      </ul>
+    </aside>
+  </div>
+</section>
+
+<section id="demo" class="uk-section calhelp-section" aria-labelledby="demo-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="demo-title" class="uk-heading-medium">Demo – Micro-Onboarding statt Formular</h2>
+      <p class="uk-text-lead">In 60–90 Sekunden zur passenden Demo: ein kurzer Frage-Flow, damit wir Ihr Szenario vorbereiten können.</p>
+    </div>
+    <div class="uk-grid-large" data-uk-grid>
+      <div class="uk-width-1-2@m">
+        <ol class="calhelp-demo-steps" aria-label="Fragen für den Demo-Flow">
+          <li>Wofür möchten Sie das System nutzen? (Labor | Instandhaltung | Verwaltung | Sonstiges)</li>
+          <li>Datenbasis? (MET/TRACK | MET/TEAM | CSV/Excel | unklar)</li>
+          <li>Umfang? (&lt;1.000 | 1.000–10.000 | &gt;10.000 | unklar)</li>
+          <li>Zeitfenster? (ASAP | 1–3 Mon | 3–6 Mon | Evaluierung offen)</li>
+          <li>Abschluss (Kontaktfelder + freiwilliger Newsletter-Opt-in)</li>
+        </ol>
+      </div>
+      <div class="uk-width-1-2@m">
+        <div class="uk-card uk-card-default uk-card-body calhelp-card">
+          <h3 class="uk-card-title">Abschluss-Screen</h3>
+          <p>Zwei Optionen führen zum nächsten Schritt – individuell vorbereitet.</p>
+          <ul class="uk-list uk-list-divider calhelp-cta-list">
+            <li>Demo-Termin wählen</li>
+            <li>MET/CAL-Handbuch öffnen</li>
+          </ul>
+          <p class="uk-text-small uk-margin-top">Abläufe sind nachvollziehbar: wer, was, wann.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="about" class="uk-section uk-section-muted calhelp-section" aria-labelledby="about-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="about-title" class="uk-heading-medium">Über calHelp</h2>
+      <p class="uk-text-lead">Wissen führt. Software liefert. – der Ansatz von René Buske.</p>
+    </div>
+    <div class="uk-grid-large" data-uk-grid>
+      <div class="uk-width-2-3@m">
+        <p>calHelp ist die Dachmarke von René Buske. Aus jahrelanger Projektarbeit im Kalibrierumfeld ist ein klarer Ansatz entstanden: <strong>Wissen führt. Software liefert.</strong> Wir migrieren Altdaten sauber, binden bestehende Systeme an (z. B. MET/TEAM) und stabilisieren Abläufe – <strong>konsistent, nachvollziehbar, auditfähig</strong>.</p>
+      </div>
+      <div class="uk-width-1-3@m">
+        <ul class="uk-list calhelp-values" aria-label="Werte von calHelp">
+          <li><strong>Präzision:</strong> Entscheidungen auf Datenbasis.</li>
+          <li><strong>Transparenz:</strong> Dokumentierte Regeln, prüfbare Schritte.</li>
+          <li><strong>Verlässlichkeit:</strong> Saubere Übergabe, stabiler Betrieb.</li>
+        </ul>
+        <p class="uk-text-small">Kontakt: Kurzes Kennenlernen (15–20 Min) – wir klären Ihr Zielbild und empfehlen den passenden Einstieg.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="news" class="uk-section calhelp-section" aria-labelledby="news-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="news-title" class="uk-heading-medium">Aktuelles &amp; Fachbeiträge</h2>
+      <p class="uk-text-lead">Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-2@m" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-changelog-title">
+        <h3 id="news-changelog-title" class="uk-card-title">Changelog kompakt</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 04.10.2025</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Migration: Delta-Sync für MET/TRACK erweitert.</li>
+          <li>Reports: Konformitätslogik mit Guardband-Optionen ergänzt.</li>
+          <li>Integrationen: MET/TEAM-Connector mit zusätzlichen Webhooks.</li>
+        </ul>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-recipe-title">
+        <h3 id="news-recipe-title" class="uk-card-title">Praxisrezept in 3 Schritten</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 27.09.2025</p>
+        <p><strong>Thema:</strong> Konformitätslegende sauber integrieren.</p>
+        <ol class="uk-list uk-list-decimal">
+          <li>Legende zentral in calHelp pflegen.</li>
+          <li>Template-Varianten für Kund:innen definieren.</li>
+          <li>Report-Diffs mit Golden Samples gegenprüfen.</li>
+        </ol>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-usecase-title">
+        <h3 id="news-usecase-title" class="uk-card-title">Use-Case-Spotlight</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 18.09.2025</p>
+        <p><strong>Ausgangslage:</strong> Stark gewachsene Kalibrierabteilung mit Inseltools.</p>
+        <p><strong>Vorgehen:</strong> Migration aus MET/TRACK, Schnittstelle zu MET/TEAM, SSO.</p>
+        <p><strong>Ergebnis:</strong> Auditberichte in 30 % weniger Zeit, klare Verantwortlichkeiten.</p>
+        <p><strong>Learnings:</strong> Frühzeitig Rollenmodell definieren, Dokumentation als laufenden Prozess etablieren.</p>
+        <p><strong>Nächste Schritte:</strong> Automatisierte Erinnerungen für Prüfmittel und Lieferant:innen.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-standards-title">
+        <h3 id="news-standards-title" class="uk-card-title">Standards verständlich</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 12.09.2025</p>
+        <p><strong>Thema:</strong> Guardband &amp; MU in 5 Minuten erklärt.</p>
+        <p>Beispiel: Messwert 10,0 mm mit MU 0,3 mm. Guardband reduziert die Toleranzgrenze auf 9,7–10,3 mm. calHelp dokumentiert automatisch, wie Entscheidung und Unsicherheit zusammenhängen.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-roadmap-title">
+        <h3 id="news-roadmap-title" class="uk-card-title">Roadmap-Ausblick</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 05.09.2025</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Q1: Templates für Prüfaufträge &amp; Zertifikate.</li>
+          <li>Q2: SSO-Starter für EntraID und Google.</li>
+          <li>Q3: API-Rezepte für ERP- und MES-Anbindungen.</li>
+        </ul>
+      </article>
+    </div>
+    <aside class="calhelp-newsletter uk-card uk-card-primary uk-card-body uk-light" aria-label="Newsletter-Box">
+      <h3 class="uk-card-title">Newsletter</h3>
+      <p>„Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.“ (Double-Opt-In, freiwillig.)</p>
+      <a class="uk-button uk-button-default" href="#demo">Zum Demo-Flow</a>
+    </aside>
+    <section class="calhelp-editorial-calendar" aria-labelledby="calendar-title">
+      <h3 id="calendar-title">Redaktionskalender – 6 Wochen Ausblick</h3>
+      <ol class="uk-list uk-list-decimal">
+        <li>Woche 1: „Die 5 größten Stolperstellen bei MET/TRACK-Migrationen“ (Praxisbeitrag)</li>
+        <li>Woche 2: Changelog kompakt (Reports &amp; Konformitätslogik)</li>
+        <li>Woche 3: Use-Case-Spotlight (anonymisiert)</li>
+        <li>Woche 4: „Guardband in 5 Minuten – verständlich erklärt“</li>
+        <li>Woche 5: Praxisrezept „Validierung mit Golden Samples“</li>
+        <li>Woche 6: Roadmap-Ausblick + Mini-Q&amp;A (aus Newsletter-Fragen)</li>
+      </ol>
+    </section>
+  </div>
+</section>
+
+<section id="faq" class="uk-section uk-section-muted calhelp-section" aria-labelledby="faq-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="faq-title" class="uk-heading-medium">FAQ – die typischen Fragen</h2>
+    </div>
+    <dl class="calhelp-faq" aria-label="Häufig gestellte Fragen">
+      <div>
+        <dt>Bleibt MET/TEAM nutzbar?</dt>
+        <dd>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und schrittweise.</dd>
+      </div>
+      <div>
+        <dt>Was wird übernommen?</dt>
+        <dd>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</dd>
+      </div>
+      <div>
+        <dt>Wie sicher ist der Betrieb?</dt>
+        <dd>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutztext.</dd>
+      </div>
+      <div>
+        <dt>Wie lange dauert der Umstieg?</dt>
+        <dd>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</dd>
+      </div>
+    </dl>
+  </div>
+</section>
+
+<section id="cta" class="uk-section calhelp-section calhelp-cta" aria-labelledby="cta-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="cta-title" class="uk-heading-medium">Der nächste Schritt ist klein – die Wirkung groß.</h2>
+      <p class="uk-text-lead">Starten Sie mit einem Migration-Check oder testen Sie unseren Demo-Flow. Wir melden uns mit einer passgenauen Empfehlung.</p>
+    </div>
+    <div class="calhelp-cta__actions" role="group" aria-label="Abschluss-CTAs">
+      <a class="uk-button uk-button-primary" href="#services">Migration prüfen lassen</a>
+      <a class="uk-button uk-button-default" href="#demo">Demo anfragen</a>
+    </div>
+    <p class="calhelp-note">Wir speichern nur, was für Rückmeldung und Terminfindung nötig ist. Details: <a href="{{ basePath }}/datenschutz">Datenschutz</a>.</p>
+  </div>
+</section>
+
+<section id="seo" class="uk-section uk-section-muted calhelp-section" aria-labelledby="seo-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="seo-title" class="uk-heading-medium">SEO &amp; Snippets</h2>
+    </div>
+    <div class="calhelp-seo-box">
+      <p><strong>Seitentitel:</strong> Umstieg auf ein zentrales Kalibrier-System – konsistent, nachvollziehbar, auditfähig</p>
+      <p><strong>Beschreibung:</strong> calHelp migriert Altdaten, bindet MET/TEAM an und stabilisiert Abläufe – konsistent, nachvollziehbar, auditfähig.</p>
+      <p><strong>Open-Graph-Hinweis:</strong> „Ein System. Klare Prozesse.“</p>
+    </div>
+  </div>
+</section>

--- a/migrations/20251202_add_calhelp_page.sql
+++ b/migrations/20251202_add_calhelp_page.sql
@@ -1,0 +1,339 @@
+INSERT INTO pages (slug, title, content)
+VALUES (
+    'calhelp',
+    'calHelp',
+    $$<section id="benefits" class="uk-section uk-section-muted calhelp-section" aria-labelledby="benefits-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="benefits-title" class="uk-heading-medium">Warum jetzt handeln?</h2>
+      <p class="uk-text-lead">Drei starke Gründe, calHelp jetzt zu starten – strukturiert, auditfest, stabil.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-migration-title">
+        <h3 id="benefit-migration-title" class="uk-card-title">Nahtlos umsteigen</h3>
+        <p>Historien aus Altsystemen verlustarm übernehmen, bestehende Tools weiter nutzen. Ohne Doppelerfassung, ohne Datenbruch.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-audit-title">
+        <h3 id="benefit-audit-title" class="uk-card-title">Auditfest arbeiten</h3>
+        <p>DAkkS-konforme Reports, nachvollziehbare Konformitätslogik und klare Freigaben – Prüfungen bestehen statt diskutieren.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-operations-title">
+        <h3 id="benefit-operations-title" class="uk-card-title">Einfach betreiben</h3>
+        <p>In Deutschland gehostet oder On-Prem – mit SSO, Rollen und API. Stabil im Alltag, skalierbar im Wachstum.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="process" class="uk-section calhelp-section" aria-labelledby="process-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="process-title" class="uk-heading-medium">Von Altdaten zu stabilen Abläufen in 5 Schritten</h2>
+      <p class="uk-text-lead">Jede Phase ist klar dokumentiert – inklusive Abnahmen, KPIs und Verantwortlichkeiten.</p>
+    </div>
+    <ol class="calhelp-process" aria-label="Migrationsprozess in fünf Schritten">
+      <li>
+        <h3>Readiness-Check</h3>
+        <p>Systeminventar, Datenumfang, Besonderheiten (z. B. Anhänge, benutzerdefinierte Felder).</p>
+      </li>
+      <li>
+        <h3>Mapping &amp; Regeln</h3>
+        <p>Felder, SI-Präfixe, Status/Workflows, Rollen. Transparent dokumentiert.</p>
+      </li>
+      <li>
+        <h3>Pilot &amp; Validierung</h3>
+        <p>Teilmenge (Golden Samples), Checksummen, Abweichungsbericht. Freigabe als Gate.</p>
+      </li>
+      <li>
+        <h3>Delta-Sync &amp; Cutover</h3>
+        <p>Downtime-arm, sauber geplantes Übergabefenster, klarer Abnahmelauf.</p>
+      </li>
+      <li>
+        <h3>Go-Live &amp; Monitoring</h3>
+        <p>KPIs, Protokolle, Hypercare-Phase. Stabil in den Betrieb überführt.</p>
+      </li>
+    </ol>
+    <p class="calhelp-note">Abnahmekriterien sind vorab definiert (z. B. ≥ 99,5 % korrekte Migration, 0 kritische Abweichungen, Report-Abnahme mit Musterdaten).</p>
+  </div>
+</section>
+
+<section id="usecases" class="uk-section uk-section-muted calhelp-section" aria-labelledby="usecases-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="usecases-title" class="uk-heading-medium">Anwendungsfälle – greifbare Szenarien</h2>
+      <p class="uk-text-lead">calHelp macht Abläufe nachvollziehbar: wer, was, wann.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-lab-title">
+        <h3 id="usecase-lab-title" class="uk-card-title">Use Case A – Kalibrierlabor</h3>
+        <p class="uk-text-emphasis">„Wir müssen Zertifikate schneller und nachvollziehbar erzeugen.“</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Zentrale Stammdaten</li>
+          <li>Automatisierte Prüfaufträge</li>
+          <li>DAkkS-Bausteine</li>
+          <li>Zweisprachige Reports</li>
+        </ul>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-service-title">
+        <h3 id="usecase-service-title" class="uk-card-title">Use Case B – Instandhaltung/Service</h3>
+        <p class="uk-text-emphasis">„Wir wollen Wartungen planen, Nachweise sichern und Rückfragen reduzieren.“</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Erinnerungen</li>
+          <li>Checklisten</li>
+          <li>Statuslogs</li>
+          <li>Revisionssichere Dokumente</li>
+        </ul>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-public-title">
+        <h3 id="usecase-public-title" class="uk-card-title">Use Case C – Öffentliche Verwaltung/Versorger:innen</h3>
+        <p class="uk-text-emphasis">„Wir brauchen konsistente Prozesse, belastbare Nachweise und DSGVO-Konformität.“</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Rollen/Rechte</li>
+          <li>Protokollierung</li>
+          <li>SSO</li>
+          <li>Strukturierte Freigaben</li>
+        </ul>
+      </article>
+    </div>
+    <div class="calhelp-microcopy">
+      <p>Alles Wichtige an einem Ort – ohne Doppelerfassung. Migration in klaren Schritten – mit Testlauf und Abnahme.</p>
+    </div>
+  </div>
+</section>
+
+<section id="proof" class="uk-section calhelp-section" aria-labelledby="proof-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="proof-title" class="uk-heading-medium">Beweis &amp; Sicherheit</h2>
+      <p class="uk-text-lead">Referenzen, Datenschutz und Qualitätsnachweise auf einen Blick.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-ref-title">
+        <h3 id="proof-ref-title" class="uk-card-title">Referenzen</h3>
+        <p>Produktiv eingesetzte Migrationen von MET/TRACK, fortlaufende MET/TEAM-Anbindung.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-security-title">
+        <h3 id="proof-security-title" class="uk-card-title">Sicherheit &amp; DSGVO</h3>
+        <p>Hosting in DE (oder On-Prem), rollenbasierte Zugriffe, Protokollierung, nachvollziehbare Lösch-/Aufbewahrungsregeln.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-quality-title">
+        <h3 id="proof-quality-title" class="uk-card-title">Qualitätscheck</h3>
+        <p>Musterzertifikate, visuelle Report-Diffs, dokumentierte Feld-Mappings.</p>
+      </article>
+    </div>
+    <p class="calhelp-kpi">15+ Jahre Projekterfahrung · 1.600+ umgesetzte Kund:innen-Wünsche · 99,9 % Betriebszeit (aktuell)</p>
+  </div>
+</section>
+
+<section id="services" class="uk-section uk-section-muted calhelp-section" aria-labelledby="services-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="services-title" class="uk-heading-medium">Produktisierte Services – verständlich &amp; kaufbar</h2>
+      <p class="uk-text-lead">Vom ersten Check bis zum stabilen Betrieb – modular buchbar.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-s-title">
+        <h3 id="service-s-title" class="uk-card-title">Paket S – Migration-Check (Fixpreis)</h3>
+        <p>Analyse, Feld-Mapping-Skizze, Risikoabschätzung, Zeitplan. Ergebnis: Entscheidungsgrundlage &amp; Angebot.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-m-title">
+        <h3 id="service-m-title" class="uk-card-title">Paket M – Pilot &amp; Cutover-Plan</h3>
+        <p>Teilmenge migrieren, Validierung, Abweichungsbericht, Go-/No-Go-Empfehlung. Ergebnis: belastbarer Cutover-Plan.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-l-title">
+        <h3 id="service-l-title" class="uk-card-title">Paket L – Vollmigration &amp; Hypercare</h3>
+        <p>Vollübernahme, Delta-Sync, Go-Live-Begleitung (30 Tage), Monitoring mit KPIs. Ergebnis: stabiler Betrieb.</p>
+      </article>
+    </div>
+    <aside class="calhelp-addons" aria-label="Add-ons">
+      <h3>Add-ons</h3>
+      <ul class="uk-list uk-list-bullet">
+        <li>DAkkS-Report-Bundle (zweisprachig)</li>
+        <li>SSO-Starter (EntraID/Google)</li>
+        <li>API-Starter (Integrationsrezepte)</li>
+      </ul>
+    </aside>
+  </div>
+</section>
+
+<section id="demo" class="uk-section calhelp-section" aria-labelledby="demo-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="demo-title" class="uk-heading-medium">Demo – Micro-Onboarding statt Formular</h2>
+      <p class="uk-text-lead">In 60–90 Sekunden zur passenden Demo: ein kurzer Frage-Flow, damit wir Ihr Szenario vorbereiten können.</p>
+    </div>
+    <div class="uk-grid-large" data-uk-grid>
+      <div class="uk-width-1-2@m">
+        <ol class="calhelp-demo-steps" aria-label="Fragen für den Demo-Flow">
+          <li>Wofür möchten Sie das System nutzen? (Labor | Instandhaltung | Verwaltung | Sonstiges)</li>
+          <li>Datenbasis? (MET/TRACK | MET/TEAM | CSV/Excel | unklar)</li>
+          <li>Umfang? (&lt;1.000 | 1.000–10.000 | &gt;10.000 | unklar)</li>
+          <li>Zeitfenster? (ASAP | 1–3 Mon | 3–6 Mon | Evaluierung offen)</li>
+          <li>Abschluss (Kontaktfelder + freiwilliger Newsletter-Opt-in)</li>
+        </ol>
+      </div>
+      <div class="uk-width-1-2@m">
+        <div class="uk-card uk-card-default uk-card-body calhelp-card">
+          <h3 class="uk-card-title">Abschluss-Screen</h3>
+          <p>Zwei Optionen führen zum nächsten Schritt – individuell vorbereitet.</p>
+          <ul class="uk-list uk-list-divider calhelp-cta-list">
+            <li>Demo-Termin wählen</li>
+            <li>MET/CAL-Handbuch öffnen</li>
+          </ul>
+          <p class="uk-text-small uk-margin-top">Abläufe sind nachvollziehbar: wer, was, wann.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="about" class="uk-section uk-section-muted calhelp-section" aria-labelledby="about-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="about-title" class="uk-heading-medium">Über calHelp</h2>
+      <p class="uk-text-lead">Wissen führt. Software liefert. – der Ansatz von René Buske.</p>
+    </div>
+    <div class="uk-grid-large" data-uk-grid>
+      <div class="uk-width-2-3@m">
+        <p>calHelp ist die Dachmarke von René Buske. Aus jahrelanger Projektarbeit im Kalibrierumfeld ist ein klarer Ansatz entstanden: <strong>Wissen führt. Software liefert.</strong> Wir migrieren Altdaten sauber, binden bestehende Systeme an (z. B. MET/TEAM) und stabilisieren Abläufe – <strong>konsistent, nachvollziehbar, auditfähig</strong>.</p>
+      </div>
+      <div class="uk-width-1-3@m">
+        <ul class="uk-list calhelp-values" aria-label="Werte von calHelp">
+          <li><strong>Präzision:</strong> Entscheidungen auf Datenbasis.</li>
+          <li><strong>Transparenz:</strong> Dokumentierte Regeln, prüfbare Schritte.</li>
+          <li><strong>Verlässlichkeit:</strong> Saubere Übergabe, stabiler Betrieb.</li>
+        </ul>
+        <p class="uk-text-small">Kontakt: Kurzes Kennenlernen (15–20 Min) – wir klären Ihr Zielbild und empfehlen den passenden Einstieg.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="news" class="uk-section calhelp-section" aria-labelledby="news-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="news-title" class="uk-heading-medium">Aktuelles &amp; Fachbeiträge</h2>
+      <p class="uk-text-lead">Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-2@m" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-changelog-title">
+        <h3 id="news-changelog-title" class="uk-card-title">Changelog kompakt</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 04.10.2025</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Migration: Delta-Sync für MET/TRACK erweitert.</li>
+          <li>Reports: Konformitätslogik mit Guardband-Optionen ergänzt.</li>
+          <li>Integrationen: MET/TEAM-Connector mit zusätzlichen Webhooks.</li>
+        </ul>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-recipe-title">
+        <h3 id="news-recipe-title" class="uk-card-title">Praxisrezept in 3 Schritten</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 27.09.2025</p>
+        <p><strong>Thema:</strong> Konformitätslegende sauber integrieren.</p>
+        <ol class="uk-list uk-list-decimal">
+          <li>Legende zentral in calHelp pflegen.</li>
+          <li>Template-Varianten für Kund:innen definieren.</li>
+          <li>Report-Diffs mit Golden Samples gegenprüfen.</li>
+        </ol>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-usecase-title">
+        <h3 id="news-usecase-title" class="uk-card-title">Use-Case-Spotlight</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 18.09.2025</p>
+        <p><strong>Ausgangslage:</strong> Stark gewachsene Kalibrierabteilung mit Inseltools.</p>
+        <p><strong>Vorgehen:</strong> Migration aus MET/TRACK, Schnittstelle zu MET/TEAM, SSO.</p>
+        <p><strong>Ergebnis:</strong> Auditberichte in 30 % weniger Zeit, klare Verantwortlichkeiten.</p>
+        <p><strong>Learnings:</strong> Frühzeitig Rollenmodell definieren, Dokumentation als laufenden Prozess etablieren.</p>
+        <p><strong>Nächste Schritte:</strong> Automatisierte Erinnerungen für Prüfmittel und Lieferant:innen.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-standards-title">
+        <h3 id="news-standards-title" class="uk-card-title">Standards verständlich</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 12.09.2025</p>
+        <p><strong>Thema:</strong> Guardband &amp; MU in 5 Minuten erklärt.</p>
+        <p>Beispiel: Messwert 10,0 mm mit MU 0,3 mm. Guardband reduziert die Toleranzgrenze auf 9,7–10,3 mm. calHelp dokumentiert automatisch, wie Entscheidung und Unsicherheit zusammenhängen.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-roadmap-title">
+        <h3 id="news-roadmap-title" class="uk-card-title">Roadmap-Ausblick</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 05.09.2025</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Q1: Templates für Prüfaufträge &amp; Zertifikate.</li>
+          <li>Q2: SSO-Starter für EntraID und Google.</li>
+          <li>Q3: API-Rezepte für ERP- und MES-Anbindungen.</li>
+        </ul>
+      </article>
+    </div>
+    <aside class="calhelp-newsletter uk-card uk-card-primary uk-card-body uk-light" aria-label="Newsletter-Box">
+      <h3 class="uk-card-title">Newsletter</h3>
+      <p>„Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.“ (Double-Opt-In, freiwillig.)</p>
+      <a class="uk-button uk-button-default" href="#demo">Zum Demo-Flow</a>
+    </aside>
+    <section class="calhelp-editorial-calendar" aria-labelledby="calendar-title">
+      <h3 id="calendar-title">Redaktionskalender – 6 Wochen Ausblick</h3>
+      <ol class="uk-list uk-list-decimal">
+        <li>Woche 1: „Die 5 größten Stolperstellen bei MET/TRACK-Migrationen“ (Praxisbeitrag)</li>
+        <li>Woche 2: Changelog kompakt (Reports &amp; Konformitätslogik)</li>
+        <li>Woche 3: Use-Case-Spotlight (anonymisiert)</li>
+        <li>Woche 4: „Guardband in 5 Minuten – verständlich erklärt“</li>
+        <li>Woche 5: Praxisrezept „Validierung mit Golden Samples“</li>
+        <li>Woche 6: Roadmap-Ausblick + Mini-Q&amp;A (aus Newsletter-Fragen)</li>
+      </ol>
+    </section>
+  </div>
+</section>
+
+<section id="faq" class="uk-section uk-section-muted calhelp-section" aria-labelledby="faq-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="faq-title" class="uk-heading-medium">FAQ – die typischen Fragen</h2>
+    </div>
+    <dl class="calhelp-faq" aria-label="Häufig gestellte Fragen">
+      <div>
+        <dt>Bleibt MET/TEAM nutzbar?</dt>
+        <dd>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und schrittweise.</dd>
+      </div>
+      <div>
+        <dt>Was wird übernommen?</dt>
+        <dd>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</dd>
+      </div>
+      <div>
+        <dt>Wie sicher ist der Betrieb?</dt>
+        <dd>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutztext.</dd>
+      </div>
+      <div>
+        <dt>Wie lange dauert der Umstieg?</dt>
+        <dd>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</dd>
+      </div>
+    </dl>
+  </div>
+</section>
+
+<section id="cta" class="uk-section calhelp-section calhelp-cta" aria-labelledby="cta-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="cta-title" class="uk-heading-medium">Der nächste Schritt ist klein – die Wirkung groß.</h2>
+      <p class="uk-text-lead">Starten Sie mit einem Migration-Check oder testen Sie unseren Demo-Flow. Wir melden uns mit einer passgenauen Empfehlung.</p>
+    </div>
+    <div class="calhelp-cta__actions" role="group" aria-label="Abschluss-CTAs">
+      <a class="uk-button uk-button-primary" href="#services">Migration prüfen lassen</a>
+      <a class="uk-button uk-button-default" href="#demo">Demo anfragen</a>
+    </div>
+    <p class="calhelp-note">Wir speichern nur, was für Rückmeldung und Terminfindung nötig ist. Details: <a href="{{ basePath }}/datenschutz">Datenschutz</a>.</p>
+  </div>
+</section>
+
+<section id="seo" class="uk-section uk-section-muted calhelp-section" aria-labelledby="seo-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="seo-title" class="uk-heading-medium">SEO &amp; Snippets</h2>
+    </div>
+    <div class="calhelp-seo-box">
+      <p><strong>Seitentitel:</strong> Umstieg auf ein zentrales Kalibrier-System – konsistent, nachvollziehbar, auditfähig</p>
+      <p><strong>Beschreibung:</strong> calHelp migriert Altdaten, bindet MET/TEAM an und stabilisiert Abläufe – konsistent, nachvollziehbar, auditfähig.</p>
+      <p><strong>Open-Graph-Hinweis:</strong> „Ein System. Klare Prozesse.“</p>
+    </div>
+  </div>
+</section>
+$$
+)
+ON CONFLICT (slug) DO UPDATE
+SET title = EXCLUDED.title,
+    content = EXCLUDED.content,
+    updated_at = CURRENT_TIMESTAMP;

--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -1,42 +1,374 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap');
-
-body {
-  font-family: 'Roboto', sans-serif;
-  background-color: #f5f7fa;
-  color: #333;
+:root {
+  --calhelp-primary: #1e87f0;
+  --calhelp-dark: #1b2333;
+  --calhelp-muted: #f4f6fb;
+  --calhelp-accent: #fbb040;
 }
 
-/* Top navigation bar styling */
+body.calhelp-theme,
+.calhelp-theme {
+  font-family: 'Poppins', 'Roboto', sans-serif;
+  background-color: var(--calhelp-muted);
+  color: var(--calhelp-dark);
+}
+
 .topbar {
-  background-color: #1e87f0;
-  border-bottom: 2px solid #e5e5e5;
+  background: linear-gradient(90deg, #0f5fff, #1e87f0);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .topbar .uk-navbar-item,
-.topbar .uk-navbar-nav > li > a,
-.topbar .uk-navbar-nav > li > a:focus,
-.topbar .uk-navbar-nav > li > a:hover {
-  color: #fff;
+.topbar .uk-navbar-nav > li > a {
+  color: #ffffff;
+  font-weight: 500;
 }
 
-/* Card appearance */
-.qr-card {
-  border-radius: 10px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+.topbar .uk-navbar-nav > li > a:hover,
+.topbar .uk-navbar-nav > li > a:focus {
+  color: #ffffff;
+  text-decoration: underline;
 }
 
-/* Primary buttons */
-.uk-button-primary {
-  background-color: #1e87f0;
-  border: none;
+.calhelp-logo {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #ffffff;
 }
 
-.uk-button-primary:hover {
-  background-color: #0f6fbf;
+.calhelp-logo__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
-#quiz-header .logo-placeholder {
-  max-width: 280px;
-  margin-bottom: 1rem;
+.calhelp-top-cta {
+  font-weight: 600;
 }
 
+.calhelp-hero {
+  background: linear-gradient(180deg, rgba(15, 95, 255, 0.08), rgba(30, 135, 240, 0));
+  padding-top: 96px;
+  padding-bottom: 96px;
+}
+
+.calhelp-hero .qr-h1 {
+  font-size: 2.8rem;
+  line-height: 1.2;
+  margin-bottom: 16px;
+}
+
+.calhelp-hero .qr-sub {
+  font-size: 1.25rem;
+  margin-bottom: 12px;
+}
+
+.calhelp-hero-card {
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(15, 95, 255, 0.15);
+  background-color: #ffffff;
+}
+
+.calhelp-hero-card ul {
+  margin-bottom: 0;
+}
+
+.calhelp-trust {
+  margin-top: 24px;
+  font-size: 0.95rem;
+  color: rgba(27, 35, 51, 0.75);
+}
+
+.calhelp-section {
+  padding-top: 80px;
+  padding-bottom: 80px;
+}
+
+.calhelp-section__header {
+  max-width: 760px;
+  margin: 0 auto 48px;
+  text-align: center;
+}
+
+.calhelp-section__header h2 {
+  font-size: 2.4rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.calhelp-section__header p {
+  margin: 0;
+  color: rgba(27, 35, 51, 0.75);
+}
+
+.calhelp-card {
+  border-radius: 16px;
+  box-shadow: 0 16px 36px rgba(15, 95, 255, 0.08);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.calhelp-card:hover,
+.calhelp-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 48px rgba(15, 95, 255, 0.12);
+}
+
+.calhelp-card .uk-card-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.calhelp-card .uk-text-emphasis {
+  font-style: italic;
+  color: rgba(27, 35, 51, 0.8);
+}
+
+.calhelp-process {
+  counter-reset: step;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.calhelp-process li {
+  position: relative;
+  padding: 24px;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 12px 32px rgba(15, 95, 255, 0.08);
+}
+
+.calhelp-process li::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  top: -16px;
+  left: 24px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--calhelp-primary);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(30, 135, 240, 0.35);
+}
+
+.calhelp-note {
+  margin-top: 32px;
+  text-align: center;
+  font-size: 0.95rem;
+  color: rgba(27, 35, 51, 0.7);
+}
+
+.calhelp-microcopy {
+  margin-top: 32px;
+  padding: 24px;
+  border-radius: 14px;
+  background: rgba(30, 135, 240, 0.08);
+  text-align: center;
+  font-weight: 500;
+}
+
+.calhelp-kpi {
+  margin-top: 32px;
+  text-align: center;
+  font-weight: 600;
+  color: var(--calhelp-dark);
+}
+
+.calhelp-addons {
+  margin-top: 48px;
+  padding: 32px;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 12px 28px rgba(27, 35, 51, 0.08);
+}
+
+.calhelp-addons h3 {
+  margin-bottom: 16px;
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.calhelp-demo-steps {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.calhelp-cta-list {
+  margin-top: 12px;
+}
+
+.calhelp-values {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.calhelp-values li {
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(27, 35, 51, 0.15);
+}
+
+.calhelp-values li:last-child {
+  border-bottom: none;
+}
+
+.calhelp-newsletter {
+  margin-top: 48px;
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(15, 95, 255, 0.2);
+}
+
+.calhelp-editorial-calendar {
+  margin-top: 48px;
+  padding: 32px;
+  border-radius: 16px;
+  background: rgba(27, 35, 51, 0.05);
+}
+
+.calhelp-editorial-calendar h3 {
+  margin-bottom: 16px;
+  font-weight: 600;
+}
+
+.calhelp-faq {
+  display: grid;
+  gap: 24px;
+}
+
+.calhelp-faq dt {
+  font-weight: 600;
+  font-size: 1.2rem;
+  margin-bottom: 6px;
+}
+
+.calhelp-faq dd {
+  margin: 0;
+  color: rgba(27, 35, 51, 0.75);
+}
+
+.calhelp-cta {
+  text-align: center;
+  background: linear-gradient(135deg, rgba(15, 95, 255, 0.85), rgba(12, 68, 207, 0.9));
+  color: #ffffff;
+}
+
+.calhelp-cta .calhelp-section__header p {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.calhelp-cta__actions {
+  margin-top: 32px;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.calhelp-cta .uk-button-primary {
+  background-color: #ffffff;
+  color: var(--calhelp-dark);
+}
+
+.calhelp-cta .uk-button-default {
+  background-color: transparent;
+  border: 1px solid #ffffff;
+  color: #ffffff;
+}
+
+.calhelp-cta .uk-button-default:hover,
+.calhelp-cta .uk-button-default:focus {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.calhelp-seo-box {
+  padding: 32px;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 16px 36px rgba(15, 95, 255, 0.08);
+}
+
+.calhelp-floating-button {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--calhelp-primary);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 16px 40px rgba(15, 95, 255, 0.35);
+  z-index: 1200;
+}
+
+.calhelp-floating-button:hover,
+.calhelp-floating-button:focus {
+  background: #0f5fff;
+  color: #ffffff;
+}
+
+.calhelp-footer {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 48px 24px;
+  background: #0b1633;
+  color: #ffffff;
+}
+
+.calhelp-footer strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 1.1rem;
+}
+
+.calhelp-footer a {
+  color: #ffffff;
+}
+
+.calhelp-footer__nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.calhelp-footer__nav li + li {
+  margin-top: 6px;
+}
+
+@media (max-width: 959px) {
+  .calhelp-hero {
+    padding-top: 72px;
+    padding-bottom: 72px;
+  }
+
+  .calhelp-section {
+    padding-top: 64px;
+    padding-bottom: 64px;
+  }
+
+  .calhelp-floating-button {
+    right: 16px;
+    bottom: 16px;
+  }
+}

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -402,6 +402,7 @@ return [
     'option_events_page' => 'Veranstaltungen',
     'option_landing_page' => 'Landing-Page',
     'option_calserver_page' => 'calServer-Seite',
+    'option_calhelp_page' => 'calHelp-Seite',
     'option_calserver_maintenance_page' => 'calHelp-Wartungsseite',
     'calserver_nav_features' => 'Funktionen',
     'calserver_nav_modules' => 'Module',

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -404,6 +404,7 @@ return [
     'option_events_page' => 'Events',
     'option_landing_page' => 'Landing page',
     'option_calserver_page' => 'calServer page',
+    'option_calhelp_page' => 'calHelp page',
     'option_calserver_maintenance_page' => 'calHelp maintenance page',
     'calserver_nav_features' => 'Features',
     'calserver_nav_modules' => 'Modules',

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -91,6 +91,11 @@ class HomeController
                         return $ctrl($request, $response);
                     }
                 }
+            } elseif ($home === 'calhelp') {
+                if ($catalogParam === '') {
+                    $ctrl = new \App\Controller\Marketing\MarketingPageController('calhelp');
+                    return $ctrl($request, $response);
+                }
             } elseif ($home === 'calserver') {
                 if ($catalogParam === '') {
                     $ctrl = new \App\Controller\Marketing\CalserverController();

--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -1722,3 +1722,338 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
     </div>
 '
 );
+
+INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
+    'calhelp',
+    'calHelp',
+    '<section id="benefits" class="uk-section uk-section-muted calhelp-section" aria-labelledby="benefits-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="benefits-title" class="uk-heading-medium">Warum jetzt handeln?</h2>
+      <p class="uk-text-lead">Drei starke Gründe, calHelp jetzt zu starten – strukturiert, auditfest, stabil.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-migration-title">
+        <h3 id="benefit-migration-title" class="uk-card-title">Nahtlos umsteigen</h3>
+        <p>Historien aus Altsystemen verlustarm übernehmen, bestehende Tools weiter nutzen. Ohne Doppelerfassung, ohne Datenbruch.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-audit-title">
+        <h3 id="benefit-audit-title" class="uk-card-title">Auditfest arbeiten</h3>
+        <p>DAkkS-konforme Reports, nachvollziehbare Konformitätslogik und klare Freigaben – Prüfungen bestehen statt diskutieren.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-operations-title">
+        <h3 id="benefit-operations-title" class="uk-card-title">Einfach betreiben</h3>
+        <p>In Deutschland gehostet oder On-Prem – mit SSO, Rollen und API. Stabil im Alltag, skalierbar im Wachstum.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<section id="process" class="uk-section calhelp-section" aria-labelledby="process-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="process-title" class="uk-heading-medium">Von Altdaten zu stabilen Abläufen in 5 Schritten</h2>
+      <p class="uk-text-lead">Jede Phase ist klar dokumentiert – inklusive Abnahmen, KPIs und Verantwortlichkeiten.</p>
+    </div>
+    <ol class="calhelp-process" aria-label="Migrationsprozess in fünf Schritten">
+      <li>
+        <h3>Readiness-Check</h3>
+        <p>Systeminventar, Datenumfang, Besonderheiten (z. B. Anhänge, benutzerdefinierte Felder).</p>
+      </li>
+      <li>
+        <h3>Mapping &amp; Regeln</h3>
+        <p>Felder, SI-Präfixe, Status/Workflows, Rollen. Transparent dokumentiert.</p>
+      </li>
+      <li>
+        <h3>Pilot &amp; Validierung</h3>
+        <p>Teilmenge (Golden Samples), Checksummen, Abweichungsbericht. Freigabe als Gate.</p>
+      </li>
+      <li>
+        <h3>Delta-Sync &amp; Cutover</h3>
+        <p>Downtime-arm, sauber geplantes Übergabefenster, klarer Abnahmelauf.</p>
+      </li>
+      <li>
+        <h3>Go-Live &amp; Monitoring</h3>
+        <p>KPIs, Protokolle, Hypercare-Phase. Stabil in den Betrieb überführt.</p>
+      </li>
+    </ol>
+    <p class="calhelp-note">Abnahmekriterien sind vorab definiert (z. B. ≥ 99,5 % korrekte Migration, 0 kritische Abweichungen, Report-Abnahme mit Musterdaten).</p>
+  </div>
+</section>
+
+<section id="usecases" class="uk-section uk-section-muted calhelp-section" aria-labelledby="usecases-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="usecases-title" class="uk-heading-medium">Anwendungsfälle – greifbare Szenarien</h2>
+      <p class="uk-text-lead">calHelp macht Abläufe nachvollziehbar: wer, was, wann.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-lab-title">
+        <h3 id="usecase-lab-title" class="uk-card-title">Use Case A – Kalibrierlabor</h3>
+        <p class="uk-text-emphasis">„Wir müssen Zertifikate schneller und nachvollziehbar erzeugen.“</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Zentrale Stammdaten</li>
+          <li>Automatisierte Prüfaufträge</li>
+          <li>DAkkS-Bausteine</li>
+          <li>Zweisprachige Reports</li>
+        </ul>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-service-title">
+        <h3 id="usecase-service-title" class="uk-card-title">Use Case B – Instandhaltung/Service</h3>
+        <p class="uk-text-emphasis">„Wir wollen Wartungen planen, Nachweise sichern und Rückfragen reduzieren.“</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Erinnerungen</li>
+          <li>Checklisten</li>
+          <li>Statuslogs</li>
+          <li>Revisionssichere Dokumente</li>
+        </ul>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-public-title">
+        <h3 id="usecase-public-title" class="uk-card-title">Use Case C – Öffentliche Verwaltung/Versorger:innen</h3>
+        <p class="uk-text-emphasis">„Wir brauchen konsistente Prozesse, belastbare Nachweise und DSGVO-Konformität.“</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Rollen/Rechte</li>
+          <li>Protokollierung</li>
+          <li>SSO</li>
+          <li>Strukturierte Freigaben</li>
+        </ul>
+      </article>
+    </div>
+    <div class="calhelp-microcopy">
+      <p>Alles Wichtige an einem Ort – ohne Doppelerfassung. Migration in klaren Schritten – mit Testlauf und Abnahme.</p>
+    </div>
+  </div>
+</section>
+
+<section id="proof" class="uk-section calhelp-section" aria-labelledby="proof-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="proof-title" class="uk-heading-medium">Beweis &amp; Sicherheit</h2>
+      <p class="uk-text-lead">Referenzen, Datenschutz und Qualitätsnachweise auf einen Blick.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-ref-title">
+        <h3 id="proof-ref-title" class="uk-card-title">Referenzen</h3>
+        <p>Produktiv eingesetzte Migrationen von MET/TRACK, fortlaufende MET/TEAM-Anbindung.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-security-title">
+        <h3 id="proof-security-title" class="uk-card-title">Sicherheit &amp; DSGVO</h3>
+        <p>Hosting in DE (oder On-Prem), rollenbasierte Zugriffe, Protokollierung, nachvollziehbare Lösch-/Aufbewahrungsregeln.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-quality-title">
+        <h3 id="proof-quality-title" class="uk-card-title">Qualitätscheck</h3>
+        <p>Musterzertifikate, visuelle Report-Diffs, dokumentierte Feld-Mappings.</p>
+      </article>
+    </div>
+    <p class="calhelp-kpi">15+ Jahre Projekterfahrung · 1.600+ umgesetzte Kund:innen-Wünsche · 99,9 % Betriebszeit (aktuell)</p>
+  </div>
+</section>
+
+<section id="services" class="uk-section uk-section-muted calhelp-section" aria-labelledby="services-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="services-title" class="uk-heading-medium">Produktisierte Services – verständlich &amp; kaufbar</h2>
+      <p class="uk-text-lead">Vom ersten Check bis zum stabilen Betrieb – modular buchbar.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-s-title">
+        <h3 id="service-s-title" class="uk-card-title">Paket S – Migration-Check (Fixpreis)</h3>
+        <p>Analyse, Feld-Mapping-Skizze, Risikoabschätzung, Zeitplan. Ergebnis: Entscheidungsgrundlage &amp; Angebot.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-m-title">
+        <h3 id="service-m-title" class="uk-card-title">Paket M – Pilot &amp; Cutover-Plan</h3>
+        <p>Teilmenge migrieren, Validierung, Abweichungsbericht, Go-/No-Go-Empfehlung. Ergebnis: belastbarer Cutover-Plan.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-l-title">
+        <h3 id="service-l-title" class="uk-card-title">Paket L – Vollmigration &amp; Hypercare</h3>
+        <p>Vollübernahme, Delta-Sync, Go-Live-Begleitung (30 Tage), Monitoring mit KPIs. Ergebnis: stabiler Betrieb.</p>
+      </article>
+    </div>
+    <aside class="calhelp-addons" aria-label="Add-ons">
+      <h3>Add-ons</h3>
+      <ul class="uk-list uk-list-bullet">
+        <li>DAkkS-Report-Bundle (zweisprachig)</li>
+        <li>SSO-Starter (EntraID/Google)</li>
+        <li>API-Starter (Integrationsrezepte)</li>
+      </ul>
+    </aside>
+  </div>
+</section>
+
+<section id="demo" class="uk-section calhelp-section" aria-labelledby="demo-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="demo-title" class="uk-heading-medium">Demo – Micro-Onboarding statt Formular</h2>
+      <p class="uk-text-lead">In 60–90 Sekunden zur passenden Demo: ein kurzer Frage-Flow, damit wir Ihr Szenario vorbereiten können.</p>
+    </div>
+    <div class="uk-grid-large" data-uk-grid>
+      <div class="uk-width-1-2@m">
+        <ol class="calhelp-demo-steps" aria-label="Fragen für den Demo-Flow">
+          <li>Wofür möchten Sie das System nutzen? (Labor | Instandhaltung | Verwaltung | Sonstiges)</li>
+          <li>Datenbasis? (MET/TRACK | MET/TEAM | CSV/Excel | unklar)</li>
+          <li>Umfang? (&lt;1.000 | 1.000–10.000 | &gt;10.000 | unklar)</li>
+          <li>Zeitfenster? (ASAP | 1–3 Mon | 3–6 Mon | Evaluierung offen)</li>
+          <li>Abschluss (Kontaktfelder + freiwilliger Newsletter-Opt-in)</li>
+        </ol>
+      </div>
+      <div class="uk-width-1-2@m">
+        <div class="uk-card uk-card-default uk-card-body calhelp-card">
+          <h3 class="uk-card-title">Abschluss-Screen</h3>
+          <p>Zwei Optionen führen zum nächsten Schritt – individuell vorbereitet.</p>
+          <ul class="uk-list uk-list-divider calhelp-cta-list">
+            <li>Demo-Termin wählen</li>
+            <li>MET/CAL-Handbuch öffnen</li>
+          </ul>
+          <p class="uk-text-small uk-margin-top">Abläufe sind nachvollziehbar: wer, was, wann.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="about" class="uk-section uk-section-muted calhelp-section" aria-labelledby="about-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="about-title" class="uk-heading-medium">Über calHelp</h2>
+      <p class="uk-text-lead">Wissen führt. Software liefert. – der Ansatz von René Buske.</p>
+    </div>
+    <div class="uk-grid-large" data-uk-grid>
+      <div class="uk-width-2-3@m">
+        <p>calHelp ist die Dachmarke von René Buske. Aus jahrelanger Projektarbeit im Kalibrierumfeld ist ein klarer Ansatz entstanden: <strong>Wissen führt. Software liefert.</strong> Wir migrieren Altdaten sauber, binden bestehende Systeme an (z. B. MET/TEAM) und stabilisieren Abläufe – <strong>konsistent, nachvollziehbar, auditfähig</strong>.</p>
+      </div>
+      <div class="uk-width-1-3@m">
+        <ul class="uk-list calhelp-values" aria-label="Werte von calHelp">
+          <li><strong>Präzision:</strong> Entscheidungen auf Datenbasis.</li>
+          <li><strong>Transparenz:</strong> Dokumentierte Regeln, prüfbare Schritte.</li>
+          <li><strong>Verlässlichkeit:</strong> Saubere Übergabe, stabiler Betrieb.</li>
+        </ul>
+        <p class="uk-text-small">Kontakt: Kurzes Kennenlernen (15–20 Min) – wir klären Ihr Zielbild und empfehlen den passenden Einstieg.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="news" class="uk-section calhelp-section" aria-labelledby="news-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="news-title" class="uk-heading-medium">Aktuelles &amp; Fachbeiträge</h2>
+      <p class="uk-text-lead">Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.</p>
+    </div>
+    <div class="uk-grid-large uk-child-width-1-2@m" data-uk-grid>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-changelog-title">
+        <h3 id="news-changelog-title" class="uk-card-title">Changelog kompakt</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 04.10.2025</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Migration: Delta-Sync für MET/TRACK erweitert.</li>
+          <li>Reports: Konformitätslogik mit Guardband-Optionen ergänzt.</li>
+          <li>Integrationen: MET/TEAM-Connector mit zusätzlichen Webhooks.</li>
+        </ul>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-recipe-title">
+        <h3 id="news-recipe-title" class="uk-card-title">Praxisrezept in 3 Schritten</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 27.09.2025</p>
+        <p><strong>Thema:</strong> Konformitätslegende sauber integrieren.</p>
+        <ol class="uk-list uk-list-decimal">
+          <li>Legende zentral in calHelp pflegen.</li>
+          <li>Template-Varianten für Kund:innen definieren.</li>
+          <li>Report-Diffs mit Golden Samples gegenprüfen.</li>
+        </ol>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-usecase-title">
+        <h3 id="news-usecase-title" class="uk-card-title">Use-Case-Spotlight</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 18.09.2025</p>
+        <p><strong>Ausgangslage:</strong> Stark gewachsene Kalibrierabteilung mit Inseltools.</p>
+        <p><strong>Vorgehen:</strong> Migration aus MET/TRACK, Schnittstelle zu MET/TEAM, SSO.</p>
+        <p><strong>Ergebnis:</strong> Auditberichte in 30 % weniger Zeit, klare Verantwortlichkeiten.</p>
+        <p><strong>Learnings:</strong> Frühzeitig Rollenmodell definieren, Dokumentation als laufenden Prozess etablieren.</p>
+        <p><strong>Nächste Schritte:</strong> Automatisierte Erinnerungen für Prüfmittel und Lieferant:innen.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-standards-title">
+        <h3 id="news-standards-title" class="uk-card-title">Standards verständlich</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 12.09.2025</p>
+        <p><strong>Thema:</strong> Guardband &amp; MU in 5 Minuten erklärt.</p>
+        <p>Beispiel: Messwert 10,0 mm mit MU 0,3 mm. Guardband reduziert die Toleranzgrenze auf 9,7–10,3 mm. calHelp dokumentiert automatisch, wie Entscheidung und Unsicherheit zusammenhängen.</p>
+      </article>
+      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-roadmap-title">
+        <h3 id="news-roadmap-title" class="uk-card-title">Roadmap-Ausblick</h3>
+        <p class="uk-text-meta">Zuletzt aktualisiert am 05.09.2025</p>
+        <ul class="uk-list uk-list-bullet">
+          <li>Q1: Templates für Prüfaufträge &amp; Zertifikate.</li>
+          <li>Q2: SSO-Starter für EntraID und Google.</li>
+          <li>Q3: API-Rezepte für ERP- und MES-Anbindungen.</li>
+        </ul>
+      </article>
+    </div>
+    <aside class="calhelp-newsletter uk-card uk-card-primary uk-card-body uk-light" aria-label="Newsletter-Box">
+      <h3 class="uk-card-title">Newsletter</h3>
+      <p>„Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.“ (Double-Opt-In, freiwillig.)</p>
+      <a class="uk-button uk-button-default" href="#demo">Zum Demo-Flow</a>
+    </aside>
+    <section class="calhelp-editorial-calendar" aria-labelledby="calendar-title">
+      <h3 id="calendar-title">Redaktionskalender – 6 Wochen Ausblick</h3>
+      <ol class="uk-list uk-list-decimal">
+        <li>Woche 1: „Die 5 größten Stolperstellen bei MET/TRACK-Migrationen“ (Praxisbeitrag)</li>
+        <li>Woche 2: Changelog kompakt (Reports &amp; Konformitätslogik)</li>
+        <li>Woche 3: Use-Case-Spotlight (anonymisiert)</li>
+        <li>Woche 4: „Guardband in 5 Minuten – verständlich erklärt“</li>
+        <li>Woche 5: Praxisrezept „Validierung mit Golden Samples“</li>
+        <li>Woche 6: Roadmap-Ausblick + Mini-Q&amp;A (aus Newsletter-Fragen)</li>
+      </ol>
+    </section>
+  </div>
+</section>
+
+<section id="faq" class="uk-section uk-section-muted calhelp-section" aria-labelledby="faq-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="faq-title" class="uk-heading-medium">FAQ – die typischen Fragen</h2>
+    </div>
+    <dl class="calhelp-faq" aria-label="Häufig gestellte Fragen">
+      <div>
+        <dt>Bleibt MET/TEAM nutzbar?</dt>
+        <dd>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und schrittweise.</dd>
+      </div>
+      <div>
+        <dt>Was wird übernommen?</dt>
+        <dd>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</dd>
+      </div>
+      <div>
+        <dt>Wie sicher ist der Betrieb?</dt>
+        <dd>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutztext.</dd>
+      </div>
+      <div>
+        <dt>Wie lange dauert der Umstieg?</dt>
+        <dd>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</dd>
+      </div>
+    </dl>
+  </div>
+</section>
+
+<section id="cta" class="uk-section calhelp-section calhelp-cta" aria-labelledby="cta-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="cta-title" class="uk-heading-medium">Der nächste Schritt ist klein – die Wirkung groß.</h2>
+      <p class="uk-text-lead">Starten Sie mit einem Migration-Check oder testen Sie unseren Demo-Flow. Wir melden uns mit einer passgenauen Empfehlung.</p>
+    </div>
+    <div class="calhelp-cta__actions" role="group" aria-label="Abschluss-CTAs">
+      <a class="uk-button uk-button-primary" href="#services">Migration prüfen lassen</a>
+      <a class="uk-button uk-button-default" href="#demo">Demo anfragen</a>
+    </div>
+    <p class="calhelp-note">Wir speichern nur, was für Rückmeldung und Terminfindung nötig ist. Details: <a href="{{ basePath }}/datenschutz">Datenschutz</a>.</p>
+  </div>
+</section>
+
+<section id="seo" class="uk-section uk-section-muted calhelp-section" aria-labelledby="seo-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="seo-title" class="uk-heading-medium">SEO &amp; Snippets</h2>
+    </div>
+    <div class="calhelp-seo-box">
+      <p><strong>Seitentitel:</strong> Umstieg auf ein zentrales Kalibrier-System – konsistent, nachvollziehbar, auditfähig</p>
+      <p><strong>Beschreibung:</strong> calHelp migriert Altdaten, bindet MET/TEAM an und stabilisiert Abläufe – konsistent, nachvollziehbar, auditfähig.</p>
+      <p><strong>Open-Graph-Hinweis:</strong> „Ein System. Klare Prozesse.“</p>
+    </div>
+  </div>
+</section>
+'
+);

--- a/src/routes.php
+++ b/src/routes.php
@@ -540,6 +540,15 @@ return function (\Slim\App $app, TranslationService $translator) {
         $controller = new \App\Controller\Marketing\FutureIsGreenController();
         return $controller($request, $response);
     });
+    $app->get('/calhelp', function (Request $request, Response $response) use ($resolveMarketingAccess) {
+        [$request, $allowed] = $resolveMarketingAccess($request);
+        if (!$allowed) {
+            return $response->withStatus(404);
+        }
+        $controller = new MarketingPageController('calhelp');
+        return $controller($request, $response);
+    });
+
     $app->get('/calserver', function (Request $request, Response $response) use ($resolveMarketingAccess) {
         [$request, $allowed] = $resolveMarketingAccess($request);
         if (!$allowed) {
@@ -618,6 +627,9 @@ return function (\Slim\App $app, TranslationService $translator) {
     };
 
     $app->post('/calserver/chat', $createChatHandler('calserver'))
+        ->add(new RateLimitMiddleware(10, 60))
+        ->add(new CsrfMiddleware());
+    $app->post('/calhelp/chat', $createChatHandler('calhelp'))
         ->add(new RateLimitMiddleware(10, 60))
         ->add(new CsrfMiddleware());
 

--- a/templates/marketing/calhelp.twig
+++ b/templates/marketing/calhelp.twig
@@ -1,0 +1,351 @@
+{% extends 'layout.twig' %}
+
+{% set links = [
+    { 'href': '#hero', 'label': 'Überblick', 'icon': 'home' },
+    { 'href': '#benefits', 'label': 'Nutzen', 'icon': 'star' },
+    { 'href': '#process', 'label': 'Prozess', 'icon': 'settings' },
+    { 'href': '#usecases', 'label': 'Use Cases', 'icon': 'users' },
+    { 'href': '#services', 'label': 'Services', 'icon': 'bag' },
+    { 'href': '#demo', 'label': 'Demo', 'icon': 'play' },
+    { 'href': '#news', 'label': 'News', 'icon': 'rss' },
+    { 'href': '#faq', 'label': 'FAQ', 'icon': 'question' },
+    { 'href': '#cta', 'label': 'Kontakt', 'icon': 'bolt' }
+] %}
+
+{% block title %}{{ metaTitle|default('Umstieg auf ein zentrales Kalibrier-System – konsistent, nachvollziehbar, auditfähig') }}{% endblock %}
+
+{% block head %}
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="preload" href="{{ basePath }}/css/landing.css" as="style">
+  <link rel="stylesheet" href="{{ basePath }}/css/landing.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/onboarding.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/topbar.landing.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/calhelp.css">
+  <meta name="page-name" content="calHelp – Marketingseite">
+{% endblock %}
+
+{% block body_theme %}light{% endblock %}
+{% block body_class %}qr-landing calhelp-theme{% endblock %}
+
+{% block body %}
+  <div class="landing-content">
+    <header class="qr-topbar topbar">
+      <nav class="uk-navbar-container" data-uk-navbar>
+        <div class="uk-navbar-left">
+          <div class="uk-navbar-item">
+            <button id="offcanvas-toggle"
+                    class="uk-navbar-toggle uk-hidden@m git-btn"
+                    data-uk-navbar-toggle-icon
+                    data-uk-toggle="target: #qr-offcanvas"
+                    aria-controls="qr-offcanvas"
+                    aria-expanded="false"
+                    aria-label="Menü"></button>
+            <a class="uk-logo calhelp-logo" href="{{ basePath }}/calhelp">
+              <span class="calhelp-logo__sr">calHelp – Zentrales Kalibrier- und Prüfmanagement</span>
+              <span aria-hidden="true">calHelp</span>
+            </a>
+          </div>
+        </div>
+        <div class="uk-navbar-right">
+          <ul class="uk-navbar-nav uk-visible@m">
+            {% for link in links %}
+              <li>
+                <a href="{{ link.href }}">
+                  <span class="uk-margin-small-right" data-uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+          <a class="uk-navbar-item uk-visible@m uk-button uk-button-primary calhelp-top-cta" href="#demo">
+            <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Demo anfragen
+          </a>
+          <div class="uk-navbar-item config-menu uk-inline">
+            <button id="configMenuToggle"
+                    type="button"
+                    class="uk-button uk-button-default git-btn"
+                    aria-label="Konfiguration"
+                    aria-expanded="false">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M19.14 12.94a7.5 7.5 0 0 0 .05-.94 7.5 7.5 0 0 0-.05-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.33a.5.5 0 0 0-.6-.22l-2.39.96a7.6 7.6 0 0 0-1.63-.94l-.36-2.54a.5.5 0 0 0-.5-.43h-3.84a.5.5 0 0 0-.5.43l-.36 2.54c-.57.24-1.12.55-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.7 7.84a.5.5 0 0 0 .12.64l2.03 1.58c-.03.31-.05.63-.05.94s.02.63.05.94L2.82 13.5a.5.5 0 0 0-.12.64l1.92 3.33a.5.5 0 0 0 .6.22l2.39-.96c.51.39 1.06.7 1.63.94l.36 2.54a.5.5 0 0 0 .5.43h3.84a.5.5 0 0 0 .5-.43l.36-2.54c.57-.24 1.12-.55 1.63-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.33a.5.5 0 0 0-.12-.64l-2.03-1.58ZM12 15.5A3.5 3.5 0 1 1 12 8.5a3.5 3.5 0 0 1 0 7Z"
+                      fill="currentColor"/>
+              </svg>
+            </button>
+            <div id="menuDrop"
+                 class="uk-dropdown"
+                 hidden
+                 data-uk-dropdown="mode: click; pos: bottom-right; flip: false; animation: uk-animation-slide-top-small">
+              <ul class="uk-nav uk-dropdown-nav" role="menu">
+                <li>
+                  <button id="themeToggle"
+                          class="uk-button uk-button-default git-btn theme-toggle"
+                          aria-label="Design umschalten"
+                          role="menuitem">
+                    <span id="themeIcon" class="theme-icon" aria-hidden="true"></span>
+                  </button>
+                </li>
+                <li>
+                  <button id="accessibilityToggle"
+                          class="uk-button uk-button-default git-btn accessibility-toggle"
+                          aria-label="Kontrast umschalten"
+                          role="menuitem">
+                    <span id="accessibilityIcon" class="accessibility-icon" aria-hidden="true"></span>
+                  </button>
+                </li>
+                <li>
+                  <div class="uk-inline">
+                    <button id="languageMenuToggle"
+                            type="button"
+                            class="uk-button uk-button-default git-btn"
+                            aria-label="{{ t('language_toggle') }}"
+                            aria-expanded="false"
+                            role="menuitem">
+                      <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm6.93 6h-2.54c-.11-1.47-.43-2.87-.92-4.17 1.84.69 3.29 2.1 4.05 3.84zM12 4c.96 1.18 1.62 2.64 1.88 4H10.12c.26-1.36.92-2.82 1.88-4zM4.26 14c-.17-.64-.26-1.31-.26-2s.09-1.36.26-2h3.09c-.07.66-.11 1.32-.11 2s.04 1.34.11 2H4.26zm.81 2h2.54c.11 1.47.43 2.87.92 4.17-1.84-.69-3.29-2.1-4.05-3.84zm2.54-8H5.07c.76-1.74 2.21-3.15 4.05-3.84-.49 1.3-.81 2.7-.92 4.17zM12 20c-.96-1.18-1.62-2.64-1.88-4h3.76c-.26 1.36-.92 2.82-1.88 4zm2.62-6H9.38c-.08-.66-.12-1.32-.12-2s.04-1.34.12-2h5.24c.08.66.12 1.32.12 2s-.04 1.34-.12 2zm.81 6c.49-1.3.81-2.7.92-4.17h2.54c-.76 1.74-2.21 3.15-4.05 3.84zM16.65 14c.07-.66.11-1.32.11-2s-.04-1.34-.11-2h3.09c.17.64.26 1.31.26 2s-.09 1.36-.26 2h-3.09z"
+                              fill="currentColor"/>
+                      </svg>
+                    </button>
+                    <div id="languageDrop" class="uk-dropdown" hidden data-uk-dropdown="mode: click; pos: left-top; offset: 0">
+                      <ul class="uk-nav uk-dropdown-nav" role="menu">
+                        <li>
+                          <button class="uk-button uk-button-default git-btn lang-option"
+                                  data-lang="de"
+                                  role="menuitem">
+                            <span class="lang-option__icon" aria-hidden="true">
+                              <svg class="lang-option__svg" viewBox="0 0 24 16" role="img" focusable="false">
+                                <rect width="24" height="16" fill="#ffce00" />
+                                <rect width="24" height="10.6667" fill="#dd0000" />
+                                <rect width="24" height="5.3333" fill="#000000" />
+                              </svg>
+                            </span>
+                            <span class="lang-option__label">{{ t('german') }}</span>
+                          </button>
+                        </li>
+                        <li>
+                          <button class="uk-button uk-button-default git-btn lang-option"
+                                  data-lang="en"
+                                  role="menuitem">
+                            <span class="lang-option__icon" aria-hidden="true">
+                              <svg class="lang-option__svg" viewBox="0 0 24 16" role="img" focusable="false">
+                                <rect width="24" height="16" fill="#012169" />
+                                <path fill="#ffffff" d="M0 0h3.2L24 13.6V16h-3.2L0 2.4z" />
+                                <path fill="#ffffff" d="M24 0h-3.2L0 13.6V16h3.2L24 2.4z" />
+                                <path fill="#c8102e" d="M0 0h1.6L24 12.8V16h-1.6L0 3.2z" />
+                                <path fill="#c8102e" d="M24 0h-1.6L0 12.8V16h1.6L24 3.2z" />
+                                <rect x="10" width="4" height="16" fill="#ffffff" />
+                                <rect y="6" width="24" height="4" fill="#ffffff" />
+                                <rect x="10.8" width="2.4" height="16" fill="#c8102e" />
+                                <rect y="6.8" width="24" height="2.4" fill="#c8102e" />
+                              </svg>
+                            </span>
+                            <span class="lang-option__label">{{ t('english') }}</span>
+                          </button>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <div id="qr-offcanvas" data-uk-offcanvas="overlay: true; flip: true">
+      <div class="uk-offcanvas-bar">
+        <button class="uk-offcanvas-close git-btn" type="button" data-uk-close aria-label="Menü schließen"></button>
+        <ul class="uk-nav uk-nav-default">
+          {% for link in links %}
+            <li>
+              <a href="{{ link.href }}">
+                <span class="uk-margin-small-right" data-uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+        <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="#demo">
+          <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Demo anfragen
+        </a>
+      </div>
+    </div>
+
+    <section id="hero" class="uk-section uk-section-large calhelp-hero">
+      <div class="uk-container">
+        <div class="uk-grid uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
+          <div>
+            <span class="qr-badge pill pill--soft">Hosting in Deutschland · DSGVO-konform</span>
+            <h1 class="qr-h1">Ein System. Klare Prozesse.</h1>
+            <p class="qr-sub">calHelp sorgt dafür, dass Kalibrierdaten, Dokumente und Abläufe verlässlich in einem zentralen System zusammenfließen – konsistent, nachvollziehbar und auditfähig.</p>
+            <p class="uk-text-lead">Altdaten werden sauber migriert (z. B. aus MET/TRACK), MET/TEAM bleibt angebunden, und Ihr Team arbeitet in klar definierten Prozessen mit belastbaren Nachweisen.</p>
+            <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
+              <a class="uk-button uk-button-primary" href="#demo">
+                <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Demo anfragen
+              </a>
+              <a class="uk-button uk-button-default" href="https://calhelp.notion.site/met-cal-handbuch" target="_blank" rel="noopener">
+                <span class="uk-margin-small-right" data-uk-icon="icon: file-text"></span>MET/CAL-Handbuch öffnen
+              </a>
+            </div>
+            <p class="calhelp-trust">Hosting in Deutschland · DSGVO-konform · &gt;15 Jahre Projekterfahrung</p>
+          </div>
+          <div>
+            <div class="calhelp-hero-card uk-card uk-card-default uk-card-body">
+              <h2 class="uk-card-title">Warum calHelp?</h2>
+              <ul class="uk-list uk-list-bullet">
+                <li>Konsistente Datenbasis für Labore, Service-Teams und Verwaltung.</li>
+                <li>Prozesssichere Migration mit klaren Gateways und Abnahmen.</li>
+                <li>Auditfähige Nachweise inklusive Report-Diffs und Protokollen.</li>
+              </ul>
+              <p class="uk-text-small uk-margin-top">Reports prüfen wir vorab mit Musterdaten.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {{ content|raw }}
+
+    <div id="marketing-chat-modal" class="uk-flex-top marketing-chat-modal" data-uk-modal>
+      <div class="uk-modal-dialog uk-modal-body marketing-chat__dialog" role="dialog" aria-modal="true" aria-label="{{ t('marketing_chat_title') }}">
+        <button class="uk-modal-close-default" type="button" data-uk-close aria-label="{{ t('marketing_chat_close') }}"></button>
+        <h2 class="uk-modal-title">{{ t('marketing_chat_title') }}</h2>
+        <p class="marketing-chat__intro">{{ t('marketing_chat_intro') }}</p>
+        <div class="marketing-chat__messages" data-marketing-chat-messages aria-live="polite"></div>
+        <p class="marketing-chat__status" data-marketing-chat-status aria-live="assertive"></p>
+        <form class="marketing-chat__form" data-marketing-chat-form>
+          <label class="uk-form-label" for="marketing-chat-question">{{ t('marketing_chat_question_label') }}</label>
+          <textarea class="uk-textarea"
+                    id="marketing-chat-question"
+                    name="question"
+                    rows="3"
+                    autocomplete="off"
+                    placeholder="{{ t('marketing_chat_placeholder') }}"
+                    data-marketing-chat-input
+                    required></textarea>
+          <div class="marketing-chat__form-actions">
+            <button type="submit" class="uk-button uk-button-primary">
+              <span class="uk-margin-small-right" data-uk-icon="icon: commenting"></span>{{ t('marketing_chat_submit') }}
+            </button>
+            <button type="button" class="uk-button uk-button-default uk-modal-close">{{ t('marketing_chat_close') }}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <button class="calhelp-floating-button marketing-chat-fab"
+            type="button"
+            data-marketing-chat-open
+            aria-haspopup="dialog"
+            aria-controls="marketing-chat-modal"
+            aria-label="{{ t('marketing_chat_title') }}">
+      <span aria-hidden="true" data-uk-icon="icon: commenting"></span>
+    </button>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  <div class="calhelp-footer">
+    <div class="calhelp-footer__brand">
+      <strong>calHelp</strong>
+      <p>Ein System. Klare Prozesse.</p>
+    </div>
+    <nav class="calhelp-footer__nav" aria-label="Footer-Navigation">
+      <strong>Links</strong>
+      <ul>
+        <li><a href="#hero">Start</a></li>
+        <li><a href="#news">Wissen</a></li>
+        <li><a href="#demo">Demo</a></li>
+        <li><a href="#services">Services</a></li>
+        <li><a href="{{ basePath }}/datenschutz">Datenschutz</a></li>
+        <li><a href="{{ basePath }}/impressum">Impressum</a></li>
+      </ul>
+    </nav>
+    <div class="calhelp-footer__contact">
+      <strong>Kontakt</strong>
+      <p>
+        René Buske<br>
+        <a class="js-email-link" data-user="office" data-domain="calhelp.de" href="#">office [at] calhelp.de</a><br>
+        <a href="tel:+4933203609080">+49&nbsp;33203&nbsp;609080</a>
+      </p>
+    </div>
+    <div class="calhelp-footer__meta">
+      <strong>Hosting</strong>
+      <p>In Deutschland oder On-Prem – auditfähig, skalierbar, sicher.</p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {% if turnstileSiteKey %}
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
+  {% endif %}
+  <script src="{{ basePath }}/js/custom-icons.js" defer></script>
+  <script src="{{ basePath }}/js/storage.js"></script>
+  <script>
+    (function () {
+      try {
+        var hasStorageHelpers = typeof STORAGE_KEYS !== 'undefined' &&
+          typeof getStored === 'function' &&
+          typeof setStored === 'function';
+        var darkKey = hasStorageHelpers ? STORAGE_KEYS.DARK_MODE : 'darkMode';
+        var storedTheme = hasStorageHelpers ? getStored(darkKey) : (function () {
+          try {
+            return (typeof localStorage !== 'undefined') ? localStorage.getItem(darkKey) : null;
+          } catch (error) {
+            return null;
+          }
+        })();
+
+        if (storedTheme === null) {
+          if (hasStorageHelpers) {
+            setStored(darkKey, 'false');
+          } else if (typeof localStorage !== 'undefined') {
+            localStorage.setItem(darkKey, 'false');
+          }
+        }
+      } catch (error) {
+        /* empty */
+      }
+    })();
+  </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      document.querySelectorAll('.js-email-link').forEach(function (anchor) {
+        var user = anchor.getAttribute('data-user');
+        var domain = anchor.getAttribute('data-domain');
+        if (user && domain) {
+          var email = user + '@' + domain;
+          anchor.href = 'mailto:' + email;
+          anchor.textContent = email;
+        }
+      });
+      var contactForm = document.getElementById('contact-form');
+      if (contactForm && !contactForm.hasAttribute('data-contact-endpoint')) {
+        contactForm.setAttribute('data-contact-endpoint', '{{ basePath }}/calhelp/contact');
+      }
+    });
+  </script>
+  <script>
+    window.marketingChatConfig = {
+      endpoint: '{{ marketingChatEndpoint|e('js') }}',
+      slug: '{{ marketingSlug|e('js') }}',
+      csrfToken: '{{ csrf_token|default('')|e('js') }}',
+      locale: '{{ locale() }}',
+      texts: {
+        intro: '{{ t('marketing_chat_intro_message')|e('js') }}',
+        loading: '{{ t('marketing_chat_loading')|e('js') }}',
+        errorGeneric: '{{ t('marketing_chat_error_generic')|e('js') }}',
+        errorValidation: '{{ t('marketing_chat_error_validation')|e('js') }}',
+        errorRateLimited: '{{ t('marketing_chat_error_rate_limited')|e('js') }}',
+        sources: '{{ t('marketing_chat_sources')|e('js') }}',
+        sourcesToggle: '{{ t('marketing_chat_sources_toggle')|e('js') }}',
+        score: '{{ t('marketing_chat_score')|e('js') }}',
+        empty: '{{ t('marketing_chat_empty')|e('js') }}',
+        question: '{{ t('marketing_chat_question_label')|e('js') }}'
+      }
+    };
+  </script>
+  <script src="{{ basePath }}/js/app.js"></script>
+  <script src="{{ basePath }}/js/marketing-chat.js" defer></script>
+  <script src="{{ basePath }}/js/landing.js" defer></script>
+{% endblock %}

--- a/tests/Controller/CalhelpControllerTest.php
+++ b/tests/Controller/CalhelpControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use Tests\TestCase;
+
+class CalhelpControllerTest extends TestCase
+{
+    protected function setUp(): void {
+        parent::setUp();
+        $pdo = $this->getDatabase();
+        try {
+            $pdo->exec("INSERT INTO pages(slug,title,content) VALUES('calhelp','calHelp','<p>calHelp</p>')");
+        } catch (\PDOException $e) {
+            // Ignore duplicates when running multiple tests with shared databases.
+        }
+    }
+
+    public function testCalhelpPage(): void {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/calhelp');
+        $request = $request->withUri($request->getUri()->withHost('main.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('calHelp – Marketingseite', $body);
+        $this->assertStringContainsString('data-marketing-chat-open', $body);
+        $this->assertStringNotContainsString("csrfToken: ''", $body);
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+
+    public function testCalhelpPageTenant(): void {
+        $old = getenv('MAIN_DOMAIN');
+        putenv('MAIN_DOMAIN=main.test');
+        $app = $this->getAppInstance();
+        $request = $this->createRequest('GET', '/calhelp');
+        $request = $request->withUri($request->getUri()->withHost('tenant.main.test'));
+        $response = $app->handle($request);
+        $this->assertEquals(404, $response->getStatusCode());
+        if ($old === false) {
+            putenv('MAIN_DOMAIN');
+        } else {
+            putenv('MAIN_DOMAIN=' . $old);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated calHelp marketing template with hero, navigation, chat modal, and footer
- seed the calHelp landing content, styles, translations, and routes including a migration for page content
- cover the new page with a controller test

## Testing
- `vendor/bin/phpunit tests/Controller/CalhelpControllerTest.php` *(fails: vendor/bin/phpunit not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e412679ee8832b995fbd069d9c12d4