### PR TITLE
Restore calServer module videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 - Add migration for sticker text toggles
 - Normalize spacing before EOF docblocks
 
+### Fix
+
+- Restore calServer module videos on the marketing page
+
 ### Ci
 
 - Rebase changelog updates before push

--- a/migrations/20251127_restore_calserver_module_videos.sql
+++ b/migrations/20251127_restore_calserver_module_videos.sql
@@ -1,0 +1,294 @@
+-- Restore calServer module videos after placeholder fallback
+-- Ensures module sections use <video> elements with MP4 sources for both locales
+
+UPDATE pages
+SET content = REPLACE(
+    REPLACE(
+        REPLACE(
+            REPLACE(
+                REPLACE(
+                    REPLACE(
+                        REPLACE(
+                            REPLACE(content,
+                                $$                    <div class="calserver-module-figure__visual"
+                         data-module="device-management"
+                         role="img"
+                         aria-label="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
+                      <span class="calserver-module-figure__visual-label" aria-hidden="true">
+                        Geräteverwaltung &amp; Historie
+                      </span>
+                    </div>$$,
+                                $$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-device-management.webp"
+                           aria-label="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
+                      <source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+                                $$                    <div class="calserver-module-figure__visual"
+                         data-module="calendar-resources"
+                         role="img"
+                         aria-label="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
+                      <span class="calserver-module-figure__visual-label" aria-hidden="true">
+                        Kalender &amp; Ressourcen
+                      </span>
+                    </div>$$,
+                                $$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
+                           aria-label="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
+                      <source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+                        $$                    <div class="calserver-module-figure__visual"
+                         data-module="order-ticketing"
+                         role="img"
+                         aria-label="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
+                      <span class="calserver-module-figure__visual-label" aria-hidden="true">
+                        Auftrags- &amp; Ticketverwaltung
+                      </span>
+                    </div>$$,
+                        $$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
+                           aria-label="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
+                      <source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+                    $$                    <div class="calserver-module-figure__visual"
+                         data-module="self-service"
+                         role="img"
+                         aria-label="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
+                      <span class="calserver-module-figure__visual-label" aria-hidden="true">
+                        Self-Service &amp; Extranet
+                      </span>
+                    </div>$$,
+                    $$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-self-service.webp"
+                           aria-label="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
+                      <source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+                $$                    <img src="{{ basePath }}/uploads/calserver-module-device-management.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">$$,
+                $$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-device-management.webp"
+                           aria-label="Screenshot der calServer-Geräteverwaltung mit Geräteakte, Historie und Messwerten">
+                      <source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+            $$                    <img src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">$$,
+            $$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"
+                           aria-label="Screenshot des calServer-Kalenders mit Ressourcen- und Terminplanung">
+                      <source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+        $$                    <img src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">$$,
+        $$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"
+                           aria-label="Screenshot der calServer-Auftrags- und Ticketverwaltung mit Workflow-Status">
+                      <source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+    $$                    <img src="{{ basePath }}/uploads/calserver-module-self-service.webp"
+                         width="1200"
+                         height="675"
+                         loading="lazy"
+                         decoding="async"
+                         alt="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">$$,
+    $$                    <video class="calserver-module-figure__video"
+                           width="1200"
+                           height="675"
+                           autoplay
+                           muted
+                           loop
+                           playsinline
+                           preload="auto"
+                           poster="{{ basePath }}/uploads/calserver-module-self-service.webp"
+                           aria-label="Screenshot des calServer-Self-Service-Portals mit Kundenansicht und Zertifikaten">
+                      <source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4">
+                      Ihr Browser unterstützt keine HTML5-Videos.
+                      <a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">
+                        Video herunterladen
+                      </a>.
+                    </video>$$),
+    updated_at = CURRENT_TIMESTAMP
+WHERE slug = 'calserver';
+
+UPDATE pages
+SET content = REPLACE(
+    REPLACE(
+        REPLACE(
+            REPLACE(
+                REPLACE(
+                    REPLACE(
+                        REPLACE(
+                            REPLACE(content,
+                                $$<div aria-label="Screenshot of the calServer device management with device files, history and measured values"
+     class="calserver-module-figure__visual"
+     data-module="device-management"
+     role="img">
+  <span aria-hidden="true" class="calserver-module-figure__visual-label">Device management &amp; history</span>
+</div>$$,
+                                $$<video aria-label="Screenshot of the calServer device management with device files, history and measured values" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-device-management.webp">
+<source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+                                $$<div aria-label="Screenshot of the calServer calendar with resource and scheduling"
+     class="calserver-module-figure__visual"
+     data-module="calendar-resources"
+     role="img">
+  <span aria-hidden="true" class="calserver-module-figure__visual-label">Calendar &amp; resources</span>
+</div>$$,
+                                $$<video aria-label="Screenshot of the calServer calendar with resource and scheduling" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp">
+<source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+                        $$<div aria-label="Screenshot of the calServer mandate and ticket management with workflow status"
+     class="calserver-module-figure__visual"
+     data-module="order-ticketing"
+     role="img">
+  <span aria-hidden="true" class="calserver-module-figure__visual-label">Order &amp; ticket management</span>
+</div>$$,
+                        $$<video aria-label="Screenshot of the calServer mandate and ticket management with workflow status" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp">
+<source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+                    $$<div aria-label="Screenshot of the calServer self-service portal with customer view and certificates"
+     class="calserver-module-figure__visual"
+     data-module="self-service"
+     role="img">
+  <span aria-hidden="true" class="calserver-module-figure__visual-label">Self-service &amp; extranet</span>
+</div>$$,
+                    $$<video aria-label="Screenshot of the calServer self-service portal with customer view and certificates" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-self-service.webp">
+<source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+                $$<img alt="Screenshot of the calServer device management with device files, history and measured values" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-device-management.webp" width="1200"/>$$,
+                $$<video aria-label="Screenshot of the calServer device management with device files, history and measured values" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-device-management.webp">
+<source src="{{ basePath }}/uploads/calserver-module-device-management.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-device-management.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+            $$<img alt="Screenshot of the calServer calendar with resource and scheduling" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-calendar-resources.webp" width="1200"/>$$,
+            $$<video aria-label="Screenshot of the calServer calendar with resource and scheduling" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp">
+<source src="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+        $$<img alt="Screenshot of the calServer mandate and ticket management with workflow status" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-order-ticketing.webp" width="1200"/>$$,
+        $$<video aria-label="Screenshot of the calServer mandate and ticket management with workflow status" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp">
+<source src="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+    $$<img alt="Screenshot of the calServer self-service portal with customer view and certificates" decoding="async" height="675" loading="lazy" src="{{ basePath }}/uploads/calserver-module-self-service.webp" width="1200"/>$$,
+    $$<video aria-label="Screenshot of the calServer self-service portal with customer view and certificates" class="calserver-module-figure__video" width="1200" height="675" autoplay muted loop playsinline preload="auto" poster="{{ basePath }}/uploads/calserver-module-self-service.webp">
+<source src="{{ basePath }}/uploads/calserver-module-self-service.mp4" type="video/mp4"/>
+Your browser does not support HTML5 video.
+<a href="{{ basePath }}/uploads/calserver-module-self-service.mp4" target="_blank" rel="noopener">Download video</a>.
+</video>$$),
+    updated_at = CURRENT_TIMESTAMP
+WHERE slug = 'calserver-en';
+
+UPDATE pages
+SET content = REPLACE(
+    REPLACE(
+        REPLACE(
+            REPLACE(content,
+                'poster="{{ basePath }}/uploads/calserver-module-device-management.mp4"',
+                'poster="{{ basePath }}/uploads/calserver-module-device-management.webp"'),
+            'poster="{{ basePath }}/uploads/calserver-module-calendar-resources.mp4"',
+            'poster="{{ basePath }}/uploads/calserver-module-calendar-resources.webp"'),
+        'poster="{{ basePath }}/uploads/calserver-module-order-ticketing.mp4"',
+        'poster="{{ basePath }}/uploads/calserver-module-order-ticketing.webp"'),
+    'poster="{{ basePath }}/uploads/calserver-module-self-service.mp4"',
+    'poster="{{ basePath }}/uploads/calserver-module-self-service.webp"'),
+    updated_at = CURRENT_TIMESTAMP
+WHERE slug IN ('calserver', 'calserver-en');


### PR DESCRIPTION
## Summary
- replace the calServer module placeholders with looping video embeds in both locales
- normalise the poster attributes back to the preview images so browsers show the animation
- document the marketing page fix in the changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e634410134832b8af6d656a3f1513a