### PR TITLE
Use admin landing news on calHelp page

### DIFF
--- a/templates/marketing/calhelp.twig
+++ b/templates/marketing/calhelp.twig
@@ -565,6 +565,21 @@
       {% set renderedContent = renderedContent|replace({'<div data-calhelp-usecases></div>': usecasesMarkup}) %}
     {% endif %}
 
+    {% set calhelpNewsPlaceholderActive = calhelpNewsPlaceholderActive|default(false) %}
+    {% set shouldRenderCalhelpNews = calhelpNewsPlaceholderActive or (landingNews is defined and landingNews) %}
+    {% if shouldRenderCalhelpNews %}
+      {% set calhelpNewsMarkup = include('marketing/partials/calhelp-news.twig', {
+        landingNews: landingNews|default([]),
+        landingNewsBasePath: landingNewsBasePath|default(null),
+        landingNewsIndexUrl: landingNewsIndexUrl|default(null)
+      }) %}
+      {% if calhelpNewsPlaceholderActive and calhelpNewsPlaceholder is defined and calhelpNewsPlaceholder %}
+        {% set renderedContent = renderedContent|replace({ (calhelpNewsPlaceholder): calhelpNewsMarkup }) %}
+      {% else %}
+        {% set renderedContent = renderedContent ~ calhelpNewsMarkup %}
+      {% endif %}
+    {% endif %}
+
     {{ renderedContent|raw }}
 
     <div id="marketing-chat-modal" class="uk-flex-top marketing-chat-modal" data-uk-modal>

--- a/templates/marketing/partials/calhelp-news-card.twig
+++ b/templates/marketing/partials/calhelp-news-card.twig
@@ -1,0 +1,44 @@
+{% set newsEntry = entry|default(null) %}
+{% if newsEntry %}
+  {% set icons = ['refresh', 'file-text', 'users', 'info', 'calendar'] %}
+  {% set iconIndex = index|default(0) %}
+  {% set icon = icons[iconIndex % (icons|length)] %}
+  {% set slug = newsEntry.slug|default('') %}
+  {% set titleId = slug ? 'news-' ~ slug ~ '-title' : 'news-entry-' ~ iconIndex ~ '-title' %}
+  {% set hasBasePath = landingNewsBasePath is defined and landingNewsBasePath %}
+  {% set detailPath = hasBasePath and slug ? landingNewsBasePath ~ '/' ~ slug : null %}
+  {% set linkHref = detailPath ? basePath ~ detailPath : null %}
+  {% set published = newsEntry.publishedAt|default(null) %}
+  {% set excerpt = newsEntry.excerpt|default(null) %}
+  {% if not excerpt %}
+    {% set rawContent = newsEntry.content|default('')|striptags|trim %}
+    {% if rawContent %}
+      {% set truncated = rawContent|slice(0, 220) %}
+      {% set excerpt = truncated ~ (rawContent|length > 220 ? '…' : '') %}
+      {% set excerpt = '<p>' ~ excerpt ~ '</p>' %}
+    {% endif %}
+  {% endif %}
+  <article class="uk-card uk-card-primary uk-card-body calhelp-card calhelp-news-card" aria-labelledby="{{ titleId }}" role="listitem">
+    <header class="calhelp-news-card__header">
+      <span class="calhelp-news-card__icon" aria-hidden="true" data-uk-icon="icon: {{ icon }}"></span>
+      <div>
+        {% if linkHref %}
+          <a class="uk-link-reset" href="{{ linkHref }}">
+            <h3 id="{{ titleId }}" class="uk-card-title">{{ newsEntry.title }}</h3>
+          </a>
+        {% else %}
+          <h3 id="{{ titleId }}" class="uk-card-title">{{ newsEntry.title }}</h3>
+        {% endif %}
+        {% if published %}
+          <p class="uk-text-meta">{{ published|date('d.m.Y') }}</p>
+        {% endif %}
+      </div>
+    </header>
+    {% if excerpt %}
+      <div class="calhelp-news-card__body">{{ excerpt|raw }}</div>
+    {% endif %}
+    {% if linkHref %}
+      <p class="uk-margin-top"><a class="uk-button uk-button-text" href="{{ linkHref }}">Weiterlesen</a></p>
+    {% endif %}
+  </article>
+{% endif %}

--- a/templates/marketing/partials/calhelp-news.twig
+++ b/templates/marketing/partials/calhelp-news.twig
@@ -1,0 +1,43 @@
+{% set entries = landingNews|default([]) %}
+<section id="news" class="uk-section calhelp-section" aria-labelledby="news-title">
+  <div class="uk-container">
+    <div class="calhelp-section__header">
+      <h2 id="news-title" class="uk-heading-medium">Aktuelles &amp; Fachbeiträge</h2>
+      <p class="uk-text-lead">Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.</p>
+    </div>
+    {% if entries %}
+      <div class="calhelp-news-grid" role="list">
+        {% for entry in entries %}
+          {% include 'marketing/partials/calhelp-news-card.twig' with {
+            entry: entry,
+            landingNewsBasePath: landingNewsBasePath|default(null),
+            index: loop.index0
+          } %}
+        {% endfor %}
+      </div>
+      {% if landingNewsIndexUrl is defined and landingNewsIndexUrl %}
+        <p class="uk-margin-medium-top uk-text-center">
+          <a class="uk-button uk-button-text" href="{{ landingNewsIndexUrl }}">Alle News</a>
+        </p>
+      {% endif %}
+    {% else %}
+      <p class="uk-text-lead uk-text-center uk-margin-large-bottom">Derzeit sind keine Beiträge veröffentlicht. Abonnieren Sie den Newsletter für Updates.</p>
+    {% endif %}
+    <aside class="calhelp-newsletter uk-card uk-card-primary uk-card-body uk-light" aria-label="Newsletter-Box">
+      <h3 class="uk-card-title">Newsletter</h3>
+      <p>„Kurz, nützlich, selten: Updates zu Migration, Reports &amp; Best Practices.“ (Double-Opt-In, freiwillig.)</p>
+      <a class="uk-button uk-button-default" href="#demo">Zum Demo-Flow</a>
+    </aside>
+    <section class="calhelp-editorial-calendar" aria-labelledby="calendar-title">
+      <h3 id="calendar-title">Redaktionskalender – 6 Wochen Ausblick</h3>
+      <ol class="uk-list uk-list-decimal">
+        <li>Woche 1: „Die 5 größten Stolperstellen bei MET/TRACK-Migrationen“ (Praxisbeitrag)</li>
+        <li>Woche 2: Changelog kompakt (Reports &amp; Konformitätslogik)</li>
+        <li>Woche 3: Use-Case-Spotlight (anonymisiert)</li>
+        <li>Woche 4: „Guardband in 5 Minuten – verständlich erklärt“</li>
+        <li>Woche 5: Praxisrezept „Validierung mit Golden Samples“</li>
+        <li>Woche 6: Roadmap-Ausblick + Mini-Q&amp;A (aus Newsletter-Fragen)</li>
+      </ol>
+    </section>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- replace the static calHelp news section with a placeholder so the marketing controller can inject admin-managed entries
- add Twig partials that render calHelp news cards and keep the newsletter plus editorial calendar layout using landing news data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e559378788832baeef769a962ca1a2