### PR TITLE
Convert Calhelp process stages to slider

### DIFF
--- a/content/marketing/calhelp.html
+++ b/content/marketing/calhelp.html
@@ -361,8 +361,9 @@
           </button>
         </li>
       </ol>
-      <div class="calhelp-process__stages">
-        <article id="process-step-readiness"
+      <div class="calhelp-process__stages" data-calhelp-slider>
+        <div class="calhelp-process__track" data-calhelp-slider-track>
+          <article id="process-step-readiness"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage calhelp-process__stage--active calhelp-process__stage--panel-open"
                  data-calhelp-step="readiness">
           <header class="calhelp-process__stage-header">
@@ -395,8 +396,8 @@
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Kick-off-Freigabe mit dokumentiertem Inventar und Risikoübersicht.</p>
           </div>
-        </article>
-        <article id="process-step-mapping"
+          </article>
+          <article id="process-step-mapping"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
                  data-calhelp-step="mapping">
           <header class="calhelp-process__stage-header">
@@ -429,8 +430,8 @@
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Fachlicher Review der Mapping-Dokumentation durch IT und Fachbereich.</p>
           </div>
-        </article>
-        <article id="process-step-pilot"
+          </article>
+          <article id="process-step-pilot"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
                  data-calhelp-step="pilot">
           <header class="calhelp-process__stage-header">
@@ -463,8 +464,8 @@
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Pilotabnahme mit höchstens 1&nbsp;% tolerierten Abweichungen.</p>
           </div>
-        </article>
-        <article id="process-step-cutover"
+          </article>
+          <article id="process-step-cutover"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
                  data-calhelp-step="cutover">
           <header class="calhelp-process__stage-header">
@@ -497,8 +498,8 @@
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Abschlussprotokoll ohne kritische Abweichungen.</p>
           </div>
-        </article>
-        <article id="process-step-golive"
+          </article>
+          <article id="process-step-golive"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
                  data-calhelp-step="golive">
           <header class="calhelp-process__stage-header">
@@ -531,7 +532,8 @@
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Betriebsfreigabe nach abgeschlossener Hypercare-Phase.</p>
           </div>
-        </article>
+          </article>
+        </div>
       </div>
       </div>
       <div class="calhelp-note uk-card uk-card-primary uk-card-body">

--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -903,13 +903,32 @@ body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-of
 }
 
 .calhelp-process__stages {
-  display: grid;
-  gap: 24px;
+  position: relative;
+  overflow: hidden;
+}
+
+.calhelp-process__track {
+  --calhelp-process-gap: 24px;
+  display: flex;
+  gap: var(--calhelp-process-gap);
+  width: 100%;
+  transform: translate3d(calc(-1 * (var(--calhelp-process-index, 0) * (100% + var(--calhelp-process-gap)))), 0, 0);
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .calhelp-process__stage {
   position: relative;
-  transition: box-shadow 0.25s ease, border-color 0.25s ease;
+  flex: 0 0 100%;
+  min-width: 0;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.45s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.calhelp-process__stage:focus-visible {
+  outline: 3px solid color-mix(in oklab, var(--calserver-primary) 60%, rgba(255, 255, 255, 0.2));
+  outline-offset: 4px;
 }
 
 .calhelp-process__stage-header > h3 {
@@ -922,6 +941,9 @@ body.qr-landing.calhelp-theme[data-theme='dark']:not(.high-contrast) .calhelp-of
 
 .calhelp-process__stage--active {
   box-shadow: 0 30px 60px -40px color-mix(in oklab, var(--calserver-primary) 80%, rgba(15, 23, 42, 0.8));
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .calhelp-process__toggle {
@@ -1994,6 +2016,23 @@ body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-process__nav-item.is-c
     transition-duration: 0.001ms !important;
     animation-duration: 0.001ms !important;
   }
+
+  .calhelp-process__stages {
+    overflow: visible;
+  }
+
+  .calhelp-process__track {
+    display: grid;
+    gap: 24px;
+    transform: none !important;
+  }
+
+  .calhelp-process__stage {
+    flex: none;
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 @media (max-width: 959px) {
@@ -2053,6 +2092,10 @@ body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-process__nav-item.is-c
     flex-direction: column;
     align-items: stretch;
     gap: 12px;
+  }
+
+  .calhelp-process__track {
+    --calhelp-process-gap: 16px;
   }
 
   .calhelp-process__nav-button {

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -458,6 +458,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const stages = Array.from(stepper.querySelectorAll('[data-calhelp-step]'));
     if (!stages.length) return;
 
+    const track = stepper.querySelector('[data-calhelp-slider-track]');
     const triggers = Array.from(stepper.querySelectorAll('[data-calhelp-step-trigger]'));
     const toggles = Array.from(stepper.querySelectorAll('[data-calhelp-step-toggle]'));
     const navItems = triggers.map((button) => button.closest('.calhelp-process__nav-item'));
@@ -466,6 +467,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let activeId = stepIds[0];
     let ignoreObserverUntil = 0;
+    let observer = null;
 
     const updateToggleLabel = (button, expanded) => {
       const label = button.querySelector('.calhelp-process__toggle-label');
@@ -505,7 +507,7 @@ document.addEventListener('DOMContentLoaded', () => {
       applyPanelState(button, !isExpanded);
     };
 
-    const setActive = (id, { force = false } = {}) => {
+    const setActive = (id, { force = false, focusStage = false } = {}) => {
       if (!id) return;
       const index = stepIds.indexOf(id);
       if (index === -1) return;
@@ -513,10 +515,34 @@ document.addEventListener('DOMContentLoaded', () => {
 
       activeId = id;
 
+      const isReducedMotion = prefersReducedMotion();
+      const hasSliderTrack = track instanceof HTMLElement;
+      const useSlider = hasSliderTrack && !isReducedMotion;
+
       stages.forEach((stage, stageIndex) => {
         const isActive = stageIndex === index;
         stage.classList.toggle('calhelp-process__stage--active', isActive);
+        if (useSlider) {
+          if (isActive) {
+            stage.removeAttribute('aria-hidden');
+            stage.setAttribute('tabindex', '-1');
+          } else {
+            stage.setAttribute('aria-hidden', 'true');
+            stage.removeAttribute('tabindex');
+          }
+        } else {
+          stage.removeAttribute('aria-hidden');
+          stage.removeAttribute('tabindex');
+        }
       });
+
+      if (hasSliderTrack) {
+        if (useSlider) {
+          track.style.setProperty('--calhelp-process-index', String(index));
+        } else {
+          track.style.removeProperty('--calhelp-process-index');
+        }
+      }
 
       triggers.forEach((trigger, triggerIndex) => {
         const isActive = triggerIndex === index;
@@ -540,33 +566,73 @@ document.addEventListener('DOMContentLoaded', () => {
         const shouldOpen = stage.dataset.calhelpStep === id;
         applyPanelState(toggle, shouldOpen);
       });
+
+      if (focusStage && useSlider) {
+        const targetStage = stages[index];
+        if (targetStage instanceof HTMLElement) {
+          requestAnimationFrame(() => {
+            targetStage.focus({ preventScroll: true });
+          });
+        }
+      }
     };
 
-    const observer = new IntersectionObserver((entries) => {
-      if (Date.now() < ignoreObserverUntil) return;
+    const enableObserver = () => {
+      if (observer || !prefersReducedMotion()) return;
+      observer = new IntersectionObserver((entries) => {
+        if (Date.now() < ignoreObserverUntil) return;
 
-      const visible = entries.filter((entry) => entry.isIntersecting);
-      if (!visible.length) return;
+        const visible = entries.filter((entry) => entry.isIntersecting);
+        if (!visible.length) return;
 
-      visible.sort((a, b) => {
-        const aIndex = stepIds.indexOf(a.target.dataset.calhelpStep || '');
-        const bIndex = stepIds.indexOf(b.target.dataset.calhelpStep || '');
-        return aIndex - bIndex;
+        visible.sort((a, b) => {
+          const aIndex = stepIds.indexOf(a.target.dataset.calhelpStep || '');
+          const bIndex = stepIds.indexOf(b.target.dataset.calhelpStep || '');
+          return aIndex - bIndex;
+        });
+
+        const candidate = visible[0];
+        const nextId = candidate.target.dataset.calhelpStep;
+        if (nextId) {
+          setActive(nextId);
+        }
+      }, {
+        rootMargin: '-40% 0px -40% 0px',
+        threshold: [0.25, 0.5, 0.75]
       });
 
-      const candidate = visible[0];
-      const id = candidate.target.dataset.calhelpStep;
-      if (id) {
-        setActive(id);
-      }
-    }, {
-      rootMargin: '-40% 0px -40% 0px',
-      threshold: [0.25, 0.5, 0.75]
-    });
+      stages.forEach((stage) => {
+        observer?.observe(stage);
+      });
+    };
 
-    stages.forEach((stage) => {
-      observer.observe(stage);
-    });
+    const disableObserver = () => {
+      if (!observer) return;
+      stages.forEach((stage) => {
+        observer?.unobserve(stage);
+      });
+      observer.disconnect();
+      observer = null;
+    };
+
+    const motionPreferenceChanged = () => {
+      if (prefersReducedMotion()) {
+        enableObserver();
+      } else {
+        disableObserver();
+      }
+      setActive(activeId, { force: true });
+    };
+
+    if (typeof reducedMotionQuery.addEventListener === 'function') {
+      reducedMotionQuery.addEventListener('change', motionPreferenceChanged);
+    } else if (typeof reducedMotionQuery.addListener === 'function') {
+      reducedMotionQuery.addListener(motionPreferenceChanged);
+    }
+
+    if (prefersReducedMotion()) {
+      enableObserver();
+    }
 
     triggers.forEach((trigger) => {
       trigger.addEventListener('click', (event) => {
@@ -575,13 +641,15 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!id) return;
 
         const stage = stages.find((item) => item.dataset.calhelpStep === id);
-        setActive(id, { force: true });
+        const isReducedMotion = prefersReducedMotion();
+        setActive(id, { force: true, focusStage: !isReducedMotion });
 
         ignoreObserverUntil = Date.now() + 600;
 
         if (stage) {
-          const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
-          stage.scrollIntoView({ behavior, block: 'start', inline: 'nearest' });
+          if (isReducedMotion) {
+            stage.scrollIntoView({ behavior: 'auto', block: 'start', inline: 'nearest' });
+          }
           const toggle = stage.querySelector('[data-calhelp-step-toggle]');
           if (toggle instanceof HTMLElement) {
             applyPanelState(toggle, true);


### PR DESCRIPTION
## Summary
- wrap the Calhelp process stage markup in a slider track container so the stepper can drive a single visible panel
- style the slider track and stages to hide inactive steps, add focus feedback, and provide reduced-motion/mobile fallbacks
- update the landing stepper script to sync the active step with the slider transform, preserve accessibility, and respect motion preferences

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e561ae6748832ba536f65b54bb5455