### PR TITLE
Align SQLite calhelp seed with latest content

### DIFF
--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -2089,8 +2089,9 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
           </button>
         </li>
       </ol>
-      <div class="calhelp-process__stages">
-        <article id="process-step-readiness"
+      <div class="calhelp-process__stages" data-calhelp-slider>
+        <div class="calhelp-process__track" data-calhelp-slider-track>
+          <article id="process-step-readiness"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage calhelp-process__stage--active calhelp-process__stage--panel-open"
                  data-calhelp-step="readiness">
           <header class="calhelp-process__stage-header">
@@ -2123,8 +2124,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Kick-off-Freigabe mit dokumentiertem Inventar und Risikoübersicht.</p>
           </div>
-        </article>
-        <article id="process-step-mapping"
+          </article>
+          <article id="process-step-mapping"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
                  data-calhelp-step="mapping">
           <header class="calhelp-process__stage-header">
@@ -2157,8 +2158,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Fachlicher Review der Mapping-Dokumentation durch IT und Fachbereich.</p>
           </div>
-        </article>
-        <article id="process-step-pilot"
+          </article>
+          <article id="process-step-pilot"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
                  data-calhelp-step="pilot">
           <header class="calhelp-process__stage-header">
@@ -2191,8 +2192,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Pilotabnahme mit höchstens 1&nbsp;% tolerierten Abweichungen.</p>
           </div>
-        </article>
-        <article id="process-step-cutover"
+          </article>
+          <article id="process-step-cutover"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
                  data-calhelp-step="cutover">
           <header class="calhelp-process__stage-header">
@@ -2225,8 +2226,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Abschlussprotokoll ohne kritische Abweichungen.</p>
           </div>
-        </article>
-        <article id="process-step-golive"
+          </article>
+          <article id="process-step-golive"
                  class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
                  data-calhelp-step="golive">
           <header class="calhelp-process__stage-header">
@@ -2259,7 +2260,8 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
             </ul>
             <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Betriebsfreigabe nach abgeschlossener Hypercare-Phase.</p>
           </div>
-        </article>
+          </article>
+        </div>
       </div>
       </div>
       <div class="calhelp-note uk-card uk-card-primary uk-card-body">
@@ -2649,131 +2651,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
         <p>Betrieb in Deutschland oder On-Prem, Zugriffe rollenbasiert, Backups verschlüsselt.</p>
       </article>
     </div>
-    <details class="calhelp-proof-details">
-      <summary class="calhelp-proof-details__summary">Details für Technik &amp; IT</summary>
-      {% set assurancePanels = [
-      {
-        id: ''cloud-de'',
-        title: ''Cloud DE'',
-        icon: ''cloud'',
-        facts: [
-          {
-            icon: ''cloud'',
-            badge: { icon: ''location'', label: ''Software hosted in Germany'' },
-            text: ''ISO 27001- und BSI C5-geprüfte Rechenzentren mit redundanten Standorten in Frankfurt & Berlin.''
-          },
-          {
-            icon: ''server'',
-            text: ''24/7-Monitoring mit Alarmierung & Incident-Response in &le; 15 Minuten.''
-          },
-          {
-            icon: ''lock'',
-            text: ''Backups verschlüsselt (AES-256) gespeichert und täglich auf Integrität geprüft.''
-          }
-        ],
-        hint: ''Zugriff kann auf Wunsch per IP-Allowlist oder mandantenbezogener VPN-Anbindung zusätzlich abgesichert werden.''
-      },
-      {
-        id: ''on-prem'',
-        title: ''On-Prem'',
-        icon: ''database'',
-        facts: [
-          {
-            icon: ''bolt'',
-            badge: { icon: ''bolt'', label: ''Setup in &le; 4 Stunden'' },
-            text: ''Installationspaket für Windows Server & Linux inkl. automatischer Preflight-Checks.''
-          },
-          {
-            icon: ''database'',
-            text: ''PostgreSQL oder SQL Server, optional im Cluster mit Failover-Testprotokoll.''
-          },
-          {
-            icon: ''refresh'',
-            text: ''Signierte Update-Pakete mit Rollback-Plan und Dokumentation der Änderungen.''
-          }
-        ],
-        hint: ''Konfigurations-Playbooks (Ansible/PowerShell) erleichtern das Patch-Management und erlauben reproduzierbare Deployments.''
-      },
-      {
-        id: ''dsgvo'',
-        title: ''DSGVO'',
-        icon: ''shield'',
-        facts: [
-          {
-            icon: ''file-text'',
-            badge: { icon: ''file-text'', label: ''AV-Vertrag & TOMs'' },
-            text: ''Aktualisierte ADV inklusive Technischer & Organisatorischer Maßnahmen, unterschriftsreif in Deutsch/Englisch.''
-          },
-          {
-            icon: ''history'',
-            text: ''Protokollierte Datenflüsse und Verarbeitungstätigkeiten für Auskunfts- & Löschbegehren.''
-          },
-          {
-            icon: ''trash'',
-            text: ''Konfigurierbare Aufbewahrungsfristen mit revisionssicherer Löschbestätigung.''
-          }
-        ],
-        hint: ''Auf Wunsch liefern wir ein Muster für Datenschutz-Folgenabschätzungen und Schnittstellen für Betroffenenanfragen (REST).''
-      },
-      {
-        id: ''rollen-protokolle'',
-        title: ''Rollen &amp; Protokolle'',
-        icon: ''users'',
-        facts: [
-          {
-            icon: ''users'',
-            badge: { icon: ''users'', label: ''5+ Rollen vorkonfiguriert'' },
-            text: ''Feingranulare Berechtigungen für Labor, QS, IT, Service und externe Partner.''
-          },
-          {
-            icon: ''file-text'',
-            text: ''Objektbezogener Audit-Trail (wer/was/wann) mit Export nach CSV oder SIEM.''
-          },
-          {
-            icon: ''key'',
-            text: ''SSO-Anbindung via SAML/OIDC inklusive SCIM-Provisioning & Gruppen-Mapping.''
-          }
-        ],
-        hint: ''Webhook- und Syslog-Forwarder ermöglichen das Streaming der Audit-Logs an bestehende SIEM-Lösungen.''
-      }
-    ] %}
-      <div class="calhelp-assurance" aria-labelledby="proof-accordion-title">
-        <h3 id="proof-accordion-title" class="calhelp-assurance__title">Trust Center – Details für IT &amp; Qualitätsmanagement</h3>
-        <p class="calhelp-assurance__intro">Vier Schwerpunktbereiche zeigen, wie calHelp Cloud, On-Premises und Compliance sicher umsetzt – inklusive konkreter IT-Hinweise.</p>
-        <ul class="uk-accordion calhelp-assurance__accordion" uk-accordion="multiple: true">
-          {% for panel in assurancePanels %}
-            <li class="calhelp-assurance__item">
-              <a class="uk-accordion-title" href="#proof-{{ panel.id }}">
-                <span class="calhelp-assurance__title-icon" aria-hidden="true" data-uk-icon="icon: {{ panel.icon }}"></span>
-                <span>{{ panel.title }}</span>
-              </a>
-              <div class="uk-accordion-content" id="proof-{{ panel.id }}">
-                <ul class="calhelp-assurance__facts" role="list">
-                  {% for fact in panel.facts %}
-                    <li class="calhelp-assurance__fact">
-                      <span class="calhelp-assurance__fact-icon" aria-hidden="true" data-uk-icon="icon: {{ fact.icon|default(''check'') }}"></span>
-                      <div class="calhelp-assurance__fact-body">
-                        {% if fact.badge is defined %}
-                          <span class="calhelp-assurance__badge">
-                            <span class="calhelp-assurance__badge-icon" aria-hidden="true" data-uk-icon="icon: {{ fact.badge.icon|default(''check'') }}"></span>
-                            <span>{{ fact.badge.label }}</span>
-                          </span>
-                        {% endif %}
-                        <p class="calhelp-assurance__fact-text">{{ fact.text }}</p>
-                      </div>
-                    </li>
-                  {% endfor %}
-                </ul>
-                <p class="calhelp-assurance__hint">
-                  <span class="calhelp-assurance__hint-icon" aria-hidden="true" data-uk-icon="icon: info"></span>
-                  <span class="calhelp-assurance__hint-text"><strong>IT-Hinweis:</strong> {{ panel.hint }}</span>
-                </p>
-              </div>
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-    </details>
+    <div data-calhelp-assurance></div>
     <div data-calhelp-proof-gallery></div>
     <div class="calhelp-kpi uk-card uk-card-primary uk-card-body">
       <p class="uk-margin-remove">Weniger Schleifen, mehr Ergebnisse – begleitet von 15+ Jahren Projekterfahrung.</p>
@@ -2804,82 +2682,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
   </div>
 </section>
 
-<section id="cases" class="uk-section calhelp-section" aria-labelledby="cases-title">
-  <div class="uk-container">
-    <div class="calhelp-section__header">
-      <h2 id="cases-title" class="uk-heading-medium">{{ ''calhelp_cases_title''|trans }}</h2>
-      <p class="uk-text-lead">{{ ''calhelp_cases_subtitle''|trans }}</p>
-    </div>
-    {% set caseStories = [
-      {
-        id: ''lab-story'',
-        icon: ''server'',
-        labelKey: ''calhelp_cases_lab_label'',
-        quoteKey: ''calhelp_cases_lab_quote'',
-        sentencesKeys: [
-          ''calhelp_cases_lab_sentence_1'',
-          ''calhelp_cases_lab_sentence_2'',
-          ''calhelp_cases_lab_sentence_3'',
-          ''calhelp_cases_lab_sentence_4'',
-          ''calhelp_cases_lab_sentence_5''
-        ]
-      },
-      {
-        id: ''service-story'',
-        icon: ''users'',
-        labelKey: ''calhelp_cases_service_label'',
-        quoteKey: ''calhelp_cases_service_quote'',
-        sentencesKeys: [
-          ''calhelp_cases_service_sentence_1'',
-          ''calhelp_cases_service_sentence_2'',
-          ''calhelp_cases_service_sentence_3'',
-          ''calhelp_cases_service_sentence_4'',
-          ''calhelp_cases_service_sentence_5''
-        ]
-      },
-      {
-        id: ''manufacturing-story'',
-        icon: ''world'',
-        labelKey: ''calhelp_cases_manufacturing_label'',
-        quoteKey: ''calhelp_cases_manufacturing_quote'',
-        sentencesKeys: [
-          ''calhelp_cases_manufacturing_sentence_1'',
-          ''calhelp_cases_manufacturing_sentence_2'',
-          ''calhelp_cases_manufacturing_sentence_3'',
-          ''calhelp_cases_manufacturing_sentence_4'',
-          ''calhelp_cases_manufacturing_sentence_5''
-        ]
-      }
-    ] %}
-    <div class="calhelp-cases" role="list">
-      {% for case in caseStories %}
-        {% set toneClass = cycle([''calhelp-case-strip--primary'', ''calhelp-case-strip--muted''], loop.index0) %}
-        <article class="calhelp-case-strip {{ toneClass }}" role="listitem" id="{{ case.id }}">
-          <header class="calhelp-case-strip__header">
-            {% if case.logo is defined %}
-              <figure class="calhelp-case-strip__media" aria-hidden="true">
-                <img src="{{ case.logo }}" alt="" loading="lazy">
-              </figure>
-            {% elseif case.icon is defined %}
-              <span class="calhelp-case-strip__icon" aria-hidden="true" data-uk-icon="icon: {{ case.icon }}"></span>
-            {% endif %}
-            <div class="calhelp-case-strip__meta">
-              <p class="calhelp-case-strip__label">{{ case.labelKey|trans }}</p>
-              <p class="calhelp-case-strip__quote">{{ case.quoteKey|trans }}</p>
-            </div>
-          </header>
-          <div class="calhelp-case-strip__body">
-            <ol class="calhelp-case-strip__story">
-              {% for sentenceKey in case.sentencesKeys %}
-                <li>{{ sentenceKey|trans }}</li>
-              {% endfor %}
-            </ol>
-          </div>
-        </article>
-      {% endfor %}
-    </div>
-  </div>
-</section>
+<div data-calhelp-cases></div>
 
 <section id="conversation" class="uk-section calhelp-section" aria-labelledby="conversation-title">
   <div class="uk-container">
@@ -3069,24 +2872,36 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
     <div class="calhelp-section__header">
       <h2 id="faq-title" class="uk-heading-medium">FAQ – die typischen Fragen</h2>
     </div>
-    <dl class="calhelp-faq" aria-label="Häufig gestellte Fragen">
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Bleibt MET/TEAM nutzbar?</dt>
-        <dd>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und schrittweise.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Was wird übernommen?</dt>
-        <dd>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Wie sicher ist der Betrieb?</dt>
-        <dd>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutztext.</dd>
-      </div>
-      <div class="uk-card uk-card-primary uk-card-body calhelp-faq__item">
-        <dt>Wie lange dauert der Umstieg?</dt>
-        <dd>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</dd>
-      </div>
-    </dl>
+    <ul class="uk-accordion calhelp-faq" aria-label="Häufig gestellte Fragen" uk-accordion="multiple: true">
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">Bleibt MET/TEAM nutzbar?</a>
+        <div class="uk-accordion-content">
+          <p>Ja. Bestehende Lösungen können angebunden bleiben (Fernsteuerung/Befüllen). Eine Ablösung ist optional und kann schrittweise erfolgen.</p>
+        </div>
+      </li>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">Was wird übernommen?</a>
+        <div class="uk-accordion-content">
+          <p>Geräte, Historien, Zertifikate/PDFs, Kund:innen/Standorte, benutzerdefinierte Felder – soweit technisch verfügbar. Alles mit Mapping-Report und Abweichungsprotokoll.</p>
+        </div>
+      </li>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">Wie sicher ist der Betrieb?</a>
+        <div class="uk-accordion-content">
+          <p>Hosting in Deutschland oder On-Prem, Rollen/Rechte, Protokollierung. DSGVO-konform – inkl. transparentem Datenschutzhinweis.</p>
+        </div>
+      </li>
+      <li class="calhelp-faq__item">
+        <a class="uk-accordion-title" href="#">Wie lange dauert der Umstieg?</a>
+        <div class="uk-accordion-content">
+          <p>Abhängig von Datenumfang und Komplexität. Der Pilot liefert einen belastbaren Zeitplan für den Produktivlauf.</p>
+        </div>
+      </li>
+    </ul>
+    <div class="calhelp-faq__footer">
+      <span class="calhelp-faq__footer-hint">Noch nicht fündig geworden?</span>
+      <a class="calhelp-faq__footer-link" href="#conversation">Weitere Fragen → Gespräch</a>
+    </div>
   </div>
 </section>
 
@@ -3094,17 +2909,60 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
   <div class="uk-container">
     <div class="calhelp-section__header">
       <h2 id="cta-title" class="uk-heading-medium">Der nächste Schritt ist klein – die Wirkung groß.</h2>
-      <p class="uk-text-lead">Starten Sie mit einem Gespräch oder lassen Sie uns Ihre Lage klären. Wir liefern eine greifbare Empfehlung.</p>
+      <p class="uk-text-lead">Schicken Sie uns ein kurzes Briefing. Wir melden uns persönlich und schlagen den passenden Einstieg vor.</p>
     </div>
-    <div class="calhelp-cta__actions" role="group" aria-label="Abschluss-CTAs">
-      <a class="uk-button uk-button-primary" href="#conversation">Gespräch starten</a>
-      <a class="uk-button uk-button-default" href="#help">Lage klären</a>
-    </div>
-    <div class="calhelp-note uk-card uk-card-primary uk-card-body">
-      <p class="uk-margin-remove">Wir speichern nur, was für Rückmeldung und Terminfindung nötig ist. Details: <a href="{{ basePath }}/datenschutz">Datenschutz</a>.</p>
+    <div class="uk-grid uk-child-width-1-2@m uk-grid-large uk-flex-top" uk-grid>
+      <div>
+        <form id="contact-form"
+              class="uk-form-stacked uk-width-large uk-margin-auto"
+              data-contact-endpoint="{{ basePath }}/calhelp/contact">
+          <div class="uk-margin">
+            <label class="uk-form-label" for="form-name">Ihr Name</label>
+            <input class="uk-input" id="form-name" name="name" type="text" required>
+          </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="form-email">E-Mail</label>
+            <input class="uk-input" id="form-email" name="email" type="email" required>
+          </div>
+          <div class="uk-margin">
+            <label class="uk-form-label" for="form-msg">Worum geht es?</label>
+            <textarea class="uk-textarea" id="form-msg" name="message" rows="5" required></textarea>
+          </div>
+          <div class="uk-margin turnstile-field" data-turnstile-container>
+            <div class="turnstile-widget">{{ turnstile_widget }}</div>
+            <p class="uk-text-small turnstile-hint" data-turnstile-hint hidden>Bitte bestätigen Sie, dass Sie kein Roboter sind.</p>
+          </div>
+          <div class="uk-margin">
+            <label><input class="uk-checkbox" name="privacy" type="checkbox" required> Ich stimme der Speicherung meiner Daten zur Bearbeitung zu.</label>
+          </div>
+          <input type="text" name="company" autocomplete="off" tabindex="-1" class="uk-hidden" aria-hidden="true">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+          <button class="btn btn-black uk-button uk-button-secondary uk-button-large uk-width-1-1" type="submit">Senden</button>
+        </form>
+      </div>
+      <div>
+        <div class="uk-card uk-card-default uk-card-body uk-text-left calhelp-cta__panel">
+          <p class="uk-text-large uk-margin-remove">Direkt einsteigen?</p>
+          <p class="uk-margin-small-top">Sie bevorzugen ein Gespräch oder möchten ein konkretes Szenario prüfen? Nutzen Sie die Schnellzugriffe.</p>
+          <div class="calhelp-cta__actions uk-margin-medium-top" role="group" aria-label="Abschluss-CTAs">
+            <a class="uk-button uk-button-primary uk-width-1-1" href="#conversation">Gespräch starten</a>
+            <a class="uk-button uk-button-default uk-width-1-1" href="#help">Lage klären</a>
+          </div>
+        </div>
+        <div class="calhelp-note uk-card uk-card-primary uk-card-body uk-margin-top">
+          <p class="uk-margin-remove">Wir speichern nur, was für Rückmeldung und Terminfindung nötig ist. Details: <a href="{{ basePath }}/datenschutz">Datenschutz</a>.</p>
+        </div>
+      </div>
     </div>
   </div>
 </section>
+
+<div id="contact-modal" uk-modal>
+  <div class="uk-modal-dialog uk-modal-body">
+    <p id="contact-modal-message" aria-live="polite"></p>
+    <button class="uk-button uk-button-primary uk-modal-close" type="button">OK</button>
+  </div>
+</div>
 
 <section id="seo" class="uk-section uk-section-muted calhelp-section" aria-labelledby="seo-title">
   <div class="uk-container">
@@ -3117,5 +2975,6 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
       <p><strong>Open-Graph-Hinweis:</strong> „Gespräch starten – wir ordnen, vereinfachen, belegen.“</p>
     </div>
   </div>
-</section>'
+</section>
+'
 );


### PR DESCRIPTION
## Summary
- refresh the SQLite calhelp page seed with the latest HTML content and placeholders
- ensure module, assurance, use case, FAQ, and CTA sections match the production marketing copy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e557f17748832b9bb7e7857fba6896