### PR TITLE
Reduce padding on calServer pricing cards

### DIFF
--- a/public/css/calserver.css
+++ b/public/css/calserver.css
@@ -1398,6 +1398,7 @@ body.qr-landing.calserver-theme .calserver-pricing-card {
     flex-direction: column;
     gap: 16px;
     height: 100%;
+    padding: clamp(24px, 3vw, 32px);
 }
 
 body.qr-landing.calserver-theme .calserver-pricing-card .uk-list {


### PR DESCRIPTION
## Summary
- decrease the padding applied to calServer pricing cards to tighten the layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e583b46014832ba50a985f86b16e1c