### PR TITLE
Update calHelp marketing page copy

### DIFF
--- a/content/marketing/calhelp.html
+++ b/content/marketing/calhelp.html
@@ -1,335 +1,163 @@
-<section id="benefits" class="uk-section uk-section-muted calhelp-section" aria-labelledby="benefits-title">
+<section id="stories" class="uk-section uk-section-muted calhelp-section" aria-labelledby="stories-title">
   <div class="uk-container">
     <div class="calhelp-section__header">
-      <h2 id="benefits-title" class="uk-heading-medium">Warum jetzt handeln?</h2>
-      <p class="uk-text-lead">Drei starke Gründe, calHelp jetzt zu starten – strukturiert, auditfest, stabil.</p>
+      <h2 id="stories-title" class="uk-heading-medium">Drei Wege – drei Realitäten</h2>
+      <p class="uk-text-lead">Ohne Pakete, ohne Technik-Overkill: calHelp schafft Klarheit dort, wo Kalibrier- und Service-Teams heute nur Insellösungen sehen.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="benefit-migration-title">
-        <h3 id="benefit-migration-title" class="uk-card-title">Nahtlos umsteigen</h3>
-        <p>Historien aus Altsystemen verlustarm übernehmen, bestehende Tools weiter nutzen. Ohne Doppelerfassung, ohne Datenbruch.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="story-ksw-title">
+        <header class="calhelp-card__header">
+          <h3 id="story-ksw-title" class="uk-card-title">1) KSW Kalibrierdienst GmbH</h3>
+          <p class="uk-text-emphasis">Vom Flickenteppich zum durchgängigen Auftrag</p>
+        </header>
+        <section aria-labelledby="story-ksw-origin">
+          <h4 id="story-ksw-origin" class="uk-heading-bullet">Ausgangslage</h4>
+          <p>Angebote in Word/Excel, Lagerbewegungen separat, Messwerte in MET/CAL, Rechnungen spät und mit Rückfragen. Jeder Schritt für sich funktionierte – nur der <strong>Fluss</strong> fehlte: doppelte Eingaben, Suchzeiten, unklare Zustände.</p>
+        </section>
+        <section aria-labelledby="story-ksw-turn">
+          <h4 id="story-ksw-turn" class="uk-heading-bullet">Wendepunkt</h4>
+          <blockquote class="uk-margin-small-top uk-margin-small-bottom">„Wir wollen vom Erstkontakt bis zur Rechnung <strong>einen</strong> nachvollziehbaren Ablauf.“</blockquote>
+        </section>
+        <section aria-labelledby="story-ksw-action">
+          <h4 id="story-ksw-action" class="uk-heading-bullet">Was calHelp getan hat</h4>
+          <p>Wir haben den Weg von der <strong>Angebotsannahme</strong> über <strong>Material/Lager</strong>, <strong>Messwert-Erfassung (MET/CAL)</strong>, <strong>Freigabe</strong> und <strong>Rechnung</strong> zu <strong>einem</strong> klaren Prozess verdichtet. Zustände sind sichtbar, Dokumente hängen da, wo sie gebraucht werden, und Freigaben sind protokolliert.</p>
+        </section>
+        <section aria-labelledby="story-ksw-today">
+          <h4 id="story-ksw-today" class="uk-heading-bullet">Heute</h4>
+          <p>Ein Auftrag wandert wie an einer klaren Leine: Angebot → Termin/Material → Messung → Bericht → Freigabe → Rechnung. Keine „Könnt ihr mal schnell…?“-Mails, weniger Schleifen, <strong>verlässlicher Cashflow</strong>.</p>
+          <p class="uk-margin-remove"><strong>Mehrwert:</strong> weniger Nacharbeit, kürzere Durchlaufzeiten, Ruhe vor Audits – weil alles an einem Ort belegt ist.</p>
+        </section>
       </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="benefit-audit-title">
-        <h3 id="benefit-audit-title" class="uk-card-title">Auditfest arbeiten</h3>
-        <p>DAkkS-konforme Reports, nachvollziehbare Konformitätslogik und klare Freigaben – Prüfungen bestehen statt diskutieren.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="story-ifm-title">
+        <header class="calhelp-card__header">
+          <h3 id="story-ifm-title" class="uk-card-title">2) i.f.m. – Laborverbund</h3>
+          <p class="uk-text-emphasis">Von Inseln zu einem abgestimmten Laborverbund</p>
+        </header>
+        <section aria-labelledby="story-ifm-origin">
+          <h4 id="story-ifm-origin" class="uk-heading-bullet">Ausgangslage</h4>
+          <p>Mehrere Labore, unterschiedliche Gewohnheiten, verteilte Listen. MET/CAL und MET/TEAM sind im Einsatz – aber <strong>Transparenz über Standorte</strong> und <strong>einheitliche Freigaben</strong> fehlen. Engpässe werden zu spät sichtbar.</p>
+        </section>
+        <section aria-labelledby="story-ifm-turn">
+          <h4 id="story-ifm-turn" class="uk-heading-bullet">Wendepunkt</h4>
+          <blockquote class="uk-margin-small-top uk-margin-small-bottom">„Wir brauchen einen <strong>gemeinsamen Arbeitsstand</strong> – ohne die bewährten Tools über Bord zu werfen.“</blockquote>
+        </section>
+        <section aria-labelledby="story-ifm-action">
+          <h4 id="story-ifm-action" class="uk-heading-bullet">Was calHelp getan hat</h4>
+          <p>Wir haben ein <strong>zentrales System</strong> als Dach etabliert: MET/TEAM bleibt angebunden, MET/CAL läuft weiter, aber <strong>Prüfketten, Rollen, Freigaben und Sichtbarkeiten</strong> sind über alle Standorte hinweg gleich geregelt. Ein <strong>Cockpit</strong> zeigt Prioritäten, Auslastung und Engpässe.</p>
+        </section>
+        <section aria-labelledby="story-ifm-today">
+          <h4 id="story-ifm-today" class="uk-heading-bullet">Heute</h4>
+          <p>Standortübergreifend sehen Menschen das Gleiche: <strong>welcher Auftrag wo steht, wer freigegeben hat, was als Nächstes anliegt</strong>. Berichte sind konsistent, Nachweise prüfbar, Übergaben reibungsarm.</p>
+          <p class="uk-margin-remove"><strong>Mehrwert:</strong> weniger Doppelarbeit, planbare Auslastung, ein Audit-Tag ist kein Stresstag mehr.</p>
+        </section>
       </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="benefit-operations-title">
-        <h3 id="benefit-operations-title" class="uk-card-title">Einfach betreiben</h3>
-        <p>In Deutschland gehostet oder On-Prem – mit SSO, Rollen und API. Stabil im Alltag, skalierbar im Wachstum.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="story-berlin-title">
+        <header class="calhelp-card__header">
+          <h3 id="story-berlin-title" class="uk-card-title">3) Berliner Stadtwerke</h3>
+          <p class="uk-text-emphasis">Vom Projektzoo zur Steuerung von Wartung &amp; Nachweisen</p>
+        </header>
+        <section aria-labelledby="story-berlin-origin">
+          <h4 id="story-berlin-origin" class="uk-heading-bullet">Ausgangslage</h4>
+          <p>Viele Anlagen, viele Dienstleister, viele Formate: Projekte, Wartungen, Abnahmen, Dokumente – alles irgendwo. <strong>Nachweise</strong> existieren, aber verteilt; <strong>Termine</strong> stehen, aber nicht gemeinsam.</p>
+        </section>
+        <section aria-labelledby="story-berlin-turn">
+          <h4 id="story-berlin-turn" class="uk-heading-bullet">Wendepunkt</h4>
+          <blockquote class="uk-margin-small-top uk-margin-small-bottom">„Wir wollen <strong>Projekt, Wartung und Nachweise</strong> unter Kontrolle – an einem Ort, in einem Takt.“</blockquote>
+        </section>
+        <section aria-labelledby="story-berlin-action">
+          <h4 id="story-berlin-action" class="uk-heading-bullet">Was calHelp getan hat</h4>
+          <p>Wir haben die Assets (PV, Wind, Speicher …) als <strong>klare Objekte</strong> modelliert: zu jeder Anlage gibt es Wartungszyklen, Checklisten, Verträge, Dokumente und Verantwortlichkeiten – <strong>zentral einsichtig</strong>. Berichte entstehen nach festen Mustern, Entscheidungen stützen sich auf denselben Daten.</p>
+        </section>
+        <section aria-labelledby="story-berlin-today">
+          <h4 id="story-berlin-today" class="uk-heading-bullet">Heute</h4>
+          <p>Ein Kalender, ein Status, ein Nachweisordner pro Objekt. <strong>SLA-Hinweise</strong>, planbare Einsätze, <strong>saubere Dokumentation</strong> – auch ohne MET/CAL, aber mit derselben Konsequenz: nachvollziehbar und auditfähig.</p>
+          <p class="uk-margin-remove"><strong>Mehrwert:</strong> schnellere Reaktion, weniger Überraschungen, klare Runden mit belastbaren Unterlagen.</p>
+        </section>
       </article>
     </div>
   </div>
 </section>
 
-<section id="process" class="uk-section calhelp-section" aria-labelledby="process-title">
+<section id="fit" class="uk-section calhelp-section" aria-labelledby="fit-title">
   <div class="uk-container">
     <div class="calhelp-section__header">
-      <h2 id="process-title" class="uk-heading-medium">Von Altdaten zu stabilen Abläufen in 5 Schritten</h2>
-      <p class="uk-text-lead">Jede Phase ist klar dokumentiert – inklusive Abnahmen, KPIs und Verantwortlichkeiten.</p>
+      <h2 id="fit-title" class="uk-heading-medium">Woran erkennst du, dass du hier richtig bist?</h2>
     </div>
-    <ol class="calhelp-process" aria-label="Migrationsprozess in fünf Schritten">
-      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
-        <h3>Readiness-Check</h3>
-        <p>Systeminventar, Datenumfang, Besonderheiten (z. B. Anhänge, benutzerdefinierte Felder).</p>
-      </li>
-      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
-        <h3>Mapping &amp; Regeln</h3>
-        <p>Felder, SI-Präfixe, Status/Workflows, Rollen. Transparent dokumentiert.</p>
-      </li>
-      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
-        <h3>Pilot &amp; Validierung</h3>
-        <p>Teilmenge (Golden Samples), Checksummen, Abweichungsbericht. Freigabe als Gate.</p>
-      </li>
-      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
-        <h3>Delta-Sync &amp; Cutover</h3>
-        <p>Downtime-arm, sauber geplantes Übergabefenster, klarer Abnahmelauf.</p>
-      </li>
-      <li class="uk-card uk-card-primary uk-card-body calhelp-process__step">
-        <h3>Go-Live &amp; Monitoring</h3>
-        <p>KPIs, Protokolle, Hypercare-Phase. Stabil in den Betrieb überführt.</p>
-      </li>
-    </ol>
+    <ul class="uk-list uk-list-bullet uk-text-large">
+      <li>Ihr fragt euch oft: <strong>„Wo steht das?“</strong> – statt zu sehen, <strong>wer, was, wann</strong> getan hat.</li>
+      <li>Ihr habt gute Werkzeuge – aber <strong>kein gemeinsames Bild</strong>.</li>
+      <li>Ihr liefert ab – aber <strong>Nachweise</strong> kosten Zeit und Nerven.</li>
+      <li>Ihr wollt nicht „alles neu“, sondern <strong>endlich einen Fluss</strong>.</li>
+    </ul>
     <div class="calhelp-note uk-card uk-card-primary uk-card-body">
-      <p class="uk-margin-remove">Abnahmekriterien sind vorab definiert (z. B. ≥ 99,5 % korrekte Migration, 0 kritische Abweichungen, Report-Abnahme mit Musterdaten).</p>
+      <p class="uk-margin-remove">Genau dort holt calHelp euch ab. Wir bringen das, was da ist, <strong>in Form</strong>: Altdaten nutzbar, Systeme verbunden, Berichte reproduzierbar – <strong>ein System, klare Prozesse</strong>.</p>
     </div>
   </div>
 </section>
 
-<section id="usecases" class="uk-section uk-section-muted calhelp-section" aria-labelledby="usecases-title">
+<section id="feeling" class="uk-section uk-section-muted calhelp-section" aria-labelledby="feeling-title">
   <div class="uk-container">
     <div class="calhelp-section__header">
-      <h2 id="usecases-title" class="uk-heading-medium">Anwendungsfälle – greifbare Szenarien</h2>
-      <p class="uk-text-lead">calHelp macht Abläufe nachvollziehbar: wer, was, wann.</p>
+      <h2 id="feeling-title" class="uk-heading-medium">Wie es sich anfühlt, wenn es passt</h2>
+      <p class="uk-text-lead">Das Ergebnis eines klaren Flows lässt sich sehen – und spüren.</p>
     </div>
-    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="usecase-lab-title">
-        <h3 id="usecase-lab-title" class="uk-card-title">Use Case A – Kalibrierlabor</h3>
-        <p class="uk-text-emphasis">„Wir müssen Zertifikate schneller und nachvollziehbar erzeugen.“</p>
-        <ul class="uk-list uk-list-bullet">
-          <li>Zentrale Stammdaten</li>
-          <li>Automatisierte Prüfaufträge</li>
-          <li>DAkkS-Bausteine</li>
-          <li>Zweisprachige Reports</li>
-        </ul>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="usecase-service-title">
-        <h3 id="usecase-service-title" class="uk-card-title">Use Case B – Instandhaltung/Service</h3>
-        <p class="uk-text-emphasis">„Wir wollen Wartungen planen, Nachweise sichern und Rückfragen reduzieren.“</p>
-        <ul class="uk-list uk-list-bullet">
-          <li>Erinnerungen</li>
-          <li>Checklisten</li>
-          <li>Statuslogs</li>
-          <li>Revisionssichere Dokumente</li>
-        </ul>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="usecase-public-title">
-        <h3 id="usecase-public-title" class="uk-card-title">Use Case C – Öffentliche Verwaltung/Versorger:innen</h3>
-        <p class="uk-text-emphasis">„Wir brauchen konsistente Prozesse, belastbare Nachweise und DSGVO-Konformität.“</p>
-        <ul class="uk-list uk-list-bullet">
-          <li>Rollen/Rechte</li>
-          <li>Protokollierung</li>
-          <li>SSO</li>
-          <li>Strukturierte Freigaben</li>
-        </ul>
-      </article>
+    <ul class="uk-list uk-list-bullet uk-text-large">
+      <li><strong>Ein Blick reicht.</strong> Status, Zuständigkeiten, nächste Schritte sind sichtbar.</li>
+      <li><strong>Keine Doppelerfassung.</strong> Systeme sprechen miteinander, Daten bleiben konsistent.</li>
+      <li><strong>Berichte bestehen.</strong> Reproduzierbar, zweisprachig, fachlich sauber.</li>
+      <li><strong>Vor Audits bleibt der Puls ruhig.</strong> Checklisten statt Bauchgefühl.</li>
+    </ul>
+  </div>
+</section>
+
+<section id="next-step" class="uk-section calhelp-section calhelp-cta" aria-labelledby="next-step-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="next-step-title" class="uk-heading-medium">Nächster Schritt</h2>
+      <p class="uk-text-lead">Lass uns 15 Minuten sprechen. <strong>Woran hapert’s gerade?</strong></p>
     </div>
-    <div class="calhelp-microcopy uk-card uk-card-primary uk-card-body">
-      <p class="uk-margin-remove">Alles Wichtige an einem Ort – ohne Doppelerfassung. Migration in klaren Schritten – mit Testlauf und Abnahme.</p>
+    <p class="uk-text-large">Wir hören zu, fassen eure Lage in <strong>klare Schritte</strong> und schlagen <strong>einen</strong> nächsten Schritt vor – klein, machbar, spürbar.</p>
+    <div class="calhelp-cta__actions" role="group" aria-label="Kontaktmöglichkeiten">
+      <a class="uk-button uk-button-primary" href="{{ basePath }}/calhelp/contact">Gespräch starten</a>
+      <a class="uk-button uk-button-default" href="https://calhelp.notion.site/met-cal-handbuch" target="_blank" rel="noopener">Handbuch ansehen</a>
+    </div>
+    <div class="calhelp-note uk-card uk-card-primary uk-card-body">
+      <p class="uk-margin-remove">Wir dokumentieren das Gespräch auf Wunsch mit und liefern die nächsten Schritte schriftlich nach. Datenschutz: <a href="{{ basePath }}/datenschutz">Hier nachlesen</a>.</p>
     </div>
   </div>
 </section>
 
-<section id="proof" class="uk-section calhelp-section" aria-labelledby="proof-title">
+<section id="why" class="uk-section uk-section-muted calhelp-section" aria-labelledby="why-title">
   <div class="uk-container">
     <div class="calhelp-section__header">
-      <h2 id="proof-title" class="uk-heading-medium">Beweis &amp; Sicherheit</h2>
-      <p class="uk-text-lead">Referenzen, Datenschutz und Qualitätsnachweise auf einen Blick.</p>
-    </div>
-    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="proof-ref-title">
-        <h3 id="proof-ref-title" class="uk-card-title">Referenzen</h3>
-        <p>Produktiv eingesetzte Migrationen von MET/TRACK, fortlaufende MET/TEAM-Anbindung.</p>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="proof-security-title">
-        <h3 id="proof-security-title" class="uk-card-title">Sicherheit &amp; DSGVO</h3>
-        <p>Hosting in DE (oder On-Prem), rollenbasierte Zugriffe, Protokollierung, nachvollziehbare Lösch-/Aufbewahrungsregeln.</p>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="proof-quality-title">
-        <h3 id="proof-quality-title" class="uk-card-title">Qualitätscheck</h3>
-        <p>Musterzertifikate, visuelle Report-Diffs, dokumentierte Feld-Mappings.</p>
-      </article>
-    </div>
-    <div class="calhelp-kpi uk-card uk-card-primary uk-card-body">
-      <p class="uk-margin-remove">15+ Jahre Projekterfahrung · 1.600+ umgesetzte Kund:innen-Wünsche · 99,9 % Betriebszeit (aktuell)</p>
-    </div>
-  </div>
-</section>
-
-<section id="services" class="uk-section uk-section-muted calhelp-section" aria-labelledby="services-title">
-  <div class="uk-container">
-    <div class="calhelp-section__header">
-      <h2 id="services-title" class="uk-heading-medium">Produktisierte Services – verständlich &amp; kaufbar</h2>
-      <p class="uk-text-lead">Vom ersten Check bis zum stabilen Betrieb – modular buchbar.</p>
-    </div>
-    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="service-s-title">
-        <h3 id="service-s-title" class="uk-card-title">Paket S – Migration-Check (Fixpreis)</h3>
-        <p>Analyse, Feld-Mapping-Skizze, Risikoabschätzung, Zeitplan. Ergebnis: Entscheidungsgrundlage &amp; Angebot.</p>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="service-m-title">
-        <h3 id="service-m-title" class="uk-card-title">Paket M – Pilot &amp; Cutover-Plan</h3>
-        <p>Teilmenge migrieren, Validierung, Abweichungsbericht, Go-/No-Go-Empfehlung. Ergebnis: belastbarer Cutover-Plan.</p>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="service-l-title">
-        <h3 id="service-l-title" class="uk-card-title">Paket L – Vollmigration &amp; Hypercare</h3>
-        <p>Vollübernahme, Delta-Sync, Go-Live-Begleitung (30 Tage), Monitoring mit KPIs. Ergebnis: stabiler Betrieb.</p>
-      </article>
-    </div>
-    <aside class="calhelp-addons uk-card uk-card-primary uk-card-body" aria-label="Add-ons">
-      <h3>Add-ons</h3>
-      <ul class="uk-list uk-list-bullet">
-        <li>DAkkS-Report-Bundle (zweisprachig)</li>
-        <li>SSO-Starter (EntraID/Google)</li>
-        <li>API-Starter (Integrationsrezepte)</li>
-      </ul>
-    </aside>
-  </div>
-</section>
-
-<section id="demo" class="uk-section calhelp-section" aria-labelledby="demo-title">
-  <div class="uk-container">
-    <div class="calhelp-section__header">
-      <h2 id="demo-title" class="uk-heading-medium">Demo – Micro-Onboarding statt Formular</h2>
-      <p class="uk-text-lead">In 60–90 Sekunden zur passenden Demo: ein kurzer Frage-Flow, damit wir Ihr Szenario vorbereiten können.</p>
-    </div>
-    <div class="uk-grid-large" data-uk-grid>
-      <div class="uk-width-1-2@m">
-        <ol class="calhelp-demo-steps uk-card uk-card-primary uk-card-body" aria-label="Fragen für den Demo-Flow">
-          <li>Wofür möchten Sie das System nutzen? (Labor | Instandhaltung | Verwaltung | Sonstiges)</li>
-          <li>Datenbasis? (MET/TRACK | MET/TEAM | CSV/Excel | unklar)</li>
-          <li>Umfang? (&lt;1.000 | 1.000–10.000 | &gt;10.000 | unklar)</li>
-          <li>Zeitfenster? (ASAP | 1–3 Mon | 3–6 Mon | Evaluierung offen)</li>
-          <li>Abschluss (Kontaktfelder + freiwilliger Newsletter-Opt-in)</li>
-        </ol>
-      </div>
-      <div class="uk-width-1-2@m">
-        <div class="uk-card uk-card-primary uk-card-body calhelp-card">
-          <h3 class="uk-card-title">Abschluss-Screen</h3>
-          <p>Zwei Optionen führen zum nächsten Schritt – individuell vorbereitet.</p>
-          <ul class="uk-list uk-list-divider calhelp-cta-list">
-            <li>Demo-Termin wählen</li>
-            <li>MET/CAL-Handbuch öffnen</li>
-          </ul>
-          <p class="uk-text-small uk-margin-top">Abläufe sind nachvollziehbar: wer, was, wann.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="about" class="uk-section uk-section-muted calhelp-section" aria-labelledby="about-title">
-  <div class="uk-container">
-    <div class="calhelp-section__header">
-      <h2 id="about-title" class="uk-heading-medium">Über calHelp</h2>
-      <p class="uk-text-lead">Wissen führt. Software liefert. – der Ansatz von René Buske.</p>
-    </div>
-    <div class="uk-grid-large" data-uk-grid>
-      <div class="uk-width-2-3@m">
-        <p>calHelp ist die Dachmarke von René Buske. Aus jahrelanger Projektarbeit im Kalibrierumfeld ist ein klarer Ansatz entstanden: <strong>Wissen führt. Software liefert.</strong> Wir migrieren Altdaten sauber, binden bestehende Systeme an (z. B. MET/TEAM) und stabilisieren Abläufe – <strong>konsistent, nachvollziehbar, auditfähig</strong>.</p>
-      </div>
-      <div class="uk-width-1-3@m">
-        <ul class="uk-list calhelp-values uk-card uk-card-primary uk-card-body" aria-label="Werte von calHelp">
-          <li><strong>Präzision:</strong> Entscheidungen auf Datenbasis.</li>
-          <li><strong>Transparenz:</strong> Dokumentierte Regeln, prüfbare Schritte.</li>
-          <li><strong>Verlässlichkeit:</strong> Saubere Übergabe, stabiler Betrieb.</li>
-        </ul>
-        <p class="uk-text-small">Kontakt: Kurzes Kennenlernen (15–20 Min) – wir klären Ihr Zielbild und empfehlen den passenden Einstieg.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="news" class="uk-section calhelp-section" aria-labelledby="news-title">
-  <div class="uk-container">
-    <div class="calhelp-section__header">
-      <h2 id="news-title" class="uk-heading-medium">Aktuelles &amp; Fachbeiträge</h2>
-      <p class="uk-text-lead">Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.</p>
+      <h2 id="why-title" class="uk-heading-medium">Warum calHelp?</h2>
+      <p class="uk-text-lead">Weil wir seit Jahren dasselbe Ziel verfolgen: Praxis in <strong>nachvollziehbare Abläufe</strong> übersetzen – mit System, ohne Theater.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-2@m" data-uk-grid>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-changelog-title">
-        <h3 id="news-changelog-title" class="uk-card-title">Changelog kompakt</h3>
-        <p class="uk-text-meta">Zuletzt aktualisiert am 04.10.2025</p>
+      <div>
         <ul class="uk-list uk-list-bullet">
-          <li>Migration: Delta-Sync für MET/TRACK erweitert.</li>
-          <li>Reports: Konformitätslogik mit Guardband-Optionen ergänzt.</li>
-          <li>Integrationen: MET/TEAM-Connector mit zusätzlichen Webhooks.</li>
+          <li><strong>Wissen führt.</strong> Wir verstehen Kalibrier- und Serviceprozesse bis ins Detail.</li>
+          <li><strong>Software liefert.</strong> Systeme werden verbunden, nicht ersetzt.</li>
+          <li><strong>Auditfähig.</strong> Entscheidungen, Dokumente und Nachweise greifen ineinander.</li>
         </ul>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-recipe-title">
-        <h3 id="news-recipe-title" class="uk-card-title">Praxisrezept in 3 Schritten</h3>
-        <p class="uk-text-meta">Zuletzt aktualisiert am 27.09.2025</p>
-        <p><strong>Thema:</strong> Konformitätslegende sauber integrieren.</p>
-        <ol class="uk-list uk-list-decimal">
-          <li>Legende zentral in calHelp pflegen.</li>
-          <li>Template-Varianten für Kund:innen definieren.</li>
-          <li>Report-Diffs mit Golden Samples gegenprüfen.</li>
-        </ol>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-usecase-title">
-        <h3 id="news-usecase-title" class="uk-card-title">Use-Case-Spotlight</h3>
-        <p class="uk-text-meta">Zuletzt aktualisiert am 18.09.2025</p>
-        <p><strong>Ausgangslage:</strong> Stark gewachsene Kalibrierabteilung mit Inseltools.</p>
-        <p><strong>Vorgehen:</strong> Migration aus MET/TRACK, Schnittstelle zu MET/TEAM, SSO.</p>
-        <p><strong>Ergebnis:</strong> Auditberichte in 30 % weniger Zeit, klare Verantwortlichkeiten.</p>
-        <p><strong>Learnings:</strong> Frühzeitig Rollenmodell definieren, Dokumentation als laufenden Prozess etablieren.</p>
-        <p><strong>Nächste Schritte:</strong> Automatisierte Erinnerungen für Prüfmittel und Lieferant:innen.</p>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-standards-title">
-        <h3 id="news-standards-title" class="uk-card-title">Standards verständlich</h3>
-        <p class="uk-text-meta">Zuletzt aktualisiert am 12.09.2025</p>
-        <p><strong>Thema:</strong> Guardband &amp; MU in 5 Minuten erklärt.</p>
-        <p>Beispiel: Messwert 10,0 mm mit MU 0,3 mm. Guardband reduziert die Toleranzgrenze auf 9,7–10,3 mm. calHelp dokumentiert automatisch, wie Entscheidung und Unsicherheit zusammenhängen.</p>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="news-roadmap-title">
-        <h3 id="news-roadmap-title" class="uk-card-title">Roadmap-Ausblick</h3>
-        <p class="uk-text-meta">Zuletzt aktualisiert am 05.09.2025</p>
-        <ul class="uk-list uk-list-bullet">
-          <li>Q1: Templates für Prüfaufträge &amp; Zertifikate.</li>
-          <li>Q2: SSO-Starter für EntraID und Google.</li>
-          <li>Q3: API-Rezepte für ERP- und MES-Anbindungen.</li>
-        </ul>
-      </article>
-    </div>
-    <aside class="calhelp-newsletter uk-card uk-card-primary uk-card-body uk-light" aria-label="Newsletter-Box">
-      <h3 class="uk-card-title">Newsletter</h3>
-      <p>„Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.“ (Double-Opt-In, freiwillig.)</p>
-      <a class="uk-button uk-button-default" href="#demo">Zum Demo-Flow</a>
-    </aside>
-    <section class="calhelp-editorial-calendar uk-card uk-card-primary uk-card-body" aria-labelledby="calendar-title">
-      <h3 id="calendar-title">Redaktionskalender – 6 Wochen Ausblick</h3>
-      <ol class="uk-list uk-list-decimal">
-        <li>Woche 1: „Die 5 größten Stolperstellen bei MET/TRACK-Migrationen“ (Praxisbeitrag)</li>
-        <li>Woche 2: Changelog kompakt (Reports &amp; Konformitätslogik)</li>
-        <li>Woche 3: Use-Case-Spotlight (anonymisiert)</li>
-        <li>Woche 4: „Guardband in 5 Minuten – verständlich erklärt“</li>
-        <li>Woche 5: Praxisrezept „Validierung mit Golden Samples“</li>
-        <li>Woche 6: Roadmap-Ausblick + Mini-Q&amp;A (aus Newsletter-Fragen)</li>
-      </ol>
-    </section>
-  </div>
-</section>
-
-<section id="faq" class="uk-section uk-section-muted calhelp-section" aria-labelledby="faq-title">
-  <div class="uk-container">
-    <div class="calhelp-section__header">
-      <h2 id="faq-title" class="uk-heading-medium">FAQ – die typischen Fragen</h2>
-    </div>
-    <dl class="calhelp-faq" aria-label="Häufig gestellte Fragen">
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Bleibt MET/TEAM nutzbar?</dt>
-        <dd>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und schrittweise.</dd>
       </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Was wird übernommen?</dt>
-        <dd>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</dd>
+      <div>
+        <p class="uk-text-large">Wir begleiten Teams über den Umstieg hinaus. Egal ob MET/CAL, MET/TEAM oder ganz ohne Kalibriersoftware – calHelp baut den roten Faden, an dem sich alle entlang bewegen.</p>
+        <p class="uk-text-small uk-margin-remove">Mehr dazu im Gespräch oder im Handbuch. Wir zeigen, wie Wissen zu belastbaren Abläufen wird.</p>
       </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Wie sicher ist der Betrieb?</dt>
-        <dd>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutztext.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Wie lange dauert der Umstieg?</dt>
-        <dd>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</dd>
-      </div>
-    </dl>
-  </div>
-</section>
-
-<section id="cta" class="uk-section calhelp-section calhelp-cta" aria-labelledby="cta-title">
-  <div class="uk-container">
-    <div class="calhelp-section__header">
-      <h2 id="cta-title" class="uk-heading-medium">Der nächste Schritt ist klein – die Wirkung groß.</h2>
-      <p class="uk-text-lead">Starten Sie mit einem Migration-Check oder testen Sie unseren Demo-Flow. Wir melden uns mit einer passgenauen Empfehlung.</p>
-    </div>
-    <div class="calhelp-cta__actions" role="group" aria-label="Abschluss-CTAs">
-      <a class="uk-button uk-button-primary" href="#services">Migration prüfen lassen</a>
-      <a class="uk-button uk-button-default" href="#demo">Demo anfragen</a>
-    </div>
-    <div class="calhelp-note uk-card uk-card-primary uk-card-body">
-      <p class="uk-margin-remove">Wir speichern nur, was für Rückmeldung und Terminfindung nötig ist. Details: <a href="{{ basePath }}/datenschutz">Datenschutz</a>.</p>
     </div>
   </div>
 </section>
 
-<section id="seo" class="uk-section uk-section-muted calhelp-section" aria-labelledby="seo-title">
+<section id="seo" class="uk-section calhelp-section" aria-labelledby="seo-title">
   <div class="uk-container">
     <div class="calhelp-section__header">
       <h2 id="seo-title" class="uk-heading-medium">SEO &amp; Snippets</h2>
     </div>
     <div class="calhelp-seo-box uk-card uk-card-primary uk-card-body">
-      <p><strong>Seitentitel:</strong> Umstieg auf ein zentrales Kalibrier-System – konsistent, nachvollziehbar, auditfähig</p>
-      <p><strong>Beschreibung:</strong> calHelp migriert Altdaten, bindet MET/TEAM an und stabilisiert Abläufe – konsistent, nachvollziehbar, auditfähig.</p>
-      <p><strong>Open-Graph-Hinweis:</strong> „Ein System. Klare Prozesse.“</p>
+      <p><strong>Seitentitel:</strong> calHelp – Vom Flickenteppich zum klaren Kalibrier-Flow.</p>
+      <p><strong>Beschreibung:</strong> Drei reale Umsetzungen zeigen, wie calHelp Angebote, Messwerte und Nachweise in einen nachvollziehbaren Ablauf überführt – ohne Tool-Brüche, mit auditfähigen Ergebnissen.</p>
+      <p><strong>Open-Graph-Hinweis:</strong> „Ein System. Ein Flow. Ein Audit – bestanden.“</p>
     </div>
   </div>
 </section>

--- a/templates/marketing/calhelp.twig
+++ b/templates/marketing/calhelp.twig
@@ -2,17 +2,14 @@
 
 {% set links = [
     { 'href': '#hero', 'label': 'Überblick', 'icon': 'home' },
-    { 'href': '#benefits', 'label': 'Nutzen', 'icon': 'star' },
-    { 'href': '#process', 'label': 'Prozess', 'icon': 'settings' },
-    { 'href': '#usecases', 'label': 'Use Cases', 'icon': 'users' },
-    { 'href': '#services', 'label': 'Services', 'icon': 'bag' },
-    { 'href': '#demo', 'label': 'Demo', 'icon': 'play' },
-    { 'href': '#news', 'label': 'News', 'icon': 'rss' },
-    { 'href': '#faq', 'label': 'FAQ', 'icon': 'question' },
-    { 'href': '#cta', 'label': 'Kontakt', 'icon': 'bolt' }
+    { 'href': '#stories', 'label': 'Einblicke', 'icon': 'file-text' },
+    { 'href': '#fit', 'label': 'Passt das?', 'icon': 'question' },
+    { 'href': '#feeling', 'label': 'Ergebnis', 'icon': 'check' },
+    { 'href': '#next-step', 'label': 'Nächster Schritt', 'icon': 'bolt' },
+    { 'href': '#why', 'label': 'Warum calHelp', 'icon': 'info' }
 ] %}
 
-{% block title %}{{ metaTitle|default('Umstieg auf ein zentrales Kalibrier-System – konsistent, nachvollziehbar, auditfähig') }}{% endblock %}
+{% block title %}{{ metaTitle|default('calHelp – Vom Flickenteppich zum klaren Kalibrier-Flow') }}{% endblock %}
 
 {% block head %}
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -162,8 +159,8 @@
             </li>
           {% endfor %}
         </ul>
-        <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="#demo">
-          <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Demo anfragen
+        <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="#next-step">
+          <span class="uk-margin-small-right" data-uk-icon="icon: receiver"></span>Gespräch starten
         </a>
       </div>
     </div>
@@ -175,29 +172,29 @@
       <div class="uk-container">
         <div class="uk-grid uk-grid-large uk-child-width-1-2@m uk-flex-middle calhelp-hero-grid" data-uk-grid>
           <div class="calhelp-hero-grid__content">
-            <span class="qr-badge pill pill--soft">Hosting in Deutschland · DSGVO-konform</span>
-            <h1 class="qr-h1">Ein System. Klare Prozesse.</h1>
-            <p class="qr-sub">calHelp sorgt dafür, dass Kalibrierdaten, Dokumente und Abläufe verlässlich in einem zentralen System zusammenfließen – konsistent, nachvollziehbar und auditfähig.</p>
-            <p class="uk-text-lead">Altdaten werden sauber migriert (z. B. aus MET/TRACK), MET/TEAM bleibt angebunden, und Ihr Team arbeitet in klar definierten Prozessen mit belastbaren Nachweisen.</p>
+            <span class="qr-badge pill pill--soft">Praxisnah · Auditfähig · Ohne Technik-Overkill</span>
+            <h1 class="qr-h1">Ein Flow vom Erstkontakt bis zum Audit.</h1>
+            <p class="qr-sub">Ohne Pakete, ohne Technik-Overkill: calHelp ordnet Kalibrier-, Service- und Wartungsprozesse so, dass Teams wieder sehen, wer was wann getan hat.</p>
+            <p class="uk-text-lead">Wir verbinden bestehende Systeme, machen Altdaten nutzbar und schaffen einen nachvollziehbaren Ablauf – vom Angebot über Messwerte bis zur Rechnung.</p>
             <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
-              <a class="uk-button uk-button-primary" href="#demo">
-                <span class="uk-margin-small-right" data-uk-icon="icon: play"></span>Demo anfragen
+              <a class="uk-button uk-button-primary" href="#next-step">
+                <span class="uk-margin-small-right" data-uk-icon="icon: receiver"></span>Gespräch starten
               </a>
               <a class="uk-button uk-button-default" href="https://calhelp.notion.site/met-cal-handbuch" target="_blank" rel="noopener">
-                <span class="uk-margin-small-right" data-uk-icon="icon: file-text"></span>MET/CAL-Handbuch öffnen
+                <span class="uk-margin-small-right" data-uk-icon="icon: book"></span>Handbuch ansehen
               </a>
             </div>
-            <p class="calhelp-trust">Hosting in Deutschland · DSGVO-konform · &gt;15 Jahre Projekterfahrung</p>
+            <p class="calhelp-trust">15+ Jahre Kalibrierpraxis · Hosting in Deutschland · Auditfeste Umsetzung</p>
           </div>
           <div class="calhelp-hero-grid__media">
             <div class="calhelp-hero-card uk-card uk-card-primary uk-card-primary--highlight uk-card-body">
-              <h2 class="uk-card-title">Warum calHelp?</h2>
+              <h2 class="uk-card-title">Was Kund:innen erleben</h2>
               <ul class="uk-list uk-list-bullet hero-list">
-                <li>Konsistente Datenbasis für Labore, Service-Teams und Verwaltung.</li>
-                <li>Prozesssichere Migration mit klaren Gateways und Abnahmen.</li>
-                <li>Auditfähige Nachweise inklusive Report-Diffs und Protokollen.</li>
+                <li>Ein Auftrag wandert ohne Lücken vom Angebot bis zur Rechnung.</li>
+                <li>Standorte sehen denselben Arbeitsstand und dieselben Freigaben.</li>
+                <li>Wartung, Nachweise und Dokumente laufen in einem Takt zusammen.</li>
               </ul>
-              <p class="uk-text-small uk-margin-top">Reports prüfen wir vorab mit Musterdaten.</p>
+              <p class="uk-text-small uk-margin-top">Wissen führt. Software liefert. So bleiben Audits planbar.</p>
             </div>
           </div>
         </div>
@@ -248,7 +245,7 @@
   <div class="footer-columns">
     <div class="footer-section footer-about">
       <strong>calHelp</strong>
-      <p>Ein System. Klare Prozesse.</p>
+      <p>Ein Flow vom Erstkontakt bis zum Audit.</p>
     </div>
     <div class="footer-section footer-contact">
       <strong>Kontakt</strong>
@@ -267,9 +264,9 @@
       <strong>Links</strong>
       <ul>
         <li><a href="#hero">Start</a></li>
-        <li><a href="#news">Wissen</a></li>
-        <li><a href="#demo">Demo</a></li>
-        <li><a href="#services">Services</a></li>
+        <li><a href="#stories">Einblicke</a></li>
+        <li><a href="#fit">Passt das?</a></li>
+        <li><a href="#next-step">Nächster Schritt</a></li>
         <li><a href="{{ basePath }}/datenschutz">Datenschutz</a></li>
         <li><a href="{{ basePath }}/impressum">Impressum</a></li>
       </ul>


### PR DESCRIPTION
## Summary
- replace the calHelp marketing page content with three detailed customer stories, clearer fit criteria, and refreshed CTA copy in German
- align the Twig template navigation, hero, and footer messaging with the new flow-focused positioning and call-to-action

## Testing
- not run (copy and template updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e4a248b08c832b9300a7912cfccd0c