### PR TITLE
Adjust calHelp hero messaging and CTA labels

### DIFF
--- a/templates/marketing/calhelp.twig
+++ b/templates/marketing/calhelp.twig
@@ -162,8 +162,8 @@
             </li>
           {% endfor %}
         </ul>
-        <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="#demo">
-          <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Demo anfragen
+        <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="#cta">
+          <span class="uk-margin-small-right" data-uk-icon="icon: commenting"></span>Gespräch starten
         </a>
       </div>
     </div>
@@ -177,14 +177,14 @@
           <div class="calhelp-hero-grid__content">
             <span class="qr-badge pill pill--soft">Hosting in Deutschland · DSGVO-konform</span>
             <h1 class="qr-h1">Ein System. Klare Prozesse.</h1>
-            <p class="qr-sub">calHelp sorgt dafür, dass Kalibrierdaten, Dokumente und Abläufe verlässlich in einem zentralen System zusammenfließen – konsistent, nachvollziehbar und auditfähig.</p>
+            <p class="qr-sub">calHelp sorgt dafür, dass Kalibrierdaten, Dokumente und Abläufe verlässlich in einem zentralen System zusammenkommen – <strong>konsistent, nachvollziehbar, auditfähig</strong>.</p>
             <p class="uk-text-lead">Altdaten werden sauber migriert (z. B. aus MET/TRACK), MET/TEAM bleibt angebunden, und Ihr Team arbeitet in klar definierten Prozessen mit belastbaren Nachweisen.</p>
             <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
-              <a class="uk-button uk-button-primary" href="#demo">
-                <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Demo anfragen
+              <a class="uk-button uk-button-primary" href="#cta">
+                <span class="uk-margin-small-right" data-uk-icon="icon: commenting"></span>Gespräch starten
               </a>
               <a class="uk-button uk-button-default" href="https://calhelp.notion.site/met-cal-handbuch" target="_blank" rel="noopener">
-                <span class="uk-margin-small-right" data-uk-icon="icon: file-text"></span>MET/CAL-Handbuch öffnen
+                <span class="uk-margin-small-right" data-uk-icon="icon: file-text"></span>MET/CAL-Handbuch ansehen
               </a>
             </div>
             <p class="calhelp-trust">Hosting in Deutschland · DSGVO-konform · &gt;15 Jahre Projekterfahrung</p>


### PR DESCRIPTION
## Summary
- update the hero subline to highlight zusammenkommen and emphasise the core qualities
- retitle the hero and offcanvas CTAs to "Gespräch starten" and "MET/CAL-Handbuch ansehen"

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4a24db934832b956405fdae01865c