### PR TITLE
Create mega menu navigation for calHelp

### DIFF
--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -45,6 +45,340 @@ body.qr-landing.calhelp-theme .landing-content {
   letter-spacing: 0.12em;
 }
 
+body.qr-landing.calhelp-theme {
+  --calhelp-nav-surface: color-mix(in oklab, #ffffff 96%, rgba(15, 23, 42, 0.04));
+  --calhelp-nav-border: color-mix(in oklab, rgba(15, 23, 42, 0.12), rgba(255, 255, 255, 0.56));
+  --calhelp-nav-shadow: 0 28px 54px -34px color-mix(in oklab, var(--calserver-primary) 68%, rgba(15, 23, 42, 0.68));
+  --calhelp-pane-surface: color-mix(in oklab, #ffffff 90%, rgba(15, 23, 42, 0.08));
+  --calhelp-pane-border: color-mix(in oklab, rgba(15, 23, 42, 0.08), rgba(255, 255, 255, 0.6));
+  --calhelp-pane-meta: color-mix(in oklab, var(--qr-landing-text) 52%, rgba(15, 23, 42, 0.28));
+  --calhelp-link-hover: color-mix(in oklab, var(--calserver-primary) 16%, rgba(15, 23, 42, 0.04));
+  --calhelp-offcanvas-bg: #ffffff;
+  --calhelp-offcanvas-border: color-mix(in oklab, rgba(15, 23, 42, 0.08), rgba(255, 255, 255, 0.5));
+  --calhelp-offcanvas-muted: color-mix(in oklab, var(--qr-landing-text) 60%, rgba(15, 23, 42, 0.28));
+}
+
+body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) {
+  --calhelp-nav-surface: color-mix(in oklab, rgba(17, 24, 39, 0.92), rgba(15, 23, 42, 0.78));
+  --calhelp-nav-border: color-mix(in oklab, rgba(79, 97, 125, 0.48), rgba(15, 23, 42, 0.48));
+  --calhelp-nav-shadow: 0 28px 54px -28px color-mix(in oklab, rgba(9, 13, 24, 0.82), rgba(11, 96, 210, 0.54));
+  --calhelp-pane-surface: color-mix(in oklab, rgba(27, 36, 56, 0.94), rgba(15, 23, 42, 0.78));
+  --calhelp-pane-border: color-mix(in oklab, rgba(62, 86, 125, 0.45), rgba(15, 23, 42, 0.6));
+  --calhelp-pane-meta: color-mix(in oklab, rgba(198, 211, 238, 0.76), rgba(162, 178, 212, 0.48));
+  --calhelp-link-hover: color-mix(in oklab, rgba(30, 64, 175, 0.35), rgba(15, 23, 42, 0.55));
+  --calhelp-offcanvas-bg: color-mix(in oklab, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.86));
+  --calhelp-offcanvas-border: color-mix(in oklab, rgba(66, 86, 132, 0.48), rgba(15, 23, 42, 0.64));
+  --calhelp-offcanvas-muted: color-mix(in oklab, rgba(198, 211, 238, 0.8), rgba(220, 230, 255, 0.68));
+}
+
+.calhelp-mega-nav {
+  align-items: stretch;
+}
+
+.calhelp-mega-nav__item {
+  position: relative;
+}
+
+.calhelp-mega-nav__toggle {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  align-items: center;
+  column-gap: 8px;
+  padding: 0 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.1;
+}
+
+.calhelp-mega-nav__toggle .uk-margin-small-right {
+  grid-row: 1 / span 2;
+}
+
+.calhelp-mega-nav__label {
+  font-size: 0.95rem;
+}
+
+.calhelp-mega-nav__hint {
+  grid-column: 2;
+  margin-top: 2px;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--qr-landing-text) 46%, rgba(15, 23, 42, 0.32));
+}
+
+.calhelp-mega-dropdown {
+  width: min(960px, calc(100vw - 96px));
+  background: var(--calhelp-nav-surface);
+  border-radius: 22px;
+  padding: 28px 32px 32px;
+  border: 1px solid var(--calhelp-nav-border);
+  box-shadow: var(--calhelp-nav-shadow);
+  color: inherit;
+}
+
+.calhelp-mega__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.calhelp-mega__column {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.calhelp-mega__heading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.calhelp-mega__description {
+  margin: 4px 0 0;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: color-mix(in oklab, var(--qr-landing-text) 58%, rgba(15, 23, 42, 0.3));
+}
+
+.calhelp-mega__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.calhelp-mega__link {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  color: inherit;
+  text-decoration: none;
+  background: transparent;
+  transition: background 0.25s ease, color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.calhelp-mega__link-sub {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.78rem;
+  color: color-mix(in oklab, var(--qr-landing-text) 52%, rgba(15, 23, 42, 0.32));
+}
+
+.calhelp-mega__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  background: color-mix(in oklab, rgba(255, 255, 255, 0.72), rgba(15, 23, 42, 0.06));
+  color: var(--calserver-primary);
+  flex-shrink: 0;
+}
+
+.calhelp-mega__link:hover,
+.calhelp-mega__link:focus-visible {
+  background: var(--calhelp-link-hover);
+  color: color-mix(in oklab, var(--qr-landing-text) 92%, rgba(15, 23, 42, 0.08));
+  outline: none;
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--calserver-primary) 38%, rgba(15, 23, 42, 0.2));
+}
+
+.calhelp-mega__link.is-active {
+  background: color-mix(in oklab, var(--calserver-primary) 12%, rgba(255, 255, 255, 0.92));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--calserver-primary) 48%, rgba(15, 23, 42, 0.18));
+}
+
+.calhelp-mega__link.is-active .calhelp-mega__link-sub {
+  color: color-mix(in oklab, var(--calserver-primary) 46%, rgba(15, 23, 42, 0.24));
+}
+
+.calhelp-mega__explain {
+  position: relative;
+  margin-top: 28px;
+  padding: 22px 26px;
+  border-radius: 20px;
+  background: var(--calhelp-pane-surface);
+  border: 1px solid var(--calhelp-pane-border);
+  min-height: 176px;
+  overflow: hidden;
+}
+
+.calhelp-mega__pane {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(8px);
+  transition: opacity 0.26s ease, transform 0.26s ease;
+}
+
+.calhelp-mega__pane.is-active {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.calhelp-mega__pane-title {
+  margin: 0 0 10px;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.calhelp-mega__pane-text {
+  margin: 0 0 10px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.calhelp-mega__pane-meta {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--calhelp-pane-meta);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .calhelp-mega__link,
+  .calhelp-mega__pane {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0.01ms !important;
+    transform: none !important;
+  }
+}
+
+.calhelp-offcanvas {
+  background: var(--calhelp-offcanvas-bg);
+  color: inherit;
+  padding: 32px 28px 40px;
+  border-left: 1px solid var(--calhelp-offcanvas-border);
+}
+
+.calhelp-offcanvas__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  margin-top: 32px;
+}
+
+.calhelp-offcanvas__group {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.calhelp-offcanvas__heading {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.calhelp-offcanvas__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--calhelp-offcanvas-muted);
+}
+
+.calhelp-offcanvas__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.calhelp-offcanvas__link {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  text-decoration: none;
+  color: inherit;
+  border-bottom: 1px solid color-mix(in oklab, var(--calhelp-offcanvas-border) 72%, rgba(255, 255, 255, 0.42));
+}
+
+.calhelp-offcanvas__item:last-child .calhelp-offcanvas__link {
+  border-bottom-color: transparent;
+}
+
+.calhelp-offcanvas__icon {
+  width: 30px;
+  height: 30px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklab, var(--calserver-primary) 12%, rgba(255, 255, 255, 0.82));
+  color: var(--calserver-primary);
+  flex-shrink: 0;
+}
+
+.calhelp-offcanvas__label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-weight: 500;
+}
+
+.calhelp-offcanvas__summary {
+  font-size: 0.78rem;
+  color: var(--calhelp-offcanvas-muted);
+}
+
+.calhelp-offcanvas__link:focus-visible,
+.calhelp-offcanvas__link:hover {
+  color: color-mix(in oklab, var(--qr-landing-text) 92%, rgba(15, 23, 42, 0.12));
+}
+
+.calhelp-offcanvas__cta {
+  margin-top: 36px;
+  box-shadow: 0 24px 48px -28px color-mix(in oklab, var(--calserver-primary) 68%, rgba(15, 23, 42, 0.68));
+}
+
+body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-mega__icon {
+  background: color-mix(in oklab, rgba(37, 56, 94, 0.6), rgba(15, 23, 42, 0.42));
+  color: color-mix(in oklab, rgba(137, 180, 255, 0.88), rgba(53, 121, 255, 0.82));
+}
+
+body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-mega__link.is-active {
+  background: color-mix(in oklab, rgba(46, 81, 156, 0.28), rgba(15, 23, 42, 0.6));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, rgba(102, 157, 255, 0.68), rgba(15, 23, 42, 0.4));
+}
+
+body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-mega__link-sub {
+  color: color-mix(in oklab, rgba(187, 204, 236, 0.72), rgba(114, 138, 181, 0.5));
+}
+
+body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-mega__pane-text {
+  color: color-mix(in oklab, rgba(221, 230, 250, 0.88), rgba(169, 184, 214, 0.68));
+}
+
+body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-offcanvas {
+  color: color-mix(in oklab, rgba(229, 238, 255, 0.92), rgba(196, 211, 242, 0.82));
+}
+
+body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-offcanvas__icon {
+  background: color-mix(in oklab, rgba(39, 64, 120, 0.58), rgba(15, 23, 42, 0.52));
+  color: color-mix(in oklab, rgba(134, 179, 255, 0.88), rgba(59, 122, 255, 0.78));
+}
+
+body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-offcanvas__link {
+  border-bottom-color: color-mix(in oklab, rgba(61, 85, 122, 0.52), rgba(22, 31, 52, 0.52));
+}
+
+body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-offcanvas__summary {
+  color: color-mix(in oklab, rgba(176, 196, 232, 0.8), rgba(119, 142, 187, 0.64));
+}
+
 .calhelp-top-cta {
   box-shadow: 0 22px 40px -26px color-mix(in oklab, var(--calserver-primary) 66%, rgba(15, 23, 42, 0.75));
 }

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -703,3 +703,56 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+  const megaRoot = document.querySelector('[data-calhelp-mega-root]');
+  if (!megaRoot) return;
+
+  const triggers = Array.from(megaRoot.querySelectorAll('[data-calhelp-explain]'));
+  const panes = Array.from(megaRoot.querySelectorAll('[data-calhelp-pane]'));
+  if (!triggers.length || !panes.length) return;
+
+  const getId = (element) => element.getAttribute('data-calhelp-explain');
+
+  const setActive = (id) => {
+    if (!id) return;
+
+    const activePane = panes.find((pane) => pane.getAttribute('data-calhelp-pane') === id);
+    if (!activePane) return;
+
+    panes.forEach((pane) => {
+      const isActive = pane === activePane;
+      pane.classList.toggle('is-active', isActive);
+      pane.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+    });
+
+    triggers.forEach((trigger) => {
+      const isActive = getId(trigger) === id;
+      trigger.classList.toggle('is-active', isActive);
+      trigger.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+    });
+
+    megaRoot.setAttribute('data-calhelp-active', id);
+  };
+
+  const handleTrigger = (event) => {
+    const trigger = event.currentTarget;
+    const id = getId(trigger);
+    if (!id) return;
+    setActive(id);
+  };
+
+  triggers.forEach((trigger) => {
+    trigger.addEventListener('focus', handleTrigger);
+    trigger.addEventListener('mouseenter', handleTrigger);
+    trigger.addEventListener('pointerenter', handleTrigger);
+    trigger.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        handleTrigger(event);
+      }
+    });
+  });
+
+  const defaultId = megaRoot.getAttribute('data-calhelp-default') || (triggers[0] ? getId(triggers[0]) : '');
+  setActive(defaultId);
+});

--- a/templates/marketing/calhelp.twig
+++ b/templates/marketing/calhelp.twig
@@ -1,18 +1,176 @@
 {% extends 'layout.twig' %}
 
-{% set links = [
-    { 'href': '#hero', 'label': 'Überblick', 'icon': 'home' },
-    { 'href': '#modules', 'label': 'Module', 'icon': 'grid' },
-    { 'href': '#fit', 'label': 'Passung', 'icon': 'users' },
-    { 'href': '#benefits', 'label': 'Ergebnisse', 'icon': 'star' },
-    { 'href': '#process', 'label': 'Ablauf', 'icon': 'settings' },
-    { 'href': '#usecases', 'label': 'Situationen', 'icon': 'file-text' },
-    { 'href': '#help', 'label': 'Unterstützung', 'icon': 'lifesaver' },
-    { 'href': '#conversation', 'label': 'Gespräch', 'icon': 'commenting' },
-    { 'href': '#news', 'label': 'News', 'icon': 'rss' },
-    { 'href': '#faq', 'label': 'FAQ', 'icon': 'question' },
-    { 'href': '#cta', 'label': 'Kontakt', 'icon': 'bolt' }
+{% set navGroups = [
+    {
+      'id': 'intro',
+      'title': 'Einstieg & Überblick',
+      'description': 'Die wichtigsten Abschnitte für Entscheider:innen und Projektleitungen.',
+      'items': [
+        {
+          'href': '#hero',
+          'label': 'Überblick',
+          'icon': 'home',
+          'summary': 'Story, Nutzen und erste Angebote im Schnelldurchlauf.',
+          'pane': {
+            'id': 'intro-overview',
+            'title': 'Warum calHelp starten?',
+            'text': 'Zeigt, wie calHelp Audits beruhigt, Verantwortlichkeiten klärt und allen Teams einen gemeinsamen Status gibt.',
+            'meta': 'Intro · Nutzenversprechen · Vertrauensanker'
+          }
+        },
+        {
+          'href': '#modules',
+          'label': 'Module',
+          'icon': 'grid',
+          'summary': 'Welche Module und Integrationen standardmäßig enthalten sind.',
+          'pane': {
+            'id': 'intro-modules',
+            'title': 'Module & Integrationen',
+            'text': 'Erklärt das Modul-Set – vom Messmittelkataster bis zu Freigabeflows – inklusive Anbindungen wie MET/TEAM.',
+            'meta': 'Module · Integrationen · Automationen'
+          }
+        },
+        {
+          'href': '#benefits',
+          'label': 'Ergebnisse',
+          'icon': 'star',
+          'summary': 'Kennzahlen und Effekte aus Projekten mit calHelp.',
+          'pane': {
+            'id': 'intro-benefits',
+            'title': 'Welche Ergebnisse erreichbar sind',
+            'text': 'Zeigt messbare Resultate wie Audit-Sicherheit, Prozessgeschwindigkeit und dokumentierte Entscheidungen.',
+            'meta': 'KPIs · Erfahrungswerte · Kennzahlen'
+          }
+        }
+      ]
+    },
+    {
+      'id': 'collaboration',
+      'title': 'Zusammenarbeit & Ablauf',
+      'description': 'Wie wir gemeinsam starten, migrieren und langfristig betreuen.',
+      'items': [
+        {
+          'href': '#fit',
+          'label': 'Passung',
+          'icon': 'users',
+          'summary': 'Abgleich mit Rollen, Verantwortlichkeiten und IT-Landschaft.',
+          'pane': {
+            'id': 'collaboration-fit',
+            'title': 'Passt calHelp zu unserem Setup?',
+            'text': 'Hilft einzuschätzen, wie calHelp in bestehende Teams, Prozesse und Compliance-Richtlinien eingebettet wird.',
+            'meta': 'Rollen · Governance · IT-Umfeld'
+          }
+        },
+        {
+          'href': '#process',
+          'label': 'Ablauf',
+          'icon': 'settings',
+          'summary': 'Projektfahrplan von Erstaufnahme bis Rollout.',
+          'pane': {
+            'id': 'collaboration-process',
+            'title': 'Projektstruktur & Migration',
+            'text': 'Beschreibt die Phasen – Analyse, Datenmigration, Guardband-Validierung und Übergabe an das Team.',
+            'meta': 'Projektphasen · Migration · Betreuung'
+          }
+        },
+        {
+          'href': '#conversation',
+          'label': 'Gespräch',
+          'icon': 'commenting',
+          'summary': 'Direktes Gespräch, Demo und Unterlagen anfordern.',
+          'pane': {
+            'id': 'collaboration-conversation',
+            'title': 'Live ins Gespräch gehen',
+            'text': 'Öffnet den direkten Kanal: Termin vereinbaren, Use Cases besprechen und individuelle Unterlagen erhalten.',
+            'meta': 'Termin · Demo · Unterlagen'
+          }
+        }
+      ]
+    },
+    {
+      'id': 'practice',
+      'title': 'Anwendung & Inhalte',
+      'description': 'Echte Szenarien, Services und laufende Unterstützung.',
+      'items': [
+        {
+          'href': '#usecases',
+          'label': 'Situationen',
+          'icon': 'file-text',
+          'summary': 'Praxisbeispiele aus Labor, Produktion und Service.',
+          'pane': {
+            'id': 'practice-usecases',
+            'title': 'Szenarien aus dem Betrieb',
+            'text': 'Zeigt, wie calHelp Guardbands dokumentiert, Audits vorbereitet und Datenflüsse verbindet.',
+            'meta': 'Branchen · Szenarien · Guardbands'
+          }
+        },
+        {
+          'href': '#help',
+          'label': 'Unterstützung',
+          'icon': 'lifesaver',
+          'summary': 'Servicepakete, Schulung und Wissenstransfer.',
+          'pane': {
+            'id': 'practice-help',
+            'title': 'Begleitung im Alltag',
+            'text': 'Erklärt, wie wir Teams onboarden, Support leisten und Wissen dauerhaft zugänglich machen.',
+            'meta': 'Onboarding · Support · Enablement'
+          }
+        },
+        {
+          'href': '#news',
+          'label': 'News',
+          'icon': 'rss',
+          'summary': 'Aktuelle Releases, Termine und Einblicke.',
+          'pane': {
+            'id': 'practice-news',
+            'title': 'Was es Neues gibt',
+            'text': 'Bündelt Produkt-Updates, Webinare und Events mit Bezug zu calHelp.',
+            'meta': 'Releases · Termine · Highlights'
+          }
+        }
+      ]
+    },
+    {
+      'id': 'contact',
+      'title': 'Antworten & Kontakt',
+      'description': 'Alle Informationen für Sicherheit, Compliance und nächste Schritte.',
+      'items': [
+        {
+          'href': '#faq',
+          'label': 'FAQ',
+          'icon': 'question',
+          'summary': 'Klärt Datenschutz, Hosting und Betrieb.',
+          'pane': {
+            'id': 'contact-faq',
+            'title': 'Häufige Fragen vorab klären',
+            'text': 'Fasst Antworten zu Sicherheit, Hosting in Deutschland und Verantwortlichkeiten zusammen.',
+            'meta': 'Compliance · Hosting · Betrieb'
+          }
+        },
+        {
+          'href': '#cta',
+          'label': 'Kontakt',
+          'icon': 'bolt',
+          'summary': 'Kontaktformular und Angebot starten.',
+          'pane': {
+            'id': 'contact-cta',
+            'title': 'Kontakt aufnehmen',
+            'text': 'Der schnellste Weg zu Angebot, Projektsteckbrief und konkretem Starttermin.',
+            'meta': 'Kontakt · Angebot · Nächste Schritte'
+          }
+        }
+      ]
+    }
 ] %}
+
+{% set defaultExplain = '' %}
+{% set firstGroup = navGroups|first %}
+{% if firstGroup %}
+  {% set firstItem = firstGroup.items|first %}
+  {% if firstItem %}
+    {% set defaultExplain = firstItem.pane.id %}
+  {% endif %}
+{% endif %}
 
 {% block title %}{{ metaTitle|default('Umstieg auf ein zentrales Kalibrier-System – konsistent, nachvollziehbar, auditfähig') }}{% endblock %}
 
@@ -51,14 +209,61 @@
           </div>
         </div>
         <div class="uk-navbar-right">
-          <ul class="uk-navbar-nav uk-visible@m">
-            {% for link in links %}
-              <li>
-                <a href="{{ link.href }}">
-                  <span class="uk-margin-small-right" data-uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
-                </a>
-              </li>
-            {% endfor %}
+          <ul class="uk-navbar-nav uk-visible@m calhelp-mega-nav" data-calhelp-mega>
+            <li class="uk-parent calhelp-mega-nav__item">
+              <a href="#hero" class="calhelp-mega-nav__toggle" aria-haspopup="true" aria-expanded="false">
+                <span class="uk-margin-small-right" data-uk-icon="icon: menu"></span>
+                <span class="calhelp-mega-nav__label">Navigation</span>
+                <span class="calhelp-mega-nav__hint">Alle Bereiche</span>
+              </a>
+              <div class="uk-navbar-dropdown uk-padding-remove calhelp-mega-dropdown" data-uk-dropdown="mode: hover; pos: bottom-right; offset: 24; delay-hide: 120; animation: uk-animation-slide-top-small">
+                <div class="calhelp-mega" data-calhelp-mega-root data-calhelp-default="{{ defaultExplain }}">
+                  <div class="calhelp-mega__grid">
+                    {% for group in navGroups %}
+                      <section class="calhelp-mega__column">
+                        <header class="calhelp-mega__column-header">
+                          <h3 class="calhelp-mega__heading">{{ group.title }}</h3>
+                          <p class="calhelp-mega__description">{{ group.description }}</p>
+                        </header>
+                        <ul class="calhelp-mega__list">
+                          {% for item in group.items %}
+                            {% set isActive = loop.parent.first and loop.first %}
+                            <li class="calhelp-mega__item">
+                              <a href="{{ item.href }}"
+                                 class="calhelp-mega__link{% if isActive %} is-active{% endif %}"
+                                 data-calhelp-explain="{{ item.pane.id }}"
+                                 aria-controls="calhelp-pane-{{ item.pane.id }}"
+                                 aria-expanded="{{ isActive ? 'true' : 'false' }}">
+                                <span class="calhelp-mega__icon" aria-hidden="true" data-uk-icon="icon: {{ item.icon }}"></span>
+                                <span class="calhelp-mega__link-label">
+                                  {{ item.label }}
+                                  <span class="calhelp-mega__link-sub">{{ item.summary }}</span>
+                                </span>
+                              </a>
+                            </li>
+                          {% endfor %}
+                        </ul>
+                      </section>
+                    {% endfor %}
+                  </div>
+                  <div class="calhelp-mega__explain" aria-live="polite">
+                    {% for group in navGroups %}
+                      {% for item in group.items %}
+                        {% set paneActive = loop.parent.first and loop.first %}
+                        <article id="calhelp-pane-{{ item.pane.id }}"
+                                 class="calhelp-mega__pane{% if paneActive %} is-active{% endif %}"
+                                 data-calhelp-pane="{{ item.pane.id }}"
+                                 aria-hidden="{{ paneActive ? 'false' : 'true' }}">
+                          <h4 class="calhelp-mega__pane-title">{{ item.pane.title }}</h4>
+                          <p class="calhelp-mega__pane-text">{{ item.pane.text }}</p>
+                          <p class="calhelp-mega__pane-meta">{{ item.pane.meta }}</p>
+                        </article>
+                      {% endfor %}
+                    {% endfor %}
+                  </div>
+                </div>
+              </div>
+            </li>
           </ul>
           <div class="uk-navbar-item config-menu uk-inline">
             <button id="configMenuToggle"
@@ -153,18 +358,30 @@
     </header>
 
     <div id="qr-offcanvas" data-uk-offcanvas="overlay: true; flip: true">
-      <div class="uk-offcanvas-bar">
+      <div class="uk-offcanvas-bar calhelp-offcanvas">
         <button class="uk-offcanvas-close git-btn" type="button" data-uk-close aria-label="Menü schließen"></button>
-        <ul class="uk-nav uk-nav-default">
-          {% for link in links %}
-            <li>
-              <a href="{{ link.href }}">
-                <span class="uk-margin-small-right" data-uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
-              </a>
-            </li>
+        <div class="calhelp-offcanvas__inner">
+          {% for group in navGroups %}
+            <section class="calhelp-offcanvas__group">
+              <h3 class="calhelp-offcanvas__heading">{{ group.title }}</h3>
+              <p class="calhelp-offcanvas__description">{{ group.description }}</p>
+              <ul class="calhelp-offcanvas__list">
+                {% for item in group.items %}
+                  <li class="calhelp-offcanvas__item">
+                    <a href="{{ item.href }}" class="calhelp-offcanvas__link">
+                      <span class="calhelp-offcanvas__icon" aria-hidden="true" data-uk-icon="icon: {{ item.icon }}"></span>
+                      <span class="calhelp-offcanvas__label">
+                        {{ item.label }}
+                        <span class="calhelp-offcanvas__summary">{{ item.summary }}</span>
+                      </span>
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </section>
           {% endfor %}
-        </ul>
-        <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top" href="#cta">
+        </div>
+        <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top calhelp-offcanvas__cta" href="#cta">
           <span class="uk-margin-small-right" data-uk-icon="icon: commenting"></span>Gespräch starten
         </a>
       </div>


### PR DESCRIPTION
## Summary
- replace the flat calHelp top navigation with a four-column mega menu including contextual explain panes
- mirror the grouped structure in the mobile offcanvas for consistent access across viewports
- extend calHelp theme styling and landing.js behavior to support the mega menu, contextual panes, and dark-mode treatments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e54bed720c832baaa1830b39b06552