### PR TITLE
Align calHelp topbar markup with calServer reference

### DIFF
--- a/templates/marketing/calhelp.twig
+++ b/templates/marketing/calhelp.twig
@@ -31,7 +31,7 @@
 
 {% block body %}
   <div class="landing-content">
-    <header class="qr-topbar topbar">
+    <header class="qr-topbar">
       <nav class="uk-navbar-container" data-uk-navbar>
         <div class="uk-navbar-left">
           <div class="uk-navbar-item">
@@ -58,9 +58,6 @@
               </li>
             {% endfor %}
           </ul>
-          <a class="uk-navbar-item uk-visible@m uk-button uk-button-primary calhelp-top-cta" href="#demo">
-            <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Demo anfragen
-          </a>
           <div class="uk-navbar-item config-menu uk-inline">
             <button id="configMenuToggle"
                     type="button"


### PR DESCRIPTION
## Summary
- drop the extra `topbar` class from the calHelp header to match the calServer reference markup
- remove the desktop-only demo CTA so the calHelp topbar mirrors the calServer structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e48f67dc60832b97f24ae762f266dd