### PR TITLE
Align calHelp SQLite seed with new markup

### DIFF
--- a/src/Infrastructure/Migrations/sqlite-schema.sql
+++ b/src/Infrastructure/Migrations/sqlite-schema.sql
@@ -1726,320 +1726,92 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
 INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
     'calhelp',
     'calHelp',
-    '
-<section id="fit" class="uk-section calhelp-section" aria-labelledby="fit-title">
+    '<section id="solutions" class="uk-section calhelp-section" aria-labelledby="solutions-title">
   <div class="uk-container">
     <div class="calhelp-section__header">
-      <h2 id="fit-title" class="uk-heading-medium">Woran merken Sie, dass wir die Richtigen sind?</h2>
-      <p class="uk-text-lead">Drei Signale zeigen, dass unser Einstieg passt.</p>
+      <h2 id="solutions-title" class="uk-heading-medium">Erkennen Sie sich wieder?</h2>
+      <p class="uk-text-lead">Drei Alltagssituationen zeigen, warum Teams zu calHelp wechseln – und was danach besser läuft.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="fit-audit-title">
-        <h3 id="fit-audit-title" class="uk-card-title">Sie wollen Ruhe vor Audits.</h3>
-        <p>Wir liefern Nachweise, die bestehen – ohne Schleifen und Sonderläufe.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="solutions-double-title">
+        <h3 id="solutions-double-title" class="uk-card-title">Doppelte Erfassung</h3>
+        <p class="uk-text-small uk-text-muted">„Excel, E-Mails, Ordner?“</p>
+        <p>Ein Arbeitsstand statt fünf Ablagen.</p>
       </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="fit-double-title">
-        <h3 id="fit-double-title" class="uk-card-title">Sie wollen weniger Doppelerfassung.</h3>
-        <p>Wir verbinden, was zusammengehört, damit Daten nur einmal gepflegt werden.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="solutions-audit-title">
+        <h3 id="solutions-audit-title" class="uk-card-title">Audit-Druck</h3>
+        <p class="uk-text-small uk-text-muted">„Nachweise jagen?“</p>
+        <p>Checkliste, Diffs &amp; Historie an einem Ort.</p>
       </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="fit-clarity-title">
-        <h3 id="fit-clarity-title" class="uk-card-title">Sie wollen Klarheit im Alltag.</h3>
-        <p>Wir machen Rollen sichtbar, Termine greifbar und Fortschritt belegbar.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="solutions-approval-title">
+        <h3 id="solutions-approval-title" class="uk-card-title">Unklare Freigaben</h3>
+        <p class="uk-text-small uk-text-muted">„Wer gibt was frei?“</p>
+        <p>Geführte Workflows, klare Verantwortung.</p>
       </article>
+    </div>
+    <div class="uk-margin-large-top">
+      <h3 class="uk-heading-bullet">So helfen wir</h3>
+      <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
+        <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="solutions-organise-title">
+          <h4 id="solutions-organise-title" class="uk-card-title">Ordnen</h4>
+          <p>Wir schaffen Überblick – Daten &amp; Rollen an einem Ort.</p>
+        </article>
+        <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="solutions-simplify-title">
+          <h4 id="solutions-simplify-title" class="uk-card-title">Vereinfachen</h4>
+          <p>Weg mit Doppelarbeiten, hin zu klaren Wegen.</p>
+        </article>
+        <article class="uk-card uk-card-default uk-card-body calhelp-card" aria-labelledby="solutions-prove-title">
+          <h4 id="solutions-prove-title" class="uk-card-title">Belegen</h4>
+          <p>Nachweise, die beim ersten Mal bestehen.</p>
+        </article>
+      </div>
     </div>
   </div>
 </section>
 
-<section id="benefits" class="uk-section uk-section-muted calhelp-section" aria-labelledby="benefits-title">
+<section id="approach" class="uk-section calhelp-section" aria-labelledby="approach-title">
   <div class="uk-container">
     <div class="calhelp-section__header">
-      <h2 id="benefits-title" class="uk-heading-medium">Was ändert sich für Sie – ganz konkret?</h2>
-      <p class="uk-text-lead">Ergebnisse, die Ihr Team sofort spürt.</p>
+      <h2 id="approach-title" class="uk-heading-medium">Vorgehen – verständlich und belastbar</h2>
+      <p class="uk-text-lead">Verstehen → Ordnen → Umsetzen. Schlanke Schritte, sichtbare Ergebnisse.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="benefit-focus-title">
-        <h3 id="benefit-focus-title" class="uk-card-title">Weniger Suchen, mehr Schaffen.</h3>
-        <p>Ein zentraler Arbeitsstand ersetzt verstreute Ordner und Excel-Listen.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="approach-understand-title">
+        <h3 id="approach-understand-title" class="uk-card-title">Verstehen</h3>
+        <p>In 30–45 Minuten klären wir Zielbild, Beteiligte und Stolpersteine.</p>
       </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="benefit-approval-title">
-        <h3 id="benefit-approval-title" class="uk-card-title">Ein Freigabeweg, den alle verstehen.</h3>
-        <p>Verantwortliche sehen Fristen, Status und Nachweise auf einen Blick.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="approach-structure-title">
+        <h3 id="approach-structure-title" class="uk-card-title">Ordnen</h3>
+        <p>Wir sortieren Daten, Rollen und Verantwortungen – zuerst dort, wo es sofort entlastet.</p>
       </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="benefit-cert-title">
-        <h3 id="benefit-cert-title" class="uk-card-title">Zertifikate, die beim ersten Mal passen.</h3>
-        <p>Vorlagen, Prüfpfade und Kommentare bleiben nachvollziehbar dokumentiert.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="approach-deliver-title">
+        <h3 id="approach-deliver-title" class="uk-card-title">Umsetzen</h3>
+        <p>Wir liefern den ersten belastbaren Nachweis und zeigen, wie der Alltag damit leichter läuft.</p>
       </article>
     </div>
+    <p class="uk-text-small uk-margin-medium-top">Technische Checklisten und KPIs finden Sie im <a href="#knowledge">Trust-Center</a>.</p>
   </div>
 </section>
 
-<section id="process" class="uk-section calhelp-section" aria-labelledby="process-title">
+<section id="results" class="uk-section uk-section-muted calhelp-section" aria-labelledby="results-title">
   <div class="uk-container">
     <div class="calhelp-section__header">
-      <h2 id="process-title" class="uk-heading-medium">So kommen wir ins Laufen – ohne großes Projekt</h2>
-      <p class="uk-text-lead">Wir sprechen, ordnen und setzen gemeinsam um – Schritt für Schritt belegbar.</p>
-    </div>
-    <ol class="uk-list calhelp-process-summary">
-      <li><strong>Verstehen.</strong> In 30–45 Minuten klären wir Zielbild, Beteiligte und Stolpersteine.</li>
-      <li><strong>Ordnen.</strong> Wir richten das Nötige zuerst: Daten dort, wo sie gebraucht werden.</li>
-      <li><strong>Umsetzen.</strong> Wir zeigen den Weg zum ersten belastbaren Nachweis – und gehen ihn mit Ihnen.</li>
-    </ol>
-    <details class="calhelp-process-details">
-      <summary class="calhelp-process-details__summary">Details für Technik &amp; IT</summary>
-      <div class="calhelp-process" data-calhelp-stepper>
-      <ol class="calhelp-process__nav" aria-label="Migrationsprozess in fünf Schritten">
-        <li class="calhelp-process__nav-item is-active">
-          <button type="button"
-                  class="calhelp-process__nav-button"
-                  data-calhelp-step-trigger="readiness"
-                  aria-controls="process-step-readiness"
-                  aria-current="step">
-            <span class="calhelp-process__nav-index" aria-hidden="true">1</span>
-            <span class="calhelp-process__nav-label">Readiness-Check</span>
-          </button>
-          <span class="calhelp-process__nav-connector" aria-hidden="true"></span>
-        </li>
-        <li class="calhelp-process__nav-item">
-          <button type="button"
-                  class="calhelp-process__nav-button"
-                  data-calhelp-step-trigger="mapping"
-                  aria-controls="process-step-mapping">
-            <span class="calhelp-process__nav-index" aria-hidden="true">2</span>
-            <span class="calhelp-process__nav-label">Mapping &amp; Regeln</span>
-          </button>
-          <span class="calhelp-process__nav-connector" aria-hidden="true"></span>
-        </li>
-        <li class="calhelp-process__nav-item">
-          <button type="button"
-                  class="calhelp-process__nav-button"
-                  data-calhelp-step-trigger="pilot"
-                  aria-controls="process-step-pilot">
-            <span class="calhelp-process__nav-index" aria-hidden="true">3</span>
-            <span class="calhelp-process__nav-label">Pilot &amp; Validierung</span>
-          </button>
-          <span class="calhelp-process__nav-connector" aria-hidden="true"></span>
-        </li>
-        <li class="calhelp-process__nav-item">
-          <button type="button"
-                  class="calhelp-process__nav-button"
-                  data-calhelp-step-trigger="cutover"
-                  aria-controls="process-step-cutover">
-            <span class="calhelp-process__nav-index" aria-hidden="true">4</span>
-            <span class="calhelp-process__nav-label">Delta-Sync &amp; Cutover</span>
-          </button>
-          <span class="calhelp-process__nav-connector" aria-hidden="true"></span>
-        </li>
-        <li class="calhelp-process__nav-item">
-          <button type="button"
-                  class="calhelp-process__nav-button"
-                  data-calhelp-step-trigger="golive"
-                  aria-controls="process-step-golive">
-            <span class="calhelp-process__nav-index" aria-hidden="true">5</span>
-            <span class="calhelp-process__nav-label">Go-Live &amp; Monitoring</span>
-          </button>
-        </li>
-      </ol>
-      <div class="calhelp-process__stages" data-calhelp-slider>
-        <div class="calhelp-process__track" data-calhelp-slider-track>
-          <article id="process-step-readiness"
-                 class="uk-card uk-card-primary uk-card-body calhelp-process__stage calhelp-process__stage--active calhelp-process__stage--panel-open"
-                 data-calhelp-step="readiness">
-          <header class="calhelp-process__stage-header">
-            <h3>Readiness-Check</h3>
-            <p>Systeminventar, Datenumfang, Besonderheiten (z. B. Anhänge, benutzerdefinierte Felder).</p>
-          </header>
-          <button type="button"
-                  class="calhelp-process__toggle"
-                  data-calhelp-step-toggle
-                  aria-expanded="true"
-                  aria-controls="process-panel-readiness">
-            <span class="calhelp-process__toggle-label"
-                  data-calhelp-i18n
-                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
-                  data-i18n-en="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
-                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
-                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
-            <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
-          </button>
-          <div id="process-panel-readiness"
-               class="calhelp-process__panel is-open"
-               data-calhelp-step-panel>
-            <h4>Was liefern wir</h4>
-            <ul class="uk-list uk-list-bullet">
-              <li>Vollständiges Systeminventar mit Datenumfang und Quellen.</li>
-              <li>Dokumentation von Anhängen, Sonderfeldern und Compliance-Vorgaben.</li>
-              <li>Abgestimmter Projektplan inklusive Rollen und Risikobewertung.</li>
-            </ul>
-            <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Kick-off-Freigabe mit dokumentiertem Inventar und Risikoübersicht.</p>
-          </div>
-          </article>
-          <article id="process-step-mapping"
-                 class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
-                 data-calhelp-step="mapping">
-          <header class="calhelp-process__stage-header">
-            <h3>Mapping &amp; Regeln</h3>
-            <p>Felder, SI-Präfixe, Status/Workflows, Rollen. Transparent dokumentiert.</p>
-          </header>
-          <button type="button"
-                  class="calhelp-process__toggle"
-                  data-calhelp-step-toggle
-                  aria-expanded="true"
-                  aria-controls="process-panel-mapping">
-            <span class="calhelp-process__toggle-label"
-                  data-calhelp-i18n
-                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
-                  data-i18n-en="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
-                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
-                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
-            <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
-          </button>
-          <div id="process-panel-mapping"
-               class="calhelp-process__panel"
-               data-calhelp-step-panel>
-            <h4>Was liefern wir</h4>
-            <ul class="uk-list uk-list-bullet">
-              <li>Mapping-Dokumentation für Felder, Einheiten und Statuslogiken.</li>
-              <li>Rollen- und Workflow-Matrix mit Verantwortlichkeiten.</li>
-              <li>Blueprint der Validierungs- und Prüfregeln.</li>
-            </ul>
-            <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Fachlicher Review der Mapping-Dokumentation durch IT und Fachbereich.</p>
-          </div>
-          </article>
-          <article id="process-step-pilot"
-                 class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
-                 data-calhelp-step="pilot">
-          <header class="calhelp-process__stage-header">
-            <h3>Pilot &amp; Validierung</h3>
-            <p>Teilmenge (Golden Samples), Checksummen, Abweichungsbericht. Freigabe als Gate.</p>
-          </header>
-          <button type="button"
-                  class="calhelp-process__toggle"
-                  data-calhelp-step-toggle
-                  aria-expanded="true"
-                  aria-controls="process-panel-pilot">
-            <span class="calhelp-process__toggle-label"
-                  data-calhelp-i18n
-                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
-                  data-i18n-en="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
-                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
-                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
-            <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
-          </button>
-          <div id="process-panel-pilot"
-               class="calhelp-process__panel"
-               data-calhelp-step-panel>
-            <h4>Was liefern wir</h4>
-            <ul class="uk-list uk-list-bullet">
-              <li>Golden-Sample-Datensätze im Zielsystem.</li>
-              <li>Checksummen- und Diff-Reports mit Kommentaren.</li>
-              <li>Abweichungsprotokoll inklusive Freigabeempfehlung.</li>
-            </ul>
-            <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Pilotabnahme mit höchstens 1&nbsp;% tolerierten Abweichungen.</p>
-          </div>
-          </article>
-          <article id="process-step-cutover"
-                 class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
-                 data-calhelp-step="cutover">
-          <header class="calhelp-process__stage-header">
-            <h3>Delta-Sync &amp; Cutover</h3>
-            <p>Downtime-arm, sauber geplantes Übergabefenster, klarer Abnahmelauf.</p>
-          </header>
-          <button type="button"
-                  class="calhelp-process__toggle"
-                  data-calhelp-step-toggle
-                  aria-expanded="true"
-                  aria-controls="process-panel-cutover">
-            <span class="calhelp-process__toggle-label"
-                  data-calhelp-i18n
-                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
-                  data-i18n-en="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
-                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
-                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
-            <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
-          </button>
-          <div id="process-panel-cutover"
-               class="calhelp-process__panel"
-               data-calhelp-step-panel>
-            <h4>Was liefern wir</h4>
-            <ul class="uk-list uk-list-bullet">
-              <li>Cutover-Playbook mit Zeitplan und Verantwortlichkeiten.</li>
-              <li>Automatisierte Delta-Migration inklusive Validierung.</li>
-              <li>Kommunikationspaket für Stakeholder und Hotline.</li>
-            </ul>
-            <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Abschlussprotokoll ohne kritische Abweichungen.</p>
-          </div>
-          </article>
-          <article id="process-step-golive"
-                 class="uk-card uk-card-primary uk-card-body calhelp-process__stage"
-                 data-calhelp-step="golive">
-          <header class="calhelp-process__stage-header">
-            <h3>Go-Live &amp; Monitoring</h3>
-            <p>KPIs, Protokolle, Hypercare-Phase. Stabil in den Betrieb überführt.</p>
-          </header>
-          <button type="button"
-                  class="calhelp-process__toggle"
-                  data-calhelp-step-toggle
-                  aria-expanded="true"
-                  aria-controls="process-panel-golive">
-            <span class="calhelp-process__toggle-label"
-                  data-calhelp-i18n
-                  data-i18n-de="Leistungen &amp; Abnahme ausblenden"
-                  data-i18n-en="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-de-expanded="Leistungen &amp; Abnahme ausblenden"
-                  data-calhelp-toggle-label-de-collapsed="Leistungen &amp; Abnahme anzeigen"
-                  data-calhelp-toggle-label-en-expanded="Hide deliverables &amp; acceptance"
-                  data-calhelp-toggle-label-en-collapsed="Show deliverables &amp; acceptance">Leistungen &amp; Abnahme ausblenden</span>
-            <span class="calhelp-process__toggle-icon" aria-hidden="true"></span>
-          </button>
-          <div id="process-panel-golive"
-               class="calhelp-process__panel"
-               data-calhelp-step-panel>
-            <h4>Was liefern wir</h4>
-            <ul class="uk-list uk-list-bullet">
-              <li>KPI-Dashboard und Monitoring-Checks.</li>
-              <li>Hypercare- und Supportplan für die ersten Wochen.</li>
-              <li>Wissensübergabe samt Trainingsunterlagen.</li>
-            </ul>
-            <p class="calhelp-process__criteria"><span>Abnahmekriterium:</span> Betriebsfreigabe nach abgeschlossener Hypercare-Phase.</p>
-          </div>
-          </article>
-        </div>
-      </div>
-      </div>
-      <div class="calhelp-note uk-card uk-card-primary uk-card-body">
-        <p class="uk-margin-remove">Abnahmekriterien sind vorab definiert (z. B. ≥ 99,5 % korrekte Migration, 0 kritische Abweichungen, Report-Abnahme mit Musterdaten).</p>
-      </div>
-    </details>
-  </div>
-</section>
-
-<section id="comparison" class="uk-section uk-section-muted calhelp-section" aria-labelledby="comparison-title">
-  <div class="uk-container">
-    <div class="calhelp-section__header">
-      <h2 id="comparison-title"
+      <h2 id="results-title"
           class="uk-heading-medium"
           data-calhelp-i18n
-          data-i18n-de="Alltag vorher vs. nachher"
-          data-i18n-en="Everyday work before vs. after">Alltag vorher vs. nachher</h2>
+          data-i18n-de="Vorher vs. Nachher – Wirkung auf einen Blick"
+          data-i18n-en="Before vs. after – impact at a glance">Vorher vs. Nachher – Wirkung auf einen Blick</h2>
       <p data-calhelp-i18n
-         data-i18n-de="Wie calHelp Abläufe verändert – drei Beispiele aus dem Betrieb."
-         data-i18n-en="How calHelp changes operations – three real-world examples.">Wie calHelp Abläufe verändert – drei Beispiele aus dem Betrieb.</p>
+         data-i18n-de="Suchzeit −35 %, Freigabe-Runden halbiert, Audit-Ordner in 1 Tag."
+         data-i18n-en="Search time −35%, approval loops halved, audit pack ready in 1 day.">Suchzeit −35 %, Freigabe-Runden halbiert, Audit-Ordner in 1 Tag.</p>
     </div>
     <div class="calhelp-comparison" data-calhelp-comparison>
       <article class="uk-card uk-card-primary uk-card-body calhelp-comparison__card"
-               aria-labelledby="comparison-card-data-title"
+               aria-labelledby="results-card-data-title"
                data-calhelp-comparison-card="data"
                data-calhelp-comparison-default="after">
         <header class="calhelp-comparison__header">
-          <p id="comparison-card-data-title"
+          <p id="results-card-data-title"
              class="calhelp-comparison__eyebrow"
              data-calhelp-i18n
              data-i18n-de="Datenpflege"
@@ -2055,7 +1827,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     class="calhelp-comparison__toggle"
                     data-comparison-toggle="before"
                     aria-pressed="false"
-                    aria-controls="comparison-card-data-before"
+                    aria-controls="results-card-data-before"
                     data-calhelp-i18n
                     data-i18n-de="Vorher"
                     data-i18n-en="Before">Vorher</button>
@@ -2063,21 +1835,21 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     class="calhelp-comparison__toggle"
                     data-comparison-toggle="after"
                     aria-pressed="true"
-                    aria-controls="comparison-card-data-after"
+                    aria-controls="results-card-data-after"
                     data-calhelp-i18n
                     data-i18n-de="Nachher"
                     data-i18n-en="After">Nachher</button>
           </div>
         </header>
         <div class="calhelp-comparison__body" aria-live="polite">
-          <div id="comparison-card-data-before"
+          <div id="results-card-data-before"
                class="calhelp-comparison__state"
                data-comparison-state="before"
                aria-hidden="true"
                hidden>
             <p data-calhelp-i18n
-               data-i18n-de="Stammdaten in Excel, lokale Ablagen, Absprachen per E-Mail. Jede Korrektur kostet Zeit und erzeugt neue Versionen."
-               data-i18n-en="Master data lives in Excel and local folders, coordination happens via email. Every correction costs time and spawns another version.">Stammdaten in Excel, lokale Ablagen, Absprachen per E-Mail. Jede Korrektur kostet Zeit und erzeugt neue Versionen.</p>
+               data-i18n-de="Stammdaten in Excel, lokale Ordner, Abstimmung per E-Mail – jeder korrigiert für sich."
+               data-i18n-en="Master data in Excel, local folders, coordination via email – everyone fixes things alone.">Stammdaten in Excel, lokale Ordner, Abstimmung per E-Mail – jeder korrigiert für sich.</p>
             <dl class="calhelp-comparison__metrics">
               <div class="calhelp-comparison__metric">
                 <dt data-calhelp-i18n
@@ -2097,12 +1869,12 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
               </div>
             </dl>
           </div>
-          <div id="comparison-card-data-after"
+          <div id="results-card-data-after"
                class="calhelp-comparison__state is-active"
                data-comparison-state="after">
             <p data-calhelp-i18n
-               data-i18n-de="Zentrale Stammdaten mit Validierungsregeln, Änderungen mit Pflichtfeldern dokumentiert. Teams pflegen direkt im System."
-               data-i18n-en="Central master data with validation rules, required fields document every change. Teams maintain records directly in the platform.">Zentrale Stammdaten mit Validierungsregeln, Änderungen mit Pflichtfeldern dokumentiert. Teams pflegen direkt im System.</p>
+               data-i18n-de="Ein gemeinsamer Datenstand mit Plausibilitätsregeln – Änderungen sind nachvollziehbar."
+               data-i18n-en="One shared data baseline with simple rules – every change stays traceable.">Ein gemeinsamer Datenstand mit Plausibilitätsregeln – Änderungen sind nachvollziehbar.</p>
             <dl class="calhelp-comparison__metrics">
               <div class="calhelp-comparison__metric">
                 <dt data-calhelp-i18n
@@ -2125,11 +1897,11 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
         </div>
       </article>
       <article class="uk-card uk-card-primary uk-card-body calhelp-comparison__card"
-               aria-labelledby="comparison-card-approval-title"
+               aria-labelledby="results-card-approval-title"
                data-calhelp-comparison-card="approval"
                data-calhelp-comparison-default="after">
         <header class="calhelp-comparison__header">
-          <p id="comparison-card-approval-title"
+          <p id="results-card-approval-title"
              class="calhelp-comparison__eyebrow"
              data-calhelp-i18n
              data-i18n-de="Report-Freigabe"
@@ -2145,7 +1917,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     class="calhelp-comparison__toggle"
                     data-comparison-toggle="before"
                     aria-pressed="false"
-                    aria-controls="comparison-card-approval-before"
+                    aria-controls="results-card-approval-before"
                     data-calhelp-i18n
                     data-i18n-de="Vorher"
                     data-i18n-en="Before">Vorher</button>
@@ -2153,21 +1925,21 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     class="calhelp-comparison__toggle"
                     data-comparison-toggle="after"
                     aria-pressed="true"
-                    aria-controls="comparison-card-approval-after"
+                    aria-controls="results-card-approval-after"
                     data-calhelp-i18n
                     data-i18n-de="Nachher"
                     data-i18n-en="After">Nachher</button>
           </div>
         </header>
         <div class="calhelp-comparison__body" aria-live="polite">
-          <div id="comparison-card-approval-before"
+          <div id="results-card-approval-before"
                class="calhelp-comparison__state"
                data-comparison-state="before"
                aria-hidden="true"
                hidden>
             <p data-calhelp-i18n
-               data-i18n-de="Freigaben per E-Mail oder Excel, unklare Versionen, jedes Audit verlangt Nachfragen. Feedbackschleifen dauern Tage."
-               data-i18n-en="Approvals travel via email or Excel, versions stay unclear and every audit triggers follow-up questions. Review loops take days.">Freigaben per E-Mail oder Excel, unklare Versionen, jedes Audit verlangt Nachfragen. Feedbackschleifen dauern Tage.</p>
+               data-i18n-de="Freigaben wandern per E-Mail, Versionen bleiben unklar, Rückfragen ziehen sich."
+               data-i18n-en="Approvals travel via email, versions stay unclear and follow-ups drag on.">Freigaben wandern per E-Mail, Versionen bleiben unklar, Rückfragen ziehen sich.</p>
             <dl class="calhelp-comparison__metrics">
               <div class="calhelp-comparison__metric">
                 <dt data-calhelp-i18n
@@ -2187,12 +1959,12 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
               </div>
             </dl>
           </div>
-          <div id="comparison-card-approval-after"
+          <div id="results-card-approval-after"
                class="calhelp-comparison__state is-active"
                data-comparison-state="after">
             <p data-calhelp-i18n
-               data-i18n-de="Geführte Freigaben mit Rollen, Versionskontrolle und Pflichtkommentaren. Signaturen landen automatisch im Audit-Trail."
-               data-i18n-en="Guided approvals with roles, version control and required comments. Sign-offs land automatically in the audit trail.">Geführte Freigaben mit Rollen, Versionskontrolle und Pflichtkommentaren. Signaturen landen automatisch im Audit-Trail.</p>
+               data-i18n-de="Geführte Freigaben mit Rollen, Kommentaren und Signaturen im Audit-Trail."
+               data-i18n-en="Guided approvals with roles, comments and signatures captured in the audit trail.">Geführte Freigaben mit Rollen, Kommentaren und Signaturen im Audit-Trail.</p>
             <dl class="calhelp-comparison__metrics">
               <div class="calhelp-comparison__metric">
                 <dt data-calhelp-i18n
@@ -2215,11 +1987,11 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
         </div>
       </article>
       <article class="uk-card uk-card-primary uk-card-body calhelp-comparison__card"
-               aria-labelledby="comparison-card-audit-title"
+               aria-labelledby="results-card-audit-title"
                data-calhelp-comparison-card="audit"
                data-calhelp-comparison-default="after">
         <header class="calhelp-comparison__header">
-          <p id="comparison-card-audit-title"
+          <p id="results-card-audit-title"
              class="calhelp-comparison__eyebrow"
              data-calhelp-i18n
              data-i18n-de="Audit-Vorbereitung"
@@ -2235,7 +2007,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     class="calhelp-comparison__toggle"
                     data-comparison-toggle="before"
                     aria-pressed="false"
-                    aria-controls="comparison-card-audit-before"
+                    aria-controls="results-card-audit-before"
                     data-calhelp-i18n
                     data-i18n-de="Vorher"
                     data-i18n-en="Before">Vorher</button>
@@ -2243,62 +2015,62 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
                     class="calhelp-comparison__toggle"
                     data-comparison-toggle="after"
                     aria-pressed="true"
-                    aria-controls="comparison-card-audit-after"
+                    aria-controls="results-card-audit-after"
                     data-calhelp-i18n
                     data-i18n-de="Nachher"
                     data-i18n-en="After">Nachher</button>
           </div>
         </header>
         <div class="calhelp-comparison__body" aria-live="polite">
-          <div id="comparison-card-audit-before"
+          <div id="results-card-audit-before"
                class="calhelp-comparison__state"
                data-comparison-state="before"
                aria-hidden="true"
                hidden>
             <p data-calhelp-i18n
-               data-i18n-de="Nachweise liegen in Ordnern, Checklisten werden händisch gepflegt. Vor Audits werden Dokumente gesucht und Medien abgeglichen."
-               data-i18n-en="Evidence lives in folders, checklists stay manual. Before an audit the team hunts documents and reconciles media files.">Nachweise liegen in Ordnern, Checklisten werden händisch gepflegt. Vor Audits werden Dokumente gesucht und Medien abgeglichen.</p>
+               data-i18n-de="Checklisten, PDFs und Kommentare liegen verstreut – der Audit-Ordner entsteht in letzter Minute."
+               data-i18n-en="Checklists, PDFs and comments are scattered – the audit pack is built at the last minute.">Checklisten, PDFs und Kommentare liegen verstreut – der Audit-Ordner entsteht in letzter Minute.</p>
             <dl class="calhelp-comparison__metrics">
               <div class="calhelp-comparison__metric">
                 <dt data-calhelp-i18n
-                    data-i18n-de="Vorbereitungszeit"
-                    data-i18n-en="Preparation time">Vorbereitungszeit</dt>
+                    data-i18n-de="Vorbereitung"
+                    data-i18n-en="Preparation">Vorbereitung</dt>
                 <dd data-calhelp-i18n
-                    data-i18n-de="3 Tage"
-                    data-i18n-en="3 days">3 Tage</dd>
+                    data-i18n-de="Mehrere Tage"
+                    data-i18n-en="Several days">Mehrere Tage</dd>
               </div>
               <div class="calhelp-comparison__metric">
                 <dt data-calhelp-i18n
-                    data-i18n-de="Ablage"
-                    data-i18n-en="Storage">Ablage</dt>
+                    data-i18n-de="Nachfragen"
+                    data-i18n-en="Follow-up questions">Nachfragen</dt>
                 <dd data-calhelp-i18n
-                    data-i18n-de="5+ verstreute Ordner"
-                    data-i18n-en="5+ scattered folders">5+ verstreute Ordner</dd>
+                    data-i18n-de="Häufig"
+                    data-i18n-en="Frequent">Häufig</dd>
               </div>
             </dl>
           </div>
-          <div id="comparison-card-audit-after"
+          <div id="results-card-audit-after"
                class="calhelp-comparison__state is-active"
                data-comparison-state="after">
             <p data-calhelp-i18n
-               data-i18n-de="Audit-Workspace mit Checkliste, Report-Diffs und Messmittelhistorie. Nachweise stehen sortiert bereit, inklusive Ansprechpartner:in."
-               data-i18n-en="Audit workspace with checklist, report diffs and instrument history. Evidence is pre-sorted including the responsible contact.">Audit-Workspace mit Checkliste, Report-Diffs und Messmittelhistorie. Nachweise stehen sortiert bereit, inklusive Ansprechpartner:in.</p>
+               data-i18n-de="Audit-Ordner entsteht aus dem System – Nachweise, Kommentare und Historie sind in Sekunden parat."
+               data-i18n-en="The audit pack comes straight from the system – evidence, comments and history are ready in seconds.">Audit-Ordner entsteht aus dem System – Nachweise, Kommentare und Historie sind in Sekunden parat.</p>
             <dl class="calhelp-comparison__metrics">
               <div class="calhelp-comparison__metric">
                 <dt data-calhelp-i18n
-                    data-i18n-de="Aufwand"
-                    data-i18n-en="Effort">Aufwand</dt>
+                    data-i18n-de="Vorbereitung"
+                    data-i18n-en="Preparation">Vorbereitung</dt>
                 <dd data-calhelp-i18n
-                    data-i18n-de="−60&nbsp;%"
-                    data-i18n-en="−60%">−60&nbsp;%</dd>
+                    data-i18n-de="1 Tag"
+                    data-i18n-en="1 day">1 Tag</dd>
               </div>
               <div class="calhelp-comparison__metric">
                 <dt data-calhelp-i18n
-                    data-i18n-de="Bereitstellung"
-                    data-i18n-en="Preparation">Bereitstellung</dt>
+                    data-i18n-de="Nachfragen"
+                    data-i18n-en="Follow-up questions">Nachfragen</dt>
                 <dd data-calhelp-i18n
-                    data-i18n-de="Audit-Ordner in 1 Tag"
-                    data-i18n-en="Audit binder in 1 day">Audit-Ordner in 1 Tag</dd>
+                    data-i18n-de="Selten"
+                    data-i18n-en="Rare">Selten</dd>
               </div>
             </dl>
           </div>
@@ -2381,53 +2153,34 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
 </script>
 <div data-calhelp-usecases></div>
 
-<section id="proof" class="uk-section calhelp-section" aria-labelledby="proof-title">
+<section id="knowledge" class="uk-section calhelp-section" aria-labelledby="knowledge-title">
   <div class="uk-container">
     <div class="calhelp-section__header">
-      <h2 id="proof-title" class="uk-heading-medium">Was Vertrauen schafft</h2>
-      <p class="uk-text-lead">Drei Zusagen, auf die Sie sich verlassen können.</p>
+      <h2 id="knowledge-title" class="uk-heading-medium">Wissen &amp; Vertrauen</h2>
+      <p class="uk-text-lead">Kurz erklärt hier, ausführlich im Trust-Center.</p>
     </div>
     <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="proof-trace-title">
-        <h3 id="proof-trace-title" class="uk-card-title">Nachweisbar.</h3>
-        <p>Freigaben und Änderungen sind protokolliert – lückenlos und exportierbar.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="knowledge-safe-title">
+        <h3 id="knowledge-safe-title" class="uk-card-title">Sicher gehostet.</h3>
+        <p>Daten bleiben in deutschen Rechenzentren, Zugriffe sind rollenbasiert und revisionssicher.</p>
       </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="proof-check-title">
-        <h3 id="proof-check-title" class="uk-card-title">Prüfbar.</h3>
-        <p>Berichte lassen sich reproduzieren, auf Wunsch zweisprachig und mit Golden Samples geprüft.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="knowledge-trace-title">
+        <h3 id="knowledge-trace-title" class="uk-card-title">Alles nachvollziehbar.</h3>
+        <p>Freigaben, Kommentare und Versionen landen automatisch im Audit-Trail.</p>
       </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="proof-safe-title">
-        <h3 id="proof-safe-title" class="uk-card-title">Sicher.</h3>
-        <p>Betrieb in Deutschland oder On-Prem, Zugriffe rollenbasiert, Backups verschlüsselt.</p>
+      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="knowledge-audit-title">
+        <h3 id="knowledge-audit-title" class="uk-card-title">Auditbereit.</h3>
+        <p>Nachweise &amp; Vorlagen stehen auf Abruf bereit – ohne zusätzliche Nachtschichten.</p>
       </article>
     </div>
-    <div data-calhelp-assurance></div>
-    <div data-calhelp-proof-gallery></div>
+    <div class="uk-margin-large-top">
+      <div data-calhelp-assurance></div>
+    </div>
+    <div class="uk-margin-large-top">
+      <div data-calhelp-proof-gallery></div>
+    </div>
     <div class="calhelp-kpi uk-card uk-card-primary uk-card-body">
-      <p class="uk-margin-remove">Weniger Schleifen, mehr Ergebnisse – begleitet von 15+ Jahren Projekterfahrung.</p>
-    </div>
-  </div>
-</section>
-
-<section id="help" class="uk-section uk-section-muted calhelp-section" aria-labelledby="help-title">
-  <div class="uk-container">
-    <div class="calhelp-section__header">
-      <h2 id="help-title" class="uk-heading-medium">Wie wir helfen</h2>
-      <p class="uk-text-lead">Wir starten klein, liefern Belege und halten Wissen fest.</p>
-    </div>
-    <div class="uk-grid-large uk-child-width-1-3@m uk-grid-match" data-uk-grid>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="help-start-title">
-        <h3 id="help-start-title" class="uk-card-title">Wir starten klein.</h3>
-        <p>Der dringendste Knoten löst sich zuerst – sichtbar für Fachbereich und IT.</p>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="help-proof-title">
-        <h3 id="help-proof-title" class="uk-card-title">Wir belegen Ergebnisse.</h3>
-        <p>Einfache Checks zeigen Fortschritt: Abnahmen, KPIs und dokumentierte Nachweise.</p>
-      </article>
-      <article class="uk-card uk-card-primary uk-card-body calhelp-card" aria-labelledby="help-doc-title">
-        <h3 id="help-doc-title" class="uk-card-title">Wir dokumentieren.</h3>
-        <p>Playbooks, Vorlagen und Mitschriften sorgen dafür, dass Wiederholungen schneller gehen.</p>
-      </article>
+      <p class="uk-margin-remove">Alle technischen Details, KPIs und Checklisten finden Sie im <a href="https://calhelp.notion.site/Trust-Center" target="_blank" rel="noopener">Trust-Center</a>. Für Fragen stehen wir jederzeit bereit.</p>
     </div>
   </div>
 </section>
@@ -2696,7 +2449,7 @@ INSERT OR IGNORE INTO pages (slug, title, content) VALUES (
           <p class="uk-margin-small-top">Sie bevorzugen ein Gespräch oder möchten ein konkretes Szenario prüfen? Nutzen Sie die Schnellzugriffe.</p>
           <div class="calhelp-cta__actions uk-margin-medium-top" role="group" aria-label="Abschluss-CTAs">
             <a class="uk-button uk-button-primary uk-width-1-1" href="#conversation">Gespräch starten</a>
-            <a class="uk-button uk-button-default uk-width-1-1" href="#help">Lage klären</a>
+            <a class="uk-button uk-button-default uk-width-1-1" href="#approach">Lage klären</a>
           </div>
         </div>
         <div class="calhelp-note uk-card uk-card-primary uk-card-body uk-margin-top">


### PR DESCRIPTION
## Summary
- remove the calHelp modules JSON block from the marketing page markup so the Bausteine section no longer renders
- ensure the consolidated SQLite seed matches the updated marketing markup with the solutions/approach/results layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6346140ac832b9b5e9919e4a65abf