### PR TITLE
Localize calhelp process toggle labels

### DIFF
--- a/content/marketing/calhelp.html
+++ b/content/marketing/calhelp.html
@@ -344,7 +344,14 @@
                   data-calhelp-step-toggle
                   aria-expanded="true"
                   aria-controls="process-panel-readiness">
-            <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+            <span class="calhelp-process__toggle-label"
+                  data-calhelp-i18n
+                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                  data-i18n-en="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
             <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
           </button>
           <div id="process-panel-readiness"
@@ -371,7 +378,14 @@
                   data-calhelp-step-toggle
                   aria-expanded="true"
                   aria-controls="process-panel-mapping">
-            <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+            <span class="calhelp-process__toggle-label"
+                  data-calhelp-i18n
+                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                  data-i18n-en="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
             <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
           </button>
           <div id="process-panel-mapping"
@@ -398,7 +412,14 @@
                   data-calhelp-step-toggle
                   aria-expanded="true"
                   aria-controls="process-panel-pilot">
-            <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+            <span class="calhelp-process__toggle-label"
+                  data-calhelp-i18n
+                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                  data-i18n-en="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
             <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
           </button>
           <div id="process-panel-pilot"
@@ -425,7 +446,14 @@
                   data-calhelp-step-toggle
                   aria-expanded="true"
                   aria-controls="process-panel-cutover">
-            <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+            <span class="calhelp-process__toggle-label"
+                  data-calhelp-i18n
+                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                  data-i18n-en="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
             <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
           </button>
           <div id="process-panel-cutover"
@@ -452,7 +480,14 @@
                   data-calhelp-step-toggle
                   aria-expanded="true"
                   aria-controls="process-panel-golive">
-            <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+            <span class="calhelp-process__toggle-label"
+                  data-calhelp-i18n
+                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                  data-i18n-en="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
             <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
           </button>
           <div id="process-panel-golive"

--- a/migrations/20251203_add_calhelp_page.sql
+++ b/migrations/20251203_add_calhelp_page.sql
@@ -349,7 +349,14 @@ VALUES (
                     data-calhelp-step-toggle
                     aria-expanded="true"
                     aria-controls="process-panel-readiness">
-              <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+              <span class="calhelp-process__toggle-label"
+                    data-calhelp-i18n
+                    data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                    data-i18n-en="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                    data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                    data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
               <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
             </button>
             <div id="process-panel-readiness"
@@ -376,7 +383,14 @@ VALUES (
                     data-calhelp-step-toggle
                     aria-expanded="true"
                     aria-controls="process-panel-mapping">
-              <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+              <span class="calhelp-process__toggle-label"
+                    data-calhelp-i18n
+                    data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                    data-i18n-en="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                    data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                    data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
               <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
             </button>
             <div id="process-panel-mapping"
@@ -403,7 +417,14 @@ VALUES (
                     data-calhelp-step-toggle
                     aria-expanded="true"
                     aria-controls="process-panel-pilot">
-              <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+              <span class="calhelp-process__toggle-label"
+                    data-calhelp-i18n
+                    data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                    data-i18n-en="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                    data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                    data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
               <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
             </button>
             <div id="process-panel-pilot"
@@ -430,7 +451,14 @@ VALUES (
                     data-calhelp-step-toggle
                     aria-expanded="true"
                     aria-controls="process-panel-cutover">
-              <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+              <span class="calhelp-process__toggle-label"
+                    data-calhelp-i18n
+                    data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                    data-i18n-en="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                    data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                    data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
               <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
             </button>
             <div id="process-panel-cutover"
@@ -457,7 +485,14 @@ VALUES (
                     data-calhelp-step-toggle
                     aria-expanded="true"
                     aria-controls="process-panel-golive">
-              <span class="calhelp-process__toggle-label">Leistungen &amp; Abnahme ausblenden</span>
+              <span class="calhelp-process__toggle-label"
+                    data-calhelp-i18n
+                    data-i18n-de="Leistungen &amp; Abnahme ausblenden"
+                    data-i18n-en="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
+                    data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
+                    data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
+                    data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
               <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
             </button>
             <div id="process-panel-golive"

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -451,6 +451,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
   const prefersReducedMotion = () => reducedMotionQuery.matches;
 
+  const htmlLang = (document.documentElement?.lang || '').toLowerCase();
+  const currentLanguage = htmlLang.startsWith('en') ? 'en' : 'de';
+
   steppers.forEach((stepper) => {
     const stages = Array.from(stepper.querySelectorAll('[data-calhelp-step]'));
     if (!stages.length) return;
@@ -467,7 +470,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const updateToggleLabel = (button, expanded) => {
       const label = button.querySelector('.calhelp-process__toggle-label');
       if (label) {
-        label.textContent = expanded ? 'Leistungen & Abnahme ausblenden' : 'Leistungen & Abnahme anzeigen';
+        const stateKey = expanded ? 'Expanded' : 'Collapsed';
+        const preferredSuffix = currentLanguage === 'en' ? 'En' : 'De';
+        const fallbackSuffix = preferredSuffix === 'En' ? 'De' : 'En';
+        const datasetKeyPreferred = `calhelpToggleLabel${preferredSuffix}${stateKey}`;
+        const datasetKeyFallback = `calhelpToggleLabel${fallbackSuffix}${stateKey}`;
+        const translatedLabel = label.dataset[datasetKeyPreferred] || label.dataset[datasetKeyFallback];
+        if (translatedLabel) {
+          label.textContent = translatedLabel;
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- read the calhelp process toggle label text from locale-specific data attributes in the landing script
- embed German and English label variants in the calhelp marketing markup and seed migration so the toggle shows the active language

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e524f11660832bb4650de51bffa7de