### PR TITLE
Add Twig translation filter alias

### DIFF
--- a/src/Twig/TranslationExtension.php
+++ b/src/Twig/TranslationExtension.php
@@ -4,6 +4,7 @@ namespace App\Twig;
 
 use App\Service\TranslationService;
 use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 class TranslationExtension extends AbstractExtension
@@ -18,6 +19,12 @@ class TranslationExtension extends AbstractExtension
         return [
             new TwigFunction('t', [$this->translator, 'translate']),
             new TwigFunction('locale', [$this->translator, 'getLocale']),
+        ];
+    }
+
+    public function getFilters(): array {
+        return [
+            new TwigFilter('trans', [$this->translator, 'translate']),
         ];
     }
 }


### PR DESCRIPTION
## Summary
- register a `trans` Twig filter that proxies to the translation service so templates can use `|trans`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e54fce6e74832bbc5802b878ef1f3a