### PR TITLE
Switch calhelp FAQ to accordion layout

### DIFF
--- a/content/marketing/calhelp.html
+++ b/content/marketing/calhelp.html
@@ -1142,24 +1142,40 @@
     <div class="calhelp-section__header">
       <h2 id="faq-title" class="uk-heading-medium">FAQ – die typischen Fragen</h2>
     </div>
-    <dl class="calhelp-faq" aria-label="Häufig gestellte Fragen">
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Bleibt MET/TEAM nutzbar?</dt>
-        <dd>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und schrittweise.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Was wird übernommen?</dt>
-        <dd>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Wie sicher ist der Betrieb?</dt>
-        <dd>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutztext.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Wie lange dauert der Umstieg?</dt>
-        <dd>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</dd>
-      </div>
-    </dl>
+    <ul class="calhelp-faq uk-accordion" aria-label="Häufig gestellte Fragen" uk-accordion>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">
+          <span class="calhelp-faq__question">Bleibt MET/TEAM nutzbar?</span>
+        </a>
+        <div class="uk-accordion-content">
+          <p class="calhelp-faq__answer">Ja. Wir binden MET/TEAM oder bestehende Lösungen weiter an – remote steuerbar oder zur Datenübernahme. Eine vollständige Ablösung ist optional und kann Schritt für Schritt erfolgen.</p>
+        </div>
+      </li>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">
+          <span class="calhelp-faq__question">Was wird übernommen?</span>
+        </a>
+        <div class="uk-accordion-content">
+          <p class="calhelp-faq__answer">Geräte, Historien, Zertifikate/PDFs, Kund:innen und Standorte sowie benutzerdefinierte Felder – soweit technisch verfügbar. Alle Migrationen kommen mit Mapping-Report, Checksummen und Abweichungsprotokoll.</p>
+        </div>
+      </li>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">
+          <span class="calhelp-faq__question">Wie sicher ist der Betrieb?</span>
+        </a>
+        <div class="uk-accordion-content">
+          <p class="calhelp-faq__answer">Wir hosten in Deutschland oder On-Prem – mit Rollen- und Rechtemodell, Protokollierung und verschlüsselter Übertragung. DSGVO-Konformität inklusive transparentem Datenschutztext ist Bestandteil des Umfangs.</p>
+        </div>
+      </li>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">
+          <span class="calhelp-faq__question">Wie lange dauert der Umstieg?</span>
+        </a>
+        <div class="uk-accordion-content">
+          <p class="calhelp-faq__answer">Die Dauer hängt von Datenumfang und Komplexität ab. Nach dem Pilotlauf liefern wir einen belastbaren Zeitplan mit Meilensteinen für den Produktivbetrieb.</p>
+        </div>
+      </li>
+    </ul>
   </div>
 </section>
 

--- a/public/css/calhelp.css
+++ b/public/css/calhelp.css
@@ -1857,20 +1857,69 @@ body.calhelp-proof-gallery--modal-open {
   gap: 24px;
   margin: 0;
   padding: 0;
+  list-style: none;
 }
 
 .calhelp-faq__item {
+  list-style: none;
   margin: 0;
+  background: var(--calhelp-pane-surface);
+  border: 1px solid var(--calhelp-pane-border);
+  border-radius: 22px;
+  box-shadow: 0 36px 68px -44px color-mix(in oklab, var(--calserver-primary) 58%, rgba(15, 23, 42, 0.62));
+  overflow: hidden;
+  transition: box-shadow 0.3s ease, border-color 0.3s ease, background 0.3s ease;
 }
 
-.calhelp-faq__item dt {
+.calhelp-faq__item:hover,
+.calhelp-faq__item:focus-within {
+  border-color: color-mix(in oklab, var(--calserver-primary) 36%, var(--calhelp-pane-border));
+  box-shadow: 0 44px 78px -42px color-mix(in oklab, var(--calserver-primary) 68%, rgba(15, 23, 42, 0.58));
+}
+
+.calhelp-faq__item.uk-open {
+  background: color-mix(in oklab, var(--calserver-primary) 10%, var(--calhelp-pane-surface));
+}
+
+.calhelp-faq__item .uk-accordion-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 26px 32px;
   font-weight: 600;
-  margin-bottom: 8px;
+  font-size: 1.05rem;
+  color: inherit;
+  text-decoration: none;
 }
 
-.calhelp-faq__item dd {
-  margin: 0;
+.calhelp-faq__item .uk-accordion-title::before {
+  order: 2;
+  margin-left: 16px;
+  float: none;
+}
+
+.calhelp-faq__item .uk-accordion-title:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--calserver-primary) 72%, rgba(15, 23, 42, 0.68));
+  outline-offset: 4px;
+}
+
+.calhelp-faq__item .uk-accordion-content {
+  padding: 0 32px 28px;
+  border-top: 1px solid color-mix(in oklab, var(--calhelp-pane-border), rgba(15, 23, 42, 0.08));
+}
+
+.calhelp-faq__question {
+  flex: 1;
+}
+
+.calhelp-faq__answer {
+  margin: 18px 0 0;
   color: color-mix(in oklab, var(--qr-landing-text) 72%, rgba(15, 23, 42, 0.45));
+}
+
+.calhelp-faq__answer + .calhelp-faq__answer {
+  margin-top: 12px;
 }
 
 .calhelp-cta {
@@ -1898,6 +1947,28 @@ body.qr-landing.calhelp-theme[data-theme='dark'] .uk-section-muted,
 body.qr-landing.calhelp-theme.dark-mode.uk-section-muted,
 body.qr-landing.calhelp-theme[data-theme='dark'].uk-section-muted {
   background: color-mix(in oklab, #0b1220 94%, rgba(15, 23, 42, 0.88));
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-faq__item,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-faq__item {
+  background: color-mix(in oklab, rgba(26, 36, 58, 0.94), rgba(15, 23, 42, 0.82));
+  border-color: color-mix(in oklab, rgba(76, 97, 140, 0.42), rgba(15, 23, 42, 0.72));
+  box-shadow: 0 38px 72px -42px color-mix(in oklab, rgba(8, 13, 24, 0.78), rgba(38, 102, 210, 0.45));
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-faq__item.uk-open,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-faq__item.uk-open {
+  background: color-mix(in oklab, rgba(37, 58, 116, 0.54), rgba(15, 23, 42, 0.78));
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-faq__item .uk-accordion-content,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-faq__item .uk-accordion-content {
+  border-top-color: color-mix(in oklab, rgba(90, 117, 168, 0.35), rgba(15, 23, 42, 0.6));
+}
+
+body.qr-landing.calhelp-theme.dark-mode .calhelp-faq__answer,
+body.qr-landing.calhelp-theme[data-theme='dark'] .calhelp-faq__answer {
+  color: color-mix(in oklab, rgba(226, 232, 240, 0.9), rgba(148, 163, 184, 0.62));
 }
 
 body.qr-landing.calhelp-theme.dark-mode .calhelp-case-strip--muted,


### PR DESCRIPTION
## Summary
- replace the calhelp FAQ definition list with the shared UIkit accordion pattern
- refresh FAQ copy and extend the calhelp theme styles to cover the accordion in light and dark modes

## Testing
- python3 tests/test_html_validity.py

------
https://chatgpt.com/codex/tasks/task_e_68e561b1cfbc832b8a9d986ba3c3349b