### PR TITLE
Fix newsletter label for calServer opt-in

### DIFF
--- a/src/Controller/Marketing/MarketingPageController.php
+++ b/src/Controller/Marketing/MarketingPageController.php
@@ -326,7 +326,7 @@ class MarketingPageController
 
         $newsletterMarkup = <<<'HTML'
           <div class="uk-margin">
-            <label><input class="uk-checkbox" type="checkbox" name="newsletter_subscribe" value="1"> Ich möchte den QuizRace Newsletter erhalten.</label>
+            <label><input class="uk-checkbox" type="checkbox" name="newsletter_subscribe" value="1"> Ich möchte den calServer Newsletter erhalten.</label>
           </div>
         HTML;
 


### PR DESCRIPTION
## Summary
- update the marketing contact form newsletter opt-in text to reference the calServer newsletter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e584cc3c34832bbbf0db3bb7e108a2