### PR TITLE
Add calHelp proof accordion with trust-focused styling

### DIFF
--- a/content/marketing/calhelp.html
+++ b/content/marketing/calhelp.html
@@ -990,6 +990,128 @@
         <p>Musterzertifikate, visuelle Report-Diffs, dokumentierte Feld-Mappings.</p>
       </article>
     </div>
+    {% set assurancePanels = [
+      {
+        id: 'cloud-de',
+        title: 'Cloud DE',
+        icon: 'cloud',
+        facts: [
+          {
+            icon: 'cloud',
+            badge: { icon: 'location', label: 'Software hosted in Germany' },
+            text: 'ISO 27001- und BSI C5-geprüfte Rechenzentren mit redundanten Standorten in Frankfurt & Berlin.'
+          },
+          {
+            icon: 'server',
+            text: '24/7-Monitoring mit Alarmierung & Incident-Response in &le; 15 Minuten.'
+          },
+          {
+            icon: 'lock',
+            text: 'Backups verschlüsselt (AES-256) gespeichert und täglich auf Integrität geprüft.'
+          }
+        ],
+        hint: 'Zugriff kann auf Wunsch per IP-Allowlist oder mandantenbezogener VPN-Anbindung zusätzlich abgesichert werden.'
+      },
+      {
+        id: 'on-prem',
+        title: 'On-Prem',
+        icon: 'database',
+        facts: [
+          {
+            icon: 'bolt',
+            badge: { icon: 'bolt', label: 'Setup in &le; 4 Stunden' },
+            text: 'Installationspaket für Windows Server & Linux inkl. automatischer Preflight-Checks.'
+          },
+          {
+            icon: 'database',
+            text: 'PostgreSQL oder SQL Server, optional im Cluster mit Failover-Testprotokoll.'
+          },
+          {
+            icon: 'refresh',
+            text: 'Signierte Update-Pakete mit Rollback-Plan und Dokumentation der Änderungen.'
+          }
+        ],
+        hint: 'Konfigurations-Playbooks (Ansible/PowerShell) erleichtern das Patch-Management und erlauben reproduzierbare Deployments.'
+      },
+      {
+        id: 'dsgvo',
+        title: 'DSGVO',
+        icon: 'shield',
+        facts: [
+          {
+            icon: 'file-text',
+            badge: { icon: 'file-text', label: 'AV-Vertrag & TOMs' },
+            text: 'Aktualisierte ADV inklusive Technischer & Organisatorischer Maßnahmen, unterschriftsreif in Deutsch/Englisch.'
+          },
+          {
+            icon: 'history',
+            text: 'Protokollierte Datenflüsse und Verarbeitungstätigkeiten für Auskunfts- & Löschbegehren.'
+          },
+          {
+            icon: 'trash',
+            text: 'Konfigurierbare Aufbewahrungsfristen mit revisionssicherer Löschbestätigung.'
+          }
+        ],
+        hint: 'Auf Wunsch liefern wir ein Muster für Datenschutz-Folgenabschätzungen und Schnittstellen für Betroffenenanfragen (REST).'
+      },
+      {
+        id: 'rollen-protokolle',
+        title: 'Rollen &amp; Protokolle',
+        icon: 'users',
+        facts: [
+          {
+            icon: 'users',
+            badge: { icon: 'users', label: '5+ Rollen vorkonfiguriert' },
+            text: 'Feingranulare Berechtigungen für Labor, QS, IT, Service und externe Partner.'
+          },
+          {
+            icon: 'file-text',
+            text: 'Objektbezogener Audit-Trail (wer/was/wann) mit Export nach CSV oder SIEM.'
+          },
+          {
+            icon: 'key',
+            text: 'SSO-Anbindung via SAML/OIDC inklusive SCIM-Provisioning & Gruppen-Mapping.'
+          }
+        ],
+        hint: 'Webhook- und Syslog-Forwarder ermöglichen das Streaming der Audit-Logs an bestehende SIEM-Lösungen.'
+      }
+    ] %}
+    <div class="calhelp-assurance" aria-labelledby="proof-accordion-title">
+      <h3 id="proof-accordion-title" class="calhelp-assurance__title">Trust Center – Details für IT &amp; Qualitätsmanagement</h3>
+      <p class="calhelp-assurance__intro">Vier Schwerpunktbereiche zeigen, wie calHelp Cloud, On-Premises und Compliance sicher umsetzt – inklusive konkreter IT-Hinweise.</p>
+      <ul class="uk-accordion calhelp-assurance__accordion" uk-accordion="multiple: true">
+        {% for panel in assurancePanels %}
+          <li class="calhelp-assurance__item">
+            <a class="uk-accordion-title" href="#proof-{{ panel.id }}">
+              <span class="calhelp-assurance__title-icon" aria-hidden="true" data-uk-icon="icon: {{ panel.icon }}"></span>
+              <span>{{ panel.title }}</span>
+            </a>
+            <div class="uk-accordion-content" id="proof-{{ panel.id }}">
+              <ul class="calhelp-assurance__facts" role="list">
+                {% for fact in panel.facts %}
+                  <li class="calhelp-assurance__fact">
+                    <span class="calhelp-assurance__fact-icon" aria-hidden="true" data-uk-icon="icon: {{ fact.icon|default('check') }}"></span>
+                    <div class="calhelp-assurance__fact-body">
+                      {% if fact.badge is defined %}
+                        <span class="calhelp-assurance__badge">
+                          <span class="calhelp-assurance__badge-icon" aria-hidden="true" data-uk-icon="icon: {{ fact.badge.icon|default('check') }}"></span>
+                          <span>{{ fact.badge.label }}</span>
+                        </span>
+                      {% endif %}
+                      <p class="calhelp-assurance__fact-text">{{ fact.text }}</p>
+                    </div>
+                  </li>
+                {% endfor %}
+              </ul>
+              <p class="calhelp-assurance__hint">
+                <span class="calhelp-assurance__hint-icon" aria-hidden="true" data-uk-icon="icon: info"></span>
+                <span class="calhelp-assurance__hint-text"><strong>IT-Hinweis:</strong> {{ panel.hint }}</span>
+              </p>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
     <div data-calhelp-proof-gallery></div>
     <div class="calhelp-kpi uk-card uk-card-primary uk-card-body">
       <p class="uk-margin-remove">15+ Jahre Projekterfahrung · 1.600+ umgesetzte Kund:innen-Wünsche · 99,9 % Betriebszeit (aktuell)</p>

--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -377,6 +377,213 @@ body.qr-landing.calhelp-theme .landing-content {
   text-align: center;
 }
 
+.calhelp-assurance {
+  margin-top: 48px;
+  display: grid;
+  gap: 16px;
+}
+
+.calhelp-assurance__title {
+  margin: 0;
+  font-size: 1.55rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.calhelp-assurance__intro {
+  margin: 0;
+  color: color-mix(in oklab, var(--qr-landing-text) 70%, rgba(15, 23, 42, 0.42));
+}
+
+.calhelp-assurance__accordion {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.calhelp-assurance__item {
+  border-radius: 16px;
+  border: 1px solid color-mix(in oklab, var(--qr-landing-text) 14%, rgba(15, 23, 42, 0.18));
+  background: color-mix(in oklab, rgba(255, 255, 255, 0.12) 80%, rgba(15, 23, 42, 0.08));
+  box-shadow: 0 22px 44px -36px color-mix(in oklab, var(--calserver-primary) 68%, rgba(15, 23, 42, 0.85));
+  overflow: hidden;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.calhelp-assurance__item:hover,
+.calhelp-assurance__item:focus-within {
+  border-color: color-mix(in oklab, var(--calserver-primary) 42%, rgba(15, 23, 42, 0.2));
+  box-shadow: 0 28px 52px -34px color-mix(in oklab, var(--calserver-primary) 76%, rgba(15, 23, 42, 0.9));
+  transform: translateY(-2px);
+}
+
+.calhelp-assurance__item .uk-accordion-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 24px;
+  font-weight: 600;
+  color: color-mix(in oklab, var(--qr-landing-text) 92%, rgba(15, 23, 42, 0.32));
+}
+
+.calhelp-assurance__title-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--calserver-primary) 22%, rgba(255, 255, 255, 0.12));
+  color: var(--calserver-primary);
+}
+
+.calhelp-assurance__title-icon svg {
+  width: 22px;
+  height: 22px;
+}
+
+.calhelp-assurance__item .uk-open > .uk-accordion-title,
+.calhelp-assurance__item.uk-open > .uk-accordion-title {
+  color: color-mix(in oklab, var(--qr-landing-text) 98%, rgba(15, 23, 42, 0.18));
+}
+
+.calhelp-assurance__item .uk-accordion-content {
+  padding: 0 24px 24px;
+  display: grid;
+  gap: 18px;
+}
+
+.calhelp-assurance__facts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.calhelp-assurance__fact {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.calhelp-assurance__fact-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--calserver-primary) 16%, rgba(255, 255, 255, 0.12));
+  color: var(--calserver-primary);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--calserver-primary) 32%, rgba(15, 23, 42, 0.18));
+}
+
+.calhelp-assurance__fact-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.calhelp-assurance__fact-body {
+  display: grid;
+  gap: 6px;
+}
+
+.calhelp-assurance__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--calserver-primary) 18%, rgba(255, 255, 255, 0.08));
+  color: color-mix(in oklab, var(--qr-landing-text) 96%, rgba(255, 255, 255, 0.06));
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.calhelp-assurance__badge-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: color-mix(in oklab, var(--calserver-primary) 70%, rgba(255, 255, 255, 0.12));
+  color: #ffffff;
+}
+
+.calhelp-assurance__badge-icon svg {
+  width: 12px;
+  height: 12px;
+}
+
+.calhelp-assurance__fact-text {
+  margin: 0;
+  color: color-mix(in oklab, var(--qr-landing-text) 86%, rgba(15, 23, 42, 0.36));
+  line-height: 1.5;
+}
+
+.calhelp-assurance__hint {
+  margin: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border-left: 4px solid color-mix(in oklab, var(--calserver-primary) 74%, rgba(15, 23, 42, 0.24));
+  background: color-mix(in oklab, var(--calserver-primary) 12%, rgba(255, 255, 255, 0.1));
+  color: color-mix(in oklab, var(--qr-landing-text) 84%, rgba(15, 23, 42, 0.4));
+}
+
+.calhelp-assurance__hint-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: color-mix(in oklab, var(--calserver-primary) 30%, rgba(255, 255, 255, 0.18));
+  color: var(--calserver-primary);
+  flex-shrink: 0;
+}
+
+.calhelp-assurance__hint-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.calhelp-assurance__hint-text {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.calhelp-assurance__hint-text strong {
+  font-weight: 600;
+  color: color-mix(in oklab, var(--qr-landing-text) 96%, rgba(15, 23, 42, 0.24));
+}
+
+.calhelp-assurance__item.uk-open,
+.calhelp-assurance__item .uk-open {
+  border-color: color-mix(in oklab, var(--calserver-primary) 54%, rgba(15, 23, 42, 0.22));
+  box-shadow: 0 30px 60px -30px color-mix(in oklab, var(--calserver-primary) 82%, rgba(15, 23, 42, 0.92));
+}
+
+@media (max-width: 959px) {
+  .calhelp-assurance__item .uk-accordion-title {
+    padding: 18px 20px;
+  }
+
+  .calhelp-assurance__item .uk-accordion-content {
+    padding: 0 20px 20px;
+  }
+}
+
 .calhelp-demo-steps {
   list-style: decimal inside;
   margin: 0;


### PR DESCRIPTION
## Summary
- add a UIkit accordion to the proof section with detailed trust panels for cloud, on-prem, GDPR, and role protocols
- style the new accordion and trust badges to match the calHelp brand palette

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e0714434832bade10a9db10e1249