### PR TITLE
Align calHelp marketing page styling with calServer theme

### DIFF
--- a/content/marketing/calhelp.html
+++ b/content/marketing/calhelp.html
@@ -5,15 +5,15 @@
       <p class="uk-text-lead">Drei starke Gründe, calHelp jetzt zu starten – strukturiert, auditfest, stabil.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-migration-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="benefit-migration-title">
         <h3 id="benefit-migration-title" class="uk-card-title">Nahtlos umsteigen</h3>
         <p>Historien aus Altsystemen verlustarm übernehmen, bestehende Tools weiter nutzen. Ohne Doppelerfassung, ohne Datenbruch.</p>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-audit-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="benefit-audit-title">
         <h3 id="benefit-audit-title" class="uk-card-title">Auditfest arbeiten</h3>
         <p>DAkkS-konforme Reports, nachvollziehbare Konformitätslogik und klare Freigaben – Prüfungen bestehen statt diskutieren.</p>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="benefit-operations-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="benefit-operations-title">
         <h3 id="benefit-operations-title" class="uk-card-title">Einfach betreiben</h3>
         <p>In Deutschland gehostet oder On-Prem – mit SSO, Rollen und API. Stabil im Alltag, skalierbar im Wachstum.</p>
       </article>
@@ -28,28 +28,30 @@
       <p class="uk-text-lead">Jede Phase ist klar dokumentiert – inklusive Abnahmen, KPIs und Verantwortlichkeiten.</p>
     </div>
     <ol class="calhelp-process" aria-label="Migrationsprozess in fünf Schritten">
-      <li>
+      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
         <h3>Readiness-Check</h3>
         <p>Systeminventar, Datenumfang, Besonderheiten (z. B. Anhänge, benutzerdefinierte Felder).</p>
       </li>
-      <li>
+      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
         <h3>Mapping &amp; Regeln</h3>
         <p>Felder, SI-Präfixe, Status/Workflows, Rollen. Transparent dokumentiert.</p>
       </li>
-      <li>
+      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
         <h3>Pilot &amp; Validierung</h3>
         <p>Teilmenge (Golden Samples), Checksummen, Abweichungsbericht. Freigabe als Gate.</p>
       </li>
-      <li>
+      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
         <h3>Delta-Sync &amp; Cutover</h3>
         <p>Downtime-arm, sauber geplantes Übergabefenster, klarer Abnahmelauf.</p>
       </li>
-      <li>
+      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
         <h3>Go-Live &amp; Monitoring</h3>
         <p>KPIs, Protokolle, Hypercare-Phase. Stabil in den Betrieb überführt.</p>
       </li>
     </ol>
-    <p class="calhelp-note">Abnahmekriterien sind vorab definiert (z. B. ≥ 99,5 % korrekte Migration, 0 kritische Abweichungen, Report-Abnahme mit Musterdaten).</p>
+    <div class="calhelp-note uk-card uk-card-primary uk-card-body">
+      <p class="uk-margin-remove">Abnahmekriterien sind vorab definiert (z. B. ≥ 99,5 % korrekte Migration, 0 kritische Abweichungen, Report-Abnahme mit Musterdaten).</p>
+    </div>
   </div>
 </section>
 
@@ -60,7 +62,7 @@
       <p class="uk-text-lead">calHelp macht Abläufe nachvollziehbar: wer, was, wann.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-lab-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="usecase-lab-title">
         <h3 id="usecase-lab-title" class="uk-card-title">Use Case A – Kalibrierlabor</h3>
         <p class="uk-text-emphasis">„Wir müssen Zertifikate schneller und nachvollziehbar erzeugen.“</p>
         <ul class="uk-list uk-list-bullet">
@@ -70,7 +72,7 @@
           <li>Zweisprachige Reports</li>
         </ul>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-service-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="usecase-service-title">
         <h3 id="usecase-service-title" class="uk-card-title">Use Case B – Instandhaltung/Service</h3>
         <p class="uk-text-emphasis">„Wir wollen Wartungen planen, Nachweise sichern und Rückfragen reduzieren.“</p>
         <ul class="uk-list uk-list-bullet">
@@ -80,7 +82,7 @@
           <li>Revisionssichere Dokumente</li>
         </ul>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="usecase-public-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="usecase-public-title">
         <h3 id="usecase-public-title" class="uk-card-title">Use Case C – Öffentliche Verwaltung/Versorger:innen</h3>
         <p class="uk-text-emphasis">„Wir brauchen konsistente Prozesse, belastbare Nachweise und DSGVO-Konformität.“</p>
         <ul class="uk-list uk-list-bullet">
@@ -91,8 +93,8 @@
         </ul>
       </article>
     </div>
-    <div class="calhelp-microcopy">
-      <p>Alles Wichtige an einem Ort – ohne Doppelerfassung. Migration in klaren Schritten – mit Testlauf und Abnahme.</p>
+    <div class="calhelp-microcopy uk-card uk-card-primary uk-card-body">
+      <p class="uk-margin-remove">Alles Wichtige an einem Ort – ohne Doppelerfassung. Migration in klaren Schritten – mit Testlauf und Abnahme.</p>
     </div>
   </div>
 </section>
@@ -104,20 +106,22 @@
       <p class="uk-text-lead">Referenzen, Datenschutz und Qualitätsnachweise auf einen Blick.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-ref-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="proof-ref-title">
         <h3 id="proof-ref-title" class="uk-card-title">Referenzen</h3>
         <p>Produktiv eingesetzte Migrationen von MET/TRACK, fortlaufende MET/TEAM-Anbindung.</p>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-security-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="proof-security-title">
         <h3 id="proof-security-title" class="uk-card-title">Sicherheit &amp; DSGVO</h3>
         <p>Hosting in DE (oder On-Prem), rollenbasierte Zugriffe, Protokollierung, nachvollziehbare Lösch-/Aufbewahrungsregeln.</p>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="proof-quality-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="proof-quality-title">
         <h3 id="proof-quality-title" class="uk-card-title">Qualitätscheck</h3>
         <p>Musterzertifikate, visuelle Report-Diffs, dokumentierte Feld-Mappings.</p>
       </article>
     </div>
-    <p class="calhelp-kpi">15+ Jahre Projekterfahrung · 1.600+ umgesetzte Kund:innen-Wünsche · 99,9 % Betriebszeit (aktuell)</p>
+    <div class="calhelp-kpi uk-card uk-card-primary uk-card-body">
+      <p class="uk-margin-remove">15+ Jahre Projekterfahrung · 1.600+ umgesetzte Kund:innen-Wünsche · 99,9 % Betriebszeit (aktuell)</p>
+    </div>
   </div>
 </section>
 
@@ -128,20 +132,20 @@
       <p class="uk-text-lead">Vom ersten Check bis zum stabilen Betrieb – modular buchbar.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-s-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="service-s-title">
         <h3 id="service-s-title" class="uk-card-title">Paket S – Migration-Check (Fixpreis)</h3>
         <p>Analyse, Feld-Mapping-Skizze, Risikoabschätzung, Zeitplan. Ergebnis: Entscheidungsgrundlage &amp; Angebot.</p>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-m-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="service-m-title">
         <h3 id="service-m-title" class="uk-card-title">Paket M – Pilot &amp; Cutover-Plan</h3>
         <p>Teilmenge migrieren, Validierung, Abweichungsbericht, Go-/No-Go-Empfehlung. Ergebnis: belastbarer Cutover-Plan.</p>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="service-l-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="service-l-title">
         <h3 id="service-l-title" class="uk-card-title">Paket L – Vollmigration &amp; Hypercare</h3>
         <p>Vollübernahme, Delta-Sync, Go-Live-Begleitung (30 Tage), Monitoring mit KPIs. Ergebnis: stabiler Betrieb.</p>
       </article>
     </div>
-    <aside class="calhelp-addons" aria-label="Add-ons">
+    <aside class="calhelp-addons uk-card uk-card-primary uk-card-body" aria-label="Add-ons">
       <h3>Add-ons</h3>
       <ul class="uk-list uk-list-bullet">
         <li>DAkkS-Report-Bundle (zweisprachig)</li>
@@ -160,7 +164,7 @@
     </div>
     <div class="uk-grid-large" data-uk-grid>
       <div class="uk-width-1-2@m">
-        <ol class="calhelp-demo-steps" aria-label="Fragen für den Demo-Flow">
+        <ol class="calhelp-demo-steps uk-card uk-card-primary uk-card-body" aria-label="Fragen für den Demo-Flow">
           <li>Wofür möchten Sie das System nutzen? (Labor | Instandhaltung | Verwaltung | Sonstiges)</li>
           <li>Datenbasis? (MET/TRACK | MET/TEAM | CSV/Excel | unklar)</li>
           <li>Umfang? (&lt;1.000 | 1.000–10.000 | &gt;10.000 | unklar)</li>
@@ -169,7 +173,7 @@
         </ol>
       </div>
       <div class="uk-width-1-2@m">
-        <div class="uk-card uk-card-default uk-card-body calhelp-card">
+        <div class="uk-card uk-card-primary uk-card-body calhelp-card">
           <h3 class="uk-card-title">Abschluss-Screen</h3>
           <p>Zwei Optionen führen zum nächsten Schritt – individuell vorbereitet.</p>
           <ul class="uk-list uk-list-divider calhelp-cta-list">
@@ -194,7 +198,7 @@
         <p>calHelp ist die Dachmarke von René Buske. Aus jahrelanger Projektarbeit im Kalibrierumfeld ist ein klarer Ansatz entstanden: <strong>Wissen führt. Software liefert.</strong> Wir migrieren Altdaten sauber, binden bestehende Systeme an (z. B. MET/TEAM) und stabilisieren Abläufe – <strong>konsistent, nachvollziehbar, auditfähig</strong>.</p>
       </div>
       <div class="uk-width-1-3@m">
-        <ul class="uk-list calhelp-values" aria-label="Werte von calHelp">
+        <ul class="uk-list calhelp-values uk-card uk-card-primary uk-card-body" aria-label="Werte von calHelp">
           <li><strong>Präzision:</strong> Entscheidungen auf Datenbasis.</li>
           <li><strong>Transparenz:</strong> Dokumentierte Regeln, prüfbare Schritte.</li>
           <li><strong>Verlässlichkeit:</strong> Saubere Übergabe, stabiler Betrieb.</li>
@@ -212,7 +216,7 @@
       <p class="uk-text-lead">Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-2@m" data-uk-grid>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-changelog-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-changelog-title">
         <h3 id="news-changelog-title" class="uk-card-title">Changelog kompakt</h3>
         <p class="uk-text-meta">Zuletzt aktualisiert am 04.10.2025</p>
         <ul class="uk-list uk-list-bullet">
@@ -221,7 +225,7 @@
           <li>Integrationen: MET/TEAM-Connector mit zusätzlichen Webhooks.</li>
         </ul>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-recipe-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-recipe-title">
         <h3 id="news-recipe-title" class="uk-card-title">Praxisrezept in 3 Schritten</h3>
         <p class="uk-text-meta">Zuletzt aktualisiert am 27.09.2025</p>
         <p><strong>Thema:</strong> Konformitätslegende sauber integrieren.</p>
@@ -231,7 +235,7 @@
           <li>Report-Diffs mit Golden Samples gegenprüfen.</li>
         </ol>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-usecase-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-usecase-title">
         <h3 id="news-usecase-title" class="uk-card-title">Use-Case-Spotlight</h3>
         <p class="uk-text-meta">Zuletzt aktualisiert am 18.09.2025</p>
         <p><strong>Ausgangslage:</strong> Stark gewachsene Kalibrierabteilung mit Inseltools.</p>
@@ -240,13 +244,13 @@
         <p><strong>Learnings:</strong> Frühzeitig Rollenmodell definieren, Dokumentation als laufenden Prozess etablieren.</p>
         <p><strong>Nächste Schritte:</strong> Automatisierte Erinnerungen für Prüfmittel und Lieferant:innen.</p>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-standards-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-standards-title">
         <h3 id="news-standards-title" class="uk-card-title">Standards verständlich</h3>
         <p class="uk-text-meta">Zuletzt aktualisiert am 12.09.2025</p>
         <p><strong>Thema:</strong> Guardband &amp; MU in 5 Minuten erklärt.</p>
         <p>Beispiel: Messwert 10,0 mm mit MU 0,3 mm. Guardband reduziert die Toleranzgrenze auf 9,7–10,3 mm. calHelp dokumentiert automatisch, wie Entscheidung und Unsicherheit zusammenhängen.</p>
       </article>
-      <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="news-roadmap-title">
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-roadmap-title">
         <h3 id="news-roadmap-title" class="uk-card-title">Roadmap-Ausblick</h3>
         <p class="uk-text-meta">Zuletzt aktualisiert am 05.09.2025</p>
         <ul class="uk-list uk-list-bullet">
@@ -261,7 +265,7 @@
       <p>„Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.“ (Double-Opt-In, freiwillig.)</p>
       <a class="uk-button uk-button-default" href="#demo">Zum Demo-Flow</a>
     </aside>
-    <section class="calhelp-editorial-calendar" aria-labelledby="calendar-title">
+    <section class="calhelp-editorial-calendar uk-card uk-card-primary uk-card-body" aria-labelledby="calendar-title">
       <h3 id="calendar-title">Redaktionskalender – 6 Wochen Ausblick</h3>
       <ol class="uk-list uk-list-decimal">
         <li>Woche 1: „Die 5 größten Stolperstellen bei MET/TRACK-Migrationen“ (Praxisbeitrag)</li>
@@ -281,19 +285,19 @@
       <h2 id="faq-title" class="uk-heading-medium">FAQ – die typischen Fragen</h2>
     </div>
     <dl class="calhelp-faq" aria-label="Häufig gestellte Fragen">
-      <div>
+      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
         <dt>Bleibt MET/TEAM nutzbar?</dt>
         <dd>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und schrittweise.</dd>
       </div>
-      <div>
+      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
         <dt>Was wird übernommen?</dt>
         <dd>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</dd>
       </div>
-      <div>
+      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
         <dt>Wie sicher ist der Betrieb?</dt>
         <dd>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutztext.</dd>
       </div>
-      <div>
+      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
         <dt>Wie lange dauert der Umstieg?</dt>
         <dd>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</dd>
       </div>
@@ -311,7 +315,9 @@
       <a class="uk-button uk-button-primary" href="#services">Migration prüfen lassen</a>
       <a class="uk-button uk-button-default" href="#demo">Demo anfragen</a>
     </div>
-    <p class="calhelp-note">Wir speichern nur, was für Rückmeldung und Terminfindung nötig ist. Details: <a href="{{ basePath }}/datenschutz">Datenschutz</a>.</p>
+    <div class="calhelp-note uk-card uk-card-primary uk-card-body">
+      <p class="uk-margin-remove">Wir speichern nur, was für Rückmeldung und Terminfindung nötig ist. Details: <a href="{{ basePath }}/datenschutz">Datenschutz</a>.</p>
+    </div>
   </div>
 </section>
 
@@ -320,7 +326,7 @@
     <div class="calhelp-section__header">
       <h2 id="seo-title" class="uk-heading-medium">SEO &amp; Snippets</h2>
     </div>
-    <div class="calhelp-seo-box">
+    <div class="calhelp-seo-box uk-card uk-card-primary uk-card-body">
       <p><strong>Seitentitel:</strong> Umstieg auf ein zentrales Kalibrier-System – konsistent, nachvollziehbar, auditfähig</p>
       <p><strong>Beschreibung:</strong> calHelp migriert Altdaten, bindet MET/TEAM an und stabilisiert Abläufe – konsistent, nachvollziehbar, auditfähig.</p>
       <p><strong>Open-Graph-Hinweis:</strong> „Ein System. Klare Prozesse.“</p>

--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -1,39 +1,32 @@
-:root {
-  --calhelp-primary: #1e87f0;
-  --calhelp-dark: #1b2333;
-  --calhelp-muted: #f4f6fb;
-  --calhelp-accent: #fbb040;
-}
-
-body.calhelp-theme,
-.calhelp-theme {
+body.qr-landing.calhelp-theme {
+  --calserver-primary: #1f63e6;
   font-family: 'Poppins', 'Roboto', sans-serif;
-  background-color: var(--calhelp-muted);
-  color: var(--calhelp-dark);
 }
 
-.topbar {
-  background: linear-gradient(90deg, #0f5fff, #1e87f0);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.topbar .uk-navbar-item,
-.topbar .uk-navbar-nav > li > a {
-  color: #ffffff;
-  font-weight: 500;
-}
-
-.topbar .uk-navbar-nav > li > a:hover,
-.topbar .uk-navbar-nav > li > a:focus {
-  color: #ffffff;
-  text-decoration: underline;
+body.qr-landing.calhelp-theme .landing-content {
+  position: relative;
 }
 
 .calhelp-logo {
-  font-size: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: var(--cs-logo-bg);
+  border: 1px solid var(--cs-logo-border);
+  color: var(--cs-logo-text);
   font-weight: 600;
-  letter-spacing: 0.04em;
-  color: #ffffff;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  line-height: 1;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.calhelp-logo:hover,
+.calhelp-logo:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 34px -20px color-mix(in oklab, var(--calserver-primary) 54%, rgba(15, 23, 42, 0.85));
 }
 
 .calhelp-logo__sr {
@@ -47,46 +40,54 @@ body.calhelp-theme,
   border: 0;
 }
 
+.calhelp-logo__wordmark {
+  font-size: 1.1rem;
+  letter-spacing: 0.12em;
+}
+
 .calhelp-top-cta {
-  font-weight: 600;
+  box-shadow: 0 22px 40px -26px color-mix(in oklab, var(--calserver-primary) 66%, rgba(15, 23, 42, 0.75));
 }
 
 .calhelp-hero {
-  background: linear-gradient(180deg, rgba(15, 95, 255, 0.08), rgba(30, 135, 240, 0));
-  padding-top: 96px;
-  padding-bottom: 96px;
+  position: relative;
+  overflow: hidden;
 }
 
-.calhelp-hero .qr-h1 {
-  font-size: 2.8rem;
-  line-height: 1.2;
-  margin-bottom: 16px;
+.calhelp-hero .qr-hero-bg {
+  inset: 0;
 }
 
-.calhelp-hero .qr-sub {
-  font-size: 1.25rem;
-  margin-bottom: 12px;
+.calhelp-hero-grid__content,
+.calhelp-hero-grid__media {
+  position: relative;
+  z-index: 2;
 }
 
 .calhelp-hero-card {
-  border-radius: 16px;
-  box-shadow: 0 20px 40px rgba(15, 95, 255, 0.15);
-  background-color: #ffffff;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 42px 72px -48px color-mix(in oklab, var(--calserver-primary) 52%, rgba(15, 23, 42, 0.82));
 }
 
-.calhelp-hero-card ul {
-  margin-bottom: 0;
+.calhelp-hero-card .uk-card-title {
+  font-weight: 600;
+}
+
+.calhelp-hero-card .hero-list > li::before {
+  color: var(--calserver-primary);
 }
 
 .calhelp-trust {
   margin-top: 24px;
   font-size: 0.95rem;
-  color: rgba(27, 35, 51, 0.75);
+  color: color-mix(in oklab, var(--qr-landing-text) 68%, rgba(15, 23, 42, 0.56));
 }
 
 .calhelp-section {
-  padding-top: 80px;
-  padding-bottom: 80px;
+  position: relative;
 }
 
 .calhelp-section__header {
@@ -96,279 +97,201 @@ body.calhelp-theme,
 }
 
 .calhelp-section__header h2 {
-  font-size: 2.4rem;
-  font-weight: 600;
   margin-bottom: 12px;
 }
 
 .calhelp-section__header p {
   margin: 0;
-  color: rgba(27, 35, 51, 0.75);
+  color: color-mix(in oklab, var(--qr-landing-text) 64%, rgba(15, 23, 42, 0.45));
 }
 
 .calhelp-card {
-  border-radius: 16px;
-  box-shadow: 0 16px 36px rgba(15, 95, 255, 0.08);
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
-}
-
-.calhelp-card:hover,
-.calhelp-card:focus-within {
-  transform: translateY(-6px);
-  box-shadow: 0 24px 48px rgba(15, 95, 255, 0.12);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .calhelp-card .uk-card-title {
-  font-size: 1.4rem;
   font-weight: 600;
 }
 
-.calhelp-card .uk-text-emphasis {
-  font-style: italic;
-  color: rgba(27, 35, 51, 0.8);
+.calhelp-card .uk-text-meta {
+  color: color-mix(in oklab, var(--qr-landing-text) 60%, rgba(15, 23, 42, 0.5));
+}
+
+.calhelp-card .uk-list-bullet > li::before,
+.calhelp-card .uk-list-decimal > li::marker {
+  color: var(--calserver-primary);
 }
 
 .calhelp-process {
   counter-reset: step;
   display: grid;
   gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.calhelp-process li {
+.calhelp-process__step {
   position: relative;
-  padding: 24px;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 12px 32px rgba(15, 95, 255, 0.08);
+  padding-left: 72px;
+  min-height: 120px;
 }
 
-.calhelp-process li::before {
+.calhelp-process__step::before {
   counter-increment: step;
   content: counter(step);
   position: absolute;
-  top: -16px;
-  left: 24px;
+  top: 32px;
+  left: 28px;
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background: var(--calhelp-primary);
-  color: #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.2rem;
+  background: color-mix(in oklab, var(--calserver-primary) 88%, rgba(255, 255, 255, 0.12));
+  color: #ffffff;
   font-weight: 600;
-  box-shadow: 0 12px 24px rgba(30, 135, 240, 0.35);
+  font-size: 1.15rem;
+  box-shadow: 0 20px 36px -26px color-mix(in oklab, var(--calserver-primary) 72%, rgba(15, 23, 42, 0.85));
 }
 
-.calhelp-note {
+.calhelp-note,
+.calhelp-microcopy,
+.calhelp-kpi,
+.calhelp-addons,
+.calhelp-editorial-calendar,
+.calhelp-seo-box {
   margin-top: 32px;
+}
+
+.calhelp-note p,
+.calhelp-microcopy p,
+.calhelp-kpi p {
+  color: color-mix(in oklab, var(--qr-landing-text) 72%, rgba(15, 23, 42, 0.45));
   text-align: center;
-  font-size: 0.95rem;
-  color: rgba(27, 35, 51, 0.7);
-}
-
-.calhelp-microcopy {
-  margin-top: 32px;
-  padding: 24px;
-  border-radius: 14px;
-  background: rgba(30, 135, 240, 0.08);
-  text-align: center;
-  font-weight: 500;
-}
-
-.calhelp-kpi {
-  margin-top: 32px;
-  text-align: center;
-  font-weight: 600;
-  color: var(--calhelp-dark);
-}
-
-.calhelp-addons {
-  margin-top: 48px;
-  padding: 32px;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 12px 28px rgba(27, 35, 51, 0.08);
-}
-
-.calhelp-addons h3 {
-  margin-bottom: 16px;
-  font-size: 1.3rem;
-  font-weight: 600;
 }
 
 .calhelp-demo-steps {
+  list-style: decimal inside;
   margin: 0;
-  padding-left: 18px;
-  font-size: 1.05rem;
-  line-height: 1.6;
+  padding: 0;
+  counter-reset: none;
 }
 
-.calhelp-cta-list {
+.calhelp-demo-steps li + li {
   margin-top: 12px;
 }
 
+.calhelp-cta-list {
+  margin: 16px 0 0;
+}
+
+.calhelp-cta-list li + li {
+  margin-top: 8px;
+}
+
 .calhelp-values {
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 12px;
 }
 
-.calhelp-values li {
-  padding: 12px 0;
-  border-bottom: 1px solid rgba(27, 35, 51, 0.15);
-}
-
-.calhelp-values li:last-child {
-  border-bottom: none;
-}
-
-.calhelp-newsletter {
-  margin-top: 48px;
-  border-radius: 16px;
-  box-shadow: 0 20px 40px rgba(15, 95, 255, 0.2);
+.calhelp-values li strong {
+  display: inline-block;
+  margin-right: 6px;
 }
 
 .calhelp-editorial-calendar {
   margin-top: 48px;
-  padding: 32px;
-  border-radius: 16px;
-  background: rgba(27, 35, 51, 0.05);
 }
 
-.calhelp-editorial-calendar h3 {
-  margin-bottom: 16px;
-  font-weight: 600;
+.calhelp-editorial-calendar ol {
+  margin: 0;
+  padding-left: 20px;
 }
 
 .calhelp-faq {
   display: grid;
   gap: 24px;
-}
-
-.calhelp-faq dt {
-  font-weight: 600;
-  font-size: 1.2rem;
-  margin-bottom: 6px;
-}
-
-.calhelp-faq dd {
-  margin: 0;
-  color: rgba(27, 35, 51, 0.75);
-}
-
-.calhelp-cta {
-  text-align: center;
-  background: linear-gradient(135deg, rgba(15, 95, 255, 0.85), rgba(12, 68, 207, 0.9));
-  color: #ffffff;
-}
-
-.calhelp-cta .calhelp-section__header p {
-  color: rgba(255, 255, 255, 0.85);
-}
-
-.calhelp-cta__actions {
-  margin-top: 32px;
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-  flex-wrap: wrap;
-}
-
-.calhelp-cta .uk-button-primary {
-  background-color: #ffffff;
-  color: var(--calhelp-dark);
-}
-
-.calhelp-cta .uk-button-default {
-  background-color: transparent;
-  border: 1px solid #ffffff;
-  color: #ffffff;
-}
-
-.calhelp-cta .uk-button-default:hover,
-.calhelp-cta .uk-button-default:focus {
-  background-color: rgba(255, 255, 255, 0.15);
-}
-
-.calhelp-seo-box {
-  padding: 32px;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 16px 36px rgba(15, 95, 255, 0.08);
-}
-
-.calhelp-floating-button {
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: var(--calhelp-primary);
-  color: #ffffff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 16px 40px rgba(15, 95, 255, 0.35);
-  z-index: 1200;
-}
-
-.calhelp-floating-button:hover,
-.calhelp-floating-button:focus {
-  background: #0f5fff;
-  color: #ffffff;
-}
-
-.calhelp-footer {
-  display: grid;
-  gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  padding: 48px 24px;
-  background: #0b1633;
-  color: #ffffff;
-}
-
-.calhelp-footer strong {
-  display: block;
-  margin-bottom: 8px;
-  font-size: 1.1rem;
-}
-
-.calhelp-footer a {
-  color: #ffffff;
-}
-
-.calhelp-footer__nav ul {
-  list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.calhelp-footer__nav li + li {
-  margin-top: 6px;
+.calhelp-faq__item {
+  margin: 0;
+}
+
+.calhelp-faq__item dt {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.calhelp-faq__item dd {
+  margin: 0;
+  color: color-mix(in oklab, var(--qr-landing-text) 72%, rgba(15, 23, 42, 0.45));
+}
+
+.calhelp-cta {
+  position: relative;
+}
+
+.calhelp-cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.calhelp-floating-button {
+  bottom: 24px;
+  right: 24px;
 }
 
 @media (max-width: 959px) {
-  .calhelp-hero {
-    padding-top: 72px;
-    padding-bottom: 72px;
+  .calhelp-hero-card {
+    margin-top: 24px;
   }
 
-  .calhelp-section {
-    padding-top: 64px;
-    padding-bottom: 64px;
+  .calhelp-process__step {
+    padding-left: 64px;
+  }
+
+  .calhelp-process__step::before {
+    left: 20px;
+    top: 24px;
   }
 
   .calhelp-floating-button {
-    right: 16px;
     bottom: 16px;
+    right: 16px;
+  }
+}
+
+@media (max-width: 639px) {
+  .calhelp-section__header {
+    margin-bottom: 36px;
+  }
+
+  .calhelp-process {
+    gap: 16px;
+  }
+
+  .calhelp-process__step {
+    padding-left: 60px;
+  }
+
+  .calhelp-process__step::before {
+    left: 16px;
+    top: 20px;
+    width: 40px;
+    height: 40px;
   }
 }

--- a/templates/marketing/calhelp.twig
+++ b/templates/marketing/calhelp.twig
@@ -18,6 +18,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="preload" href="{{ basePath }}/css/landing.css" as="style">
   <link rel="stylesheet" href="{{ basePath }}/css/landing.css">
+  <link rel="stylesheet" href="{{ basePath }}/css/calserver.css">
   <link rel="stylesheet" href="{{ basePath }}/css/highcontrast.css">
   <link rel="stylesheet" href="{{ basePath }}/css/onboarding.css">
   <link rel="stylesheet" href="{{ basePath }}/css/topbar.landing.css">
@@ -26,7 +27,7 @@
 {% endblock %}
 
 {% block body_theme %}light{% endblock %}
-{% block body_class %}qr-landing calhelp-theme{% endblock %}
+{% block body_class %}qr-landing calserver-theme calhelp-theme{% endblock %}
 
 {% block body %}
   <div class="landing-content">
@@ -43,7 +44,7 @@
                     aria-label="Menü"></button>
             <a class="uk-logo calhelp-logo" href="{{ basePath }}/calhelp">
               <span class="calhelp-logo__sr">calHelp – Zentrales Kalibrier- und Prüfmanagement</span>
-              <span aria-hidden="true">calHelp</span>
+              <span class="calhelp-logo__wordmark" aria-hidden="true">calHelp</span>
             </a>
           </div>
         </div>
@@ -170,10 +171,13 @@
       </div>
     </div>
 
-    <section id="hero" class="uk-section uk-section-large calhelp-hero">
+    <section id="hero" class="qr-hero uk-section uk-section-large calhelp-hero">
+      <div class="qr-hero-bg hero-bg-calserver" aria-hidden="true">
+        <canvas class="calserver-hero-bg__canvas"></canvas>
+      </div>
       <div class="uk-container">
-        <div class="uk-grid uk-grid-large uk-child-width-1-2@m uk-flex-middle" data-uk-grid>
-          <div>
+        <div class="uk-grid uk-grid-large uk-child-width-1-2@m uk-flex-middle calhelp-hero-grid" data-uk-grid>
+          <div class="calhelp-hero-grid__content">
             <span class="qr-badge pill pill--soft">Hosting in Deutschland · DSGVO-konform</span>
             <h1 class="qr-h1">Ein System. Klare Prozesse.</h1>
             <p class="qr-sub">calHelp sorgt dafür, dass Kalibrierdaten, Dokumente und Abläufe verlässlich in einem zentralen System zusammenfließen – konsistent, nachvollziehbar und auditfähig.</p>
@@ -188,10 +192,10 @@
             </div>
             <p class="calhelp-trust">Hosting in Deutschland · DSGVO-konform · &gt;15 Jahre Projekterfahrung</p>
           </div>
-          <div>
-            <div class="calhelp-hero-card uk-card uk-card-default uk-card-body">
+          <div class="calhelp-hero-grid__media">
+            <div class="calhelp-hero-card uk-card uk-card-primary uk-card-primary--highlight uk-card-body">
               <h2 class="uk-card-title">Warum calHelp?</h2>
-              <ul class="uk-list uk-list-bullet">
+              <ul class="uk-list uk-list-bullet hero-list">
                 <li>Konsistente Datenbasis für Labore, Service-Teams und Verwaltung.</li>
                 <li>Prozesssichere Migration mit klaren Gateways und Abnahmen.</li>
                 <li>Auditfähige Nachweise inklusive Report-Diffs und Protokollen.</li>
@@ -232,7 +236,7 @@
       </div>
     </div>
 
-    <button class="calhelp-floating-button marketing-chat-fab"
+    <button class="calserver-floating-button calhelp-floating-button marketing-chat-fab"
             type="button"
             data-marketing-chat-open
             aria-haspopup="dialog"
@@ -244,12 +248,25 @@
 {% endblock %}
 
 {% block footer %}
-  <div class="calhelp-footer">
-    <div class="calhelp-footer__brand">
+  <div class="footer-columns">
+    <div class="footer-section footer-about">
       <strong>calHelp</strong>
       <p>Ein System. Klare Prozesse.</p>
     </div>
-    <nav class="calhelp-footer__nav" aria-label="Footer-Navigation">
+    <div class="footer-section footer-contact">
+      <strong>Kontakt</strong>
+      <p>
+        René Buske<br>
+        <a
+          class="js-email-link"
+          data-user="office"
+          data-domain="calhelp.de"
+          href="#"
+        >office [at] calhelp.de</a><br>
+        <a href="tel:+4933203609080">+49&nbsp;33203&nbsp;609080</a>
+      </p>
+    </div>
+    <div class="footer-section footer-navigation">
       <strong>Links</strong>
       <ul>
         <li><a href="#hero">Start</a></li>
@@ -259,16 +276,8 @@
         <li><a href="{{ basePath }}/datenschutz">Datenschutz</a></li>
         <li><a href="{{ basePath }}/impressum">Impressum</a></li>
       </ul>
-    </nav>
-    <div class="calhelp-footer__contact">
-      <strong>Kontakt</strong>
-      <p>
-        René Buske<br>
-        <a class="js-email-link" data-user="office" data-domain="calhelp.de" href="#">office [at] calhelp.de</a><br>
-        <a href="tel:+4933203609080">+49&nbsp;33203&nbsp;609080</a>
-      </p>
     </div>
-    <div class="calhelp-footer__meta">
+    <div class="footer-section footer-legal">
       <strong>Hosting</strong>
       <p>In Deutschland oder On-Prem – auditfähig, skalierbar, sicher.</p>
     </div>


### PR DESCRIPTION
## Summary
- extend the calHelp template to load the calServer landing styles, updated hero layout, and footer structure
- restyle the marketing content so all feature cards, processes, and support blocks reuse the calServer primary card design
- replace the dedicated calHelp stylesheet with calServer-aligned component styling for consistent typography and spacing

## Testing
- php -S 0.0.0.0:8000 -t public public/router.php

------
https://chatgpt.com/codex/tasks/task_e_68e4174bafbc832b93550cc9e9b84cb3