### PR TITLE
Simplify calHelp landing layout and styling

### DIFF
--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -45,6 +45,11 @@ body.qr-landing.calhelp-theme .landing-content {
   letter-spacing: 0.12em;
 }
 
+.calhelp-nav > li > a {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
 body.qr-landing.calhelp-theme {
   --calhelp-nav-surface: color-mix(in oklab, #ffffff 96%, rgba(15, 23, 42, 0.04));
   --calhelp-nav-border: color-mix(in oklab, rgba(15, 23, 42, 0.12), rgba(255, 255, 255, 0.56));
@@ -269,6 +274,14 @@ body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) {
   margin-top: 32px;
 }
 
+.calhelp-offcanvas__nav > li > a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  padding: 6px 0;
+}
+
 .calhelp-offcanvas__group {
   display: flex;
   flex-direction: column;
@@ -403,7 +416,10 @@ body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-of
   display: flex;
   flex-direction: column;
   gap: 12px;
-  box-shadow: 0 42px 72px -48px color-mix(in oklab, var(--calserver-primary) 52%, rgba(15, 23, 42, 0.82));
+  background: #ffffff;
+  border-radius: 24px;
+  border: 1px solid color-mix(in oklab, rgba(15, 23, 42, 0.08), rgba(255, 255, 255, 0.92));
+  box-shadow: 0 32px 56px -40px rgba(15, 23, 42, 0.18);
 }
 
 .calhelp-hero-card .uk-card-title {
@@ -418,6 +434,13 @@ body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-of
   margin-top: 24px;
   font-size: 0.95rem;
   color: color-mix(in oklab, var(--qr-landing-text) 68%, rgba(15, 23, 42, 0.56));
+}
+
+.calhelp-data-note {
+  margin-top: 12px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: color-mix(in oklab, var(--qr-landing-text) 72%, rgba(15, 23, 42, 0.45));
 }
 
 .calhelp-section {
@@ -1684,7 +1707,7 @@ body.calhelp-proof-gallery--modal-open {
 }
 
 .calhelp-modules__grid {
-  row-gap: 0;
+  row-gap: 32px;
 }
 
 .calhelp-modules__grid.uk-grid {
@@ -1700,61 +1723,32 @@ body.calhelp-proof-gallery--modal-open {
   margin-top: 0 !important;
 }
 
+
 .calhelp-module-card {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 22px 20px;
-  border-radius: 0;
-  overflow: hidden;
-  background: color-mix(in oklab, rgba(15, 23, 42, 0.88) 88%, rgba(255, 255, 255, 0.06));
-  box-shadow: 0 26px 44px -36px color-mix(in oklab, var(--calserver-primary) 70%, rgba(15, 23, 42, 0.82));
-}
-
-.calhelp-module-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  border: 1px solid color-mix(in oklab, var(--calserver-primary) 74%, rgba(255, 255, 255, 0.7));
-  box-shadow: 0 0 18px -8px color-mix(in oklab, var(--calserver-primary) 88%, rgba(255, 255, 255, 0.7));
-  opacity: 0.7;
-  transition: opacity 0.3s ease, box-shadow 0.3s ease;
-}
-
-.calhelp-module-card:hover::before,
-.calhelp-module-card:focus-within::before {
-  opacity: 1;
-  box-shadow: 0 0 24px -6px color-mix(in oklab, var(--calserver-primary) 92%, rgba(255, 255, 255, 0.75));
+  gap: 16px;
+  padding: 26px 24px;
+  border-radius: 20px;
+  border: 1px solid color-mix(in oklab, rgba(15, 23, 42, 0.08), rgba(255, 255, 255, 0.92));
+  background: #ffffff;
+  box-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.18);
 }
 
 .calhelp-module-card--accent {
-  background: linear-gradient(135deg,
-      color-mix(in oklab, rgba(15, 23, 42, 0.9) 70%, var(--calserver-primary) 30%),
-      color-mix(in oklab, rgba(15, 23, 42, 0.86) 60%, var(--calserver-primary) 40%));
+  background: color-mix(in oklab, #ffffff 92%, var(--calserver-primary) 8%);
+  border-color: color-mix(in oklab, var(--calserver-primary) 20%, rgba(15, 23, 42, 0.08));
 }
 
 .calhelp-module-card--muted {
-  background: linear-gradient(135deg,
-      color-mix(in oklab, rgba(15, 23, 42, 0.88), rgba(255, 255, 255, 0.05)),
-      color-mix(in oklab, rgba(15, 23, 42, 0.92), rgba(255, 255, 255, 0.08)));
-}
-
-.calhelp-modules__grid.uk-grid > .uk-grid-margin .calhelp-module-card {
-  margin-top: -1px;
-}
-
-@media (min-width: 960px) {
-  .calhelp-modules__grid.uk-grid > *:not(.uk-first-column) .calhelp-module-card {
-    margin-left: -1px;
-  }
+  background: #ffffff;
 }
 
 .calhelp-module-card__header {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 
 .calhelp-module-card__icon {
@@ -1764,10 +1758,10 @@ body.calhelp-proof-gallery--modal-open {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 12px;
-  background: linear-gradient(145deg, color-mix(in oklab, var(--calserver-primary) 92%, #ffffff 8%), var(--calserver-primary));
-  color: #ffffff;
-  box-shadow: 0 16px 24px -18px color-mix(in oklab, var(--calserver-primary) 84%, rgba(15, 23, 42, 0.6));
+  border-radius: 14px;
+  background: color-mix(in oklab, var(--calserver-primary) 18%, rgba(15, 23, 42, 0.04));
+  color: var(--calserver-primary);
+  box-shadow: none;
 }
 
 .calhelp-module-card__icon svg {
@@ -1776,43 +1770,39 @@ body.calhelp-proof-gallery--modal-open {
   stroke-width: 1.6px;
 }
 
-.calhelp-module-card--muted .calhelp-module-card__icon {
-  background: linear-gradient(145deg, color-mix(in oklab, var(--calserver-primary) 72%, #ffffff 18%), color-mix(in oklab, var(--calserver-primary) 54%, #111827 12%));
-}
-
 .calhelp-module-card__eyebrow {
   margin: 0;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: color-mix(in oklab, var(--qr-landing-text) 58%, rgba(255, 255, 255, 0.7));
+  color: color-mix(in oklab, var(--qr-landing-text) 58%, rgba(15, 23, 42, 0.4));
 }
 
 .calhelp-module-card__pitch {
-  margin-bottom: 2px;
-  color: color-mix(in oklab, var(--qr-landing-text) 78%, rgba(255, 255, 255, 0.88));
+  margin: 0;
+  color: color-mix(in oklab, var(--qr-landing-text) 85%, rgba(15, 23, 42, 0.12));
 }
 
 .calhelp-module-card__list {
   margin: 0;
   padding-left: 20px;
-  color: color-mix(in oklab, var(--qr-landing-text) 75%, rgba(255, 255, 255, 0.82));
+  color: color-mix(in oklab, var(--qr-landing-text) 80%, rgba(15, 23, 42, 0.16));
 }
 
 .calhelp-module-card__footer {
   margin-top: auto;
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 12px;
   align-items: center;
-  border-top: 1px solid color-mix(in oklab, rgba(255, 255, 255, 0.35) 35%, rgba(15, 23, 42, 0.3));
-  padding-top: 12px;
+  border-top: 1px solid color-mix(in oklab, rgba(15, 23, 42, 0.08), rgba(255, 255, 255, 0.9));
+  padding-top: 14px;
 }
 
 .calhelp-module-card__kpi {
   font-weight: 600;
   font-size: 0.95rem;
-  color: color-mix(in oklab, var(--qr-landing-text) 92%, rgba(255, 255, 255, 0.92));
+  color: color-mix(in oklab, var(--qr-landing-text) 92%, rgba(15, 23, 42, 0.08));
 }
 
 .calhelp-module-card__link {
@@ -1820,7 +1810,7 @@ body.calhelp-proof-gallery--modal-open {
   align-items: center;
   gap: 6px;
   font-weight: 600;
-  color: color-mix(in oklab, var(--calserver-primary) 86%, #ffffff 14%);
+  color: var(--calserver-primary);
   text-decoration: none;
 }
 
@@ -1835,7 +1825,7 @@ body.calhelp-proof-gallery--modal-open {
   }
 
   .calhelp-modules__grid {
-    row-gap: 0;
+    row-gap: 24px;
   }
 
   .calhelp-news-card {
@@ -1918,6 +1908,61 @@ body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-case-strip--muted {
 body.qr-landing.calhelp-theme.dark-mode .calhelp-case-strip--muted .calhelp-case-strip__label,
 body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-case-strip--muted .calhelp-case-strip__label {
   color: color-mix(in oklab, var(--calserver-primary) 48%, #0f172a 52%);
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-hero-card,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-hero-card {
+  background: color-mix(in oklab, rgba(24, 35, 58, 0.92), rgba(15, 23, 42, 0.82));
+  border-color: color-mix(in oklab, rgba(76, 94, 124, 0.38), rgba(15, 23, 42, 0.72));
+  box-shadow: 0 28px 48px -32px rgba(8, 13, 24, 0.6);
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-data-note,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-data-note {
+  color: color-mix(in oklab, rgba(203, 213, 225, 0.82), rgba(148, 163, 184, 0.68));
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-module-card,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-module-card {
+  background: color-mix(in oklab, rgba(20, 31, 52, 0.96), rgba(11, 17, 30, 0.92));
+  border-color: color-mix(in oklab, rgba(71, 85, 105, 0.32), rgba(15, 23, 42, 0.72));
+  box-shadow: 0 26px 44px -28px rgba(8, 13, 24, 0.7);
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-module-card--accent,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-module-card--accent {
+  background: color-mix(in oklab, rgba(37, 56, 112, 0.86), rgba(15, 23, 42, 0.78));
+  border-color: color-mix(in oklab, rgba(96, 123, 191, 0.45), rgba(15, 23, 42, 0.7));
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-module-card__icon,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-module-card__icon {
+  background: color-mix(in oklab, rgba(59, 130, 246, 0.42), rgba(15, 23, 42, 0.58));
+  color: #e2e8f0;
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-module-card__eyebrow,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-module-card__eyebrow {
+  color: color-mix(in oklab, rgba(203, 213, 225, 0.78), rgba(148, 163, 184, 0.6));
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-module-card__pitch,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-module-card__pitch,
+body.qr-landing.calhelp-theme.dark-mode .calhelp-module-card__list,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-module-card__list,
+body.qr-landing.calhelp-theme.dark-mode .calhelp-module-card__kpi,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-module-card__kpi {
+  color: color-mix(in oklab, rgba(226, 232, 240, 0.88), rgba(148, 163, 184, 0.48));
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-module-card__footer,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-module-card__footer {
+  border-top-color: color-mix(in oklab, rgba(96, 113, 141, 0.35), rgba(15, 23, 42, 0.7));
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-module-card__link,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-module-card__link {
+  color: color-mix(in oklab, rgba(125, 189, 255, 0.86), rgba(190, 227, 248, 0.68));
 }
 
 body.qr-landing.calhelp-theme.dark-mode .calhelp-section__header p,

--- a/templates/marketing/calhelp.twig
+++ b/templates/marketing/calhelp.twig
@@ -1,176 +1,17 @@
 {% extends 'layout.twig' %}
 
-{% set navGroups = [
-    {
-      'id': 'intro',
-      'title': 'Einstieg & Überblick',
-      'description': 'Die wichtigsten Abschnitte für Entscheider:innen und Projektleitungen.',
-      'items': [
-        {
-          'href': '#hero',
-          'label': 'Überblick',
-          'icon': 'home',
-          'summary': 'Story, Nutzen und erste Angebote im Schnelldurchlauf.',
-          'pane': {
-            'id': 'intro-overview',
-            'title': 'Warum calHelp starten?',
-            'text': 'Zeigt, wie calHelp Audits beruhigt, Verantwortlichkeiten klärt und allen Teams einen gemeinsamen Status gibt.',
-            'meta': 'Intro · Nutzenversprechen · Vertrauensanker'
-          }
-        },
-        {
-          'href': '#modules',
-          'label': 'Module',
-          'icon': 'grid',
-          'summary': 'Welche Module und Integrationen standardmäßig enthalten sind.',
-          'pane': {
-            'id': 'intro-modules',
-            'title': 'Module & Integrationen',
-            'text': 'Erklärt das Modul-Set – vom Messmittelkataster bis zu Freigabeflows – inklusive Anbindungen wie MET/TEAM.',
-            'meta': 'Module · Integrationen · Automationen'
-          }
-        },
-        {
-          'href': '#benefits',
-          'label': 'Ergebnisse',
-          'icon': 'star',
-          'summary': 'Kennzahlen und Effekte aus Projekten mit calHelp.',
-          'pane': {
-            'id': 'intro-benefits',
-            'title': 'Welche Ergebnisse erreichbar sind',
-            'text': 'Zeigt messbare Resultate wie Audit-Sicherheit, Prozessgeschwindigkeit und dokumentierte Entscheidungen.',
-            'meta': 'KPIs · Erfahrungswerte · Kennzahlen'
-          }
-        }
-      ]
-    },
-    {
-      'id': 'collaboration',
-      'title': 'Zusammenarbeit & Ablauf',
-      'description': 'Wie wir gemeinsam starten, migrieren und langfristig betreuen.',
-      'items': [
-        {
-          'href': '#fit',
-          'label': 'Passung',
-          'icon': 'users',
-          'summary': 'Abgleich mit Rollen, Verantwortlichkeiten und IT-Landschaft.',
-          'pane': {
-            'id': 'collaboration-fit',
-            'title': 'Passt calHelp zu unserem Setup?',
-            'text': 'Hilft einzuschätzen, wie calHelp in bestehende Teams, Prozesse und Compliance-Richtlinien eingebettet wird.',
-            'meta': 'Rollen · Governance · IT-Umfeld'
-          }
-        },
-        {
-          'href': '#process',
-          'label': 'Ablauf',
-          'icon': 'settings',
-          'summary': 'Projektfahrplan von Erstaufnahme bis Rollout.',
-          'pane': {
-            'id': 'collaboration-process',
-            'title': 'Projektstruktur & Migration',
-            'text': 'Beschreibt die Phasen – Analyse, Datenmigration, Guardband-Validierung und Übergabe an das Team.',
-            'meta': 'Projektphasen · Migration · Betreuung'
-          }
-        },
-        {
-          'href': '#conversation',
-          'label': 'Gespräch',
-          'icon': 'commenting',
-          'summary': 'Direktes Gespräch, Demo und Unterlagen anfordern.',
-          'pane': {
-            'id': 'collaboration-conversation',
-            'title': 'Live ins Gespräch gehen',
-            'text': 'Öffnet den direkten Kanal: Termin vereinbaren, Use Cases besprechen und individuelle Unterlagen erhalten.',
-            'meta': 'Termin · Demo · Unterlagen'
-          }
-        }
-      ]
-    },
-    {
-      'id': 'practice',
-      'title': 'Anwendung & Inhalte',
-      'description': 'Echte Szenarien, Services und laufende Unterstützung.',
-      'items': [
-        {
-          'href': '#usecases',
-          'label': 'Situationen',
-          'icon': 'file-text',
-          'summary': 'Praxisbeispiele aus Labor, Produktion und Service.',
-          'pane': {
-            'id': 'practice-usecases',
-            'title': 'Szenarien aus dem Betrieb',
-            'text': 'Zeigt, wie calHelp Guardbands dokumentiert, Audits vorbereitet und Datenflüsse verbindet.',
-            'meta': 'Branchen · Szenarien · Guardbands'
-          }
-        },
-        {
-          'href': '#help',
-          'label': 'Unterstützung',
-          'icon': 'lifesaver',
-          'summary': 'Servicepakete, Schulung und Wissenstransfer.',
-          'pane': {
-            'id': 'practice-help',
-            'title': 'Begleitung im Alltag',
-            'text': 'Erklärt, wie wir Teams onboarden, Support leisten und Wissen dauerhaft zugänglich machen.',
-            'meta': 'Onboarding · Support · Enablement'
-          }
-        },
-        {
-          'href': '#news',
-          'label': 'News',
-          'icon': 'rss',
-          'summary': 'Aktuelle Releases, Termine und Einblicke.',
-          'pane': {
-            'id': 'practice-news',
-            'title': 'Was es Neues gibt',
-            'text': 'Bündelt Produkt-Updates, Webinare und Events mit Bezug zu calHelp.',
-            'meta': 'Releases · Termine · Highlights'
-          }
-        }
-      ]
-    },
-    {
-      'id': 'contact',
-      'title': 'Antworten & Kontakt',
-      'description': 'Alle Informationen für Sicherheit, Compliance und nächste Schritte.',
-      'items': [
-        {
-          'href': '#faq',
-          'label': 'FAQ',
-          'icon': 'question',
-          'summary': 'Klärt Datenschutz, Hosting und Betrieb.',
-          'pane': {
-            'id': 'contact-faq',
-            'title': 'Häufige Fragen vorab klären',
-            'text': 'Fasst Antworten zu Sicherheit, Hosting in Deutschland und Verantwortlichkeiten zusammen.',
-            'meta': 'Compliance · Hosting · Betrieb'
-          }
-        },
-        {
-          'href': '#cta',
-          'label': 'Kontakt',
-          'icon': 'bolt',
-          'summary': 'Kontaktformular und Angebot starten.',
-          'pane': {
-            'id': 'contact-cta',
-            'title': 'Kontakt aufnehmen',
-            'text': 'Der schnellste Weg zu Angebot, Projektsteckbrief und konkretem Starttermin.',
-            'meta': 'Kontakt · Angebot · Nächste Schritte'
-          }
-        }
-      ]
-    }
+{% set links = [
+  { 'href': '#hero', 'label': 'Überblick', 'icon': 'home' },
+  { 'href': '#modules', 'label': 'Module', 'icon': 'grid' },
+  { 'href': '#fit', 'label': 'Passung', 'icon': 'users' },
+  { 'href': '#process', 'label': 'Ablauf', 'icon': 'settings' },
+  { 'href': '#usecases', 'label': 'Praxis', 'icon': 'file-text' },
+  { 'href': '#cases', 'label': 'Erfahrungen', 'icon': 'star' },
+  { 'href': '#proof', 'label': 'Nachweise', 'icon': 'shield' },
+  { 'href': '#news', 'label': 'News', 'icon': 'rss' },
+  { 'href': '#faq', 'label': 'FAQ', 'icon': 'question' },
+  { 'href': '#cta', 'label': 'Kontakt', 'icon': 'bolt' }
 ] %}
-
-{% set defaultExplain = '' %}
-{% set firstGroup = navGroups|first %}
-{% if firstGroup %}
-  {% set firstItem = firstGroup.items|first %}
-  {% if firstItem %}
-    {% set defaultExplain = firstItem.pane.id %}
-  {% endif %}
-{% endif %}
 
 {% block title %}{{ metaTitle|default('Umstieg auf ein zentrales Kalibrier-System – konsistent, nachvollziehbar, auditfähig') }}{% endblock %}
 
@@ -209,61 +50,14 @@
           </div>
         </div>
         <div class="uk-navbar-right">
-          <ul class="uk-navbar-nav uk-visible@m calhelp-mega-nav" data-calhelp-mega>
-            <li class="uk-parent calhelp-mega-nav__item">
-              <a href="#hero" class="calhelp-mega-nav__toggle" aria-haspopup="true" aria-expanded="false">
-                <span class="uk-margin-small-right" data-uk-icon="icon: menu"></span>
-                <span class="calhelp-mega-nav__label">Navigation</span>
-                <span class="calhelp-mega-nav__hint">Alle Bereiche</span>
-              </a>
-              <div class="uk-navbar-dropdown uk-padding-remove calhelp-mega-dropdown" data-uk-dropdown="mode: hover; pos: bottom-right; offset: 24; delay-hide: 120; animation: uk-animation-slide-top-small">
-                <div class="calhelp-mega" data-calhelp-mega-root data-calhelp-default="{{ defaultExplain }}">
-                  <div class="calhelp-mega__grid">
-                    {% for group in navGroups %}
-                      <section class="calhelp-mega__column">
-                        <header class="calhelp-mega__column-header">
-                          <h3 class="calhelp-mega__heading">{{ group.title }}</h3>
-                          <p class="calhelp-mega__description">{{ group.description }}</p>
-                        </header>
-                        <ul class="calhelp-mega__list">
-                          {% for item in group.items %}
-                            {% set isActive = loop.parent.first and loop.first %}
-                            <li class="calhelp-mega__item">
-                              <a href="{{ item.href }}"
-                                 class="calhelp-mega__link{% if isActive %} is-active{% endif %}"
-                                 data-calhelp-explain="{{ item.pane.id }}"
-                                 aria-controls="calhelp-pane-{{ item.pane.id }}"
-                                 aria-expanded="{{ isActive ? 'true' : 'false' }}">
-                                <span class="calhelp-mega__icon" aria-hidden="true" data-uk-icon="icon: {{ item.icon }}"></span>
-                                <span class="calhelp-mega__link-label">
-                                  {{ item.label }}
-                                  <span class="calhelp-mega__link-sub">{{ item.summary }}</span>
-                                </span>
-                              </a>
-                            </li>
-                          {% endfor %}
-                        </ul>
-                      </section>
-                    {% endfor %}
-                  </div>
-                  <div class="calhelp-mega__explain" aria-live="polite">
-                    {% for group in navGroups %}
-                      {% for item in group.items %}
-                        {% set paneActive = loop.parent.first and loop.first %}
-                        <article id="calhelp-pane-{{ item.pane.id }}"
-                                 class="calhelp-mega__pane{% if paneActive %} is-active{% endif %}"
-                                 data-calhelp-pane="{{ item.pane.id }}"
-                                 aria-hidden="{{ paneActive ? 'false' : 'true' }}">
-                          <h4 class="calhelp-mega__pane-title">{{ item.pane.title }}</h4>
-                          <p class="calhelp-mega__pane-text">{{ item.pane.text }}</p>
-                          <p class="calhelp-mega__pane-meta">{{ item.pane.meta }}</p>
-                        </article>
-                      {% endfor %}
-                    {% endfor %}
-                  </div>
-                </div>
-              </div>
-            </li>
+          <ul class="uk-navbar-nav uk-visible@m calhelp-nav">
+            {% for link in links %}
+              <li>
+                <a href="{{ link.href }}">
+                  <span class="uk-margin-small-right" data-uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+                </a>
+              </li>
+            {% endfor %}
           </ul>
           <div class="uk-navbar-item config-menu uk-inline">
             <button id="configMenuToggle"
@@ -361,25 +155,15 @@
       <div class="uk-offcanvas-bar calhelp-offcanvas">
         <button class="uk-offcanvas-close git-btn" type="button" data-uk-close aria-label="Menü schließen"></button>
         <div class="calhelp-offcanvas__inner">
-          {% for group in navGroups %}
-            <section class="calhelp-offcanvas__group">
-              <h3 class="calhelp-offcanvas__heading">{{ group.title }}</h3>
-              <p class="calhelp-offcanvas__description">{{ group.description }}</p>
-              <ul class="calhelp-offcanvas__list">
-                {% for item in group.items %}
-                  <li class="calhelp-offcanvas__item">
-                    <a href="{{ item.href }}" class="calhelp-offcanvas__link">
-                      <span class="calhelp-offcanvas__icon" aria-hidden="true" data-uk-icon="icon: {{ item.icon }}"></span>
-                      <span class="calhelp-offcanvas__label">
-                        {{ item.label }}
-                        <span class="calhelp-offcanvas__summary">{{ item.summary }}</span>
-                      </span>
-                    </a>
-                  </li>
-                {% endfor %}
-              </ul>
-            </section>
-          {% endfor %}
+          <ul class="uk-nav uk-nav-default calhelp-offcanvas__nav">
+            {% for link in links %}
+              <li>
+                <a href="{{ link.href }}">
+                  <span class="uk-margin-small-right" data-uk-icon="icon: {{ link.icon }}"></span>{{ link.label }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
         </div>
         <a class="uk-button uk-button-primary uk-width-1-1 uk-margin-top calhelp-offcanvas__cta" href="#cta">
           <span class="uk-margin-small-right" data-uk-icon="icon: commenting"></span>Gespräch starten
@@ -398,6 +182,7 @@
             <h1 class="qr-h1">Ein System. Klare Prozesse.</h1>
             <p class="qr-sub">Wir bringen Kalibrierdaten, Dokumente und Abläufe an einen Ort – <strong>übersichtlich, nachvollziehbar, auditfähig</strong>. Sie sagen, wo es hakt. Wir machen den Weg frei.</p>
             <p class="uk-text-lead">Wir ordnen, vereinfachen und belegen. So entsteht ein Arbeitsstand, den alle sehen und Audits sofort verstehen.</p>
+            <p class="calhelp-data-note">Hinweis: Inhalte wie Module, Use Cases und FAQs pflegen wir direkt über die calHelp Datenbank – das Layout hier sorgt lediglich für einen sauberen Rahmen.</p>
             <div class="uk-margin-medium-top uk-flex uk-flex-left uk-flex-wrap" style="gap:16px;">
               <a class="uk-button uk-button-primary" href="#cta">
                 <span class="uk-margin-small-right" data-uk-icon="icon: commenting"></span>Gespräch starten
@@ -409,7 +194,7 @@
             <p class="calhelp-trust">Ein Blick – und alle wissen, wo wir stehen.</p>
           </div>
           <div class="calhelp-hero-grid__media">
-            <div class="calhelp-hero-card uk-card uk-card-primary uk-card-primary--highlight uk-card-body">
+            <div class="calhelp-hero-card uk-card uk-card-default uk-card-body">
               <h2 class="uk-card-title">Warum calHelp?</h2>
               <ul class="uk-list uk-list-bullet hero-list">
                 <li>Wir schaffen Ruhe vor Audits und liefern Nachweise, die bestehen.</li>


### PR DESCRIPTION
## Summary
- replace the calHelp marketing navigation with a lean anchor list and matching offcanvas menu for a calmer layout
- clarify the hero copy with a database-maintained content notice and align the hero card visuals with the rest of the site
- refresh the module card styling to deliver a lighter presentation in both light and dark themes

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e558f3c7bc832b86aa6fb2a28ad964