### PR TITLE
Align calhelp FAQ with calserver accordion layout

### DIFF
--- a/content/marketing/calhelp.html
+++ b/content/marketing/calhelp.html
@@ -1142,24 +1142,36 @@
     <div class="calhelp-section__header">
       <h2 id="faq-title" class="uk-heading-medium">FAQ – die typischen Fragen</h2>
     </div>
-    <dl class="calhelp-faq" aria-label="Häufig gestellte Fragen">
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Bleibt MET/TEAM nutzbar?</dt>
-        <dd>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und schrittweise.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Was wird übernommen?</dt>
-        <dd>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Wie sicher ist der Betrieb?</dt>
-        <dd>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutztext.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Wie lange dauert der Umstieg?</dt>
-        <dd>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</dd>
-      </div>
-    </dl>
+    <ul class="calhelp-faq" aria-label="Häufig gestellte Fragen" data-uk-accordion="multiple: true">
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">Bleibt MET/TEAM nutzbar?</a>
+        <div class="uk-accordion-content">
+          <p>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und schrittweise.</p>
+        </div>
+      </li>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">Was wird übernommen?</a>
+        <div class="uk-accordion-content">
+          <p>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</p>
+        </div>
+      </li>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">Wie sicher ist der Betrieb?</a>
+        <div class="uk-accordion-content">
+          <p>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutztext.</p>
+        </div>
+      </li>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">Wie lange dauert der Umstieg?</a>
+        <div class="uk-accordion-content">
+          <p>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</p>
+        </div>
+      </li>
+    </ul>
+    <div class="calhelp-faq__footer">
+      <span class="calhelp-faq__footer-hint">Noch nicht fündig geworden?</span>
+      <a class="calhelp-faq__footer-link" href="#conversation">Weitere Fragen → Gespräch</a>
+    </div>
   </div>
 </section>
 

--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -1853,8 +1853,7 @@ body.calhelp-proof-gallery--modal-open {
 }
 
 .calhelp-faq {
-  display: grid;
-  gap: 24px;
+  list-style: none;
   margin: 0;
   padding: 0;
 }
@@ -1863,14 +1862,52 @@ body.calhelp-proof-gallery--modal-open {
   margin: 0;
 }
 
-.calhelp-faq__item dt {
-  font-weight: 600;
-  margin-bottom: 8px;
+.calhelp-faq__item + .calhelp-faq__item {
+  margin-top: 16px;
 }
 
-.calhelp-faq__item dd {
-  margin: 0;
+.calhelp-faq__item .uk-accordion-title {
+  border-radius: 12px;
+  padding: 16px 24px;
+  background: color-mix(in oklab, var(--qr-landing-card-bg, #ffffff) 92%, rgba(15, 23, 42, 0.04));
+  color: var(--qr-landing-text);
+  font-weight: 600;
+}
+
+.calhelp-faq__item .uk-accordion-title::before {
+  color: inherit;
+}
+
+.calhelp-faq__item .uk-accordion-content {
+  border-radius: 0 0 12px 12px;
+  background: color-mix(in oklab, var(--qr-landing-card-bg, #ffffff) 96%, rgba(15, 23, 42, 0.02));
+  padding: 0 24px 16px;
+  color: color-mix(in oklab, var(--qr-landing-text) 80%, rgba(15, 23, 42, 0.45));
+}
+
+.calhelp-faq__item .uk-open > .uk-accordion-title {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.calhelp-faq__footer {
+  margin-top: 32px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
   color: color-mix(in oklab, var(--qr-landing-text) 72%, rgba(15, 23, 42, 0.45));
+}
+
+.calhelp-faq__footer-link {
+  font-weight: 600;
+  color: var(--qr-landing-text);
+}
+
+.calhelp-faq__footer-link:hover,
+.calhelp-faq__footer-link:focus {
+  color: var(--qr-landing-accent, #1e87f0);
 }
 
 .calhelp-cta {


### PR DESCRIPTION
## Summary
- update the calHelp FAQ section markup to use a UIkit accordion that mirrors the calServer layout and adds a follow-up contact hint
- adjust the calHelp stylesheet so the accordion items and footer adopt the landing theme styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e560b73484832b953f556e7a8eca5c