### PR TITLE
Fix PHPStan warnings in mail provider logic

### DIFF
--- a/src/Controller/Admin/MailProviderController.php
+++ b/src/Controller/Admin/MailProviderController.php
@@ -230,9 +230,6 @@ class MailProviderController
     {
         $byName = [];
         foreach ($stored as $row) {
-            if (!is_array($row)) {
-                continue;
-            }
             $name = strtolower((string) ($row['provider_name'] ?? ''));
             if ($name === '') {
                 continue;
@@ -298,7 +295,7 @@ class MailProviderController
             $host = $this->normalizeString($config['smtp_host'] ?? null);
             $user = $this->normalizeString($config['smtp_user'] ?? null);
             $encryption = $this->normalizeString($config['smtp_encryption'] ?? null);
-            $hasPassword = array_key_exists('has_smtp_pass', $config) ? (bool) $config['has_smtp_pass'] : false;
+            $hasPassword = (bool) $config['has_smtp_pass'];
             $port = $config['smtp_port'] ?? null;
             $hasPort = is_int($port) && $port > 0;
 

--- a/src/Infrastructure/MailProviderRepository.php
+++ b/src/Infrastructure/MailProviderRepository.php
@@ -30,7 +30,7 @@ class MailProviderRepository
 
         $binaryKey = hash('sha256', $secret, true);
         $ivLength = openssl_cipher_iv_length(self::CIPHER);
-        if (!is_int($ivLength) || $ivLength <= 0) {
+        if ($ivLength <= 0) {
             throw new RuntimeException('Unable to determine IV length for mail provider encryption.');
         }
 

--- a/src/Service/MailProvider/BrevoProvider.php
+++ b/src/Service/MailProvider/BrevoProvider.php
@@ -131,8 +131,7 @@ class BrevoProvider implements MailProviderInterface
             ]);
         } catch (ClientException $exception) {
             $response = $exception->getResponse();
-            $statusCode = $response?->getStatusCode();
-            if ($statusCode !== 404) {
+            if ($response->getStatusCode() !== 404) {
                 throw new RuntimeException(
                     'Failed to unsubscribe contact via Brevo: ' . $exception->getMessage(),
                     0,
@@ -365,9 +364,6 @@ class BrevoProvider implements MailProviderInterface
         $parts = array_filter($parts, static fn (string $part): bool => $part !== '');
         $ids = [];
         foreach ($parts as $part) {
-            if ($part === '') {
-                continue;
-            }
             $ids[] = (int) $part;
         }
 


### PR DESCRIPTION
## Summary
- remove redundant collection guards when merging stored provider metadata and domain overrides
- simplify the mail provider repository IV length validation to satisfy static analysis
- adjust Brevo provider unsubscribe handling and list parsing for PHPStan compliance

## Testing
- vendor/bin/phpstan analyse -c phpstan.neon.dist

------
https://chatgpt.com/codex/tasks/task_e_68e4e28c03dc832b8455a2660e745783